### PR TITLE
docs: HTML版の数式レンダリング不具合を修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,11 +15,10 @@
   .sidebar a { text-decoration: none; color: #0969da; }
   .sidebar a:hover { text-decoration: underline; }
   .main-content { flex: 1; padding: 2rem 3rem; max-width: calc(100vw - var(--sidebar-width)); box-sizing: border-box; overflow-x: hidden; }
-  .markdown-body { max-width: 850px; margin: 0 auto; font-size: 16px; }
+  .markdown-body { max-width: 850px; margin: 0 auto; font-size: 16px; line-height: 1.8; }
   @media (max-width: 768px) { body { flex-direction: column; } .sidebar { width: 100%; height: auto; position: relative; border-right: none; } .main-content { max-width: 100%; padding: 1.5rem; } }
   blockquote { border-left: 4px solid #d0d7de; color: #57606a; background: #f6f8fa; padding: 0.5em 1em; margin: 1.5em 0; border-radius: 0 6px 6px 0; }
-  /* 数式がはみ出さないように調整 */
-  .mjx-container { overflow-x: auto !important; overflow-y: hidden !important; max-width: 100%; }
+  .mjx-container { overflow-x: auto !important; overflow-y: hidden !important; max-width: 100%; padding: 0.5em 0; }
 </style>
 <script>
 window.MathJax = {
@@ -27,13 +26,12 @@ window.MathJax = {
     inlineMath: [['$', '$'], ['\\(', '\\)']],
     displayMath: [['$$', '$$']],
     processEscapes: true,
-    packages: {'[+]': ['base', 'ams', 'noerrors', 'noundefined']}
+    tags: 'ams'
   },
-  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] },
-  loader: {load: ['[tex]/ams', '[tex]/noerrors', '[tex]/noundefined']}
+  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
 };
 </script>
-<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
 <body>
   <nav class="sidebar">
@@ -41,22 +39,22 @@ window.MathJax = {
     <div class="toc"><div class="toc">
 <ul>
 <li><a href="#sns">はじめに —— かつての私への贈り物、およびSNS時代の予防線</a></li>
-<li><a href="#1dx">第1章：$dx$ とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</a><ul>
+<li><a href="#1mathblock493placeholder">第1章：MATHBLOCK493PLACEHOLDER とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</a><ul>
 <li><a href="#10-11">§1.0 数学者の1次元、物理学者の1次元</a></li>
 <li><a href="#11">§1.1 リーマン積分は行列の積である</a><ul>
 <li><a href="#111">1.1.1 リーマン和の標準的構成（復習）</a></li>
 <li><a href="#112">1.1.2 小区間ごとの変位</a></li>
-<li><a href="#113-dx">1.1.3 $dx$ の登場 — 本書最大の特徴としての「断言」</a></li>
+<li><a href="#113-mathblock543placeholder">1.1.3 MATHBLOCK543PLACEHOLDER の登場 — 本書最大の特徴としての「断言」</a></li>
 <li><a href="#114">1.1.4 リーマン和のベクトル再解釈と積分記号</a></li>
 <li><a href="#115">1.1.5 物理的解釈 — 仕事の計算を例に</a></li>
-<li><a href="#116-1-form">1.1.6 一次形式（$1$-form）</a></li>
+<li><a href="#116-mathblock596placeholder-form">1.1.6 一次形式（MATHBLOCK596PLACEHOLDER-form）</a></li>
 </ul>
 </li>
-<li><a href="#12-df">§1.2 全微分 $df$ — 変化率を行列にまとめた演算子</a><ul>
+<li><a href="#12-mathblock637placeholder">§1.2 全微分 MATHBLOCK637PLACEHOLDER — 変化率を行列にまとめた演算子</a><ul>
 <li><a href="#121">1.2.1 微分可能性の行列表現</a></li>
-<li><a href="#122-df-dfmathbfv">1.2.2 $df$ の行列としての定義と $df(\mathbf{v})$</a></li>
-<li><a href="#123-y-z-dy-dz">1.2.3 $y$ 方向と $z$ 方向の物差し $dy$, $dz$</a></li>
-<li><a href="#124-fx-x2">1.2.4 具体例： $f(x) = x^2$ の場合</a></li>
+<li><a href="#122-mathblock650placeholder-mathblock651placeholder">1.2.2 MATHBLOCK650PLACEHOLDER の行列としての定義と MATHBLOCK651PLACEHOLDER</a></li>
+<li><a href="#123-mathblock667placeholder-mathblock668placeholder-mathblock669placeholder-mathblock670placeholder">1.2.3 MATHBLOCK667PLACEHOLDER 方向と MATHBLOCK668PLACEHOLDER 方向の物差し MATHBLOCK669PLACEHOLDER, MATHBLOCK670PLACEHOLDER</a></li>
+<li><a href="#124-mathblock703placeholder">1.2.4 具体例： MATHBLOCK703PLACEHOLDER の場合</a></li>
 <li><a href="#125">1.2.5 置換積分の行列解釈</a></li>
 <li><a href="#126">1.2.6 三次元への拡張</a></li>
 <li><a href="#127">1.2.7 線積分の先取り</a></li>
@@ -98,7 +96,7 @@ window.MathJax = {
 <li><a href="#242">2.4.2 欲しい結果からマス目を埋める</a></li>
 <li><a href="#243">2.4.3 テンソル積の導入</a></li>
 <li><a href="#244">2.4.4 ウェッジ積の完成</a></li>
-<li><a href="#245-32-form">2.4.5 3つの基底$2$-form</a></li>
+<li><a href="#245-3mathblock1131placeholder-form">2.4.5 3つの基底MATHBLOCK1131PLACEHOLDER-form</a></li>
 <li><a href="#246">2.4.6 向き付き面積の正体と「図形側の基底」</a></li>
 <li><a href="#247">2.4.7 小学校のスカラー面積に戻すには</a></li>
 <li><a href="#248-10">2.4.8 1次元の「面積」（長さ）と0次元の「面積」（点）</a></li>
@@ -108,13 +106,13 @@ window.MathJax = {
 <li><a href="#25">§2.5 体積測定器と行列式</a><ul>
 <li><a href="#251">2.5.1 体積測定器が満たすべきルール</a></li>
 <li><a href="#252">2.5.2 ルールから形を決める——基底展開と消去</a></li>
-<li><a href="#253-2-form">2.5.3 $2$-form の行列式としての再解釈</a></li>
-<li><a href="#254-dx-wedge-dy-wedge-dz">2.5.4 $dx \wedge dy \wedge dz$ の定義——行列式パターンの完成</a></li>
-<li><a href="#255-3-times-3">2.5.5 体積測定器のテンソル積表現——$3 \times 3$ ブロックを横に並べた配列</a></li>
+<li><a href="#253-mathblock1240placeholder-form">2.5.3 MATHBLOCK1240PLACEHOLDER-form の行列式としての再解釈</a></li>
+<li><a href="#254-mathblock1243placeholder">2.5.4 MATHBLOCK1243PLACEHOLDER の定義——行列式パターンの完成</a></li>
+<li><a href="#255-mathblock1252placeholder">2.5.5 体積測定器のテンソル積表現——MATHBLOCK1252PLACEHOLDER ブロックを横に並べた配列</a></li>
 <li><a href="#256">2.5.6 具体例：平行六面体の符号付き体積</a></li>
 <li><a href="#257">2.5.7 スカラー三重積との符合</a></li>
 <li><a href="#258">2.5.8 体積における「図形側の基底」</a></li>
-<li><a href="#259-3-form-1">2.5.9 $3$-form の「サイズ」——なぜ独立成分は1つだけか</a></li>
+<li><a href="#259-mathblock1316placeholder-form-1">2.5.9 MATHBLOCK1316PLACEHOLDER-form の「サイズ」——なぜ独立成分は1つだけか</a></li>
 <li><a href="#2510-2">2.5.10 測定器の階層——第2章で手に入れた武器の整理</a></li>
 </ul>
 </li>
@@ -137,7 +135,7 @@ window.MathJax = {
 </li>
 <li><a href="#32-21">§3.2 表面積——2次元、係数1</a><ul>
 <li><a href="#321">3.2.1 平行四辺形から曲面へ</a></li>
-<li><a href="#322-dx-wedge-dy">3.2.2 $dx \wedge dy$ が測るもの——球面で試す</a></li>
+<li><a href="#322-mathblock1581placeholder">3.2.2 MATHBLOCK1581PLACEHOLDER が測るもの——球面で試す</a></li>
 <li><a href="#323">3.2.3 三つの影から本当の面積へ</a></li>
 <li><a href="#324">3.2.4 ここまででわかったこと</a></li>
 </ul>
@@ -145,14 +143,14 @@ window.MathJax = {
 <li><a href="#33-11">§3.3 曲線——1次元、係数1（限界があらわになる）</a><ul>
 <li><a href="#331">3.3.1 直線から曲線へ——リーマン和で定義する</a></li>
 <li><a href="#332">3.3.2 円周で試す——弧長は出ない</a></li>
-<li><a href="#333-1-form">3.3.3 では $1$-form で何が測れるのか</a></li>
+<li><a href="#333-mathblock1703placeholder-form">3.3.3 では MATHBLOCK1703PLACEHOLDER-form で何が測れるのか</a></li>
 </ul>
 </li>
 <li><a href="#34">§3.4 係数をつける——密度と幾何の積</a><ul>
 <li><a href="#340">3.4.0 なぜ係数なのか——物理が要求する</a></li>
-<li><a href="#341-1-form">3.4.1 一般の $1$-form の線積分（仕事）</a></li>
-<li><a href="#342-2-form">3.4.2 一般の $2$-form の面積分（流量）</a></li>
-<li><a href="#343-3-form">3.4.3 一般の $3$-form の体積分（総質量）</a></li>
+<li><a href="#341-mathblock1734placeholder-form">3.4.1 一般の MATHBLOCK1734PLACEHOLDER-form の線積分（仕事）</a></li>
+<li><a href="#342-mathblock1767placeholder-form">3.4.2 一般の MATHBLOCK1767PLACEHOLDER-form の面積分（流量）</a></li>
+<li><a href="#343-mathblock1780placeholder-form">3.4.3 一般の MATHBLOCK1780PLACEHOLDER-form の体積分（総質量）</a></li>
 <li><a href="#344">3.4.4 線・面・体の統一像</a></li>
 <li><a href="#345">3.4.5 積分の一般形</a></li>
 </ul>
@@ -160,7 +158,7 @@ window.MathJax = {
 <li><a href="#35">§3.5 本章のまとめと次章への展望</a></li>
 </ul>
 </li>
-<li><a href="#4-phi">第4章：変数変換とは何か —— 引き戻し $\Phi^*$：測定器のつじつま合わせ</a><ul>
+<li><a href="#4-mathblock1861placeholder">第4章：変数変換とは何か —— 引き戻し MATHBLOCK1861PLACEHOLDER：測定器のつじつま合わせ</a><ul>
 <li><a href="#40">§4.0 物理は曲がる、計算は四角</a></li>
 <li><a href="#41-1-form">§4.1 1-form の引き戻し——仕事と運動エネルギー定理</a></li>
 <li><a href="#42-2-form">§4.2 2-form の引き戻し——角運動量保存と面積速度</a></li>
@@ -169,32 +167,32 @@ window.MathJax = {
 <li><a href="#45-5">§4.5 本章のまとめと第5章（外微分）への展望</a></li>
 </ul>
 </li>
-<li><a href="#5-d">第5章：微分するとは何か —— 外微分 $d$：局所のズレと積分の逆</a><ul>
+<li><a href="#5-mathblock2184placeholder">第5章：微分するとは何か —— 外微分 MATHBLOCK2184PLACEHOLDER：局所のズレと積分の逆</a><ul>
 <li><a href="#50-ii">§5.0 第II部の扉——観測は積分、法則は微分</a></li>
-<li><a href="#51-df">§5.1 $df$ 再訪——微分と積分は逆演算か</a><ul>
-<li><a href="#511-df">5.1.1 $df$ は「次元上げ」をしている</a></li>
+<li><a href="#51-mathblock2208placeholder">§5.1 MATHBLOCK2208PLACEHOLDER 再訪——微分と積分は逆演算か</a><ul>
+<li><a href="#511-mathblock2209placeholder">5.1.1 MATHBLOCK2209PLACEHOLDER は「次元上げ」をしている</a></li>
 <li><a href="#512">5.1.2 線積分すると端点の差だけが残る</a></li>
 <li><a href="#513-3">5.1.3 第3章の例で確かめる</a></li>
 </ul>
 </li>
 <li><a href="#52">§5.2 閉ループで姿を現す「ズレ」</a><ul>
-<li><a href="#521-1-form">5.2.1 一般の $1$-form ではどうか</a></li>
+<li><a href="#521-mathblock2260placeholder-form">5.2.1 一般の MATHBLOCK2260PLACEHOLDER-form ではどうか</a></li>
 <li><a href="#522">5.2.2 局所情報はどこに宿るか</a></li>
 </ul>
 </li>
 <li><a href="#53">§5.3 微小ループの解剖——ズレは面積に比例する</a><ul>
-<li><a href="#531-xy">5.3.1 $xy$ 平面の微小長方形</a></li>
+<li><a href="#531-mathblock2286placeholder">5.3.1 MATHBLOCK2286PLACEHOLDER 平面の微小長方形</a></li>
 <li><a href="#532">5.3.2 決定的な事実</a></li>
 </ul>
 </li>
-<li><a href="#54-d">§5.4 $d$ の誕生——面積あたりのズレを測る新しい測定器</a><ul>
+<li><a href="#54-mathblock2354placeholder">§5.4 MATHBLOCK2354PLACEHOLDER の誕生——面積あたりのズレを測る新しい測定器</a><ul>
 <li><a href="#541">5.4.1 ウェッジ積の再確認</a></li>
-<li><a href="#542-domega">5.4.2 $d\omega$ の定義</a></li>
+<li><a href="#542-mathblock2364placeholder">5.4.2 MATHBLOCK2364PLACEHOLDER の定義</a></li>
 </ul>
 </li>
-<li><a href="#55-1-form-3">§5.5 一般の $1$-form の外微分——3次元への拡張</a><ul>
-<li><a href="#551-yz-zx">5.5.1 $yz$ 平面と $zx$ 平面</a></li>
-<li><a href="#552-ddx0">5.5.2 代数的導出——ライプニッツ則と $d(dx)=0$</a></li>
+<li><a href="#55-mathblock2400placeholder-form-3">§5.5 一般の MATHBLOCK2400PLACEHOLDER-form の外微分——3次元への拡張</a><ul>
+<li><a href="#551-mathblock2401placeholder-mathblock2402placeholder">5.5.1 MATHBLOCK2401PLACEHOLDER 平面と MATHBLOCK2402PLACEHOLDER 平面</a></li>
+<li><a href="#552-mathblock2416placeholder">5.5.2 代数的導出——ライプニッツ則と MATHBLOCK2416PLACEHOLDER</a></li>
 <li><a href="#553">5.5.3 係数のパターン</a></li>
 </ul>
 </li>
@@ -204,21 +202,21 @@ window.MathJax = {
 <li><a href="#563">5.6.3 生き残るのは境界だけ</a></li>
 </ul>
 </li>
-<li><a href="#57-2-form">§5.7 同じことをもう一段——$2$-form の外微分と発散</a><ul>
-<li><a href="#571-2-form">5.7.1 $2$-form は面の測定器</a></li>
+<li><a href="#57-mathblock2510placeholder-form">§5.7 同じことをもう一段——MATHBLOCK2510PLACEHOLDER-form の外微分と発散</a><ul>
+<li><a href="#571-mathblock2511placeholder-form">5.7.1 MATHBLOCK2511PLACEHOLDER-form は面の測定器</a></li>
 <li><a href="#572">5.7.2 微小直方体の表面で測る</a></li>
-<li><a href="#573-deta">5.7.3 $d\eta$ の定義と代数的導出</a></li>
+<li><a href="#573-mathblock2539placeholder">5.7.3 MATHBLOCK2539PLACEHOLDER の定義と代数的導出</a></li>
 <li><a href="#574">5.7.4 ガウスの定理</a></li>
 </ul>
 </li>
-<li><a href="#58-d2-0">§5.8 $d^2 = 0$——二度測れば必ずゼロ</a><ul>
-<li><a href="#581-ddf-0">5.8.1 $d(df) = 0$</a></li>
-<li><a href="#582-ddomega-0">5.8.2 $d(d\omega) = 0$</a></li>
+<li><a href="#58-mathblock2590placeholder">§5.8 MATHBLOCK2590PLACEHOLDER——二度測れば必ずゼロ</a><ul>
+<li><a href="#581-mathblock2591placeholder">5.8.1 MATHBLOCK2591PLACEHOLDER</a></li>
+<li><a href="#582-mathblock2607placeholder">5.8.2 MATHBLOCK2607PLACEHOLDER</a></li>
 </ul>
 </li>
 <li><a href="#59">§5.9 外微分の統合——一つの式、一つのルール</a><ul>
 <li><a href="#591">5.9.1 ストークスとガウスは同じ式だった</a></li>
-<li><a href="#592-k-form">5.9.2 一般の $k$-form の外微分</a></li>
+<li><a href="#592-mathblock2648placeholder-form">5.9.2 一般の MATHBLOCK2648PLACEHOLDER-form の外微分</a></li>
 <li><a href="#593">5.9.3 計算ルールまとめ</a></li>
 </ul>
 </li>
@@ -229,61 +227,61 @@ window.MathJax = {
 </li>
 <li><a href="#511-ii">§5.11 第II部への展望——ホッジ・スターへの伏線</a></li>
 <li><a href="#c">付録C：外微分の行列表示</a><ul>
-<li><a href="#c1-0-formdf-1-times-3">C.1 $0$-form：$df$ の $1 \times 3$ 行ベクトル</a></li>
-<li><a href="#c2-1-form-mathbfj">C.2 $1$-form：係数のヤコビ行列 $\mathbf{J}$</a></li>
-<li><a href="#c3-domega-mathbfjt-mathbfj">C.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</a></li>
-<li><a href="#c4-2-formdeta">C.4 $2$-form：$d\eta$ とヤコビ行列のトレース</a><ul>
-<li><a href="#c41-deta-273">C.4.1 $d\eta$ の27成分——3枚の行列に展開する</a></li>
+<li><a href="#c1-mathblock2743placeholder-formmathblock2744placeholder-mathblock2745placeholder">C.1 MATHBLOCK2743PLACEHOLDER-form：MATHBLOCK2744PLACEHOLDER の MATHBLOCK2745PLACEHOLDER 行ベクトル</a></li>
+<li><a href="#c2-mathblock2748placeholder-form-mathblock2749placeholder">C.2 MATHBLOCK2748PLACEHOLDER-form：係数のヤコビ行列 MATHBLOCK2749PLACEHOLDER</a></li>
+<li><a href="#c3-mathblock2755placeholder">C.3 MATHBLOCK2755PLACEHOLDER</a></li>
+<li><a href="#c4-mathblock2762placeholder-formmathblock2763placeholder">C.4 MATHBLOCK2762PLACEHOLDER-form：MATHBLOCK2763PLACEHOLDER とヤコビ行列のトレース</a><ul>
+<li><a href="#c41-mathblock2768placeholder-273">C.4.1 MATHBLOCK2768PLACEHOLDER の27成分——3枚の行列に展開する</a></li>
 </ul>
 </li>
-<li><a href="#c5-d2-f-0">C.5 $d^2 f = 0$ とヘッセ行列</a></li>
+<li><a href="#c5-mathblock2792placeholder">C.5 MATHBLOCK2792PLACEHOLDER とヘッセ行列</a></li>
 </ul>
 </li>
 </ul>
 </li>
-<li><a href="#6-g-ast">第6章：計量 $g$ とホッジ・スター $\ast$ — 内積の召喚と次数の反転</a><ul>
+<li><a href="#6-mathblock2807placeholder-mathblock2808placeholder">第6章：計量 MATHBLOCK2807PLACEHOLDER とホッジ・スター MATHBLOCK2808PLACEHOLDER — 内積の召喚と次数の反転</a><ul>
 <li><a href="#60">§6.0 言い訳の終焉——内積を解放する</a></li>
-<li><a href="#61-g">§6.1 パラメータ空間の内積——計量 $g$ の正体</a><ul>
+<li><a href="#61-mathblock2818placeholder">§6.1 パラメータ空間の内積——計量 MATHBLOCK2818PLACEHOLDER の正体</a><ul>
 <li><a href="#611">6.1.1 実空間の内積</a></li>
 <li><a href="#612">6.1.2 内積を測定器として読み直す</a></li>
 <li><a href="#613">6.1.3 パラメータ空間で内積をとるには</a></li>
 </ul>
 </li>
-<li><a href="#62-g">§6.2 $g$ による縦ベクトルと横ベクトルの変換</a><ul>
-<li><a href="#621-mathbfvt-mathbfg">6.2.1 $\mathbf{v}^T \mathbf{g}$ は横ベクトルである</a></li>
-<li><a href="#622-k">6.2.2 計量が与えるもの——平行 $k$ 面体の幾何学的な大きさ</a></li>
+<li><a href="#62-mathblock2878placeholder">§6.2 MATHBLOCK2878PLACEHOLDER による縦ベクトルと横ベクトルの変換</a><ul>
+<li><a href="#621-mathblock2879placeholder">6.2.1 MATHBLOCK2879PLACEHOLDER は横ベクトルである</a></li>
+<li><a href="#622-mathblock2907placeholder">6.2.2 計量が与えるもの——平行 MATHBLOCK2907PLACEHOLDER 面体の幾何学的な大きさ</a></li>
 <li><a href="#623">6.2.3 内積の性質</a></li>
 <li><a href="#624">6.2.4 計量行列の幾何を成分に宿らせる</a></li>
 </ul>
 </li>
-<li><a href="#63-ast">§6.3 ホッジ・スター $\ast$ ——二つの方法を繫ぐ対応</a><ul>
+<li><a href="#63-mathblock2978placeholder">§6.3 ホッジ・スター MATHBLOCK2978PLACEHOLDER ——二つの方法を繫ぐ対応</a><ul>
 <li><a href="#631">6.3.1 スカラーを得る二つの方法</a></li>
-<li><a href="#632-ast">6.3.2 行列から $\ast$ を構成する</a></li>
-<li><a href="#633-ast">6.3.3 実空間での $\ast$ 辞書</a></li>
-<li><a href="#634-astast-mathrmid">6.3.4 $\ast\ast = \mathrm{id}$</a></li>
-<li><a href="#635-ast">6.3.5 $\ast$ の性質</a></li>
+<li><a href="#632-mathblock3010placeholder">6.3.2 行列から MATHBLOCK3010PLACEHOLDER を構成する</a></li>
+<li><a href="#633-mathblock3043placeholder">6.3.3 実空間での MATHBLOCK3043PLACEHOLDER 辞書</a></li>
+<li><a href="#634-mathblock3072placeholder">6.3.4 MATHBLOCK3072PLACEHOLDER</a></li>
+<li><a href="#635-mathblock3088placeholder">6.3.5 MATHBLOCK3088PLACEHOLDER の性質</a></li>
 </ul>
 </li>
 <li><a href="#64">§6.4 対応の実例——微分形式とベクトル解析</a><ul>
-<li><a href="#641-pvi">6.4.1 ジュール熱 $P=VI$ ——二つの経路</a></li>
-<li><a href="#642-a-cdot-nabla-times-a-ast">6.4.2 ヘリシティ $A \cdot (\nabla \times A)$ ——$\ast$ の往復</a></li>
+<li><a href="#641-mathblock3109placeholder">6.4.1 ジュール熱 MATHBLOCK3109PLACEHOLDER ——二つの経路</a></li>
+<li><a href="#642-mathblock3155placeholder-mathblock3156placeholder">6.4.2 ヘリシティ MATHBLOCK3155PLACEHOLDER ——MATHBLOCK3156PLACEHOLDER の往復</a></li>
 </ul>
 </li>
 <li><a href="#65">§6.5 ナブラの三兄弟を解体する</a><ul>
-<li><a href="#651-mathrmgradf-df">6.5.1 勾配 $\mathrm{grad}\,f = df$</a></li>
-<li><a href="#652-mathrmrotmathbff-astdomega">6.5.2 回転 $\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$</a></li>
-<li><a href="#653-mathrmdivmathbff-astdastomega">6.5.3 発散 $\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$</a></li>
-<li><a href="#654-d2-0">6.5.4 $d^2 = 0$ の当然の帰結</a></li>
+<li><a href="#651-mathblock3225placeholder">6.5.1 勾配 MATHBLOCK3225PLACEHOLDER</a></li>
+<li><a href="#652-mathblock3236placeholder">6.5.2 回転 MATHBLOCK3236PLACEHOLDER</a></li>
+<li><a href="#653-mathblock3254placeholder">6.5.3 発散 MATHBLOCK3254PLACEHOLDER</a></li>
+<li><a href="#654-mathblock3282placeholder">6.5.4 MATHBLOCK3282PLACEHOLDER の当然の帰結</a></li>
 </ul>
 </li>
 <li><a href="#66-ii-iii">§6.6 第II部の結び —— 第III部へ</a></li>
 <li><a href="#d">付録D：フロベニウス積とホッジ・スターの完全な行列表現</a><ul>
 <li><a href="#d1">D.1 行列の内積——フロベニウス積</a></li>
-<li><a href="#d2-ast_1to2">D.2 $\ast_{1\to2}$ ——行列の縦ベクトル</a></li>
-<li><a href="#d3-ast_2to1">D.3 $\ast_{2\to1}$ ——フロベニウス積による係数抽出</a></li>
+<li><a href="#d2-mathblock3366placeholder">D.2 MATHBLOCK3366PLACEHOLDER ——行列の縦ベクトル</a></li>
+<li><a href="#d3-mathblock3384placeholder">D.3 MATHBLOCK3384PLACEHOLDER ——フロベニウス積による係数抽出</a></li>
 <li><a href="#d4">D.4 転置関係</a></li>
-<li><a href="#d5-e_k-cdot-m">D.5 $E_k \cdot M$ の成分</a></li>
-<li><a href="#d6-ast">D.6 $\ast$ の二回作用</a></li>
+<li><a href="#d5-mathblock3422placeholder">D.5 MATHBLOCK3422PLACEHOLDER の成分</a></li>
+<li><a href="#d6-mathblock3440placeholder">D.6 MATHBLOCK3440PLACEHOLDER の二回作用</a></li>
 </ul>
 </li>
 </ul>
@@ -295,8 +293,8 @@ window.MathJax = {
 <li><a href="#712">7.1.2 クロス積</a></li>
 </ul>
 </li>
-<li><a href="#72-nabla">§7.2 $\nabla$ と勾配</a><ul>
-<li><a href="#721-nabla">7.2.1 $\nabla$ の定義</a></li>
+<li><a href="#72-mathblock3502placeholder">§7.2 MATHBLOCK3502PLACEHOLDER と勾配</a><ul>
+<li><a href="#721-mathblock3503placeholder">7.2.1 MATHBLOCK3503PLACEHOLDER の定義</a></li>
 <li><a href="#722">7.2.2 勾配</a></li>
 </ul>
 </li>
@@ -304,8 +302,8 @@ window.MathJax = {
 <li><a href="#74">§7.4 回転</a></li>
 <li><a href="#75">§7.5 ラプラシアン</a></li>
 <li><a href="#76">§7.6 恒等式</a><ul>
-<li><a href="#761-mathrmrotmathrmgradf-mathbf0">7.6.1 $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</a></li>
-<li><a href="#762-mathrmdivmathrmrotmathbff-0">7.6.2 $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</a></li>
+<li><a href="#761-mathblock3547placeholder">7.6.1 MATHBLOCK3547PLACEHOLDER</a></li>
+<li><a href="#762-mathblock3550placeholder">7.6.2 MATHBLOCK3550PLACEHOLDER</a></li>
 </ul>
 </li>
 <li><a href="#77">§7.7 ナブラの公式集</a><ul>
@@ -327,8 +325,8 @@ window.MathJax = {
 <li><a href="#8">第8章：二つの言語 —— 測定器の微分と、場の微分</a><ul>
 <li><a href="#80">§8.0 本書のハイライト</a></li>
 <li><a href="#81">§8.1 二つの微分、二つの世界</a><ul>
-<li><a href="#811-d">8.1.1 測定器に微分を乗せる——$d$ の立場</a></li>
-<li><a href="#812-nabla">8.1.2 測定器はそのまま、新たな場を考える——$\nabla$ の立場</a></li>
+<li><a href="#811-mathblock3652placeholder">8.1.1 測定器に微分を乗せる——MATHBLOCK3652PLACEHOLDER の立場</a></li>
+<li><a href="#812-mathblock3679placeholder">8.1.2 測定器はそのまま、新たな場を考える——MATHBLOCK3679PLACEHOLDER の立場</a></li>
 </ul>
 </li>
 <li><a href="#82">§8.2 翻訳辞書の完成</a><ul>
@@ -339,7 +337,7 @@ window.MathJax = {
 </ul>
 </li>
 <li><a href="#83">§8.3 ストークスの定理を翻訳する</a><ul>
-<li><a href="#831-nabla-d">8.3.1 $\nabla$ から $d$ へ</a></li>
+<li><a href="#831-mathblock3764placeholder-mathblock3765placeholder">8.3.1 MATHBLOCK3764PLACEHOLDER から MATHBLOCK3765PLACEHOLDER へ</a></li>
 <li><a href="#832">8.3.2 翻訳の往復——どちらからでも行ける</a></li>
 </ul>
 </li>
@@ -364,14 +362,14 @@ window.MathJax = {
 <li><a href="#9">第9章：実戦 —— 辞書を作り、難問を解く</a><ul>
 <li><a href="#90">§9.0 本書の目的はすでに果たされた</a></li>
 <li><a href="#91">§9.1 辞書をその場で作る——機械的手順</a></li>
-<li><a href="#92-rthetaz">§9.2 円柱座標 $(r,\theta,z)$</a><ul>
+<li><a href="#92-mathblock3996placeholder">§9.2 円柱座標 MATHBLOCK3996PLACEHOLDER</a><ul>
 <li><a href="#921">9.2.1 辞書の導出</a></li>
 <li><a href="#922">9.2.2 勾配</a></li>
 <li><a href="#923">9.2.3 発散</a></li>
 <li><a href="#924">9.2.4 回転</a></li>
 </ul>
 </li>
-<li><a href="#93-rhothetaphi">§9.3 球座標 $(\rho,\theta,\phi)$</a><ul>
+<li><a href="#93-mathblock4042placeholder">§9.3 球座標 MATHBLOCK4042PLACEHOLDER</a><ul>
 <li><a href="#931">9.3.1 辞書の導出</a></li>
 <li><a href="#932">9.3.2 発散</a></li>
 <li><a href="#933">9.3.3 回転</a></li>
@@ -390,32 +388,32 @@ window.MathJax = {
 <li><a href="#10">第10章：マクスウェル方程式 —— 美しさのその先へ</a><ul>
 <li><a href="#100">§10.0 お約束</a></li>
 <li><a href="#101-2">§10.1 マクスウェル方程式——2本で書く</a></li>
-<li><a href="#102-f">§10.2 $F$ の中身——行列で全部書く</a></li>
-<li><a href="#103-mathbbr3-4">§10.3 ミンコフスキー計量——$\mathbb{R}^3$ から4次元へ</a></li>
-<li><a href="#104-df0">§10.4 $dF=0$ を全部書き下す</a></li>
-<li><a href="#105-ast-f-2">§10.5 $\ast F$ と残りの2本</a></li>
-<li><a href="#106-f-da">§10.6 ポテンシャル構成——$F=-dA$ から始める</a><ul>
-<li><a href="#dd0-df0">$dd=0$ が $dF=0$ を証明する</a></li>
+<li><a href="#102-mathblock4167placeholder">§10.2 MATHBLOCK4167PLACEHOLDER の中身——行列で全部書く</a></li>
+<li><a href="#103-mathblock4195placeholder-4">§10.3 ミンコフスキー計量——MATHBLOCK4195PLACEHOLDER から4次元へ</a></li>
+<li><a href="#104-mathblock4215placeholder">§10.4 MATHBLOCK4215PLACEHOLDER を全部書き下す</a></li>
+<li><a href="#105-mathblock4237placeholder-2">§10.5 MATHBLOCK4237PLACEHOLDER と残りの2本</a></li>
+<li><a href="#106-mathblock4304placeholder">§10.6 ポテンシャル構成——MATHBLOCK4304PLACEHOLDER から始める</a><ul>
+<li><a href="#mathblock4373placeholder-mathblock4374placeholder">MATHBLOCK4373PLACEHOLDER が MATHBLOCK4374PLACEHOLDER を証明する</a></li>
 <li><a href="#1">もう1本の式——ポテンシャルで書く</a></li>
 </ul>
 </li>
-<li><a href="#edf-dast-f-4times4times4">付録E：$dF$ と $d(\ast F)$ のスライス行列表示 —— $4\times4\times4$ 配列で見るマクスウェル方程式</a><ul>
-<li><a href="#e1-3-form-16">E.1 基底 $3$-form とそのスライス行列 —— 全16枚</a></li>
-<li><a href="#e2-df">E.2 $dF$ をスライス行列で書く</a></li>
+<li><a href="#emathblock4420placeholder-mathblock4421placeholder-mathblock4422placeholder">付録E：MATHBLOCK4420PLACEHOLDER と MATHBLOCK4421PLACEHOLDER のスライス行列表示 —— MATHBLOCK4422PLACEHOLDER 配列で見るマクスウェル方程式</a><ul>
+<li><a href="#e1-mathblock4428placeholder-form-16">E.1 基底 MATHBLOCK4428PLACEHOLDER-form とそのスライス行列 —— 全16枚</a></li>
+<li><a href="#e2-mathblock4451placeholder">E.2 MATHBLOCK4451PLACEHOLDER をスライス行列で書く</a></li>
 <li><a href="#e3">E.3 フロベニウス積で係数を抜き出す</a></li>
-<li><a href="#e4-df0">E.4 $dF=0$ をスライスで読む</a></li>
-<li><a href="#e5-dast-f-mu_0astmathcalj">E.5 $d(\ast F) = \mu_0(\ast\mathcal{J})$ のスライス表示</a></li>
+<li><a href="#e4-mathblock4478placeholder">E.4 MATHBLOCK4478PLACEHOLDER をスライスで読む</a></li>
+<li><a href="#e5-mathblock4494placeholder">E.5 MATHBLOCK4494PLACEHOLDER のスライス表示</a></li>
 </ul>
 </li>
 </ul>
 </li>
 <li><a href="#11_1">第11章：曲がった空間へ —— 本書の先にあるもの</a><ul>
 <li><a href="#110">§11.0 この章の立ち位置 —— さらに先を見たい読者のための道標</a></li>
-<li><a href="#111-mathbfgx">§11.1 多様体 —— $\mathbf{g}(x)$ から始める</a><ul>
+<li><a href="#111-mathblock4533placeholder">§11.1 多様体 —— MATHBLOCK4533PLACEHOLDER から始める</a><ul>
 <li><a href="#1111">11.1.1 定義 —— チャートとアトラス</a></li>
 <li><a href="#1112">11.1.2 接空間 —— 「曲がった空間での微分」の定義</a></li>
 <li><a href="#1113">11.1.3 微分形式 —— 余接束とテンソル場</a></li>
-<li><a href="#1114-d">11.1.4 外微分 $d$ —— 多様体上で変わらないもの</a></li>
+<li><a href="#1114-mathblock4665placeholder">11.1.4 外微分 MATHBLOCK4665PLACEHOLDER —— 多様体上で変わらないもの</a></li>
 <li><a href="#1115">11.1.5 計量とホッジ・スター —— 場所ごとに変わるもの</a></li>
 <li><a href="#1116-1">11.1.6 積分 —— 1の分割と向き付け可能性</a></li>
 <li><a href="#1117">11.1.7 接続と曲率 —— 一言だけ</a></li>
@@ -442,13 +440,13 @@ window.MathJax = {
 </ul>
 </li>
 <li><a href="#123">§12.3 ディラック演算子と真のナブラ</a><ul>
-<li><a href="#1231-bmsigmacdotnabla">12.3.1 $\bm{\sigma}!\cdot!\nabla$ —— すべてを統合する演算子</a></li>
-<li><a href="#1232-d2">12.3.2 $D^2$ —— ラプラシアン</a></li>
+<li><a href="#1231-mathblock4928placeholder">12.3.1 MATHBLOCK4928PLACEHOLDER —— すべてを統合する演算子</a></li>
+<li><a href="#1232-mathblock4970placeholder">12.3.2 MATHBLOCK4970PLACEHOLDER —— ラプラシアン</a></li>
 <li><a href="#1233">12.3.3 マクスウェルを一本に —— 再訪</a></li>
-<li><a href="#1234-cancelpartial-f-j-4">12.3.4 $\cancel{\partial} F = J$ —— 4次元時空のディラック演算子</a></li>
+<li><a href="#1234-mathblock5002placeholder-4">12.3.4 MATHBLOCK5002PLACEHOLDER —— 4次元時空のディラック演算子</a></li>
 </ul>
 </li>
-<li><a href="#124-nabla">§12.4 演算子$\nabla$</a></li>
+<li><a href="#124-mathblock5023placeholder">§12.4 演算子MATHBLOCK5023PLACEHOLDER</a></li>
 </ul>
 </li>
 <li><a href="#_1">おわりに：『ナブラ解体新書』はいかにして生まれたか</a></li>
@@ -501,7 +499,7 @@ window.MathJax = {
 </tbody>
 </table>
 <p>\newpage</p>
-<h1 id="1dx">第1章：$dx$ とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</h1>
+<h1 id="1mathblock493placeholder">第1章：$dx$ とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</h1>
 <h3 id="10-11">§1.0 数学者の1次元、物理学者の1次元</h3>
 <p>高校で $\int f(x) dx$ という1次元の積分を習ったとき、教科書の記述では「$x$軸という1本の線」が置かれる。数学の教科書としてはそれで妥当だ。<strong>数学者</strong>は1次元空間 $\mathbb{R}^1$ という自己完結した抽象世界を仮定し、その上で論理を積み上げる。点は実数 $x$、変位は実数 $\Delta x$、積分は「関数×微小幅」の極限として定義される。すべてが完結している。</p>
 <p><strong>しかし、我々は物理学者である。</strong></p>
@@ -512,7 +510,7 @@ window.MathJax = {
 * 空気抵抗による横方向の微小変動もある</p>
 <p>物理学者の「1次元運動」とは、<strong>3次元空間内で特定の方向への変位が支配的であり、他の方向の変位が無視できるほど小さいか、系の対称性によって厳密にゼロに拘束されている状況</strong>を指す。
 したがって、物理学者が「1次元の微小変位」と呼ぶものの真の姿は、単なるスカラー $\Delta x$ ではなく、次のような<strong>縦ベクトル（列ベクトル）</strong>で表すのがふさわしい：
-$$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$</p>
+$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$</p>
 <blockquote>
 <p><strong>注</strong> （標準的でない呼び方）本書全体を通して<strong>縦ベクトル・横ベクトル</strong>という言い方をする（縦が列、横が行、と対応させて読んでほしい）。筆者は行と列という語の区別が苦手だからだ。</p>
 </blockquote>
@@ -528,7 +526,7 @@ $$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$</p>
 <hr />
 <h3 id="11">§1.1 リーマン積分は行列の積である</h3>
 <p>前節で、物理的な微小変位を縦ベクトル $\mathbf{v}$ として捉え直した。§1.0 と同じく
-$$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$
+$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$
 である。この視点を持って、今度は高校以来慣れ親しんだリーマン積分のプロセスを徹底的に解体し、その中に潜む「行列としての $dx$」を炙り出してみよう。</p>
 <blockquote>
 <p><strong>注</strong> （転置の記法について）数学や他文献では、縦ベクトルの成分を横に並べ、右上に ${}^T$ を添えて略記することもある。本書では縦ベクトルはすべて $\begin{pmatrix}\cdots\end{pmatrix}$ の形で書く。${}^T$ が出てきたときは、行列の転置演算の記号として読んでほしい。</p>
@@ -539,7 +537,7 @@ $$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$
 <p><strong>注</strong> （閉区間とは）記号 $[a,b]$ は、端点 $a$ と $b$ を両方含む<strong>閉区間</strong>（$a \le x \le b$ の実数 $x$ の集合）を表す。数学者の流儀に慣れていない読者のために明示しておく。</p>
 </blockquote>
 <ol>
-<li>区間を $n$ 個の小区間に分割： $a = x_0 &lt; x_1 &lt; \cdots &lt; x_n = b$</li>
+<li>区間を $n$ 個の小区間に分割： $a = x_0 < x_1 < \cdots < x_n = b$</li>
 <li>小区間の幅を $\Delta x_i = x_i - x_{i-1}$</li>
 <li>各小区間 $[x_{i-1}, x_i]$ の<strong>中から</strong>代表点 $\xi_i$ を1つ選ぶ</li>
 <li>リーマン和 $R_n = \sum_{i=1}^n f(\xi_i) \Delta x_i$ を作る（この $n$ 分割に対する和を $R_n$ と書く）</li>
@@ -548,33 +546,33 @@ $$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$
 <p>この教科書的な説明では、$\Delta x_i$ は「微小な幅」という一次元の量だ。しかし、我々はもう一歩踏み込めるはずだ。</p>
 <h4 id="112">1.1.2 小区間ごとの変位</h4>
 <p>第 $i$ 小区間 $[x_{i-1}, x_i]$ における変位は、§1.0 の<strong>変位ベクトル</strong>を、その区間の幅に合わせて
-$$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \ 0 \ 0 \end{pmatrix}$$
+$$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$$
 と書く。添字 $i$ は「第 $i$ 小区間の分」という意味だけで、$\mathbf{v}_i$ もまた変位ベクトルである。今は直線運動を考えているので $y,z$ 成分はゼロだが、それは条件ではなく結果としてゼロになっているだけだ。</p>
 <p>\clearpage</p>
-<h4 id="113-dx">1.1.3 $dx$ の登場 — 本書最大の特徴としての「断言」</h4>
+<h4 id="113-mathblock543placeholder">1.1.3 $dx$ の登場 — 本書最大の特徴としての「断言」</h4>
 <p>さて、本書では $dx$ という記号に次のような意味を与える。<strong>大胆で奇妙に思えるかもしれないが、これが本書最大の特徴でもある——ここでは $dx$ を次の $1\times 3$ 行列だと断言する。</strong></p>
 <p>すなわち、<strong>横ベクトル</strong>（$1\times 3$ <strong>行列</strong>として成分を横に並べて書く）として
-$$\displaystyle dx = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$$
+\begin{center}\scalebox{1.8}{$\displaystyle dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$}\end{center}
 と<strong>定義する</strong>。これは、入力された縦ベクトルから $x$ 成分だけを抜き出して返す線形演算子の行列表現である。</p>
 <blockquote>
 <p><strong>注</strong>（これはトンデモか？）<br />
 双対ベクトルを横ベクトルで表すこと自体は、テンソル解析や線形代数、量子力学のブラケット記法などの文脈で普通に行われる。たとえば標準基底 $e_1,e_2,e_3$ に対する双対基底のひとつ $e^1$ は、行列表現では
 $$
-e^1=\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}
-$$
+> e^1=\begin{pmatrix}1&0&0\end{pmatrix}
+> $$
 と書ける。テンソル解析でいう共変成分を、行ベクトルとして配列に起こしたものに対応する。本書では、標準デカルト座標のもとで、$dx$ をこの $e^1$ と同一視する。</p>
 <p>もちろんこれは、多様体論における座標自由な幾何学的実体としての $dx$ を否定するものではない。その立場では、$dx$ そのものと、その標準基底に関する行列表現は区別される。すなわち、
 $$
-dx \longleftrightarrow \begin{pmatrix}1&amp;0&amp;0\end{pmatrix}
-$$
+> dx \longleftrightarrow \begin{pmatrix}1&0&0\end{pmatrix}
+> $$
 という「表示の対応」として理解するのがより慎重だ。</p>
-<p>しかし本文では、等号 $=$ を採用する。理由は、日本の高校数学を通ってきた初学者にとって、$\longleftrightarrow$ や $\mapsto$ と $=$ の違いへ初手から立ち入ることが、余計な認知的負荷になると考えるからである。重要なのは、$=$ か $\mapsto$ かという記号そのものではなく、どの同一視を読者と約束しているかだ。本書では、「標準デカルト座標を固定した表示として、$dx$ を $\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ と書く」という約束のもとで、この省略記法を用いる。この同一視の裏側やテンソル解析・多様体論への発展は第11章で改めて述べる。</p>
+<p>しかし本文では、等号 $=$ を採用する。理由は、日本の高校数学を通ってきた初学者にとって、$\longleftrightarrow$ や $\mapsto$ と $=$ の違いへ初手から立ち入ることが、余計な認知的負荷になると考えるからである。重要なのは、$=$ か $\mapsto$ かという記号そのものではなく、どの同一視を読者と約束しているかだ。本書では、「標準デカルト座標を固定した表示として、$dx$ を $\begin{pmatrix}1&0&0\end{pmatrix}$ と書く」という約束のもとで、この省略記法を用いる。この同一視の裏側やテンソル解析・多様体論への発展は第11章で改めて述べる。</p>
 <p><strong>注</strong>（なぜこんなに必死なのか）<br />
 この種の発見的・構築的な導入は、しばしば「不正確だ」「一般論を矮小化している」と誤解される。したがって、本書の射程をあらかじめ明示しておく。本書の主戦場は、物理数学としての三次元ベクトル解析であり、一般多様体上の微分形式論やド・ラームコホモロジーではない。詳しくは「付録：本書で語らなかったもの」を参照のこと。
 \clearpage</p>
 </blockquote>
 <p>変位ベクトル $\mathbf{v}_i$ に左から掛けると
-$$dx\,\mathbf{v}_i = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \ 0 \ 0 \end{pmatrix} = \Delta x_i$$
+$$dx\,\mathbf{v}_i = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \Delta x_i$$
 となる。ここで「$dx$ が変位ベクトル $\mathbf{v}_i$ を食べてスカラー $\Delta x_i$ を吐く」というイメージを、<strong>関数の値のように書く</strong>ことにする：
 $$dx(\mathbf{v}_i) = dx\,\mathbf{v}_i = \Delta x_i$$
 <strong>本書では、しばしばこの $dx(\mathbf{v})$ の形で「横ベクトル $dx$ が縦ベクトル $\mathbf{v}$ に作用する」と強調する。何度繰り返しても強調しすぎることはない。</strong></p>
@@ -594,14 +592,14 @@ $$dx(\mathbf{v}_i) = dx\,\mathbf{v}_i = \Delta x_i$$
 <p>この視点でリーマン和を書き直すと：
 $$R_n = \sum_{i=1}^n f(\xi_i) \cdot dx(\mathbf{v}_i)$$</p>
 <p>さらに、各小区間で
-$$f(\xi_i)\,dx = \begin{pmatrix} f(\xi_i) &amp; 0 &amp; 0 \end{pmatrix}$$
+$$f(\xi_i)\,dx = \begin{pmatrix} f(\xi_i) & 0 & 0 \end{pmatrix}$$
 とおけば（スカラー $f(\xi_i)$ が各行をスケールする）、
-$$\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}<em>i) = f(\xi_i) \cdot dx(\mathbf{v}_i) = f(\xi_i)\,\Delta x_i$$
+$$\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i) = f(\xi_i) \cdot dx(\mathbf{v}_i) = f(\xi_i)\,\Delta x_i$$
 であり、リーマン和の各項そのものが得られる：
-$$R_n = \sum</em>{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$</p>
+$$R_n = \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$</p>
 <p>分割を無限に細かくする極限では（手順5と同じく、幅の最大値が $0$ に近づく意味で）、リーマン積分の定義より
-$$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n = \lim_{n\to\infty} \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}<em>i)$$
-左辺の $\int_a^b f(x)\,dx$ は、高校以来おなじみの積分記号そのものである——すなわち、上の手順5で書いた $\lim</em>{n\to\infty} R_n$ と同じ量だ。右辺は、<strong>各小区間で「行列 $f(\xi_i)\,dx$ を変位ベクトルに作用させた値」を足し上げたものの極限</strong>という、同じ積分の別顔だ。</p>
+$$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n = \lim_{n\to\infty} \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$
+左辺の $\int_a^b f(x)\,dx$ は、高校以来おなじみの積分記号そのものである——すなわち、上の手順5で書いた $\lim_{n\to\infty} R_n$ と同じ量だ。右辺は、<strong>各小区間で「行列 $f(\xi_i)\,dx$ を変位ベクトルに作用させた値」を足し上げたものの極限</strong>という、同じ積分の別顔だ。</p>
 <h4 id="115">1.1.5 物理的解釈 — 仕事の計算を例に</h4>
 <blockquote>
 <p><strong>注</strong> （力学になじみがない読者へ）ここで力学の講義をしようとするわけではない。下に出す $W=\int F\,dx$ は、<strong>積分を行列作用の極限としてどう読むか</strong>を示すための、馴染みのある例として借りるだけである。力の厳密な定義や単位の細部まで押さえなくとも、本節の主眼を追ううえで支障はない。想定読者の多くは高校程度の力学に触れているであろうが、これから初学者の読者も、上の趣旨だけ押さえていれば、同様に支障はない。</p>
@@ -609,10 +607,10 @@ $$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n = \lim_{n\to\infty} \sum_{i=1}^n \bi
 <p>直線上の質点に力 $F(x)$ が作用する場合の仕事を考えよう。力学を学んだ読者であれば
 $$W = \int_a^b F(x)\,dx$$
 という表現を知っているだろう。本書の流儀で行列表現すると、
-$$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) &amp; 0 &amp; 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \ 0 \ 0 \end{pmatrix} = \lim_{n\to\infty} \sum_{i=1}^n \bigl(F(\xi_i)\,dx\bigr)(\mathbf{v}_i) = \int_a^b F(x)\,dx$$
-である。左から順に、<strong>成分を明示したリーマン和の極限</strong>、<strong>演算子記法による同じ極限</strong>、<strong>慣用の積分記号</strong>であり、<strong>同じ量</strong>を三通りに表している。ここで $\mathbf{v}_i = \begin{pmatrix} \Delta x_i \ 0 \ 0 \end{pmatrix}$ である。</p>
-<p>$F(x)\,dx = \begin{pmatrix} F(x) &amp; 0 &amp; 0 \end{pmatrix}$ は演算子であり、$\bigl(F(x)\,dx\bigr)(\mathbf{v}) = F(x)\,\Delta x$ が一次近似としての微小仕事になる。</p>
-<h4 id="116-1-form">1.1.6 一次形式（$1$-form）</h4>
+$$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \lim_{n\to\infty} \sum_{i=1}^n \bigl(F(\xi_i)\,dx\bigr)(\mathbf{v}_i) = \int_a^b F(x)\,dx$$
+である。左から順に、<strong>成分を明示したリーマン和の極限</strong>、<strong>演算子記法による同じ極限</strong>、<strong>慣用の積分記号</strong>であり、<strong>同じ量</strong>を三通りに表している。ここで $\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$ である。</p>
+<p>$F(x)\,dx = \begin{pmatrix} F(x) & 0 & 0 \end{pmatrix}$ は演算子であり、$\bigl(F(x)\,dx\bigr)(\mathbf{v}) = F(x)\,\Delta x$ が一次近似としての微小仕事になる。</p>
+<h4 id="116-mathblock596placeholder-form">1.1.6 一次形式（$1$-form）</h4>
 <p>ここまで、我々は $dx$ を「変位ベクトルに作用して特定の成分を抽出し、スカラー（実数）を返す横ベクトル」として定義してきた。このような、ベクトルを食べてスカラーを吐き出す<strong>線形</strong>な測定器のことを、専門的には<strong>一次形式（$1$-form）</strong>と呼ぶ。本稿で「行列としての $dx$」と呼んできたものは、まさにこの一次形式に他ならない。</p>
 <blockquote>
 <p><strong>注</strong> （余ベクトルという用語）数学者は <strong>一次形式（$1$-form）</strong> の別名として <strong>余ベクトル（covector）</strong>と呼ぶ流儀をとることもよくある。他書を読むときの辞書として、頭の片隅に置いておけばよい。</p>
@@ -640,7 +638,7 @@ $$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) &amp; 0 &amp; 0 \e
 - 積分記号 $\int_a^b f(x)\,dx$ の末尾の $dx$ は慣用記法であり、変位そのものは $\Delta x$ や $dx(\mathbf{v})$ で書く（§1.1.6 の契約）。</p>
 </blockquote>
 <hr />
-<h3 id="12-df">§1.2 全微分 $df$ — 変化率を行列にまとめた演算子</h3>
+<h3 id="12-mathblock637placeholder">§1.2 全微分 $df$ — 変化率を行列にまとめた演算子</h3>
 <p>前節では、リーマン積分を「行列 $f(x)\,dx$ の変位ベクトルへの作用の和の極限」として解剖した。この節では、その考え方を関数自体の微分へと拡張し、<strong>全微分 $df$ を横ベクトル（行列）として定義する</strong>。「微分」は、単なる数値の変化率ではなく、<strong>変位ベクトルに掛けて初めて「変化量の一次部分」が出てくる演算子</strong>として扱う。</p>
 <h4 id="121">1.2.1 微分可能性の行列表現</h4>
 <p>関数 $f(x)$ が点 $x$ で微分可能であるとは、次の一次近似が成り立つことである：
@@ -649,13 +647,13 @@ $$\Delta f = f(x + \Delta x) - f(x) = f'(x) \Delta x + o(|\Delta x|) \quad (|\De
 <p><strong>注</strong> （ランダウのオーダー記法）<strong>$o(|\Delta x|)$</strong> は<strong>ランダウのオーダー記法</strong>である。$\Delta x \to 0$ のとき、$o(|\Delta x|)$ でまとめて書いた量は <strong>$|\Delta x|$ よりずっと速くゼロに近づく余り</strong>を意味し、主項 $f'(x)\Delta x$ に比べれば<strong>無視してよいほど小さい</strong>、という約束である。理工系の専門書ではよく出るが、初めて見る読者もいるかもしれない。</p>
 </blockquote>
 <p>ここで $\Delta x$ はスカラーだが、我々はこれを前節同様、3次元の変位ベクトルとして捉え直す：
-$$\mathbf{v} = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}$$</p>
+$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$</p>
 <p>すると、関数の変化 $\Delta f$ は、この $\mathbf{v}$ によって引き起こされる効果と見なせる。</p>
-<h4 id="122-df-dfmathbfv">1.2.2 $df$ の行列としての定義と $df(\mathbf{v})$</h4>
+<h4 id="122-mathblock650placeholder-mathblock651placeholder">1.2.2 $df$ の行列としての定義と $df(\mathbf{v})$</h4>
 <p>点 $x$ における関数 $f$ の<strong>全微分</strong> $df$ を、次の $1 \times 3$ 横ベクトルとして定義する：
-$$df = f'(x) \, dx = \begin{pmatrix} f'(x) &amp; 0 &amp; 0 \end{pmatrix}$$</p>
+$$df = f'(x) \, dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$$</p>
 <p>この $df$ を変位 $\mathbf{v}$ に作用させた結果を、前節と同様に <strong>$df(\mathbf{v})$</strong> と書く：
-$$df(\mathbf{v}) = \begin{pmatrix} f'(x) &amp; 0 &amp; 0 \end{pmatrix} \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix} = f'(x)\,\Delta x$$</p>
+$$df(\mathbf{v}) = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix} = f'(x)\,\Delta x$$</p>
 <p><strong>重要な認識の転換</strong>（<strong>常に次のように読む</strong>）：
 * 式 $df = f'(x)\,dx$ は、微積分でおなじみの<strong>全微分の記法</strong>だが、本書では <strong>$df$ も $dx$ も演算子としての横ベクトル</strong>であり、<strong>単体では微小変化量ではない</strong>、と読む。
 * <strong>$df(\mathbf{v})$</strong> と書いたときは、<strong>有限の（ただし十分小さい）変位 $\mathbf{v}$ に対する一次近似としての変化量</strong>を意味する。</p>
@@ -663,23 +661,23 @@ $$df(\mathbf{v}) = \begin{pmatrix} f'(x) &amp; 0 &amp; 0 \end{pmatrix} \begin{pm
 <blockquote>
 <p><strong>注</strong> （$df$ は演算子、$df(\mathbf{v})$ が変化量）§1.1.6 の記号契約と同じ区別を、ここでもう一度述べる。くどいと感じるかもしれないが、<strong>ここを誤読すると以降すべてがずれる</strong>ので、繰り返しに価値がある。</p>
 </blockquote>
-<h4 id="123-y-z-dy-dz">1.2.3 $y$ 方向と $z$ 方向の物差し $dy$, $dz$</h4>
+<h4 id="123-mathblock667placeholder-mathblock668placeholder-mathblock669placeholder-mathblock670placeholder">1.2.3 $y$ 方向と $z$ 方向の物差し $dy$, $dz$</h4>
 <p>この視点の強みを、§1.1.5 の力学の例に戻せば、<strong>力が $y$ 方向にも成分を持つ一般的な場合に自然に拡張できる</strong>点だ。
 <strong>いま定める $dy$</strong>を使えば、$F_x dx + F_y dy$ という形で2次元の仕事を統一的に扱える。
 $dx$ が $x$ 成分を抜き出すのと同様に、実空間では <strong>$dy$ は $y$ 成分</strong>、<strong>$dz$ は $z$ 成分</strong>を抜き出す横ベクトル（一次形式）と定める。行列表現は
-$$dy = \begin{pmatrix} 0 &amp; 1 &amp; 0 \end{pmatrix}, \qquad dz = \begin{pmatrix} 0 &amp; 0 &amp; 1 \end{pmatrix}$$
-である。変位 $\mathbf{v} = \begin{pmatrix} \Delta x \ \Delta y \ \Delta z \end{pmatrix}$ に対して $dy(\mathbf{v}) = \Delta y$, $dz(\mathbf{v}) = \Delta z$ となる。</p>
+$$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}, \qquad dz = \begin{pmatrix} 0 & 0 & 1 \end{pmatrix}$$
+である。変位 $\mathbf{v} = \begin{pmatrix} \Delta x \\ \Delta y \\ \Delta z \end{pmatrix}$ に対して $dy(\mathbf{v}) = \Delta y$, $dz(\mathbf{v}) = \Delta z$ となる。</p>
 <blockquote>
 <p><strong>注</strong> （$dy$, $dz$ の契約）単独の $dy$, $dz$ は演算子であり、$y$ や $z$ の微小幅を語るときは $\Delta y$, $\Delta z$ または $dy(\mathbf{v})$, $dz(\mathbf{v})$ と書く。積分記号の末尾に並ぶ $dy$, $dz$ も、高校以来の慣用記法として <strong>$dx$ と同じ仕方で読めばよい</strong>。細部の約束は、§1.1.6 で $dx$ についてまとめた<strong>記号契約</strong>と<strong>同じ考え方</strong>を適用する。</p>
 </blockquote>
 <p>3次元の空間には、<strong>三つの物差し</strong>がそろった。本章では説明の主線として $x$ 方向の断面に寄せてきたが、座標 $y,z$ と測定子 $dy,dz$ は最初からそろっている、と考えてほしい。
 いま、一変数の $df=f'(x)\,dx$ に $dy$, $dz$ を同じ型の物差しとして足しそろえた。以下の具体例と §1.2.6 での三次元への拡張で、この三つがどう効いてくるかを追う。</p>
-<h4 id="124-fx-x2">1.2.4 具体例： $f(x) = x^2$ の場合</h4>
+<h4 id="124-mathblock703placeholder">1.2.4 具体例： $f(x) = x^2$ の場合</h4>
 <p>$f(x) = x^2$ とする。$f'(x) = 2x$ である。</p>
 <p>たとえば <strong>$x=3$ において</strong>全微分を具体的に書き下ろす。横ベクトルと縦ベクトルを並べて、
-$$df = 6\,dx = \begin{pmatrix} 6 &amp; 0 &amp; 0 \end{pmatrix}, \qquad \mathbf{v} = \begin{pmatrix} 0.1 \ 0 \ 0 \end{pmatrix}$$
+$$df = 6\,dx = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix}, \qquad \mathbf{v} = \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix}$$
 であるから、行列の積は
-$$df(\mathbf{v}) = \begin{pmatrix} 6 &amp; 0 &amp; 0 \end{pmatrix} \begin{pmatrix} 0.1 \ 0 \ 0 \end{pmatrix} = 6\cdot 0.1 + 0\cdot 0 + 0\cdot 0 = 0.6$$</p>
+$$df(\mathbf{v}) = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix} \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix} = 6\cdot 0.1 + 0\cdot 0 + 0\cdot 0 = 0.6$$</p>
 <p>実際、$f(3.1) - f(3) = 9.61 - 9 = 0.61$ であり、一次近似 $0.6$ はよく一致している。</p>
 <h4 id="125">1.2.5 置換積分の行列解釈</h4>
 <blockquote>
@@ -688,12 +686,12 @@ $$df(\mathbf{v}) = \begin{pmatrix} 6 &amp; 0 &amp; 0 \end{pmatrix} \begin{pmatri
 <p>置換積分は、積分変数を取り換えて被積分関数を書き換える操作である（高校数学で扱う）。本節の目的はそれ<strong>単体の公式暗記ではない</strong>。§1.1 までに整えた言葉で言えば、<strong>「空間側の一次形式 $F\,dx$ が各ステップの変位 $\Delta\mathbf{r}$ に作用する」リーマン和</strong>と、<strong>「時間パラメータ $t$ 上のステップ幅 $\Delta t$」</strong>を、<strong>同じステップの中で対応づける</strong>と、置換後の積分 $\int F(x(t))\,\frac{dx}{dt}\,dt$ の形に自然に落ちる、という骨格を見せることである。</p>
 <p>仕事を例に取る。仕事は
 $$W = \int_a^b F(x)\,dx$$
-と書ける（§1.1.5 でも同じ量を行列作用の極限として見た）。位置が時間 $t$ とともに動き、$t_0&lt;t_1$ で $x(t_0)=a,\; x(t_1)=b$ となるようにパラメータ表示すると、空間内の点は
-$$\mathbf{r}(t) = \begin{pmatrix} x(t) \ 0 \ 0 \end{pmatrix}$$
+と書ける（§1.1.5 でも同じ量を行列作用の極限として見た）。位置が時間 $t$ とともに動き、$t_0<t_1$ で $x(t_0)=a,\; x(t_1)=b$ となるようにパラメータ表示すると、空間内の点は
+$$\mathbf{r}(t) = \begin{pmatrix} x(t) \\ 0 \\ 0 \end{pmatrix}$$
 と書ける。</p>
 <p><strong>時間軸側の1ステップ</strong>を、縦1成分のベクトル
 $$\mathbf{w} = \begin{pmatrix} \Delta t \end{pmatrix}$$
-で表す。$dx=\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ と<strong>並べて考えるなら</strong>、$t$ 成分だけを抜き出す「測定器」を $1\times 1$ 行列
+で表す。$dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と<strong>並べて考えるなら</strong>、$t$ 成分だけを抜き出す「測定器」を $1\times 1$ 行列
 $$dt = \begin{pmatrix} 1 \end{pmatrix}$$
 とおき、$dt(\mathbf{w})=\Delta t$ と読む。これは §1.1.6 の「横が測定器・縦がステップ・作用でスカラー」という<strong>型</strong>を、時間だけに縮めたものである。</p>
 <blockquote>
@@ -727,13 +725,13 @@ $$dt = \begin{pmatrix} 1 \end{pmatrix}$$
 </tbody>
 </table>
 <p>この $\Delta t$ に対応する<strong>空間での実際の変位</strong>は
-$$\Delta \mathbf{r} = \mathbf{r}(t+\Delta t) - \mathbf{r}(t) = \begin{pmatrix} \Delta x \ 0 \ 0 \end{pmatrix}, \qquad \Delta x = x(t+\Delta t)-x(t)$$
+$$\Delta \mathbf{r} = \mathbf{r}(t+\Delta t) - \mathbf{r}(t) = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}, \qquad \Delta x = x(t+\Delta t)-x(t)$$
 である。ここで $\Delta t \neq 0$ とする。商 $\Delta x/\Delta t$ は<strong>そのステップにおける $x$ の平均変化率</strong>であり、中学生でも知っている恒等式
 $$\Delta x = \frac{\Delta x}{\Delta t}\,\Delta t$$
 が成り立つ。したがって
 $$\begin{aligned}
-\Delta \mathbf{r} &amp;= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \ 0 \ 0 \end{pmatrix}\,\Delta t \
-&amp;= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \ 0 \ 0 \end{pmatrix}\,dt(\mathbf{w})
+\Delta \mathbf{r} &= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \\ 0 \\ 0 \end{pmatrix}\,\Delta t \\
+&= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \\ 0 \\ 0 \end{pmatrix}\,dt(\mathbf{w})
 \end{aligned}$$
 と書ける。<strong>これは近似でも微積の魔法でもなく、$\Delta x$ を $\Delta t$ で割った商を途中に挟んだだけの書き換えである。</strong>左の縦ベクトルは「そのステップでの $x$ 方向の平均変化率」、右の $dt(\mathbf{w})=\Delta t$ は時間ステップの幅である。</p>
 <p>さて $F\,dx$ は横ベクトル（演算子）なので、各ステップで
@@ -749,23 +747,23 @@ $$\bigl(F(x(t))\,dx\bigr)(\Delta \mathbf{r}) \approx F(x(t))\,\frac{dx}{dt}\,\De
 <blockquote>
 <p><strong>注</strong> （スカラー場）物理学ではこのような関数を<strong>スカラー場</strong>と呼ぶことが多い。</p>
 </blockquote>
-<p>その $f(x,y,z)$ が点 $(x,y,z)$ で<strong>（全）微分可能である</strong>とは、変位 $\mathbf{v}=\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ に対して
-$$\Delta f = f(x+\Delta x,\,y+\Delta y,\,z+\Delta z) - f(x,y,z) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z + o(|\mathbf{v}|) \quad (|\mathbf{v}|\to 0)$$
-が成り立つことである。§1.2.1 の1変数の定義と形式がそろっている。$o(|\mathbf{v}|)$ は余り項の略記（$o(|\Delta x|)$ と同趣旨）であり、ここでは深追いしないが、理解に支障はないであろう。</p>
+<p>その $f(x,y,z)$ が点 $(x,y,z)$ で<strong>（全）微分可能である</strong>とは、変位 $\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ に対して
+$$\Delta f = f(x+\Delta x,\,y+\Delta y,\,z+\Delta z) - f(x,y,z) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z + o(\|\mathbf{v}\|) \quad (\|\mathbf{v}\|\to 0)$$
+が成り立つことである。§1.2.1 の1変数の定義と形式がそろっている。$o(\|\mathbf{v}\|)$ は余り項の略記（$o(|\Delta x|)$ と同趣旨）であり、ここでは深追いしないが、理解に支障はないであろう。</p>
 <p>§1.2.3 の物差し $dx,dy,dz$ を使い、§1.2.2 と同じ型の演算子として
-$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} &amp; \frac{\partial f}{\partial y} &amp; \frac{\partial f}{\partial z} \end{pmatrix}$$
-と定義する。いちばん初めの式にあった $o(|\mathbf{v}|)$ は、ここから数行では省略し、<strong>記号の骨格だけ</strong>を追う。$\mathbf{v}=\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ のとき、微分可能性の定義より $\Delta f = df(\mathbf{v}) + o(|\mathbf{v}|)$ である——すなわち <strong>$df(\mathbf{v})$ は厳密な変化量 $\Delta f$ そのものではなく、剰余を除いた一次（主）項</strong>である。以下ではその主項を行列の積で書き下ろす：
-$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix} + \frac{\partial f}{\partial y}\begin{pmatrix}0&amp;1&amp;0\end{pmatrix}\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix} + \frac{\partial f}{\partial z}\begin{pmatrix}0&amp;0&amp;1\end{pmatrix}\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$$
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+と定義する。いちばん初めの式にあった $o(\|\mathbf{v}\|)$ は、ここから数行では省略し、<strong>記号の骨格だけ</strong>を追う。$\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ のとき、微分可能性の定義より $\Delta f = df(\mathbf{v}) + o(\|\mathbf{v}\|)$ である——すなわち <strong>$df(\mathbf{v})$ は厳密な変化量 $\Delta f$ そのものではなく、剰余を除いた一次（主）項</strong>である。以下ではその主項を行列の積で書き下ろす：
+$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\begin{pmatrix}1&0&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial y}\begin{pmatrix}0&1&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial z}\begin{pmatrix}0&0&1\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$$
 $$= \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z.$$
 第一行は、§1.2.3 の物差し $dx,dy,dz$ が行ベクトルとして $\mathbf{v}$ から $x,y,z$ 成分を抜き出し、偏導関数が係数としてかかる様子を<strong>行列の積</strong>で見せたものである。第二行はその評価結果であり、先の $\Delta f$ の定義式における<strong>線形主項</strong>と同じ形である。<strong>横ベクトル（演算子）× 縦ベクトル（変位）→ スカラー</strong>という §1.2.2 の読みが、三次元でも変わらない。</p>
 <p>座標が二つまでしか現れない $f(x,y)$ も、$z$ に依らなければ $\partial f/\partial z=0$ として上の枠に含めればよい——<strong>三次元に載せた枠組みが、そのまま低次元に退化する</strong>。</p>
 <p>見比べてみよう。
-1変数では： $df = f'(x) dx = \begin{pmatrix} f'(x) &amp; 0 &amp; 0 \end{pmatrix}$
-2変数関数 $f(x, y)$ では（§1.2.3 の $dy$ を用いる）： $df = \frac{\partial f}{\partial x} dx + \frac{\partial f}{\partial y} dy = \begin{pmatrix} \frac{\partial f}{\partial x} &amp; \frac{\partial f}{\partial y} &amp; 0 \end{pmatrix}$
+1変数では： $df = f'(x) dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$
+2変数関数 $f(x, y)$ では（§1.2.3 の $dy$ を用いる）： $df = \frac{\partial f}{\partial x} dx + \frac{\partial f}{\partial y} dy = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & 0 \end{pmatrix}$
 3変数 $f(x,y,z)$ では、§1.2.6 の式のとおり、横ベクトルの成分が三つそろうだけである。</p>
 <p>このように、<strong>形式は同じで、ただ成分の個数が増える</strong>。これが行列表示の威力である。$df$ を行列と見なすことで、微分は「変位に対する線形近似を与える演算子」として統一的に扱える。</p>
 <h4 id="127">1.2.7 線積分の先取り</h4>
-<p>空間内の曲線をパラメータ $t$ で $\mathbf{r}(t)=\begin{pmatrix}x(t)\y(t)\z(t)\end{pmatrix}$ と表し、細かいステップの変位を $\Delta\mathbf{r}$ と書くとき、各ステップで $\bigl(df\bigr)(\Delta\mathbf{r})$ を足し上げる操作の極限を、記号では
+<p>空間内の曲線をパラメータ $t$ で $\mathbf{r}(t)=\begin{pmatrix}x(t)\\y(t)\\z(t)\end{pmatrix}$ と表し、細かいステップの変位を $\Delta\mathbf{r}$ と書くとき、各ステップで $\bigl(df\bigr)(\Delta\mathbf{r})$ を足し上げる操作の極限を、記号では
 $$\int_\gamma df$$
 の形で表す（$\gamma$ は曲線）。§1.2.5 で見た $\int f'(x)\,dx$ と同じく、<strong>一次形式 $df$ が各ステップの変位に作用するリーマン和の極限</strong>という骨格である。閉曲線・向き・パラメータの取り換えなど、厳密な定式化は<strong>後の章に譲る</strong>。</p>
 <blockquote>
@@ -798,7 +796,7 @@ $$\int_\gamma df$$
 </blockquote>
 <hr />
 <h3 id="14">§1.4 座標変換——「物差し」の目盛りを書き換える</h3>
-<p>本章を通じて、我々は $dx$ の<strong>行列表現</strong>を $\begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$ と置いて議論してきた。これが場所によらず一定なのは、我々が物理空間を<strong>デカルト座標（直交直線座標）</strong>という最も素直な目盛りで測っているからだ。</p>
+<p>本章を通じて、我々は $dx$ の<strong>行列表現</strong>を $\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ と置いて議論してきた。これが場所によらず一定なのは、我々が物理空間を<strong>デカルト座標（直交直線座標）</strong>という最も素直な目盛りで測っているからだ。</p>
 <p>しかし物理学の現実はいつでも四角いとは限らない。円形パイプ内の流れや、直線電流の周りの磁場——こうした問題では、点を $(r,\theta,z)$ という数の組で指定する<strong>円柱座標</strong>を使ったほうが格段に扱いやすい。では、「成分を抜き出す物差し」である $dx$ は、別の座標系ではどう書けるのだろうか。</p>
 <h4 id="141">1.4.1 連鎖律は「物差し」の成分表示を与える</h4>
 <p>座標変換の式を思い出そう。</p>
@@ -806,20 +804,20 @@ $$\int_\gamma df$$
 <p>この変換則を、§1.2.2 で定義した<strong>全微分（演算子としての $d$）</strong>の枠組みに入れる。座標関数 $x(r,\theta,z)=r\cos\theta$ の<strong>全微分 $dx$</strong>（あくまで一次形式としての演算子であり、§1.1.6 の「微小変化」ではない）は、連鎖律によって次のように展開される。</p>
 <p>$$dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz = \cos\theta\,dr - r\sin\theta\,d\theta$$</p>
 <p>ここで $dx, dr, d\theta, dz$ はいずれも<strong>演算子（一次形式）</strong>だ。右辺の式が告げているのは、<strong>「実空間の物差し $dx$ を、$(dr,d\theta,dz)$ を目盛りとして表現し直すと、場所ごとに変わる係数 $(\cos\theta,\,-r\sin\theta,\,0)$ を持つ行列になる」</strong>という事実である。</p>
-<p>$$dx \;\xrightarrow{\text{円柱座標の目盛りで書くと}} \;\begin{pmatrix} \cos\theta &amp; -r\sin\theta &amp; 0 \end{pmatrix}$$</p>
-<p>実空間の $(x,y,z)$ では定数成分 $\begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$ だった $dx$ が、目盛りを取り替えた途端、場所 $(r,\theta)$ に依存する関数を成分に持つ行列へと姿を変える。対象そのものは不変であっても、「別の座標で書けば、その成分表示も変わる」——これが座標変換の代数的な正体である。</p>
+<p>$$dx \;\xrightarrow{\text{円柱座標の目盛りで書くと}} \;\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$$</p>
+<p>実空間の $(x,y,z)$ では定数成分 $\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ だった $dx$ が、目盛りを取り替えた途端、場所 $(r,\theta)$ に依存する関数を成分に持つ行列へと姿を変える。対象そのものは不変であっても、「別の座標で書けば、その成分表示も変わる」——これが座標変換の代数的な正体である。</p>
 <blockquote>
 <p><strong>注</strong> （連鎖律と変数変換——第3章への伏線）上では多変数関数の連鎖律 $dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz$ を計算ルールとして使った。本書ではまだ<strong>微分形式の変数変換を正式には定式化していない</strong>——この公式の厳密な意味づけ、すなわち「別の座標で書く」ことの一般論は、第3章 §3.5 の<strong>引き戻し（pullback）</strong>で改めて扱う。読者の既知の計算経験と、本章の「横ベクトル $dx$ が変位に作用する」という流儀がのちほど接続できそうだという動機だけ先に示す。いまは「行列の成分が機械的に出てくる」という感覚だけ掴めば十分である。</p>
-<p><strong>注</strong> （行列の積で読むときの約束）横ベクトル $\begin{pmatrix} \cos\theta &amp; -r\sin\theta &amp; 0 \end{pmatrix}$ を左から掛ける相手は、デカルト成分 $\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ ではなく、円柱座標のパラメータの変化量を並べた縦ベクトル $\begin{pmatrix}\Delta r\\Delta\theta\\Delta z\end{pmatrix}$ である。測定器（一次形式）を円柱座標の目盛りで書き換えた以上、測られる側の変位も同じ目盛りで入力しなければならない、という当たり前の理屈だ。§1.5 の演習で、その積が $dx(\mathbf{v})$ と一致することを手で確かめる。</p>
+<p><strong>注</strong> （行列の積で読むときの約束）横ベクトル $\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$ を左から掛ける相手は、デカルト成分 $\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ ではなく、円柱座標のパラメータの変化量を並べた縦ベクトル $\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$ である。測定器（一次形式）を円柱座標の目盛りで書き換えた以上、測られる側の変位も同じ目盛りで入力しなければならない、という当たり前の理屈だ。§1.5 の演習で、その積が $dx(\mathbf{v})$ と一致することを手で確かめる。</p>
 </blockquote>
 <h4 id="142">1.4.2 行列の一歩一歩に幾何を宿らせる</h4>
 <p>多くの教科書では、実空間に $(r,\theta)$ の「曲がったグリッド」を描き込み、「$\theta$ 方向の弧の長さは約 $r\Delta\theta$」と幾何学的に説明する。この直感自体は正しい——問題は、その絵を「証明」の土台に据えることだ。座標系が複雑になるほど、曲がった図形を相手にした幾何学的な「見積もり」はすぐに限界を迎える。</p>
-<p>本書がやりたいことは、幾何を代数で置き換えることではない。<strong>大きな幾何を、行列の一つひとつの成分という小さい幾何に分割すること</strong>だ。係数 $-r\sin\theta$ は「$\theta$ 方向の一歩が実空間の $x$ 方向にどれだけ効くか」という、それ自体で完結した幾何的情報を一つの数値として担っている。同様に $\cos\theta$ は $r$ 方向→$x$ 方向の効きを、$0$ は $z$ 方向が $x$ に効かないことを示す。つまり $dx = \begin{pmatrix} \cos\theta &amp; -r\sin\theta &amp; 0 \end{pmatrix}$ という一行が、$x$ 成分の変位に関する幾何を<strong>3つの独立した小問題</strong>に分解した姿なのである。幾何的直感と代数的な見通しの良さは、行列の上で両立する。</p>
+<p>本書がやりたいことは、幾何を代数で置き換えることではない。<strong>大きな幾何を、行列の一つひとつの成分という小さい幾何に分割すること</strong>だ。係数 $-r\sin\theta$ は「$\theta$ 方向の一歩が実空間の $x$ 方向にどれだけ効くか」という、それ自体で完結した幾何的情報を一つの数値として担っている。同様に $\cos\theta$ は $r$ 方向→$x$ 方向の効きを、$0$ は $z$ 方向が $x$ に効かないことを示す。つまり $dx = \begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$ という一行が、$x$ 成分の変位に関する幾何を<strong>3つの独立した小問題</strong>に分解した姿なのである。幾何的直感と代数的な見通しの良さは、行列の上で両立する。</p>
 <h4 id="143">1.4.3 二つのデカルト座標</h4>
 <p>ここで、いま扱っている二つの数の組——実空間の $(x,y,z)$ と円柱座標の $(r,\theta,z)$——の関係をはっきりさせておこう。計算用紙の上では、<strong>どちらも互いに直交し等間隔な軸を持つデカルト座標</strong>である。$\theta$ 軸は物理的には「角度」だが、数式の上では単なる一つの真っ直ぐな数直線にすぎない。</p>
 <p>実空間も円柱座標のパラメータ空間も、どちらも「平坦な方眼紙」だ。両者の違いは、そのあいだに $\cos\theta$ や $-r\sin\theta$ といった偏微分係数（換算係数）が挟まっているかどうか、それだけである。計算のあいだは「実空間の中に曲がった座標軸がある」のではなく「二つの空間のあいだに翻訳規則があるだけ」と割り切って考えると、見通しがよい。</p>
 <blockquote>
-<p><strong>注</strong> （$dr$, $d\theta$ の行列表現）では $dr$ や $d\theta$ についても、「数ベクトルとしての行列表現は何か」と気になるだろう。パラメータ空間もまたデカルト座標なのだから、答えは単純だ——$dr$ はパラメータ空間の第1成分を抜く $(1\ 0\ 0)$ であり、$d\theta$ は $(0\ 1\ 0)$、$dz$ は $(0\ 0\ 1)$ である。デカルトの実空間で書いた $dx=\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ と同じ見た目をしているが、載っている座標系が違う。数学者ならば「$\omega \in \Omega^1(M)$、局所では $\omega = \omega_i(x)\,dx^i$、座標系の取り替え、$\phi^<em>\omega$、開集合の重なりでの整合……」と衒学的な呪文を唱えるだろう。</em><em>なるほど、頭が痛くなってきた。私も読者も疲れてしまう。深追いはしないでおく。</em>*</p>
+<p><strong>注</strong> （$dr$, $d\theta$ の行列表現）では $dr$ や $d\theta$ についても、「数ベクトルとしての行列表現は何か」と気になるだろう。パラメータ空間もまたデカルト座標なのだから、答えは単純だ——$dr$ はパラメータ空間の第1成分を抜く $(1\ 0\ 0)$ であり、$d\theta$ は $(0\ 1\ 0)$、$dz$ は $(0\ 0\ 1)$ である。デカルトの実空間で書いた $dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と同じ見た目をしているが、載っている座標系が違う。数学者ならば「$\omega \in \Omega^1(M)$、局所では $\omega = \omega_i(x)\,dx^i$、座標系の取り替え、$\phi^*\omega$、開集合の重なりでの整合……」と衒学的な呪文を唱えるだろう。<strong>なるほど、頭が痛くなってきた。私も読者も疲れてしまう。深追いはしないでおく。</strong></p>
 </blockquote>
 <h4 id="144-3">1.4.4 第3章への伏線——引き戻し</h4>
 <p>このように、元の世界の測定器を別の目盛り用に焼き直す操作を、数学の専門用語で<strong>引き戻し（pullback）</strong>と呼ぶ。いまは「偏微分を使えば行列の成分が機械的に書き換えられる」という感覚さえ掴めれば十分だ。第3章において、面積や体積の物差しを一気に引き戻す際、この代数的アプローチの圧倒的な強さを確信することになるだろう。</p>
@@ -832,7 +830,7 @@ $$\int_\gamma df$$
 - $dx$ という測定器自体は不変だが、座標系を取り替えると行列表現（成分）が変わる。
 - 座標変換の係数は、図形的なイメージからではなく、連鎖律（偏微分）から機械的に求まる。
 - 座標の取り替えの影響はすべて行列の成分に現れるため、我々は常に「真っ直ぐな変数」として計算を進めればよい。
-- <strong>確認：</strong>実空間の $(x,y,z)$ では $dx = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$ だが、円柱座標の目盛り $(dr,d\theta,dz)$ ではどう書けるか、§1.4.1 を振り返れ。</p>
+- <strong>確認：</strong>実空間の $(x,y,z)$ では $dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ だが、円柱座標の目盛り $(dr,d\theta,dz)$ ではどう書けるか、§1.4.1 を振り返れ。</p>
 </blockquote>
 <hr />
 <h3 id="15">§1.5 別の座標で書く——演習</h3>
@@ -841,12 +839,12 @@ $$\int_\gamma df$$
 <p><strong>問題設定</strong><br />
 前節で見た通り、円柱座標 $(r, \theta, z)$ における $dx$ の行列表示は以下のようになる：
 $$
-dx = \begin{pmatrix} \cos\theta &amp; -r\sin\theta &amp; 0 \end{pmatrix}
+dx = \begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}
 $$
-（上の行は §1.4.3 の $(dr,d\theta,dz)$ 展開の係数を並べたものであり、§1.1.3 のデカルト表示 $\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ とは<strong>右に立てる縦ベクトルの意味が違う</strong>。）</p>
+（上の行は §1.4.3 の $(dr,d\theta,dz)$ 展開の係数を並べたものであり、§1.1.3 のデカルト表示 $\begin{pmatrix}1&0&0\end{pmatrix}$ とは<strong>右に立てる縦ベクトルの意味が違う</strong>。）</p>
 <p>このとき、次の問いに答えよ。</p>
 <p><strong>問1</strong><br />
-円柱座標空間内の点 $P(r=2, \theta=\pi/6, z=0)$ に質点があるとする。この質点が、$r$ 方向に $0.1$ だけ微小変位した。<strong>この節では記号 $\mathbf{v}$ を、$r,\theta,z$ のパラメータの変化量を並べた $\begin{pmatrix}\Delta r\\Delta\theta\\Delta z\end{pmatrix}$ とする</strong>（§1.0–§1.2 のデカルト列 $\begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ とは別の並べ方である）。この変位ベクトル $\mathbf{v}$ を、その成分で表せ。</p>
+円柱座標空間内の点 $P(r=2, \theta=\pi/6, z=0)$ に質点があるとする。この質点が、$r$ 方向に $0.1$ だけ微小変位した。<strong>この節では記号 $\mathbf{v}$ を、$r,\theta,z$ のパラメータの変化量を並べた $\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$ とする</strong>（§1.0–§1.2 のデカルト列 $\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ とは別の並べ方である）。この変位ベクトル $\mathbf{v}$ を、その成分で表せ。</p>
 <p><strong>問2</strong><br />
 問1の変位ベクトル $\mathbf{v}$ に対して、点 $P$ における行列 $dx$ を作用させよ。（$\cos(\pi/6) = \sqrt{3}/2$ を用いよ）</p>
 <p><strong>問3</strong><br />
@@ -855,18 +853,18 @@ $$
 <p><strong>問1の解答</strong><br />
 変位は $r$ 方向に $0.1$、$\theta$ 方向と $z$ 方向にはゼロなので、<strong>円柱座標のパラメータの変化量</strong>を縦に並べたベクトルとして次のように書ける：
 $$
-\mathbf{v} = \begin{pmatrix} 0.1 \ 0 \ 0 \end{pmatrix}
+\mathbf{v} = \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix}
 $$</p>
 <p><strong>問2の解答</strong><br />
 点 $P$ における行列 $dx$ は、$\theta = \pi/6, r=2$ を代入して得られる $1\times 3$ 行ベクトルとして
 $$
-dx = \begin{pmatrix} \cos(\frac{\pi}{6}) &amp; -2\sin(\frac{\pi}{6}) &amp; 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} &amp; -2 \times \frac{1}{2} &amp; 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} &amp; -1 &amp; 0 \end{pmatrix}
+dx = \begin{pmatrix} \cos(\frac{\pi}{6}) & -2\sin(\frac{\pi}{6}) & 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} & -2 \times \frac{1}{2} & 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix}
 $$
 と書く（円柱座標では $dx$ の成分は $r,\theta$ に依存するので、ここでは点 $P$ の座標で評価したあとを指す。$\mathbf{v}$ への作用の記号 $dx(\mathbf{v})$ 自体は §1.1.3 以来と同じである）。</p>
 <p>重要なのは、第2成分は一般に <strong>$-r\sin\theta$</strong> という係数であり、$r$ のおかげで<strong>長さの次元を持つ</strong>ことだ。$r=2,\;\theta=\pi/6$ と代入するとその係数の値として $-1$ が見えるが、<strong>数値の $-1$ そのものに次元が付いているのではない</strong>。行列の成分としての $-r\sin\theta$ が長さの次元を運んでいる、と読むのが正確である。これが次元解析の鍵となる。
 これを変位ベクトル $\mathbf{v}$ に作用させると：
 $$
-dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} &amp; -1 &amp; 0 \end{pmatrix} \begin{pmatrix} 0.1 \ 0 \ 0 \end{pmatrix} = 0.1 \times \frac{\sqrt{3}}{2} \approx 0.0866
+dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix} = 0.1 \times \frac{\sqrt{3}}{2} \approx 0.0866
 $$</p>
 <p><strong>問3の解答（物理的意味）</strong><br />
 この結果は、<strong>「円柱座標において外側（$r$方向）へ $0.1$ だけ進むという運動は、実空間の $x$ 軸方向から見ると約 $0.0866$ の前進に相当する」</strong>という物理的事実を表している。</p>
@@ -875,8 +873,8 @@ $$</p>
 </blockquote>
 <h4 id="153">1.5.3 次元解析の深い考察</h4>
 <p>計算結果 $dx(\mathbf{v}) = 0.1 \times \frac{\sqrt{3}}{2}$ を見ると、$r$方向成分$0.1$（長さの次元）と、第1成分の係数$\frac{\sqrt{3}}{2}$（無次元）の積となっており、出力は確かに長さの次元を持つ。
-しかし、もし$\theta$方向の変位$\mathbf{v} = \begin{pmatrix} 0 \ 0.1 \ 0 \end{pmatrix}$（角度変位$0.1$ラジアン）を入力したとすると（係数はいまも点 $P$ で評価した同じ行ベクトル）：
-$$dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} &amp; -1 &amp; 0 \end{pmatrix} \begin{pmatrix} 0 \ 0.1 \ 0 \end{pmatrix} = -0.1$$
+しかし、もし$\theta$方向の変位$\mathbf{v} = \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix}$（角度変位$0.1$ラジアン）を入力したとすると（係数はいまも点 $P$ で評価した同じ行ベクトル）：
+$$dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix} = -0.1$$
 この場合、<strong>入力ベクトルの第2成分</strong> $0.1$ は角度（無次元）だが、<strong>行列の第2列に対応する係数</strong> $-r\sin\theta$ が長さの次元を運ぶため、積としての出力 $-0.1$ は長さの次元を持つ。</p>
 <p>ここに<strong>一次形式</strong>の驚くべき性質がある： $dx$ の行列成分自体が $r$ を含む関数であり、入力が座標成分（次元がバラバラでも）であっても、出力は常に「$x$ 方向の長さ」という正しい物理的次元を持つように自動調整される。<strong>一次形式は、座標系の歪みを吸収し、物理的に意味のある測定値を出力する「賢い測定器」</strong>なのである。</p>
 <h3 id="16">§1.6 本章のまとめと次章への展望</h3>
@@ -940,11 +938,11 @@ $$S(\mathbf{v}_1, \mathbf{v}_1) = 0$$</p>
 <p>入力するベクトルの順番を入れ替えると、<strong>面積の符号がマイナスに反転してしまう</strong>のだ。</p>
 <blockquote>
 <p><strong>注</strong>（面積の符号1）「面積がマイナスになる？ それは困る」と驚くかもしれない。しかし、物理学者は自然界の「向き」を無視しない。電流の向き、磁場の向き——すべてベクトルの「向き」が本質だ。だから「面積にも向き（向き付き面積）がある」という発想は、我々物理学者にはむしろ自然なのだ。この概念は後で曲面の「裏表」を区別したり、空間を貫く磁束や流体の流れを計算する際に絶対に不可欠なものとなる。今のところはこだわりすぎずに進んでほしい。</p>
-<p><strong>注</strong> （面積の符号2）1変数でも、$f(x)&lt;0$ の区間では $\displaystyle\int_a^b f(x)\,dx&lt;0$ となり得る——符号付き「面積」はそこで既に現れている。向き付き面積は、その考え方を2次元に持ち上げたものだ。</p>
+<p><strong>注</strong> （面積の符号2）1変数でも、$f(x)<0$ の区間では $\displaystyle\int_a^b f(x)\,dx<0$ となり得る——符号付き「面積」はそこで既に現れている。向き付き面積は、その考え方を2次元に持ち上げたものだ。</p>
 </blockquote>
 <h4 id="223-3">2.2.3 ルール3：基準の決定（規格化）</h4>
 <p>最後に、「どのくらいの大きさを1とするか」を決めなければならない。ここでは素直に、$x$方向の<strong>基底ベクトル</strong>（標準基底の一つ）$\hat{e}_x$ と $y$方向の基底ベクトル $\hat{e}_y$ が作る正方形の面積を $1$ としよう。本書の慣例どおり<strong>縦ベクトル</strong>で書けば
-$$\hat{e}_x = \begin{pmatrix} 1 \ 0 \ 0 \end{pmatrix}, \quad \hat{e}_y = \begin{pmatrix} 0 \ 1 \ 0 \end{pmatrix}$$
+$$\hat{e}_x = \begin{pmatrix} 1 \\ 0 \\ 0 \end{pmatrix}, \quad \hat{e}_y = \begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix}$$
 である。</p>
 <p>$$S(\hat{e}_x, \hat{e}_y) = 1$$</p>
 <blockquote>
@@ -960,30 +958,30 @@ $$\hat{e}_x = \begin{pmatrix} 1 \ 0 \ 0 \end{pmatrix}, \quad \hat{e}_y = \begin{
 我々は今、この「平行四辺形」という<strong>図形のイメージ</strong>を頭に描きながら3つのルールを設定した。しかし、一度ルールを決めてしまえば、もはや図形を思い浮かべる必要はない。<strong>「この3つのルールを満たす代数的な計算式」を探せば、それが面積の定義になるからだ。</strong></p>
 <p>本質を抽出するため、まずは $z$成分が常にゼロのベクトル、つまり $xy$平面上にある2つのベクトルで考えよう。</p>
 <p>$$
-\mathbf{v}_1 = \begin{pmatrix} x_1 \ y_1 \ 0 \end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix} x_2 \ y_2 \ 0 \end{pmatrix}
+\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ 0 \end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
 $$</p>
 <p>結論から言おう。この <strong>$xy$ 平面上のベクトルという制約のもとで</strong>、先ほどの3ルールを完璧に満たす量を出力する装置は、線形代数の世界にただ一つしか存在しない。</p>
 <p>それは、真ん中に特定の <strong>$3 \times 3$ 行列</strong> を挟んだ、次のような「<strong>横ベクトル</strong> $\times$ 行列 $\times$ <strong>縦ベクトル</strong>」の計算である：</p>
 <p>$$
-\begin{pmatrix} x_1 &amp; y_1 &amp; 0 \end{pmatrix}
+\begin{pmatrix} x_1 & y_1 & 0 \end{pmatrix}
 \begin{pmatrix}
-  0 &amp; 1 &amp; 0 \
-  -1 &amp; 0 &amp; 0 \
-  0 &amp; 0 &amp; 0
+  0 & 1 & 0 \\
+  -1 & 0 & 0 \\
+  0 & 0 & 0
 \end{pmatrix}
-\begin{pmatrix} x_2 \ y_2 \ 0 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
 $$</p>
 <p>実際に $\mathbf{v}_1$ と $\mathbf{v}_2$ を代入して計算してみよう：</p>
 <p>$$
-\begin{pmatrix} x_1 &amp; y_1 &amp; 0 \end{pmatrix}
+\begin{pmatrix} x_1 & y_1 & 0 \end{pmatrix}
 \begin{pmatrix}
-  0 &amp; 1 &amp; 0 \
-  -1 &amp; 0 &amp; 0 \
-  0 &amp; 0 &amp; 0
+  0 & 1 & 0 \\
+  -1 & 0 & 0 \\
+  0 & 0 & 0
 \end{pmatrix}
-\begin{pmatrix} x_2 \ y_2 \ 0 \end{pmatrix}
-= \begin{pmatrix} -y_1 &amp; x_1 &amp; 0 \end{pmatrix}
-\begin{pmatrix} x_2 \ y_2 \ 0 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
+= \begin{pmatrix} -y_1 & x_1 & 0 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
 = x_1 y_2 - x_2 y_1
 $$</p>
 <p>出てきた出力 $x_1 y_2 - x_2 y_1$ は、まさしく冒頭で触れた「2次元の面積公式」の中身そのものである！</p>
@@ -1009,7 +1007,7 @@ $$</p>
 <p>さて、読者はこう思っているはずだ。
 「なるほど、行列で面積が出るのは分かった。でも、この行列は第3行・第3列がゼロだから、$z$成分を完全に無視しているじゃないか。これではあの『3次元の大変な計算』の解決になっていないぞ」と。</p>
 <p><strong>まったくその通りである。</strong>
-今我々が手にした $\begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}$ という行列は、3次元空間に3種類ある基本測定器の一つ——<strong>$xy$平面専用の面積測定器</strong>——に過ぎない。
+今我々が手にした $\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$ という行列は、3次元空間に3種類ある基本測定器の一つ——<strong>$xy$平面専用の面積測定器</strong>——に過ぎない。
 言い換えれば、これは<strong>$xy$平面「だけ」を見る「偏った眼鏡」</strong>のようなものだ。空間には、$yz$平面を見る眼鏡や、$zx$平面を見る眼鏡も存在する。</p>
 <hr />
 <blockquote>
@@ -1036,13 +1034,13 @@ $xy$ 平面の面積公式だ。</p>
 <p>$$\text{欲しい出力} = x_1 y_2 - x_2 y_1$$</p>
 <p>この出力を吐き出すためには、行列 $M$ のマス目にどんな数字を配置すればよいか？ 読者も一緒に、$\mathbf{v}_1^T M \mathbf{v}_2$ の展開式を想像しながらマス目を埋めるパズルをしてほしい。</p>
 <p>$$
-\begin{pmatrix} x_1 &amp; y_1 &amp; z_1 \end{pmatrix}
+\begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
 \begin{pmatrix}
-  ? &amp; ? &amp; ? \
-  ? &amp; ? &amp; ? \
-  ? &amp; ? &amp; ?
+  ? & ? & ? \\
+  ? & ? & ? \\
+  ? & ? & ?
 \end{pmatrix}
-\begin{pmatrix} x_2 \ y_2 \ z_2 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
 $$</p>
 <ol>
 <li><strong>$x_1 y_2$ を作る：</strong> $\mathbf{v}_1$ の $x$ 成分（$x_1$）と $\mathbf{v}_2$ の $y$ 成分（$y_2$）が掛け合わされる場所、すなわち「1行2列目」には $+1$ を置けばよい。</li>
@@ -1052,17 +1050,17 @@ $$</p>
 <p>こうして出来上がったのが、§2.3 で天下り的に登場したあの反対称行列なのだ！</p>
 <p>$$
 M = \begin{pmatrix}
-  0 &amp; 1 &amp; 0 \
-  -1 &amp; 0 &amp; 0 \
-  0 &amp; 0 &amp; 0
+  0 & 1 & 0 \\
+  -1 & 0 & 0 \\
+  0 & 0 & 0
 \end{pmatrix}
 $$</p>
 <h4 id="243">2.4.3 テンソル積の導入</h4>
 <p>さて、この面積測定器の行列 $M$ をよく見ると、2つの部品の「引き算」でできていることがわかる。</p>
 <p>$$
-\begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}
-= \begin{pmatrix} 0 &amp; 1 &amp; 0 \ 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix} - 
- \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+= \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} - 
+ \begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 $$</p>
 <p>右辺の第1項は「1行2列目だけが $1$ の行列」であり、これは $\mathbf{v}_1$ から $x$ 成分を、$\mathbf{v}_2$ から $y$ 成分を抽出して掛ける（$x_1 y_2$）という<strong>片道切符の演算</strong>を表している。</p>
 <p>ここで第1章の物差しを思い出そう。$x$ 成分を抽出する物差しは $dx$、$y$ 成分を抽出する物差しは $dy$ だった。
@@ -1070,7 +1068,7 @@ $$</p>
 <p>$$(dx \otimes dy)(\mathbf{v}_1, \mathbf{v}_2) := dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) = x_1 y_2$$</p>
 <p>テンソル積 $dx \otimes dy$ というといかにも難しそうな響きだが、恐れることはない。行列表現の世界では、これは単に<strong>「1行2列目のマス目だけを $1$ にする」</strong>スイッチのような操作に過ぎないのだ。</p>
 <blockquote>
-<p><strong>注</strong> （テンソル積の行列表現）数式が好きな読者のために書いておくと、$dx = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$、$dy = \begin{pmatrix} 0 &amp; 1 &amp; 0 \end{pmatrix}$ としたとき、「前のベクトルを転置して縦にし、後ろの横ベクトルと隣り合わせに置き（$dx^T dy$）、縦と横の成分を総当たりで掛け合わせて行列のマス目に配置する」という操作で$dx \otimes dy$の行列表現が機械的に得られる。</p>
+<p><strong>注</strong> （テンソル積の行列表現）数式が好きな読者のために書いておくと、$dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$、$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}$ としたとき、「前のベクトルを転置して縦にし、後ろの横ベクトルと隣り合わせに置き（$dx^T dy$）、縦と横の成分を総当たりで掛け合わせて行列のマス目に配置する」という操作で$dx \otimes dy$の行列表現が機械的に得られる。</p>
 </blockquote>
 <h4 id="244">2.4.4 ウェッジ積の完成</h4>
 <p>これで準備は整った。
@@ -1085,19 +1083,19 @@ $$</p>
 $$</p>
 <p>見事に、第1章の物差し（$1$-form）の組み合わせから、面積測定器（$2$-form）をシステマティックに構成することができた。
 テンソル積の引き算で構成したことにより、<strong>引数を入れ替えると符号が反転する（交代性）</strong>という §2.2 のルール2が、自動的に「仕込まれている」ことにも注目してほしい。</p>
-<h4 id="245-32-form">2.4.5 3つの基底$2$-form</h4>
+<h4 id="245-3mathblock1131placeholder-form">2.4.5 3つの基底$2$-form</h4>
 <p>同じ方法で、残る2つの「偏った眼鏡」も構成できる。</p>
 <p><strong>$yz$ 平面を見る眼鏡：$dy \wedge dz$</strong></p>
 <p>$$
-dy \otimes dz - dz \otimes dy = \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; 0 &amp; 0 \end{pmatrix} - \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \ 0 &amp; 1 &amp; 0 \end{pmatrix} = \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix}
+dy \otimes dz - dz \otimes dy = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 0 & 0 \end{pmatrix} - \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 0 \\ 0 & 1 & 0 \end{pmatrix} = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}
 $$</p>
 <p><strong>$zx$ 平面を見る眼鏡：$dz \wedge dx$</strong></p>
 <p>$$
-dz \otimes dx - dx \otimes dz = \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix} - \begin{pmatrix} 0 &amp; 0 &amp; 1 \ 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix} = \begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix}
+dz \otimes dx - dx \otimes dz = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} - \begin{pmatrix} 0 & 0 & 1 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} = \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}
 $$</p>
 <p><strong>これで全部だ！</strong></p>
 <p>では、3つの眼鏡を一つずつ一般のベクトルにかけて、それぞれ何を測るか見てみよう。</p>
-<p>一般の3次元ベクトル $\mathbf{v}_1 = \begin{pmatrix} x_1 \ y_1 \ z_1 \end{pmatrix}$, $\mathbf{v}_2 = \begin{pmatrix} x_2 \ y_2 \ z_2 \end{pmatrix}$ に対し、§2.4.4 の定義どおりに（第1引数に $\mathbf{v}_1$、第2引数に $\mathbf{v}_2$ を入れる）計算すればよい：</p>
+<p>一般の3次元ベクトル $\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$, $\mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$ に対し、§2.4.4 の定義どおりに（第1引数に $\mathbf{v}_1$、第2引数に $\mathbf{v}_2$ を入れる）計算すればよい：</p>
 <p>$$
 (dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2) = y_1 z_2 - z_1 y_2
 $$</p>
@@ -1112,7 +1110,7 @@ $$</p>
 <p>さて、読者は当然こう期待していただろう——「3つの眼鏡の計算結果を何かうまく合成すれば、最終的に一つのスカラー（数値）が出てくるんだろう？」と。</p>
 <p>実は、そう単純ではない。</p>
 <p>§2.2 で面積測定器を設計したとき、$xy$平面に張り付いた話では確かに<strong>一つの数</strong>で足りた。しかし3次元空間の一般の平行四辺形では、向きは $+/-$ の2択では済まない。3つの基底 $2$-form（眼鏡）を通した測定値
-$$A_{yz} = (dy \wedge dz)(\mathbf{v}<em>1,\mathbf{v}_2),\quad A</em>{zx} = (dz \wedge dx)(\mathbf{v}<em>1,\mathbf{v}_2),\quad A</em>{xy} = (dx \wedge dy)(\mathbf{v}_1,\mathbf{v}_2)$$
+$$A_{yz} = (dy \wedge dz)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{zx} = (dz \wedge dx)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{xy} = (dx \wedge dy)(\mathbf{v}_1,\mathbf{v}_2)$$
 が、まるごと「向き付き面積」として必要な情報になる。</p>
 <p>ここで、鋭い読者は一つの疑問に行き着くはずだ。
 「この3つの数は、いったい<strong>何の基底</strong>に乗っている係数なのか？」と。</p>
@@ -1121,7 +1119,7 @@ $$A_{yz} = (dy \wedge dz)(\mathbf{v}<em>1,\mathbf{v}_2),\quad A</em>{zx} = (dz \
 横ベクトル同士をウェッジ積 $\wedge$ で結んで装置を作ったのなら、<strong>縦ベクトル同士も $\wedge$ で結べばよいのだ！</strong></p>
 <p>すなわち、図形側の基底は $\hat{e}_y \wedge \hat{e}_z$ という「二重ベクトル（2-vector）」もしくは「面素（area element）」と呼ばれるものである。
 これを用いれば、測られた結果である「向き付き面積の正体」は、次のような明確な実体（図形）として書き下される。</p>
-<p>$$\text{向き付き面積} = A_{yz}\,(\hat{e}<em>y \wedge \hat{e}_z) + A</em>{zx}\,(\hat{e}<em>z \wedge \hat{e}_x) + A</em>{xy}\,(\hat{e}_x \wedge \hat{e}_y)$$</p>
+<p>$$\text{向き付き面積} = A_{yz}\,(\hat{e}_y \wedge \hat{e}_z) + A_{zx}\,(\hat{e}_z \wedge \hat{e}_x) + A_{xy}\,(\hat{e}_x \wedge \hat{e}_y)$$</p>
 <p>これで完全にスッキリしたはずだ。
 係数に場を含む一般の $\alpha\,dy \wedge dz + \cdots$ は<strong>「面積測定器（はかり）」</strong>であり、測定結果の数値を入れた $A_{yz}(\hat{e}_y \wedge \hat{e}_z) + \cdots$ は<strong>「測られた図形（面積そのもの）」</strong>である。両者は横と縦の関係にあり、決して混同してはならない。</p>
 <blockquote>
@@ -1130,7 +1128,7 @@ $$A_{yz} = (dy \wedge dz)(\mathbf{v}<em>1,\mathbf{v}_2),\quad A</em>{zx} = (dz \
 <h4 id="247">2.4.7 小学校のスカラー面積に戻すには</h4>
 <p>では、小学校で習った「正の値の面積」に戻していこう。</p>
 <p>読者は、1次元の図形データであるベクトル $\mathbf{v} = x\hat{e}_x + y\hat{e}_y + z\hat{e}_z$ から「長さ（スカラー）」を取り出すとき、各基底の係数の二乗和の平方根 $\sqrt{x^2+y^2+z^2}$ を計算すればよいことを知っているだろう。</p>
-<p>2次元の図形データである二重ベクトルの「大きさ（スカラー面積）」を取り出す操作も、これと同じ形である。向き付き面積を構成する3つの基底 $\hat{e}<em>y \wedge \hat{e}_z,\,\hat{e}_z \wedge \hat{e}_x,\,\hat{e}_x \wedge \hat{e}_y$ の係数 $A</em>{yz}, A_{zx}, A_{xy}$ について、縦ベクトルに並べ替えずに、直接その二乗和の平方根をとればよい。</p>
+<p>2次元の図形データである二重ベクトルの「大きさ（スカラー面積）」を取り出す操作も、これと同じ形である。向き付き面積を構成する3つの基底 $\hat{e}_y \wedge \hat{e}_z,\,\hat{e}_z \wedge \hat{e}_x,\,\hat{e}_x \wedge \hat{e}_y$ の係数 $A_{yz}, A_{zx}, A_{xy}$ について、縦ベクトルに並べ替えずに、直接その二乗和の平方根をとればよい。</p>
 <p>$$S = \sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2} = \sqrt{(y_1 z_2 - z_1 y_2)^2 + (z_1 x_2 - x_1 z_2)^2 + (x_1 y_2 - x_2 y_1)^2}$$</p>
 <p>これはまさしく §2.1 で「大変な計算」と呼んだ高校数学の面積の式と完全に一致する。我々はついに、代数的な測定器の設計から出発し、小学校の「タイルの枚数」にまで無事に帰還したのである。</p>
 <h4 id="248-10">2.4.8 1次元の「面積」（長さ）と0次元の「面積」（点）</h4>
@@ -1149,7 +1147,7 @@ $0$-form が測る「0次元の図形」とは単なる「点」であり、成�
 <p>本書の舞台は3次元空間だから $k=0,1,2,3$ で打ち止めだが、「$k$-form が $k$-vector を食べてスカラーを返す」という原理は $k$ によらない。このパターンが第3章の積分、第5章の外微分へと受け継がれていく。</p>
 <h4 id="249">2.4.9 クロス積との符合</h4>
 <p>大学の線形代数で「ベクトルの外積（クロス積）」を学んだ読者なら、次の3成分に見覚えがあるだろう。</p>
-<p>$$\mathbf{v}_1 \times \mathbf{v}_2 = (y_1 z_2 - z_1 y_2)\,\hat{e}_x + (z_1 x_2 - x_1 z_2)\,\hat{e}_y + (x_1 y_2 - x_2 y_1)\,\hat{e}_z = \begin{pmatrix} y_1 z_2 - z_1 y_2 \ z_1 x_2 - x_1 z_2 \ x_1 y_2 - x_2 y_1 \end{pmatrix}$$</p>
+<p>$$\mathbf{v}_1 \times \mathbf{v}_2 = (y_1 z_2 - z_1 y_2)\,\hat{e}_x + (z_1 x_2 - x_1 z_2)\,\hat{e}_y + (x_1 y_2 - x_2 y_1)\,\hat{e}_z = \begin{pmatrix} y_1 z_2 - z_1 y_2 \\ z_1 x_2 - x_1 z_2 \\ x_1 y_2 - x_2 y_1 \end{pmatrix}$$</p>
 <p>これは、いまの $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ の<strong>値</strong>を、この順に並べたものにほかならない。</p>
 <blockquote>
 <p><strong>注</strong>（不安な読者へ）見覚えがなくとも、本書ではウェッジ積を先に発見した、というだけでこの先の理解に支障はない。</p>
@@ -1159,8 +1157,8 @@ $0$-form が測る「0次元の図形」とは単なる「点」であり、成�
 <blockquote>
 <p><strong>【ここまでのチェックポイント】</strong>
 - ウェッジ積 $dx \wedge dy := dx \otimes dy - dy \otimes dx$ は、テンソル積の引き算で反対称行列を自動生成する。$dy \wedge dz$, $dz \wedge dx$ も同様に構成され、3つの基底 $2$-form の線形結合で任意の面積測定器を組み立てられる。
-- 向き付き面積の正体は、測定値 $A_{yz}, A_{zx}, A_{xy}$ を図形側の基底 $\hat{e}<em>y \wedge \hat{e}_z$, $\hat{e}_z \wedge \hat{e}_x$, $\hat{e}_x \wedge \hat{e}_y$ に乗じた二重ベクトルである——はかり（基底 $2$-form）と図形（$k$-ベクトル）は横と縦の関係にあり、混同してはならない。
-- スカラー面積（タイルの枚数に相当する正の大きさ）は、係数の二乗和の平方根 $\sqrt{A</em>{yz}^2 + A_{zx}^2 + A_{xy}^2}$ で §2.1 の式に戻る（ラグランジュの恒等式）。ベクトルの長さの公式と同じ形の操作だ。</p>
+- 向き付き面積の正体は、測定値 $A_{yz}, A_{zx}, A_{xy}$ を図形側の基底 $\hat{e}_y \wedge \hat{e}_z$, $\hat{e}_z \wedge \hat{e}_x$, $\hat{e}_x \wedge \hat{e}_y$ に乗じた二重ベクトルである——はかり（基底 $2$-form）と図形（$k$-ベクトル）は横と縦の関係にあり、混同してはならない。
+- スカラー面積（タイルの枚数に相当する正の大きさ）は、係数の二乗和の平方根 $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ で §2.1 の式に戻る（ラグランジュの恒等式）。ベクトルの長さの公式と同じ形の操作だ。</p>
 </blockquote>
 <hr />
 <h3 id="25">§2.5 体積測定器と行列式</h3>
@@ -1183,8 +1181,8 @@ $$V(\hat{e}_x, \hat{e}_y, \hat{e}_z) = 1$$</p>
 <h4 id="252">2.5.2 ルールから形を決める——基底展開と消去</h4>
 <p>§2.3 で面積測定器の行列を導いたときと同じ手順を踏もう。3つのベクトルを基底で展開する：
 $$\mathbf{v}_1 = x_1 \hat{e}_x + y_1 \hat{e}_y + z_1 \hat{e}_z, \quad \mathbf{v}_2 = x_2 \hat{e}_x + y_2 \hat{e}_y + z_2 \hat{e}_z, \quad \mathbf{v}_3 = x_3 \hat{e}_x + y_3 \hat{e}_y + z_3 \hat{e}_z$$</p>
-<p>ルール1（多重線形性）により、$V(\mathbf{v}<em>1, \mathbf{v}_2, \mathbf{v}_3)$ は $3 \times 3 \times 3 = 27$ 個の項に展開される：
-$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k v</em>{1i}\,v_{2j}\,v_{3k}\; V(\hat{e}_i, \hat{e}_j, \hat{e}_k)$$
+<p>ルール1（多重線形性）により、$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$ は $3 \times 3 \times 3 = 27$ 個の項に展開される：
+$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k v_{1i}\,v_{2j}\,v_{3k}\; V(\hat{e}_i, \hat{e}_j, \hat{e}_k)$$
 ここで $i, j, k$ はそれぞれ<strong>独立に</strong> $x, y, z$ のいずれかをとる添字だ（「走る」＝和をとるときに $x,y,z$ の三通りそれぞれをめぐる、と読めばよい）。</p>
 <p>27項は多いが、ルール2（交代性）が大量の項を消してくれる：
 - 添字に<strong>重複がある項はすべてゼロ</strong>（例：$V(\hat{e}_x, \hat{e}_x, \hat{e}_z) = 0$）
@@ -1234,31 +1232,31 @@ $$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k v</em>{1i}\,v
 <p>したがって：
 $$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_2 x_3$$</p>
 <p>線形代数を学んだ読者なら、3つのベクトルを列に並べた行列
-$$\begin{pmatrix} x_1 &amp; x_2 &amp; x_3 \ y_1 &amp; y_2 &amp; y_3 \ z_1 &amp; z_2 &amp; z_3 \end{pmatrix}$$
+$$\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$
 の<strong>行列式（determinant）</strong>に見えるはずだ。知らない読者も、<strong>いまこの6項の和を「行列式」と呼ぶ</strong>と決めて先に進んでかまわない——上のルールからこの形に落ちた、という事実のほうが本質である。</p>
 <p>ここで押さえたいのは次の一点だけだ。行列式は、単なる「成分を掛けて引く手続き」にとどまらず、<strong>3本の列ベクトルをこの順に食わせたときの「符号付き体積」という1つの数</strong>を返す演算子としても読める。第1章の $1$-form は「ベクトル1つ → スカラー」、§2.3 の $2$-form は「ベクトル2つ → スカラー」——行列式は「ベクトル3つ → スカラー」で、この系列をつなぐ。</p>
 <p>面積測定器のときは反対称行列、体積測定器のときは行列式が立ち上がったが、<strong>いずれも、先に課したルールが代数的な形を決めた</strong>のだ。</p>
 <blockquote>
 <p><strong>注</strong> （行列式の6項の順序）教科書によっては、いきなり「行列式の定義はこの6項」と置く。本書の流れでは、<strong>測定器のルール → 6項</strong>の順である。</p>
 </blockquote>
-<h4 id="253-2-form">2.5.3 $2$-form の行列式としての再解釈</h4>
+<h4 id="253-mathblock1240placeholder-form">2.5.3 $2$-form の行列式としての再解釈</h4>
 <p>実は、§2.4 で定義した $2$-form のウェッジ積にも、行列式が隠れていた。定義を振り返ろう：
 $$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) - dy(\mathbf{v}_1)\,dx(\mathbf{v}_2)$$</p>
 <p>右辺は、次の $2 \times 2$ 行列式に他ならない：
-$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) &amp; dx(\mathbf{v}_2) \ dy(\mathbf{v}_1) &amp; dy(\mathbf{v}_2) \end{pmatrix}$$</p>
+$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$</p>
 <p>つまり、横に「どの物差しか」、縦に「どのベクトルか」を並べた行列の行列式が、ウェッジ積の値だったのだ。</p>
-<h4 id="254-dx-wedge-dy-wedge-dz">2.5.4 $dx \wedge dy \wedge dz$ の定義——行列式パターンの完成</h4>
+<h4 id="254-mathblock1243placeholder">2.5.4 $dx \wedge dy \wedge dz$ の定義——行列式パターンの完成</h4>
 <p>この「行列式パターン」を素直に $3 \times 3$ に拡張すれば、体積測定器が手に入る。</p>
 <p><strong>定義：</strong> 3つのベクトル $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ に対し、
-$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) := \det\begin{pmatrix} dx(\mathbf{v}_1) &amp; dx(\mathbf{v}_2) &amp; dx(\mathbf{v}_3) \ dy(\mathbf{v}_1) &amp; dy(\mathbf{v}_2) &amp; dy(\mathbf{v}_3) \ dz(\mathbf{v}_1) &amp; dz(\mathbf{v}_2) &amp; dz(\mathbf{v}_3) \end{pmatrix}$$</p>
+$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) := \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) & dx(\mathbf{v}_3) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) & dy(\mathbf{v}_3) \\ dz(\mathbf{v}_1) & dz(\mathbf{v}_2) & dz(\mathbf{v}_3) \end{pmatrix}$$</p>
 <p>右辺の各成分は「一次形式 $dx, dy, dz$ がベクトル $\mathbf{v}_i$ から抽出した座標成分」だから、これはまさに：
-$$= \det\begin{pmatrix} x_1 &amp; x_2 &amp; x_3 \ y_1 &amp; y_2 &amp; y_3 \ z_1 &amp; z_2 &amp; z_3 \end{pmatrix}$$</p>
+$$= \det\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$</p>
 <p>§2.5.2 で導いた $V$ と完全に一致する。<strong>体積測定器は、3つの物差し $dx, dy, dz$ のウェッジ積として構成できた。</strong></p>
 <p>線形代数で行列式を学んだ読者なら、この定義が §2.5.1 の3ルールを満たすことが容易に分かるだろう：
 - <strong>多重線形性</strong>：行列式は各列について線形だから、自動的に満たされる。
 - <strong>交代性</strong>：行列式の2つの列を入れ替えると符号が反転する。
 - <strong>規格化</strong>：$\hat{e}_x, \hat{e}_y, \hat{e}_z$ を入れると行列は単位行列になり、$\det(I) = 1$。</p>
-<h4 id="255-3-times-3">2.5.5 体積測定器のテンソル積表現——$3 \times 3$ ブロックを横に並べた配列</h4>
+<h4 id="255-mathblock1252placeholder">2.5.5 体積測定器のテンソル積表現——$3 \times 3$ ブロックを横に並べた配列</h4>
 <p>§2.4.3–2.4.4 で我々は、面積測定器 $dx \wedge dy$ がテンソル積の引き算 $dx \otimes dy - dy \otimes dx$ で構成でき、その結果が $3 \times 3$ の反対称行列であることを見た。体積測定器 $dx \wedge dy \wedge dz$ にも同じ手が使えるだろうか？</p>
 <p>なぜここで敢えてテンソル配列を持ち出すのか——それは、<strong>ベクトル3本を食べて行列式を返す操作が、実は面積測定器のときとまったく同じ「添字の縮約」という統一的視点で書ける</strong>ことを示すためである。これを理解すれば、$1$-form・$2$-form・$3$-form がすべて同じ原理で動いていることが見えてくる。</p>
 <p>答えはイエスだ。ただし、2つの物差しのテンソル積は $3 \times 3$ 行列に収まったが、3つの物差しでは添字が1つ増えて $3 \times 3 \times 3 = 27$ 成分の<strong>3次元配列</strong>になる。添字を3つ持つこのような多次元配列は数学でも物理学でも<strong>テンソル</strong>（tensor）と呼ばれる。行列（添字2つ）はテンソルの特殊例であり、今回登場するのは添字を3つ持つ<strong>3階のテンソル</strong>だ。</p>
@@ -1269,21 +1267,21 @@ $$= \det\begin{pmatrix} x_1 &amp; x_2 &amp; x_3 \ y_1 &amp; y_2 &amp; y_3 \ z_1 
 </blockquote>
 <p>さて、この27成分の配列を反対称化（6つの置換を符号つきで足す）すると、27成分のうち6箇所だけが $\pm 1$、残りはゼロの配列が立ち上がる。§2.5.2 で導いた置換の表そのものだ——成分の取り方は次のとおりだ（$\widehat{\epsilon}$ の $(i,j,k)$ 成分）：</p>
 <p>$$
-\epsilon_{ijk} = \begin{cases} +1 &amp; (i,j,k) \text{ が } (x,y,z) \text{ の偶置換} \ -1 &amp; (i,j,k) \text{ が } (x,y,z) \text{ の奇置換} \ 0 &amp; \text{添字に重複あり} \end{cases}
+\epsilon_{ijk} = \begin{cases} +1 & (i,j,k) \text{ が } (x,y,z) \text{ の偶置換} \\ -1 & (i,j,k) \text{ が } (x,y,z) \text{ の奇置換} \\ 0 & \text{添字に重複あり} \end{cases}
 $$</p>
 <p>27個の数をどう並べて見せるか——良い方法がある。<strong>$3 \times 3$ 行列を3枚、横一列に並べた</strong>と考えるとよい：</p>
 <p>$$
 \widehat{\epsilon} \;\longleftrightarrow\;
 \begin{pmatrix}
-\begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix} &amp;
-\begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix} &amp;
-\begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}
+\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
 $$</p>
 <p>第1添字 $i$ が「左から何枚目の断面か」を指定し、各断面の中身は $j,k$ で添字づけされた $3 \times 3$ ブロックだ。</p>
 <p>ここで、
-$$\mathbf{v}<em>1 = \begin{pmatrix} x_1 \ y_1 \ z_1 \end{pmatrix}$$
-としたとき、$1$-form（横ベクトル）が縦ベクトルを食べてスカラーを返すアナロジーの延長として、左から $i$ 枚目のブロック $M_i$ と成分 $v</em>{1i}$ を添字 $i$ で対応付けて掛けて足す——すなわち
+$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$$
+としたとき、$1$-form（横ベクトル）が縦ベクトルを食べてスカラーを返すアナロジーの延長として、左から $i$ 枚目のブロック $M_i$ と成分 $v_{1i}$ を添字 $i$ で対応付けて掛けて足す——すなわち
 $$
 M := x_1 M_1 + y_1 M_2 + z_1 M_3 = \sum_{i=1}^3 v_{1i}\, M_i
 $$
@@ -1314,10 +1312,10 @@ $$
 <p><strong>ベクトル3本を食べてスカラーに潰す</strong></p>
 <p>$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ を代入する手順は、<strong>配列の添字とベクトル成分を、合うところどうしで掛けて足す</strong>——と見るのが早い：</p>
 <p>$$
-V(\mathbf{v}<em>1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k \epsilon</em>{ijk}\, v_{1i}\, v_{2j}\, v_{3k}
+V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k \epsilon_{ijk}\, v_{1i}\, v_{2j}\, v_{3k}
 $$</p>
 <ul>
-<li><strong>ステップ1（3次元配列 → 行列）：</strong> 添字 $i$ について、$\mathbf{v}<em>1$ の各成分で3つの面積測定器行列を重みづけして足す——すなわち $\displaystyle M = \sum</em>{i=1}^3 v_{1i}\,\epsilon_{i,\cdot,\cdot}$（$\epsilon_{i,\cdot,\cdot}$ は $\widehat{\epsilon}$ の左から $i$ 枚目の $3 \times 3$ ブロック）。結果は1つの $3 \times 3$ 行列 $M$ に降りる。</li>
+<li><strong>ステップ1（3次元配列 → 行列）：</strong> 添字 $i$ について、$\mathbf{v}_1$ の各成分で3つの面積測定器行列を重みづけして足す——すなわち $\displaystyle M = \sum_{i=1}^3 v_{1i}\,\epsilon_{i,\cdot,\cdot}$（$\epsilon_{i,\cdot,\cdot}$ は $\widehat{\epsilon}$ の左から $i$ 枚目の $3 \times 3$ ブロック）。結果は1つの $3 \times 3$ 行列 $M$ に降りる。</li>
 <li><strong>ステップ2（行列 → スカラー）：</strong> 残り2本で「横 $\times$ 行列 $\times$ 縦」—— $V = \mathbf{v}_2^T\, M\, \mathbf{v}_3$。§2.4 で慣れ親しんだ操作だ。</li>
 </ul>
 <blockquote>
@@ -1326,9 +1324,9 @@ $$</p>
 <p>この手順で §2.5.2 の行列式の6項が一つ残らず再現されること、および数値検算は、<strong>付録A</strong>で全成分を書き下して確認する。</p>
 <h4 id="256">2.5.6 具体例：平行六面体の符号付き体積</h4>
 <p>手を動かして確認しよう。§2.4.5 で面積を測った2つのベクトルに、3つ目を加えてみる：</p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix}1\0\1\end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix}0\1\1\end{pmatrix}, \quad \mathbf{v}_3 = \begin{pmatrix}1\1\0\end{pmatrix}$$</p>
+<p>$$\mathbf{v}_1 = \begin{pmatrix}1\\0\\1\end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix}0\\1\\1\end{pmatrix}, \quad \mathbf{v}_3 = \begin{pmatrix}1\\1\\0\end{pmatrix}$$</p>
 <p>体積測定器に投入する：
-$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \det\begin{pmatrix}1 &amp; 0 &amp; 1 \ 0 &amp; 1 &amp; 1 \ 1 &amp; 1 &amp; 0\end{pmatrix}$$</p>
+$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \det\begin{pmatrix}1 & 0 & 1 \\ 0 & 1 & 1 \\ 1 & 1 & 0\end{pmatrix}$$</p>
 <p>これを定義に従って計算すると：
 $$= 1\cdot1\cdot0 + 0\cdot1\cdot1 + 1\cdot0\cdot1 - 1\cdot1\cdot1 - 0\cdot0\cdot0 - 1\cdot1\cdot1 = 0 + 0 + 0 - 1 - 0 - 1 = -2$$</p>
 <blockquote>
@@ -1338,7 +1336,7 @@ $$= 1\cdot1\cdot0 + 0\cdot1\cdot1 + 1\cdot0\cdot1 - 1\cdot1\cdot1 - 0\cdot0\cdot
 $$(dx \wedge dy \wedge dz)(\mathbf{v}_2, \mathbf{v}_1, \mathbf{v}_3) = -(-2) = +2$$</p>
 <h4 id="257">2.5.7 スカラー三重積との符合</h4>
 <p>ベクトル解析で「スカラー三重積」を学んだ読者は、次の恒等式を知っているかもしれない：
-$$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1 &amp; x_2 &amp; x_3 \ y_1 &amp; y_2 &amp; y_3 \ z_1 &amp; z_2 &amp; z_3\end{pmatrix}$$</p>
+$$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3\end{pmatrix}$$</p>
 <p>右辺は、我々が定義した $(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$ そのものだ。</p>
 <blockquote>
 <p><strong>注</strong> （内積記号の先取り）左辺の「$\cdot$」は<strong>内積</strong>の記号であり、ここでは小学校以来おなじみの「成分ごとの積の和」という意味で使っている。第6章で計量 $g$ を使った形式的な定義を与える。</p>
@@ -1352,7 +1350,7 @@ $$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1
 <p>$$\text{向き付き体積} = V\,(\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z)$$</p>
 <p>係数となる $V$ は、体積測定器にベクトルを入れて計算した行列式の値（§2.5.6 の例なら $-2$）である。
 そして「小学校の正の体積（スカラー体積）」が欲しければ、成分の二乗和の平方根（$\sqrt{V^2} = |V|$）をとればよい。独立成分が1つしかないので、ただの絶対値になるというわけだ。</p>
-<h4 id="259-3-form-1">2.5.9 $3$-form の「サイズ」——なぜ独立成分は1つだけか</h4>
+<h4 id="259-mathblock1316placeholder-form-1">2.5.9 $3$-form の「サイズ」——なぜ独立成分は1つだけか</h4>
 <p>面積測定器（$2$-form）は $3 \times 3$ 反対称行列で表現でき、独立な成分は3つだった（$dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ の係数）。</p>
 <p>では体積測定器（$3$-form）の独立成分はいくつか？ 基底 $3$-form として作れる候補を考えてみよう。3つの物差し $dx, dy, dz$ から<strong>重複なく</strong>3つを選ぶ方法は……1通りしかない。$dx \wedge dy \wedge dz$ だけだ（順序を変えると符号が変わるだけで、新しい基底にはならない）。</p>
 <blockquote>
@@ -1432,30 +1430,30 @@ $$(dx \otimes dy \otimes dz)_{ijk} = (dx)_i\,(dy)_j\,(dz)_k$$</p>
 <p><strong>注</strong> （対称群と置換の符号）$S_3$ は3次対称群（置換の集合）。$\mathrm{sgn}(\sigma)$ は<strong>偶置換なら $+1$、奇置換なら $-1$</strong> と定める符号。</p>
 </blockquote>
 <p>書き下すと：</p>
-<p>$$\underbrace{dx \otimes dy \otimes dz}<em>{(1,2,3)\text{ に }+1} - \underbrace{dx \otimes dz \otimes dy}</em>{(1,3,2)\text{ に }-1} + \underbrace{dy \otimes dz \otimes dx}<em>{(2,3,1)\text{ に }+1}$$
-$$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbrace{dz \otimes dx \otimes dy}<em>{(3,1,2)\text{ に }+1} - \underbrace{dz \otimes dy \otimes dx}</em>{(3,2,1)\text{ に }-1}$$</p>
+<p>$$\underbrace{dx \otimes dy \otimes dz}_{(1,2,3)\text{ に }+1} - \underbrace{dx \otimes dz \otimes dy}_{(1,3,2)\text{ に }-1} + \underbrace{dy \otimes dz \otimes dx}_{(2,3,1)\text{ に }+1}$$
+$$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{dz \otimes dx \otimes dy}_{(3,1,2)\text{ に }+1} - \underbrace{dz \otimes dy \otimes dx}_{(3,2,1)\text{ に }-1}$$</p>
 <p>6つの「1箇所だけ非ゼロの配列」を符号つきで重ねると、27成分のうち6箇所だけが $\pm 1$ で、残り21箇所はゼロになる。§2.5.2 の置換の表と見比べてほしい——これが $\widehat{\epsilon}$ の各成分 $\epsilon_{ijk}$ を与える構成原理だ。</p>
 <h4 id="a3">A.3 各成分の行列を書き下す</h4>
 <p>§2.5.5 で示した3つの成分行列を、ここでは1マスずつ確認しよう。</p>
 <p><strong>第1成分（$i = 1$, $x$）：</strong> 6項のうち $i = 1$ を持つのは $(1,2,3)$ に $+1$ と $(1,3,2)$ に $-1$。</p>
-<p>$$\epsilon_{1,\cdot,\cdot} = \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix}$$</p>
+<p>$$\epsilon_{1,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}$$</p>
 <p><strong>第2成分（$i = 2$, $y$）：</strong> $(2,3,1)$ に $+1$ と $(2,1,3)$ に $-1$。</p>
-<p>$$\epsilon_{2,\cdot,\cdot} = \begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix}$$</p>
+<p>$$\epsilon_{2,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}$$</p>
 <p><strong>第3成分（$i = 3$, $z$）：</strong> $(3,1,2)$ に $+1$ と $(3,2,1)$ に $-1$。</p>
-<p>$$\epsilon_{3,\cdot,\cdot} = \begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}$$</p>
+<p>$$\epsilon_{3,\cdot,\cdot} = \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$</p>
 <p>繰り返しになるが、これらはそれぞれ $dy \wedge dz$、$dz \wedge dx$、$dx \wedge dy$ の行列そのものである。</p>
 <h4 id="a4-3">A.4 ベクトル3本を食わせる——縮約の全過程</h4>
 <p><strong>ステップ1：添字 $i$ について $\mathbf{v}_1$ の成分で加重和（添字 $i$ を潰す）</strong></p>
 <p>$\mathbf{v}_1$ の各成分を重みにして3つの面積測定器行列を足し合わせる。3次元配列がベクトル1本を食べて $3 \times 3$ 行列に降りる：</p>
-<p>$$M := \sum_i v_{1i}\, \epsilon_{i,\cdot,\cdot} = x_1 \begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix} + y_1 \begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix} + z_1 \begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}$$</p>
+<p>$$M := \sum_i v_{1i}\, \epsilon_{i,\cdot,\cdot} = x_1 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} + y_1 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} + z_1 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$</p>
 <p>各成分を足し合わせると：</p>
-<p>$$M = \begin{pmatrix} 0 &amp; z_1 &amp; -y_1 \ -z_1 &amp; 0 &amp; x_1 \ y_1 &amp; -x_1 &amp; 0 \end{pmatrix}$$</p>
+<p>$$M = \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix}$$</p>
 <p>面積測定器3つを $\mathbf{v}_1$ の成分で配合した、「$\mathbf{v}_1$ 専用の面積測定器」が出現した。反対称行列であることに注目——$\widehat{\epsilon}$ の添字に対する反対称性が受け継がれている。</p>
 <p><strong>ステップ2：残り2本で行列を挟む（添字 $j, k$ を潰す）</strong></p>
 <p>あとは §2.4 で馴染んだ「横 $\times$ 行列 $\times$ 縦」だ：</p>
-<p>$$V = \mathbf{v}_2^T\, M\, \mathbf{v}_3 = \begin{pmatrix} x_2 &amp; y_2 &amp; z_2 \end{pmatrix} \begin{pmatrix} 0 &amp; z_1 &amp; -y_1 \ -z_1 &amp; 0 &amp; x_1 \ y_1 &amp; -x_1 &amp; 0 \end{pmatrix} \begin{pmatrix} x_3 \ y_3 \ z_3 \end{pmatrix}$$</p>
+<p>$$V = \mathbf{v}_2^T\, M\, \mathbf{v}_3 = \begin{pmatrix} x_2 & y_2 & z_2 \end{pmatrix} \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix} \begin{pmatrix} x_3 \\ y_3 \\ z_3 \end{pmatrix}$$</p>
 <p>まず $\mathbf{v}_2^T \times M$（横 $\times$ 行列 → 横）を計算する：</p>
-<p>$$= \begin{pmatrix} y_1 z_2 - z_1 y_2, &amp; z_1 x_2 - x_1 z_2, &amp; x_1 y_2 - x_2 y_1 \end{pmatrix}$$</p>
+<p>$$= \begin{pmatrix} y_1 z_2 - z_1 y_2, & z_1 x_2 - x_1 z_2, & x_1 y_2 - x_2 y_1 \end{pmatrix}$$</p>
 <p>最後に、得た横ベクトルと $\mathbf{v}_3$ の対応成分の積の和（横 $\times$ 縦 → スカラー）：</p>
 <p>$$V = (y_1 z_2 - z_1 y_2)\,x_3 + (z_1 x_2 - x_1 z_2)\,y_3 + (x_1 y_2 - x_2 y_1)\,z_3$$</p>
 <p>展開して整理すると：</p>
@@ -1477,7 +1475,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>いま、空間内の領域 $V$ の体積を測りたい。$V$ の形がどんなに曲がっていても、十分細かく刻めば各小片はほぼ直方体と見なせる。そこで $V$ を $x$ 方向・$y$ 方向・$z$ 方向に刻み、$V$ の内部にある小直方体に番号 $i$ を振る。第 $i$ 小直方体の三辺を</p>
 <p>$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z$$</p>
 <p>とする。これら三本のベクトルを体積測定器 $dx \wedge dy \wedge dz$ に食わせると：</p>
-<p>$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i &amp; 0 &amp; 0 \ 0 &amp; \Delta y_i &amp; 0 \ 0 &amp; 0 &amp; \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i$$</p>
+<p>$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i$$</p>
 <blockquote>
 <p><strong>注</strong> （はかりと図形の縮約）ここで起きていることは、第2章 §2.5.10 で見たパターンそのものだ。<strong>$3$-form（体積測定器＝はかり）</strong>が<strong>$3$-vector（体積素＝図形）</strong>を食べてスカラーを吐き出す。この縮約が各小直方体で行われる。</p>
 </blockquote>
@@ -1502,16 +1500,16 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>ここで置換積分（高校数学）を使う。$y = a\sin t$ とおくと、$dy = a\cos t\,dt$。$y$ が $-a \to a$ のとき $t$ は $-\pi/2 \to \pi/2$。また $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$（$t \in [-\pi/2,\pi/2]$ では $\cos t \ge 0$ だから絶対値が外れる）。したがって：</p>
 <p>$$\begin{aligned}
 \int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy
-&amp;= \int_{-\pi/2}^{\pi/2} 2\cdot a\cos t \cdot a\cos t\,dt \
-&amp;= 2a^2!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
+&= \int_{-\pi/2}^{\pi/2} 2\cdot a\cos t \cdot a\cos t\,dt \\
+&= 2a^2\!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
 \end{aligned}$$</p>
 <p>$\cos^2 t = (1 + \cos 2t)/2$ だから：</p>
 <p>$$\begin{aligned}
-2a^2!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
-&amp;= a^2\int_{-\pi/2}^{\pi/2} (1 + \cos 2t)\,dt \[4pt]
-&amp;= a^2\Bigl[t + \frac{\sin 2t}{2}\Bigr]_{-\pi/2}^{\pi/2} \[4pt]
-&amp;= a^2\Bigl[\Bigl(\frac{\pi}{2} + 0\Bigr) - \Bigl(-\frac{\pi}{2} + 0\Bigr)\Bigr] \[4pt]
-&amp;= \pi a^2 = \pi(R^2 - z^2)
+2a^2\!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
+&= a^2\int_{-\pi/2}^{\pi/2} (1 + \cos 2t)\,dt \\[4pt]
+&= a^2\Bigl[t + \frac{\sin 2t}{2}\Bigr]_{-\pi/2}^{\pi/2} \\[4pt]
+&= a^2\Bigl[\Bigl(\frac{\pi}{2} + 0\Bigr) - \Bigl(-\frac{\pi}{2} + 0\Bigr)\Bigr] \\[4pt]
+&= \pi a^2 = \pi(R^2 - z^2)
 \end{aligned}$$</p>
 <p>最後に $z$ 積分：</p>
 <p>$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3$$</p>
@@ -1529,7 +1527,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <h3 id="32-21">§3.2 表面積——2次元、係数1</h3>
 <h4 id="321">3.2.1 平行四辺形から曲面へ</h4>
 <p>第2章 §2.4 で、我々は $dx \wedge dy$ という面積測定器を組み立てた。これに二本のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を食わせると、それらが $xy$ 平面に落とす影の符号付き面積が返ってくる。同様に $dy \wedge dz$ は $yz$ 平面への影、$dz \wedge dx$ は $zx$ 平面への影を測る。</p>
-<p>では曲面の面積を測るにはどうすればよいか。まず平らな場合で確認しておこう。$xy$ 平面に乗った単位正方形 $\mathbf{r}(u,v) = (u,\,v,\,0),\; 0 \le u,v \le 1$ を考える。$\mathbf{r}<em>u = (1,0,0),\; \mathbf{r}_v = (0,1,0)$ だから、$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix}1&amp;0\0&amp;1\end{pmatrix} = 1$。全区間で集計すれば $\iint</em>{[0,1]^2} 1 = 1$——正方形の面積だ。これは第2章の平らな平行四辺形の拡張にすぎず、面素という新しい道具が平らな面では正しく面積を返すことの確認である。</p>
+<p>では曲面の面積を測るにはどうすればよいか。まず平らな場合で確認しておこう。$xy$ 平面に乗った単位正方形 $\mathbf{r}(u,v) = (u,\,v,\,0),\; 0 \le u,v \le 1$ を考える。$\mathbf{r}_u = (1,0,0),\; \mathbf{r}_v = (0,1,0)$ だから、$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix}1&0\\0&1\end{pmatrix} = 1$。全区間で集計すれば $\iint_{[0,1]^2} 1 = 1$——正方形の面積だ。これは第2章の平らな平行四辺形の拡張にすぎず、面素という新しい道具が平らな面では正しく面積を返すことの確認である。</p>
 <p>では曲面が曲がっていたらどうなるか。一般に、曲面 $S$ が二つのパラメータ $u, v$ で</p>
 <p>$$\mathbf{r}(u,v) = \bigl(x(u,v),\, y(u,v),\, z(u,v)\bigr)$$</p>
 <p>と表されているとする。$u, v$ が平面内の領域 $D$ を動くとき、$\mathbf{r}(u,v)$ が曲面 $S$ を描く。</p>
@@ -1542,7 +1540,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>この面素 $\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v$ を面積測定器 $dx \wedge dy$ に食わせる。$u,v$ 方向の刻みに番号 $i,j$ を振れば、第 $(i,j)$ 小区画からの寄与は：</p>
 <p>$$(dx \wedge dy)(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = (dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$</p>
 <p>第2章 §2.4.4 の定義より：</p>
-<p>$$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix} \frac{\partial x}{\partial u} &amp; \frac{\partial x}{\partial v} \ \frac{\partial y}{\partial u} &amp; \frac{\partial y}{\partial v} \end{pmatrix} = \frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$$</p>
+<p>$$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix} \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\ \frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} \end{pmatrix} = \frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$$</p>
 <blockquote>
 <p><strong>注</strong> （$2$-form と $2$-vector の縮約）ここでも同じ構図だ。<strong>$2$-form（面積測定器＝はかり）</strong>が<strong>$2$-vector（面素＝図形）</strong>を食べてスカラー（影の面積）を返す。各小区画でこの縮約が行われる。</p>
 </blockquote>
@@ -1551,14 +1549,14 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>刻みを無限に細かくする極限を</p>
 <p>$$\iint_S dx \wedge dy$$</p>
 <p>と<strong>書くことにする</strong>。これが $2$-form の積分——面積分——の定義である。構成は §3.1 の体積分と同じ型で、食わせるベクトルが2本になっただけだ。</p>
-<h4 id="322-dx-wedge-dy">3.2.2 $dx \wedge dy$ が測るもの——球面で試す</h4>
+<h4 id="322-mathblock1581placeholder">3.2.2 $dx \wedge dy$ が測るもの——球面で試す</h4>
 <p>実際に球面で計算してみよう。半径 $R$ の球面の上半分（$z \ge 0$）を考える。この曲面は、$x, y$ をそのままパラメータとして</p>
 <p>$$z = f(x,y) = \sqrt{R^2 - x^2 - y^2},\qquad x^2 + y^2 \le R^2$$</p>
 <p>と書ける（グラフ表示）。$\mathbf{r}(x,y) = (x,\; y,\; f(x,y))$ とパラメータ表示すれば、偏微分は：</p>
-<p>$$\mathbf{r}_x = \frac{\partial \mathbf{r}}{\partial x} = \begin{pmatrix} 1 \[2pt] 0 \[2pt] \frac{\partial f}{\partial x} \end{pmatrix},\qquad \mathbf{r}_y = \frac{\partial \mathbf{r}}{\partial y} = \begin{pmatrix} 0 \[2pt] 1 \[2pt] \frac{\partial f}{\partial y} \end{pmatrix}$$</p>
+<p>$$\mathbf{r}_x = \frac{\partial \mathbf{r}}{\partial x} = \begin{pmatrix} 1 \\[2pt] 0 \\[2pt] \frac{\partial f}{\partial x} \end{pmatrix},\qquad \mathbf{r}_y = \frac{\partial \mathbf{r}}{\partial y} = \begin{pmatrix} 0 \\[2pt] 1 \\[2pt] \frac{\partial f}{\partial y} \end{pmatrix}$$</p>
 <p>ここで $\frac{\partial f}{\partial x} = \dfrac{\partial f}{\partial x} = -\dfrac{x}{\sqrt{R^2 - x^2 - y^2}},\; \frac{\partial f}{\partial y} = \dfrac{\partial f}{\partial y} = -\dfrac{y}{\sqrt{R^2 - x^2 - y^2}}$。</p>
 <p>まず $dx \wedge dy$ だけを曲面に食わせてみる：</p>
-<p>$$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = \det\begin{pmatrix} 1 &amp; 0 \ 0 &amp; 1 \end{pmatrix} = 1$$</p>
+<p>$$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = \det\begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix} = 1$$</p>
 <p>したがって上半球面での $dx \wedge dy$ の積分は：</p>
 <p>$$\iint_{S_{\text{upper}}} dx \wedge dy$$</p>
 <p>の計算は §3.1.2 の $y$ 積分と同じ方法でできて（$a$ を $R$ と思えばまったく同じ）、結果は $\pi R^2$ である。これは上半球を $xy$ 平面に落とした影——半径 $R$ の円板——の面積にほかならない。</p>
@@ -1568,17 +1566,17 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>では曲面の本当の面積はどう測ればよいのか。各点で三つの面積測定器すべてに面素を食わせ、その結果を合成する。</p>
 <p>上半球面で残り二つも計算しよう（§3.2.1 の $u=x,\;v=y$ の例）：</p>
 <p>$$\begin{aligned}
-(dy \wedge dz)(\mathbf{r}_x, \mathbf{r}_y) &amp;= y_x z_y - y_y z_x = 0\cdot \frac{\partial f}{\partial y} - 1\cdot \frac{\partial f}{\partial x} = -\frac{\partial f}{\partial x} = \frac{x}{\sqrt{R^2 - x^2 - y^2}} \[4pt]
-(dz \wedge dx)(\mathbf{r}_x, \mathbf{r}_y) &amp;= z_x x_y - z_y x_x = \frac{\partial f}{\partial x}\cdot 0 - \frac{\partial f}{\partial y}\cdot 1 = -\frac{\partial f}{\partial y} = \frac{y}{\sqrt{R^2 - x^2 - y^2}} \[4pt]
-(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) &amp;= 1
+(dy \wedge dz)(\mathbf{r}_x, \mathbf{r}_y) &= y_x z_y - y_y z_x = 0\cdot \frac{\partial f}{\partial y} - 1\cdot \frac{\partial f}{\partial x} = -\frac{\partial f}{\partial x} = \frac{x}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
+(dz \wedge dx)(\mathbf{r}_x, \mathbf{r}_y) &= z_x x_y - z_y x_x = \frac{\partial f}{\partial x}\cdot 0 - \frac{\partial f}{\partial y}\cdot 1 = -\frac{\partial f}{\partial y} = \frac{y}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
+(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) &= 1
 \end{aligned}$$</p>
 <p>これら三つの値——$A_{yz},\,A_{zx},\,A_{xy}$——が、各点での面素の<strong>向きと大きさ</strong>の情報を完全にエンコードしている。第2章 §2.4.6 で見た「向き付き面積＝三つの基底 $\hat{e}_y \wedge \hat{e}_z$ 等の線形結合」の曲面版である。</p>
 <p>では、これら三つの「影」から曲面のスカラー面積を取り出す。やることは第2章 §2.4.7 の平行四辺形のときと<strong>一字一句同じ</strong>——三つの値の二乗和の平方根をとればよい：</p>
 <p>$$\begin{aligned}
 \sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}
-&amp;= \sqrt{\Bigl(\frac{x}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + \Bigl(\frac{y}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + 1^2} \
-&amp;= \sqrt{\frac{x^2 + y^2}{R^2 - x^2 - y^2} + 1} \
-&amp;= \sqrt{\frac{R^2}{R^2 - x^2 - y^2}}
+&= \sqrt{\Bigl(\frac{x}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + \Bigl(\frac{y}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + 1^2} \\
+&= \sqrt{\frac{x^2 + y^2}{R^2 - x^2 - y^2} + 1} \\
+&= \sqrt{\frac{R^2}{R^2 - x^2 - y^2}}
 = \frac{R}{\sqrt{R^2 - x^2 - y^2}}
 \end{aligned}$$</p>
 <p>これをパラメータ領域 $x^2 + y^2 \le R^2$ 全体で積分すれば、上半球面の面積が得られる：</p>
@@ -1605,12 +1603,12 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <hr />
 <h3 id="33-11">§3.3 曲線——1次元、係数1（限界があらわになる）</h3>
 <h4 id="331">3.3.1 直線から曲線へ——リーマン和で定義する</h4>
-<p>第1章で、我々は $dx, dy, dz$ を「ベクトルを食べて各成分を返す $1$-form（横ベクトル）」として定義した。$dx = \begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$、$\mathbf{v} = \begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ のとき $dx(\mathbf{v}) = \Delta x$ である。$dy, dz$ も同様。</p>
+<p>第1章で、我々は $dx, dy, dz$ を「ベクトルを食べて各成分を返す $1$-form（横ベクトル）」として定義した。$dx = \begin{pmatrix}1&0&0\end{pmatrix}$、$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ のとき $dx(\mathbf{v}) = \Delta x$ である。$dy, dz$ も同様。</p>
 <p>では曲線に沿ってこれらを適用し、集計すると何が出るか。曲線を時刻 $t$ の関数として</p>
 <p>$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$</p>
 <p>と表す。曲線を小区間に刻み、$i$ 番目の小区間での変位ベクトルを $\Delta\mathbf{r}_i = \gamma(t_i + \Delta t) - \gamma(t_i)$ とする。$\Delta\mathbf{r}_i$ は有限の変位であり、近似ではない。成分を明示すれば $\Delta\mathbf{r}_i = (\Delta x_i,\; \Delta y_i,\; \Delta z_i)$ である。</p>
 <p>各小区間で<strong>行列 $dx$ を変位ベクトル $\Delta\mathbf{r}_i$ に作用させる</strong>：</p>
-<p>$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&amp;0&amp;0\end{pmatrix} \begin{pmatrix}\Delta x_i \ \Delta y_i \ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$</p>
+<p>$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$</p>
 <p>この $\Delta x_i/\Delta t$ は有限のままの比であり、近似ではない。全区間で足し上げれば、各項が $\Delta t$ ごとの換算率 $\Delta x_i/\Delta t$ を持つ正確な和になる：</p>
 <p>$$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$</p>
 <p>刻みを無限に細かくする極限で、換算率は導関数に収束する：$\Delta x_i/\Delta t \to dx/dt$。この極限を</p>
@@ -1628,15 +1626,15 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>$$\gamma(t) = (R\cos t,\; R\sin t,\; 0),\qquad t \in [0, 2\pi]$$</p>
 <p>とパラメータ表示する。$\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$ だから：</p>
 <p>$$\begin{aligned}
-\int_\gamma dx &amp;= \int_0^{2\pi} dx(\gamma'(t))\,dt = \int_0^{2\pi} (-R\sin t)\,dt = R\bigl[\cos t\bigr]<em>0^{2\pi} = 0 \[4pt]
-\int</em>\gamma dy &amp;= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
+\int_\gamma dx &= \int_0^{2\pi} dx(\gamma'(t))\,dt = \int_0^{2\pi} (-R\sin t)\,dt = R\bigl[\cos t\bigr]_0^{2\pi} = 0 \\[4pt]
+\int_\gamma dy &= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
 \end{aligned}$$</p>
 <p>いずれもゼロである。閉曲線だから始点と終点が同じで、行きと帰りで打ち消し合う——当然の結果だ。</p>
 <p>しかし、この円の弧長が $2\pi R$ であることも我々は知っている。係数1の $dx, dy$ だけではゼロになってしまうが、では<strong>どうすれば弧長が出るのか</strong>。</p>
 <p>各瞬間に $dx, dy$ が測った値はすでに手元にある。$dx(\gamma'(t)) = -R\sin t$、$dy(\gamma'(t)) = R\cos t$。これらはスカラーだから、二乗して足すことができる：</p>
 <p>$$dx(\gamma'(t))^2 + dy(\gamma'(t))^2 = R^2\sin^2 t + R^2\cos^2 t = R^2$$</p>
 <p>その平方根をとれば、その瞬間の速さ $|\gamma'(t)| = R$ が得られる。全区間で積分すれば：</p>
-<p>$$\int_0^{2\pi} !\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} !R\,dt = 2\pi R$$</p>
+<p>$$\int_0^{2\pi} \!\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} \!R\,dt = 2\pi R$$</p>
 <p>弧長 $2\pi R$ が出た。ここで起きていることは重要だ——$dx$ も $dy$ も単独では閉曲線でゼロになったのに、それらの二乗和の平方根をとって積分すると、正しい弧長が姿を現した。係数1の $1$-form にはなかった「長さを測る力」が、二乗和という代数的な組み換えによって回復されたのである。</p>
 <p>弧長 $2\pi R$ が出た。</p>
 <p>ここで起きていることを整理しよう。各時刻 $t$ で $dx(\gamma'(t))$ と $dy(\gamma'(t))$ という二つのスカラーを得て、それらの二乗和の平方根 $\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$ をとり、$t$ で積分した。これはすなわち、「変位 $\mathbf{v}$ に対して $\sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$ を返す」という新しい $1$-form を曲線上で積分したことにほかならない。この $1$-form を $ds$ と書く：</p>
@@ -1648,7 +1646,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <blockquote>
 <p><strong>注</strong> （計量への伏線）$dx(\mathbf{v})^2 + dy(\mathbf{v})^2$ という「成分の二乗和」の形は、第2章 §2.4.7 で平行四辺形のスカラー面積を $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ と出したのと完全に並行である。この「ピタゴラスの組み合わせ方」は、直交デカルト座標における自然な長さの定義に他ならない。任意の座標系への一般化は第6章で計量 $g$ を使って行う。ここでは「$dx, dy, dz$ の作用結果の二乗和の平方根をとれば、向きを捨てた正の大きさ（長さ・面積・体積）が得られる」という事実だけを押さえておけばよい。</p>
 </blockquote>
-<h4 id="333-1-form">3.3.3 では $1$-form で何が測れるのか</h4>
+<h4 id="333-mathblock1703placeholder-form">3.3.3 では $1$-form で何が測れるのか</h4>
 <p>弧長は $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$ という $1$-form の積分として測れた。この $ds$ は $dx$ と $dy$ の線形結合では書けず、二乗和の平方根を必要とする。この組み合わせ方を任意の座標系へ一般化するのが第6章の計量 $g$ の役割だが、ここではまず、計量を必要としない $1$-form——すなわち $dx, dy, dz$ の線形結合で書ける $1$-form——が、いったい何を測るのかを見ていこう。</p>
 <p>空間の各点に力の場 $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ が働いている。曲線に沿って質点を動かすとき、各小区間で力がする微小仕事は、力の変位方向成分と変位の大きさの積——すなわち $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$——である。これを全区間で足し上げたものが仕事 $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$ だ。</p>
 <p>ここで重要なのは、力の成分 $F_x, F_y, F_z$ は<strong>場所ごとに変わる</strong>ことである。体積（§3.1）や表面積（§3.2）では係数1で十分な部分が多かったが、仕事を測るには場所ごとに変わる係数が不可欠だ。これが係数の必然性をもっとも鮮明に示す。</p>
@@ -1670,7 +1668,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 </ul>
 <p>ここに共通する構造は明白だ。<strong>「場所ごとに変わる重み（$0$-form ＝ スカラー場）」</strong>と<strong>「幾何的な測り方（$k$-form）」</strong>の積が、一般の $k$-form を構成する。第2章 §2.4.8 で「$0$-form はベクトルを0本食べる測定器、すなわちスカラー場」と述べたのは、まさにこの布石である。</p>
 <p>以下、1次元・2次元・3次元の順に、係数付き形式の積分を定義していく。</p>
-<h4 id="341-1-form">3.4.1 一般の $1$-form の線積分（仕事）</h4>
+<h4 id="341-mathblock1734placeholder-form">3.4.1 一般の $1$-form の線積分（仕事）</h4>
 <p>実空間で、係数が点 $(x,y,z)$ に依存するスカラー場 $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ をとり、</p>
 <p>$$\omega = \frac{\partial f}{\partial x}(x,y,z)\,dx + \frac{\partial f}{\partial y}(x,y,z)\,dy + \frac{\partial f}{\partial z}(x,y,z)\,dz$$</p>
 <p>を<strong>$1$-form の一般形</strong>と呼ぶ。各 $dx, dy, dz$ は第1章どおり、縦ベクトルから成分を読み取る横ベクトルである。係数 $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ は場所ごとに変わる重み——$0$-form——である。</p>
@@ -1680,7 +1678,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>各成分の変化を「有限の比 $\times \Delta t$」の形に整理する：</p>
 <p>$$\omega(\Delta\mathbf{r}_i) = \bigl(\frac{\partial f}{\partial x}\frac{\Delta x_i}{\Delta t} + \frac{\partial f}{\partial y}\frac{\Delta y_i}{\Delta t} + \frac{\partial f}{\partial z}\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$</p>
 <p>$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ は点 $\gamma(t_i)$ での値。全区間で足し上げて極限をとる。$\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$ だから：</p>
-<p>$$\sum_i \omega(\Delta\mathbf{r}<em>i) \;\xrightarrow{\Delta t \to 0}\; \int</em>{t_0}^{t_1} \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,dt$$</p>
+<p>$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,dt$$</p>
 <p>この極限を</p>
 <p>$$\int_\gamma \omega$$</p>
 <p>と書く。§3.3.1 の係数1の場合とまったく同じ型で、各瞬間に<strong>横ベクトル（係数付き $1$-form）</strong>が<strong>縦ベクトル（$\gamma'(t)$）</strong>を食べてスカラーを返し、それを集計している。これは第1章 §1.2.5 の $F(x)\,dx$ を3次元に自然拡張しただけである。</p>
@@ -1689,11 +1687,11 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 </blockquote>
 <p>具体例を見よう。力場 $\mathbf{F} = (y,\; x,\; 0)$ が、単位円 $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$ に沿ってする仕事を計算する。</p>
 <p>$\omega = y\,dx + x\,dy$ だから、係数は $\frac{\partial f}{\partial x} = y,\; \frac{\partial f}{\partial y} = x$。曲線上では $\frac{\partial f}{\partial x} = \sin t,\; \frac{\partial f}{\partial y} = \cos t$。また $dx/dt = -\sin t,\; dy/dt = \cos t$ より：</p>
-<p>$$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2!t + \cos^2!t = \cos 2t$$</p>
+<p>$$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$</p>
 <p>したがって：</p>
 <p>$$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$</p>
 <p>仕事がゼロになった。この力場は単位円に沿って正味の仕事をしないのである。</p>
-<h4 id="342-2-form">3.4.2 一般の $2$-form の面積分（流量）</h4>
+<h4 id="342-mathblock1767placeholder-form">3.4.2 一般の $2$-form の面積分（流量）</h4>
 <p>同様に、三つのスカラー場 $P, Q, R$ を係数とする一般の $2$-form：</p>
 <p>$$\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy$$</p>
 <p>曲面 $\mathbf{r}(u,v)$ に沿った積分も、§3.2.1 のリーマン和に係数を乗せるだけだ。各小区画の面素 $(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v)$ に $\eta$ を食わせる：</p>
@@ -1705,7 +1703,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <blockquote>
 <p><strong>注</strong> （ここではベクトル解析との対応は補助線）流量との対応は、既にベクトル解析を知っている読者のための橋渡しにすぎない。本書の本線はあくまで「$2$-form を食わせて集計する」という操作であり、ベクトル解析の知識がなくともこの先の議論に支障はない。</p>
 </blockquote>
-<h4 id="343-3-form">3.4.3 一般の $3$-form の体積分（総質量）</h4>
+<h4 id="343-mathblock1780placeholder-form">3.4.3 一般の $3$-form の体積分（総質量）</h4>
 <p>$3$-form の一般形は、スカラー場 $\rho(x,y,z)$ を係数として：</p>
 <p>$$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$</p>
 <p>§3.1.1 のリーマン和に密度 $\rho$ を乗せればよい。各小直方体の体積素に $\Omega$ を食わせる：</p>
@@ -1778,7 +1776,7 @@ $$- \underbrace{dy \otimes dx \otimes dz}</em>{(2,1,3)\text{ に }-1} + \underbr
 <p>次章（第4章）では、これらの積分を「別の変数で計算する」とは何かを掘り下げる。すなわち<strong>引き戻し</strong>——積分値を保つために測定器を作り替える操作——を、三つの保存則を通じて発見する。</p>
 <p>引き戻しを終えた先、ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 $d$</strong> を導入する。$d$ は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。</p>
 <p>\newpage</p>
-<h1 id="4-phi">第4章：変数変換とは何か —— 引き戻し $\Phi^*$：測定器のつじつま合わせ</h1>
+<h1 id="4-mathblock1861placeholder">第4章：変数変換とは何か —— 引き戻し $\Phi^*$：測定器のつじつま合わせ</h1>
 <h3 id="40">§4.0 物理は曲がる、計算は四角</h3>
 <p>物理で本当に測りたい量は、座標の名前に依らない。</p>
 <p>質点にした仕事は、軌道を $x$ で書いても、時刻 $t$ で書いても同じでなければならない。惑星が掃く面積は、直交座標で測っても、極座標で測っても同じでなければならない。物体の質量は、直交座標で積分しても、円柱座標で積分しても同じでなければならない。</p>
@@ -1852,28 +1850,28 @@ $dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替�
 <p><strong>注</strong> （物理学者の二次元）忘れないでほしい——本書は一貫して三次元空間の実在を前提としている。以下の角運動量の議論で $z=0$ と置くのは、計算を見やすくするための一時的な簡略化であり、我々は依然として三次元空間の中の一つの平面を眺めているにすぎない。</p>
 </blockquote>
 <p><strong>② 素朴な置き換え——必ず間違える。</strong> 右辺の扇形は $(x,y)$ の式では書きづらい。そこで $(r,\theta)$ で書きたくなる。しかし、$dx \wedge dy$ をそのまま $dr \wedge d\theta$ に置き換えるとどうなるか。半径 $C$ の完全な円の面積を計算してみよう。正しい値は $\pi C^2$ である。ところが、素朴に置き換えると：</p>
-<p>$$A_{\text{素朴}} = \iint dr \wedge d\theta = \int_0^{2\pi}!\int_0^C dr\,d\theta = 2\pi C$$</p>
+<p>$$A_{\text{素朴}} = \iint dr \wedge d\theta = \int_0^{2\pi}\!\int_0^C dr\,d\theta = 2\pi C$$</p>
 <p>これは $\pi C^2$ とはまったく違う。$dr \wedge d\theta$ のままでは、正しい面積が出ない。</p>
 <p><strong>③ 有限マス目で原因を見る。</strong> §4.1 と同じことをする。$(r,\theta)$ 空間に、有限の大きさ $\Delta r \times \Delta\theta$ のグリッドを切る。座標 $(r, \theta)$ にある一マスが、$(x,y)$ 空間で占める面積を求める。</p>
 <p>$\Delta r$ 方向の辺：$r$ だけ変えて $\theta$ を固定するから、差は正確に求まる：</p>
 <p>$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$</p>
 <p>$\Delta\theta$ 方向の辺：三角関数の差の公式を用いる：</p>
 <p>$$\begin{aligned}
-\Delta x_\theta &amp;= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
-= -2r\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr)\sin\tfrac{\Delta\theta}{2} \[4pt]
-\Delta y_\theta &amp;= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
+\Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
+= -2r\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr)\sin\tfrac{\Delta\theta}{2} \\[4pt]
+\Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
 = 2r\cos\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr)\sin\tfrac{\Delta\theta}{2}
 \end{aligned}$$</p>
-<p>二辺 $\mathbf{v}<em>r = (\Delta x_r, \Delta y_r)$ と $\mathbf{v}</em>\theta = (\Delta x_\theta, \Delta y_\theta)$ が張る平行四辺形の面積を行列式で求める：</p>
+<p>二辺 $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ と $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ が張る平行四辺形の面積を行列式で求める：</p>
 <p>$$\begin{aligned}
-\det(\mathbf{v}<em>r,\mathbf{v}</em>\theta) &amp;= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \
-&amp;= 2r\Delta r\,\sin\tfrac{\Delta\theta}{2}\bigl[ \cos\theta\cos\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) + \sin\theta\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) \bigr] \
-&amp;= r\Delta r\,\sin\Delta\theta
+\det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
+&= 2r\Delta r\,\sin\tfrac{\Delta\theta}{2}\bigl[ \cos\theta\cos\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) + \sin\theta\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) \bigr] \\
+&= r\Delta r\,\sin\Delta\theta
 \end{aligned}$$</p>
 <p>結果は $\det = r\Delta r\,\sin\Delta\theta$。マス目全体を足し上げるリーマン和：</p>
 <p>$$A \approx \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j$$</p>
 <p>$\sin\Delta\theta_j$ は有限の $\Delta\theta_j$ に対して厳密な値である。総和の極限をとる最終段階で $\sin\Delta\theta_j \approx \Delta\theta_j$ と置き：</p>
-<p>$$A = \lim_{\substack{\Delta r_i \to 0 \ \Delta\theta_j \to 0}} \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j = \iint_D r\,dr\,d\theta$$</p>
+<p>$$A = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0}} \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j = \iint_D r\,dr\,d\theta$$</p>
 <blockquote>
 <p><strong>注</strong> （$\Delta r,\Delta\theta$ は微小である必要はない）ここまでの計算に、$\Delta r$ や $\Delta\theta$ が「十分小さい」という仮定は一切使っていない。上で求めた $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ は、$\Delta r,\Delta\theta$ がどれほど大きくても厳密に成り立つ式である。微小量への移行は、あくまで積分の最終段階——総和の極限をとるとき——で初めて行う。</p>
 </blockquote>
@@ -1908,7 +1906,7 @@ $dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替�
 <p>円柱全体の質量は、マス目 $(i,j,k)$ の寄与を足し上げたリーマン和である：</p>
 <p>$$M \approx \sum_i\sum_j\sum_k \rho\; r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k$$</p>
 <p>総和の極限をとる最終段階で $\sin\Delta\theta_j \approx \Delta\theta_j$ と置く：</p>
-<p>$$M = \lim_{\substack{\Delta r_i \to 0 \ \Delta\theta_j \to 0 \ \Delta z_k \to 0}} \sum_i\sum_j\sum_k \rho\, r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k = \rho \iiint_{V'} r\,dr\,d\theta\,dz = \rho \cdot \pi C^2 H$$</p>
+<p>$$M = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0 \\ \Delta z_k \to 0}} \sum_i\sum_j\sum_k \rho\, r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k = \rho \iiint_{V'} r\,dr\,d\theta\,dz = \rho \cdot \pi C^2 H$$</p>
 <p><strong>④ 具体例の引き戻しを書く。</strong> 円柱座標への変換 $\Phi(r,\theta,z) = (r\cos\theta,\; r\sin\theta,\; z)$ に対して：</p>
 <p>$$\Phi^*(dx \wedge dy \wedge dz) = r\,dr \wedge d\theta \wedge dz$$</p>
 <p>これが $3$-form の引き戻しの具体例である。この $r$ が、§4.2 の $r$ をそのまま引き継いだつじつま係数である。</p>
@@ -1916,10 +1914,10 @@ $dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替�
 <p>$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(r\cos\theta,\, r\sin\theta,\, z)\; r\,dr \wedge d\theta \wedge dz$$</p>
 <p>係数 $\rho$ は座標を焼き直すだけ（$0$-form の引き戻し）で、$dx \wedge dy \wedge dz$ の部分だけが $r\,dr \wedge d\theta \wedge dz$ に変わる。</p>
 <p><strong>⑥ 一般の変換で定義する。</strong> より一般に、$3$-form $\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$ と、空間の変換 $\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$ に対して、引き戻し $\Phi^*$ は三個の方向すべてで辺ベクトルを求め、その $3 \times 3$ 行列式をとる：</p>
-<p>$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(x(u,v,w), y(u,v,w), z(u,v,w))\ \det!\begin{pmatrix}
-\Delta x_u &amp; \Delta x_v &amp; \Delta x_w \[2pt]
-\Delta y_u &amp; \Delta y_v &amp; \Delta y_w \[2pt]
-\Delta z_u &amp; \Delta z_v &amp; \Delta z_w
+<p>$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(x(u,v,w), y(u,v,w), z(u,v,w))\ \det\!\begin{pmatrix}
+\Delta x_u & \Delta x_v & \Delta x_w \\[2pt]
+\Delta y_u & \Delta y_v & \Delta y_w \\[2pt]
+\Delta z_u & \Delta z_v & \Delta z_w
 \end{pmatrix}\,du \wedge dv \wedge dw$$</p>
 <p>この $3 \times 3$ 行列式を $J(u,v,w)$ と書けば</p>
 <p>$$\Phi^*(\rho\,dx \wedge dy \wedge dz) = \rho(\Phi(u,v,w))\,J\,du \wedge dv \wedge dw$$</p>
@@ -1933,19 +1931,19 @@ $dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替�
 <h3 id="44">§4.4 引き戻しの性質 —— ここまでに確立したこと</h3>
 <p>§4.1〜§4.3 で三つの具体例を通じて引き戻しを構成してきた。ここで、これらに共通する代数的な性質を整理しておく。あわせて、§4.3 で現れた $3 \times 3$ 行列式 $J$ を <strong>ヤコビアン（ヤコビ行列式）</strong> と定義する。もととなる行列</p>
 <p>$$\begin{pmatrix}
-\frac{\partial x}{\partial u} &amp; \frac{\partial x}{\partial v} &amp; \frac{\partial x}{\partial w} \[4pt]
-\frac{\partial y}{\partial u} &amp; \frac{\partial y}{\partial v} &amp; \frac{\partial y}{\partial w} \[4pt]
-\frac{\partial z}{\partial u} &amp; \frac{\partial z}{\partial v} &amp; \frac{\partial z}{\partial w}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[4pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
 \end{pmatrix}$$</p>
 <p>を <strong>ヤコビ行列</strong> と呼び、その行列式 $\det$ がヤコビアン $J$ である。</p>
 <p><strong>① 0-form（スカラー場）の引き戻し。</strong> スカラー場 $f(x,y,z)$ を変換 $\Phi$ で引き戻すとは、単に座標をパラメータ表示に焼き直すことである：</p>
 <p>$$\Phi^*(f) = f(\Phi(u,v,w))$$</p>
 <p>たとえば §4.1 で $F(x)\,dx$ の $F(x)$ を $F(\gamma(t))$ に焼き直した操作は、$F$ という $0$-form の引き戻しにほかならない。</p>
 <p><strong>② 線形性。</strong> 二つの $k$-form $\omega, \eta$ とスカラー $a,b$ に対し</p>
-<p>$$\Phi^<em>(a\omega + b\eta) = a\,\Phi^</em>(\omega) + b\,\Phi^*(\eta)$$</p>
+<p>$$\Phi^*(a\omega + b\eta) = a\,\Phi^*(\omega) + b\,\Phi^*(\eta)$$</p>
 <p>が成り立つ。これは測定器の和や定数倍が、引き戻しの前後で整合することを保証する。</p>
 <p><strong>③ ウェッジ積との整合性。</strong> $k$-form $\omega$ と $\ell$-form $\eta$ に対し</p>
-<p>$$\Phi^<em>(\omega \wedge \eta) = \Phi^</em>(\omega) \wedge \Phi^*(\eta)$$</p>
+<p>$$\Phi^*(\omega \wedge \eta) = \Phi^*(\omega) \wedge \Phi^*(\eta)$$</p>
 <p>が成り立つ。すなわち「組み立ててから引き戻す」のと「引き戻してから組み立てる」のは同じ結果を与える。§4.2 で $dx$ と $dy$ を個別に展開してから $\wedge$ で組み立てた操作が、まさにこの性質を実行していた。</p>
 <p><strong>④ 次数ごとのつじつま係数。</strong> $k$-form の引き戻しでは、変換 $\Phi$ の $k$ 個の方向に関する辺ベクトルを並べた $k \times k$ 行列式がつじつま係数となる。本書の範囲では：</p>
 <blockquote>
@@ -1959,7 +1957,7 @@ $dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替�
 <p>次数が上がるごとに行列式のサイズが一つずつ大きくなる。この構造は $n$ 次元の一般の $k$-form でもまったく同じである。$k$-form の引き戻しとは、<strong>$k$ 個の辺ベクトルを並べた $k \times k$ 行列式で、$k$ 次元のマス目ごとのつじつま係数を測る操作</strong>にほかならない。</p>
 <blockquote>
 <p><strong>注</strong> （外微分 $d$ との可換性——第5章への伏線）これらに加えて、引き戻しと外微分 $d$ のあいだには重要な関係
-$$\Phi^<em>(d\omega) = d(\Phi^</em>\omega)$$
+$$\Phi^*(d\omega) = d(\Phi^*\omega)$$
 が成り立つ。すなわち「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は第5章で $d$ を正式に導入したのち、§5.9 で改めて取り上げる。</p>
 </blockquote>
 <p>これ以上深く立ち入ることはしない——第 10 章で多様体の言葉による一般論に触れる——が、本書の $3$ 次元での経験は、その一般論を学ぶ際の確かな足場となるだろう。</p>
@@ -1985,7 +1983,7 @@ $$\Phi^<em>(d\omega) = d(\Phi^</em>\omega)$$
 <hr />
 <p>ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 $d$</strong> を導入する。$d$ は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。</p>
 <p>\newpage</p>
-<h1 id="5-d">第5章：微分するとは何か —— 外微分 $d$：局所のズレと積分の逆</h1>
+<h1 id="5-mathblock2184placeholder">第5章：微分するとは何か —— 外微分 $d$：局所のズレと積分の逆</h1>
 <h3 id="50-ii">§5.0 第II部の扉——観測は積分、法則は微分</h3>
 <p>第3章で我々は、曲線・曲面・領域上の積分を $k$-form の言葉で定義した。曲線 $\gamma$ に沿った仕事は $\int_\gamma \omega$、曲面 $S$ を貫く流量は $\iint_S \eta$、領域 $V$ の総質量は $\iiint_V \Omega$ である。いずれも「$k$-form（はかり）を $k$-vector（図形）に食わせてスカラーを得、領域全体で集計する」という同一の原理に従っていた。</p>
 <p>ここで我々が手にした積分は、すべて<strong>領域全体にわたる</strong>量である（以下こうした量を<strong>大域的</strong>と呼ぶ）。仕事は曲線全体にわたる総和であり、流量は曲面全体を貫く総量であり、質量は領域全体での総計だ。それらは測定器の当て方と領域の選び方に依存する。</p>
@@ -2000,21 +1998,21 @@ $$\Phi^<em>(d\omega) = d(\Phi^</em>\omega)$$
 <p>この問いに答えるのが本章の主題——<strong>外微分 $d$</strong>——である。$d$ は $k$-form に作用して $(k+1)$-form を返す演算子であり、第3章で定義した積分と組み合わせることで「境界で測った大域的な積分」を「内部の局所的な変化の集積」へと翻訳する。いわば、<strong>$d$ は積分法則を微分法則に変換する装置</strong>なのである。</p>
 <p>本章の構成はこうだ。まず第1章で導入した $df$ を思い出し、それが $0$-form → $1$-form の「次元上げ」だったことを確認する（§5.1）。次に一般の $1$-form ではその逆演算が破綻することを見て（§5.2）、微小ループの解剖から $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ という「面積あたりのズレ」を発見する（§5.3）。この発見を手がかりに $d$ の定義へと至り（§5.4）、3次元への拡張（§5.5）、ストークスの定理（§5.6）へと進む。同じ論法を $2$-form にも適用し（§5.7）、$d^2=0$ の構造的意味を明らかにする（§5.8）。最後に、この $d$ がどのように物理法則を局所化するかを示し（§5.10）、次章のホッジ・スターへとつなぐ（§5.11）。</p>
 <hr />
-<h3 id="51-df">§5.1 $df$ 再訪——微分と積分は逆演算か</h3>
-<h4 id="511-df">5.1.1 $df$ は「次元上げ」をしている</h4>
+<h3 id="51-mathblock2208placeholder">§5.1 $df$ 再訪——微分と積分は逆演算か</h3>
+<h4 id="511-mathblock2209placeholder">5.1.1 $df$ は「次元上げ」をしている</h4>
 <p>第1章 §1.2 で、我々は関数 $f(x,y,z)$ の全微分を横ベクトルとして定義した：</p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} &amp; \frac{\partial f}{\partial y} &amp; \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
+<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
 <p>これは <strong>$0$-form（スカラー場 $f$）を入力として $1$-form（横ベクトル $df$）を出力する</strong>操作である。次数が 0 から 1 へ上がった。</p>
-<p>ここで思い出してほしいのは、$df(\mathbf{v})$ が変位 $\mathbf{v}$ に対する $f$ の一次変化量を返す、ということだ。$\mathbf{v} = \begin{pmatrix}\Delta x\\Delta y\\Delta z\end{pmatrix}$ が十分小さいとき：</p>
+<p>ここで思い出してほしいのは、$df(\mathbf{v})$ が変位 $\mathbf{v}$ に対する $f$ の一次変化量を返す、ということだ。$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ が十分小さいとき：</p>
 <p>$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$</p>
 <p>$df$ 単独では「変化量そのもの」ではない——第1章 §1.1.6 の契約どおり、$df$ は演算子であり、変位ベクトルに作用して初めて数値が得られる。</p>
 <h4 id="512">5.1.2 線積分すると端点の差だけが残る</h4>
 <p>この $df$ を曲線 $\gamma$ に沿って積分する。第3章 §3.3.1 の定義どおり、曲線を小区間に刻み、各ステップの変位 $\Delta\mathbf{r}_i$ に $df$ を食わせて足し上げる。</p>
-<p>各区間で $df(\Delta\mathbf{r}<em>i) \approx f(\mathbf{r}_i) - f(\mathbf{r}</em>{i-1})$ だから、全区間の和は：</p>
-<p>$$\sum_{i=1}^n df(\Delta\mathbf{r}<em>i) \approx \sum</em>{i=1}^n \bigl(f(\mathbf{r}<em>i) - f(\mathbf{r}</em>{i-1})\bigr)$$</p>
+<p>各区間で $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$ だから、全区間の和は：</p>
+<p>$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$</p>
 <p>この和を展開すると：</p>
-<p>$$\bigl(f(\mathbf{r}<em>1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}</em>{n-1})\bigr)$$</p>
-<p>隣り合う項 $f(\mathbf{r}<em>1), f(\mathbf{r}_2), \dots, f(\mathbf{r}</em>{n-1})$ がプラスとマイナスで打ち消し合う——<strong>望遠和（telescoping sum）</strong>だ。生き残るのは最初と最後だけ。刻みを無限に細かくする極限で：</p>
+<p>$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$</p>
+<p>隣り合う項 $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ がプラスとマイナスで打ち消し合う——<strong>望遠和（telescoping sum）</strong>だ。生き残るのは最初と最後だけ。刻みを無限に細かくする極限で：</p>
 <p>$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$</p>
 <p>ここで $A$ は曲線の始点、$B$ は終点である。</p>
 <blockquote>
@@ -2035,7 +2033,7 @@ $$\Phi^<em>(d\omega) = d(\Phi^</em>\omega)$$
 </blockquote>
 <hr />
 <h3 id="52">§5.2 閉ループで姿を現す「ズレ」</h3>
-<h4 id="521-1-form">5.2.1 一般の $1$-form ではどうか</h4>
+<h4 id="521-mathblock2260placeholder-form">5.2.1 一般の $1$-form ではどうか</h4>
 <p>では、一般の $1$-form</p>
 <p>$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$</p>
 <p>ではどうか。ここで $P, Q, R$ は場所ごとに変わる係数（スカラー場）であり、第3章 §3.4.1 で導入した「一般の $1$-form」である。</p>
@@ -2060,7 +2058,7 @@ $$\Phi^<em>(d\omega) = d(\Phi^</em>\omega)$$
 <p>次節で実際に、$xy$ 平面に置いた微小長方形でこの問いに答える。</p>
 <hr />
 <h3 id="53">§5.3 微小ループの解剖——ズレは面積に比例する</h3>
-<h4 id="531-xy">5.3.1 $xy$ 平面の微小長方形</h4>
+<h4 id="531-mathblock2286placeholder">5.3.1 $xy$ 平面の微小長方形</h4>
 <p>空間内の点 $(x, y, z)$ を左下の頂点とし、$xy$ 平面に平行な微小長方形を考える。$x$ 方向の幅を $\Delta x$、$y$ 方向の幅を $\Delta y$ とする。この長方形の四辺を<strong>反時計回り（右手系）</strong>に一周し、$\omega = P\,dx + Q\,dy + R\,dz$ を積分する。</p>
 <p>各辺での積分を、テイラー展開の1次近似（$\Delta x, \Delta y$ が十分小さいとして）で評価しよう。</p>
 <blockquote>
@@ -2077,9 +2075,9 @@ $$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y
 <p><strong>辺4（左辺、下向き）</strong>：$(x, y+\Delta y)$ から $(x, y)$ へ戻る。寄与は $-Q(x, y, z)\,\Delta y$。</p>
 <p>四辺の寄与を合計する：</p>
 <p>$$\begin{aligned}
-\oint \omega &amp;\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \
-&amp;= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \
-&amp;= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
+\oint \omega &\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \\
+&= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \\
+&= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
 \end{aligned}$$</p>
 <p>$P\Delta x$ と $Q\Delta y$ の項が美しく相殺し、残ったのは $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ だけだ。</p>
 <h4 id="532">5.3.2 決定的な事実</h4>
@@ -2095,12 +2093,12 @@ $$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y
 <p><strong>注</strong> （なぜ $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ だけが残るか）$\frac{\partial P}{\partial x}$ や $\frac{\partial Q}{\partial y}$ は出てこない。$P$ の $x$ 方向の変化（$\frac{\partial P}{\partial x}$）は下辺と上辺で同じ向きに効くため相殺し、$Q$ の $y$ 方向の変化（$\frac{\partial Q}{\partial y}$）も右辺と左辺で相殺する。生き残るのは「$P$ の $y$ 方向の変化」と「$Q$ の $x$ 方向の変化」——互いに<strong>直交する方向への偏微分の差</strong>だけだ。この交叉性が、次節以降のすべての鍵になる。</p>
 </blockquote>
 <hr />
-<h3 id="54-d">§5.4 $d$ の誕生——面積あたりのズレを測る新しい測定器</h3>
+<h3 id="54-mathblock2354placeholder">§5.4 $d$ の誕生——面積あたりのズレを測る新しい測定器</h3>
 <h4 id="541">5.4.1 ウェッジ積の再確認</h4>
 <p>§5.3 で得た $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ を、第2章の言葉で言い直そう。第2章 §2.4.4 で我々は、$dx \wedge dy$ という面積測定器を定義した。これは2本のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を食わせると、それらが $xy$ 平面に落とす影の符号付き面積を返す装置だった：</p>
-<p>$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) &amp; dx(\mathbf{v}_2) \ dy(\mathbf{v}_1) &amp; dy(\mathbf{v}_2) \end{pmatrix}$$</p>
+<p>$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$</p>
 <p>特に、$x$ 方向の変位 $\Delta x\,\hat{e}_x$ と $y$ 方向の変位 $\Delta y\,\hat{e}_y$ を食わせれば $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$ である。</p>
-<h4 id="542-domega">5.4.2 $d\omega$ の定義</h4>
+<h4 id="542-mathblock2364placeholder">5.4.2 $d\omega$ の定義</h4>
 <p>§5.3 の結果をこの言葉で書けば、微小長方形の二辺 $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ に対して、ある<strong>新しい $2$-form</strong> が $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ という主項を返したことになる。この $2$-form を $\omega$ の<strong>外微分</strong>と呼び、$d\omega$ と書く：</p>
 <p>$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</p>
 <p>$d\omega$ は $2$-form である——2本のベクトルを食べてスカラーを返す。その値は「食わせた2本が張る微小平行四辺形に対する、単位面積あたりの閉ループのズレ」を表す。</p>
@@ -2120,15 +2118,15 @@ $$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y
 - この比例係数を測る $2$-form を $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$ と定義する。$d$ は次数を上げる演算子。</p>
 </blockquote>
 <hr />
-<h3 id="55-1-form-3">§5.5 一般の $1$-form の外微分——3次元への拡張</h3>
-<h4 id="551-yz-zx">5.5.1 $yz$ 平面と $zx$ 平面</h4>
+<h3 id="55-mathblock2400placeholder-form-3">§5.5 一般の $1$-form の外微分——3次元への拡張</h3>
+<h4 id="551-mathblock2401placeholder-mathblock2402placeholder">5.5.1 $yz$ 平面と $zx$ 平面</h4>
 <p>§5.3–§5.4 では $xy$ 平面のループだけを考えた。しかし 3次元空間には面の向きが3種類ある。$yz$ 平面の微小長方形では同様の計算で $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$ が、$zx$ 平面では $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$ が得られる。それぞれ $dy \wedge dz$ と $dz \wedge dx$ に対応する。</p>
 <p>直感から導かれる完全な式はこうだ：</p>
 <p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</p>
 <blockquote>
 <p><strong>注</strong> （$2$-form は傾いた平行四辺形を測る）この $d\omega$ は $2$-form——<strong>2本のベクトルを食べる測定器</strong>——である。食わせる2本は、$xy$ 平面に平行とは限らない。3次元空間の中に斜めに浮かぶ微小平行四辺形の二辺 $\mathbf{v}_1, \mathbf{v}_2$ を食わせれば、その面に対する単位面積あたりの閉ループのズレを返す。§5.3 でやったのとまったく同じこと——測定する面が座標平面に平行とは限らなくなっただけだ。2本のベクトルから平行四辺形の面積（と向き）を取り出すしくみは、第2章 §2.4 で $dy \wedge dz$ 等を反対称行列として構成したときにすでに確かめてある。</p>
 </blockquote>
-<h4 id="552-ddx0">5.5.2 代数的導出——ライプニッツ則と $d(dx)=0$</h4>
+<h4 id="552-mathblock2416placeholder">5.5.2 代数的導出——ライプニッツ則と $d(dx)=0$</h4>
 <p>上記の式は、各平面で別々にループ計算をしても当然導ける。しかし、$xy$平面の例から得た直感を使って次のような計算ルールを作り上げれば機械的に導ける。やってみよう。</p>
 <blockquote>
 <p><strong>注</strong> （定義と定理——数学者のいじわる）多くの数学書では、ライプニッツ則と $d(dx)=0$ を $d$ の<strong>定義</strong>としてしまう。物理学者である筆者にはそれではわからない——我々は微小ループの解剖から出発した。これから確かめるのは、その幾何的な $d$ と代数的な計算ルールが整合することだ。ルールは計算の便宜、<strong>意味は §5.3 にある</strong>。もっとも、高次元まで見据えたときこの代数的定義の簡潔さに悔しさを覚えることも、認めないわけにはいかない。</p>
@@ -2154,21 +2152,21 @@ $$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y
 <p>$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$</p>
 <p>同様に：</p>
 <p>$$\begin{aligned}
-d(Q\,dy) &amp;= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \
-d(R\,dz) &amp;= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
+d(Q\,dy) &= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \\
+d(R\,dz) &= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
 \end{aligned}$$</p>
 <p>三つを足し合わせ、基底 $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ の順に整理する（この巡回順は次章の右手系との整合のための布石である）：</p>
 <p>$$\begin{aligned}
-d\omega &amp;= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \
-&amp;= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
+d\omega &= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \\
+&= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
 \end{aligned}$$</p>
 <p>これは §5.3 で幾何的に導いた $xy$ 成分 $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ を含み、$yz$ と $zx$ の成分も同じ交叉パターンで揃っている。</p>
 <h4 id="553">5.5.3 係数のパターン</h4>
 <p>係数の並び方に注目してほしい。$(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ は、$(P, Q, R)$ の偏微分を<strong>自分以外の軸方向に関して交叉させ、差をとった</strong>ものである。巡回的な対称性がある：</p>
 <p>$$\begin{aligned}
-dy \wedge dz &amp;\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \
-dz \wedge dx &amp;\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \
-dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
+dy \wedge dz &\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \\
+dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
 \end{aligned}$$</p>
 <blockquote>
 <p><strong>注</strong> （既習者への補助線）ベクトル解析を既習の読者には、この3つの係数の並びに見覚えがあるだろう。本書ではその名前に依存せず、まず $d$ という操作そのものを組み立てる。対応関係は後の章で整理する。</p>
@@ -2203,8 +2201,8 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 - 第3章の曲面積分と同じく、面を小さなパッチに分け、各パッチで測定器を作用させて集計している。</p>
 </blockquote>
 <hr />
-<h3 id="57-2-form">§5.7 同じことをもう一段——$2$-form の外微分と発散</h3>
-<h4 id="571-2-form">5.7.1 $2$-form は面の測定器</h4>
+<h3 id="57-mathblock2510placeholder-form">§5.7 同じことをもう一段——$2$-form の外微分と発散</h3>
+<h4 id="571-mathblock2511placeholder-form">5.7.1 $2$-form は面の測定器</h4>
 <p>第3章 §3.4.2 で、一般の $2$-form を次の形で書いた：</p>
 <p>$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$</p>
 <p>これは「面に沿って流量を測る測定器」である。第2章 §2.4.5 で見たように、3つの基底 $2$-form がそれぞれ $yz$ 平面、$zx$ 平面、$xy$ 平面への影の面積を測る。</p>
@@ -2219,7 +2217,7 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 <p>全6面の合計は：</p>
 <p>$$\iint_{\partial (\text{直方体})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$</p>
 <p>ここでも同じ構造だ——<strong>表面で測ったズレの主項は、囲んだ体積に比例する</strong>。比例係数 $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ が「単位体積あたりの湧き出し」を表す。</p>
-<h4 id="573-deta">5.7.3 $d\eta$ の定義と代数的導出</h4>
+<h4 id="573-mathblock2539placeholder">5.7.3 $d\eta$ の定義と代数的導出</h4>
 <p>直方体の三辺 $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ を食わせる $3$-form として：</p>
 <p>$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$</p>
 <p>この式は、§5.5.2 の代数的ルールからも導ける。その前に、§5.5.2 でやったのと同じく、幾何的な結果がライプニッツ則と整合することを $A\,dy \wedge dz$ の項で確かめておこう。</p>
@@ -2248,8 +2246,8 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 - $\iint_{\partial V} \eta = \iiint_V d\eta$。ストークス（$1$-form→面）とガウス（$2$-form→立体）は次数が違うだけで同じ構造。</p>
 </blockquote>
 <hr />
-<h3 id="58-d2-0">§5.8 $d^2 = 0$——二度測れば必ずゼロ</h3>
-<h4 id="581-ddf-0">5.8.1 $d(df) = 0$</h4>
+<h3 id="58-mathblock2590placeholder">§5.8 $d^2 = 0$——二度測れば必ずゼロ</h3>
+<h4 id="581-mathblock2591placeholder">5.8.1 $d(df) = 0$</h4>
 <p>§5.1 で $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ を定義した。これをさらにもう一度外微分してみる。§5.5 の公式で $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$ とすれば：</p>
 <p>$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$</p>
 <p>混合偏微分の対称性（$f$ が $C^2$ 級（2階連続微分可能）なら $\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$ など。第1章 §1.2 参照）により、すべての係数がゼロになる：</p>
@@ -2257,7 +2255,7 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 <blockquote>
 <p><strong>注</strong> （数学者へのエクスキューズ——$d^2=0$ と $C^2$ 条件）本書では「$f$ が $C^2$ 級（2階連続微分可能）なら混合偏微分が可換、ゆえに $d(df)=0$」という順序で進めた。しかし微分形式の公理的な立場では、<strong>$d^2=0$ こそが $d$ の定義の一部</strong>であり、$d(df)=0$ は定理ではなく要請である。逆に言えば、$d^2=0$ を課すことが「混合偏微分の対称性が成り立つ関数クラス（＝$C^2$ 級の関数）を相手にしている」という宣言に相当する。どちらの順序で学んでも、両者が同値な条件として噛み合うことに変わりはない。</p>
 </blockquote>
-<h4 id="582-ddomega-0">5.8.2 $d(d\omega) = 0$</h4>
+<h4 id="582-mathblock2607placeholder">5.8.2 $d(d\omega) = 0$</h4>
 <p>§5.5 の $d\omega$ に §5.7 の公式を適用する。$A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ として：</p>
 <p>$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$</p>
 <p>括弧内を展開：</p>
@@ -2282,7 +2280,7 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 <blockquote>
 <p><strong>注</strong> （3次元までで十分）本書の舞台は 3次元空間だから、$M$ の次元は1・2・3のいずれかであり、$\omega$ は $0$-form・$1$-form・$2$-form のいずれかである。$k=3$（$M$ が4次元）には立ち入らない。しかしこの式が $k$ によらず成立するという事実は、頭の片隅に置いておいて損はない。</p>
 </blockquote>
-<h4 id="592-k-form">5.9.2 一般の $k$-form の外微分</h4>
+<h4 id="592-mathblock2648placeholder-form">5.9.2 一般の $k$-form の外微分</h4>
 <p>同様に、$d$ の作用も次数によらず一つのパターンにまとまる。任意の $k$-form $\omega$ が係数 $a_{i_1\cdots i_k}$ と基底 $dx^{i_1}\wedge\cdots\wedge dx^{i_k}$ の和で書かれているとき：</p>
 <p>$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x^j}\,dx^j \Bigr) \wedge dx^{i_1}\wedge\cdots\wedge dx^{i_k}$$</p>
 <p>本書で必要なのは $k=0,1,2$ の三つの場合だけであり、それぞれ §5.1（$df$）、§5.5（$d\omega$）、§5.7（$d\eta$）で具体的に書き下した。上の一般形は「どの次数でも、係数を全微分してウェッジでつなぐ」という単一の原理に従っていることの確認にすぎない。</p>
@@ -2297,9 +2295,9 @@ dx \wedge dy &amp;\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\par
 <p>ルール4 は、座標基底 $dx,dy,dz$ 自身には位置による係数の変化がなく、微小ループで測っても局所的なズレを生まない、という幾何的事実を反映している。§5.8 の $d^2=0$ とも整合する。</p>
 <p>これら4つのルールさえあれば、$0$-form から $3$-form までの任意の形式の外微分が機械的に計算できる。実際に、本章で扱ったすべての計算はこのルールの組み合わせにすぎない。</p>
 <blockquote>
-<p><strong>注</strong> （引き戻しとの可換性——§3.5.4 の伏線回収）第3章 §3.5.4 で予告したように、引き戻し $\Phi^<em>$ と外微分 $d$ のあいだには
-$$\Phi^</em>(d\omega) = d(\Phi^<em>\omega)$$
-という可換関係が成り立つ。「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は、これまでの4ルールからは直接導けないが、$d$ が「局所的なズレを測る」操作であり、$\Phi^</em>$ が「座標を焼き直す」操作であることを思い出せば自然に納得できる——局所的なズレの構造は、座標のとり方に依存しないのだ。この事実は、第11章で一般の多様体上の微分形式を考える際の重要な足場となる。</p>
+<p><strong>注</strong> （引き戻しとの可換性——§3.5.4 の伏線回収）第3章 §3.5.4 で予告したように、引き戻し $\Phi^*$ と外微分 $d$ のあいだには
+$$\Phi^*(d\omega) = d(\Phi^*\omega)$$
+という可換関係が成り立つ。「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は、これまでの4ルールからは直接導けないが、$d$ が「局所的なズレを測る」操作であり、$\Phi^*$ が「座標を焼き直す」操作であることを思い出せば自然に納得できる——局所的なズレの構造は、座標のとり方に依存しないのだ。この事実は、第11章で一般の多様体上の微分形式を考える際の重要な足場となる。</p>
 <p><strong>【ここまでのチェックポイント】</strong>
 - $\int_{\partial M} \omega = \int_M d\omega$ 一本で、微積分学の基本定理・ストークスの定理・ガウスの定理を統合できる。
 - $d$ の計算は 4 ルール（$df$、線形性、ライプニッツ則、$d(dx)=0$）に集約される。
@@ -2360,74 +2358,74 @@ $$\Phi^</em>(d\omega) = d(\Phi^<em>\omega)$$
 <hr />
 <h2 id="c">付録C：外微分の行列表示</h2>
 <p>本章本文は基底 $dx, dy, dz$ とウェッジ積の代数で進めた。ここでは第2章以来の本書の真骨頂——<strong>成分をひとつ残らず行列に並べる</strong>——によって、外微分を行列表示の言葉で書き直す。</p>
-<h3 id="c1-0-formdf-1-times-3">C.1 $0$-form：$df$ の $1 \times 3$ 行ベクトル</h3>
+<h3 id="c1-mathblock2743placeholder-formmathblock2744placeholder-mathblock2745placeholder">C.1 $0$-form：$df$ の $1 \times 3$ 行ベクトル</h3>
 <p>$f = f(x,y,z)$ に対し、第1章 §1.2 の定義どおり：</p>
 <p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$</p>
 <p>行ベクトル（$1 \times 3$ 行列）として：</p>
-<p>$$df = \begin{pmatrix} \frac{\partial f}{\partial x} &amp; \frac{\partial f}{\partial y} &amp; \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
+<p>$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
 <p>である。</p>
-<h3 id="c2-1-form-mathbfj">C.2 $1$-form：係数のヤコビ行列 $\mathbf{J}$</h3>
+<h3 id="c2-mathblock2748placeholder-form-mathblock2749placeholder">C.2 $1$-form：係数のヤコビ行列 $\mathbf{J}$</h3>
 <p>$\omega = P\,dx + Q\,dy + R\,dz$ に対し、係数 $(P,Q,R)$ の偏微分を<strong>すべて</strong>並べた $3 \times 3$ 行列を：</p>
 <p>$$\mathbf{J} := \begin{pmatrix}
-\frac{\partial P}{\partial x} &amp; \frac{\partial P}{\partial y} &amp; \frac{\partial P}{\partial z} \
-\frac{\partial Q}{\partial x} &amp; \frac{\partial Q}{\partial y} &amp; \frac{\partial Q}{\partial z} \
-\frac{\partial R}{\partial x} &amp; \frac{\partial R}{\partial y} &amp; \frac{\partial R}{\partial z}
+\frac{\partial P}{\partial x} & \frac{\partial P}{\partial y} & \frac{\partial P}{\partial z} \\
+\frac{\partial Q}{\partial x} & \frac{\partial Q}{\partial y} & \frac{\partial Q}{\partial z} \\
+\frac{\partial R}{\partial x} & \frac{\partial R}{\partial y} & \frac{\partial R}{\partial z}
 \end{pmatrix}$$</p>
 <p>とする。これは $(P,Q,R)$ を「縦に積んだ」ベクトル場のヤコビ行列にあたる。§5.1 で「単なる偏微分の行列では足りない」と述べたのは、まさにこの $\mathbf{J}$ が反対称でないからだ。</p>
-<h3 id="c3-domega-mathbfjt-mathbfj">C.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</h3>
+<h3 id="c3-mathblock2755placeholder">C.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</h3>
 <p>§5.5 の結果は：</p>
 <p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</p>
 <p>第2章 §2.4.4 の流儀に従い、任意の縦ベクトル $\mathbf{v}_1, \mathbf{v}_2$ に対して $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$ となる反対称行列 $\mathbf{M}$ を求めよう。</p>
 <p>$\mathbf{J}^T - \mathbf{J}$ の成分を書き下す：</p>
 <p>$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
-0 &amp; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} &amp; \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \
-\frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} &amp; 0 &amp; \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \
-\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} &amp; \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} &amp; 0
+0 & \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} & \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \\
+\frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} & 0 & \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
 \end{pmatrix}$$</p>
 <p>すなわち、2章で求めた$2$-formの行列表示と照らし合わせて：</p>
 <p>$$d\omega = \mathbf{J}^T - \mathbf{J}$$</p>
 <p>となり、<strong>外微分 $d\omega$ の行列表示は、転置から係数のヤコビ行列を引いた反対称行列である。</strong></p>
-<h3 id="c4-2-formdeta">C.4 $2$-form：$d\eta$ とヤコビ行列のトレース</h3>
+<h3 id="c4-mathblock2762placeholder-formmathblock2763placeholder">C.4 $2$-form：$d\eta$ とヤコビ行列のトレース</h3>
 <p>$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$ に対し、係数 $(A,B,C)$ のヤコビ行列を：</p>
 <p>$$\mathbf{J}_\eta := \begin{pmatrix}
-\frac{\partial A}{\partial x} &amp; \frac{\partial A}{\partial y} &amp; \frac{\partial A}{\partial z} \
-\frac{\partial B}{\partial x} &amp; \frac{\partial B}{\partial y} &amp; \frac{\partial B}{\partial z} \
-\frac{\partial C}{\partial x} &amp; \frac{\partial C}{\partial y} &amp; \frac{\partial C}{\partial z}
+\frac{\partial A}{\partial x} & \frac{\partial A}{\partial y} & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial x} & \frac{\partial B}{\partial y} & \frac{\partial B}{\partial z} \\
+\frac{\partial C}{\partial x} & \frac{\partial C}{\partial y} & \frac{\partial C}{\partial z}
 \end{pmatrix}$$</p>
 <p>とすると、§5.7 の結果 $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$ の係数は $\mathbf{J}_\eta$ の<strong>トレース</strong>（対角成分の和）に一致する：</p>
 <p>$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$</p>
-<h4 id="c41-deta-273">C.4.1 $d\eta$ の27成分——3枚の行列に展開する</h4>
-<p>$\eta$ の反対称成分は $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$（他は符号反転または $0$）である。$d\eta$ の成分 $d\eta_{abc} = \frac{\partial \eta_{bc}}{\partial x^a}$ は $a,b,c \in {x,y,z}$ で $3^3=27$ 個。$a$ を固定した $3 \times 3$ 行列3枚に並べると：</p>
+<h4 id="c41-mathblock2768placeholder-273">C.4.1 $d\eta$ の27成分——3枚の行列に展開する</h4>
+<p>$\eta$ の反対称成分は $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$（他は符号反転または $0$）である。$d\eta$ の成分 $d\eta_{abc} = \frac{\partial \eta_{bc}}{\partial x^a}$ は $a,b,c \in \{x,y,z\}$ で $3^3=27$ 個。$a$ を固定した $3 \times 3$ 行列3枚に並べると：</p>
 <p>$$d\eta_{x,\cdot,\cdot} = \begin{pmatrix}
-0 &amp; \frac{\partial C}{\partial x} &amp; -\frac{\partial B}{\partial x} \
--\frac{\partial C}{\partial x} &amp; 0 &amp; \frac{\partial A}{\partial x} \
-\frac{\partial B}{\partial x} &amp; -\frac{\partial A}{\partial x} &amp; 0
+0 & \frac{\partial C}{\partial x} & -\frac{\partial B}{\partial x} \\
+-\frac{\partial C}{\partial x} & 0 & \frac{\partial A}{\partial x} \\
+\frac{\partial B}{\partial x} & -\frac{\partial A}{\partial x} & 0
 \end{pmatrix}, \quad
 d\eta_{y,\cdot,\cdot} = \begin{pmatrix}
-0 &amp; \frac{\partial C}{\partial y} &amp; -\frac{\partial B}{\partial y} \
--\frac{\partial C}{\partial y} &amp; 0 &amp; \frac{\partial A}{\partial y} \
-\frac{\partial B}{\partial y} &amp; -\frac{\partial A}{\partial y} &amp; 0
+0 & \frac{\partial C}{\partial y} & -\frac{\partial B}{\partial y} \\
+-\frac{\partial C}{\partial y} & 0 & \frac{\partial A}{\partial y} \\
+\frac{\partial B}{\partial y} & -\frac{\partial A}{\partial y} & 0
 \end{pmatrix}, \quad
 d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
-0 &amp; \frac{\partial C}{\partial z} &amp; -\frac{\partial B}{\partial z} \
--\frac{\partial C}{\partial z} &amp; 0 &amp; \frac{\partial A}{\partial z} \
-\frac{\partial B}{\partial z} &amp; -\frac{\partial A}{\partial z} &amp; 0
+0 & \frac{\partial C}{\partial z} & -\frac{\partial B}{\partial z} \\
+-\frac{\partial C}{\partial z} & 0 & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial z} & -\frac{\partial A}{\partial z} & 0
 \end{pmatrix}$$</p>
 <p>この $27$ 成分が $dx^a \wedge dx^b \wedge dx^c$ のウェッジ積と縮約するとき、添字の重複がある項（対角成分や $b=c$ 等）は $dx \wedge dx = 0$ で消え、生き残るのは $a,b,c$ がすべて異なる $6$ 項（$3!$ の順列）だけ。それぞれを符号つきで和をとると、因子 $\frac{1}{2}$ の補正も入って</p>
 <p>$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$</p>
 <p>すなわち $d\eta$ は $27$ 成分のうち $6$ 項が生き残り、ペアで足し合わさって $\mathbf{J}_\eta$ のトレースへ収束する。</p>
 <p>$3$-form は基底が $dx \wedge dy \wedge dz$ の 1 つだけなので、行列としてはスカラー係数に縮退している。</p>
-<h3 id="c5-d2-f-0">C.5 $d^2 f = 0$ とヘッセ行列</h3>
+<h3 id="c5-mathblock2792placeholder">C.5 $d^2 f = 0$ とヘッセ行列</h3>
 <p>$0$-form $f$ のヘッセ行列：</p>
 <p>$$\mathbf{H}_f := \begin{pmatrix}
-\frac{\partial^2 f}{\partial x^2} &amp; \frac{\partial^2 f}{\partial x \partial y} &amp; \frac{\partial^2 f}{\partial x \partial z} \
-\frac{\partial^2 f}{\partial y \partial x} &amp; \frac{\partial^2 f}{\partial y^2} &amp; \frac{\partial^2 f}{\partial y \partial z} \
-\frac{\partial^2 f}{\partial z \partial x} &amp; \frac{\partial^2 f}{\partial z \partial y} &amp; \frac{\partial^2 f}{\partial z^2}
+\frac{\partial^2 f}{\partial x^2} & \frac{\partial^2 f}{\partial x \partial y} & \frac{\partial^2 f}{\partial x \partial z} \\
+\frac{\partial^2 f}{\partial y \partial x} & \frac{\partial^2 f}{\partial y^2} & \frac{\partial^2 f}{\partial y \partial z} \\
+\frac{\partial^2 f}{\partial z \partial x} & \frac{\partial^2 f}{\partial z \partial y} & \frac{\partial^2 f}{\partial z^2}
 \end{pmatrix}$$</p>
 <p>は $f$ の 2 階偏導関数を並べたものだ。$f$ が $C^2$ 級なら $\mathbf{H}_f$ は対称行列（$\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$ など）である。</p>
 <p>$d(df) = 0$ は §5.5 の $d\omega$ 公式で $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ とおいたもの。$\mathbf{J} = \mathbf{H}_f$ であり、$\mathbf{H}_f$ が対称だから $\mathbf{J}^T - \mathbf{J} = 0$、したがって $d(df) = 0$。行列の言葉では「ヘッセ行列の反対称成分がゼロ」と言い換えられる。</p>
 <p>\newpage</p>
-<h1 id="6-g-ast">第6章：計量 $g$ とホッジ・スター $\ast$ — 内積の召喚と次数の反転</h1>
+<h1 id="6-mathblock2807placeholder-mathblock2808placeholder">第6章：計量 $g$ とホッジ・スター $\ast$ — 内積の召喚と次数の反転</h1>
 <h3 id="60">§6.0 言い訳の終焉——内積を解放する</h3>
 <p>第2章で球の表面積 $4\pi R^2$ を導出したとき、第3章で弧長を二乗和の平方根として測ったとき——本書ではこれまで長さや面積を計算するたびに「数学者からは計量がないと怒られるだろうが、知らん顔で押し通そう」といったエクスキューズを書き連ねてきた。</p>
 <p>読者もそろそろくどいと感じている頃だろう。正直に言えば、筆者も飽きてきた。</p>
@@ -2444,21 +2442,21 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p>結論から言えば、<strong>まったく別物</strong>だ。横ベクトル掛ける縦ベクトルは「横と縦という異種のベクトル間」の計算である。対して内積は「横と横」あるいは「縦と縦」という<strong>同種のベクトル間</strong>の計算だ。</p>
 <p>そう、事は読者が思ったよりも深遠だ。実空間という特別な舞台では、この二つがたまたま同じ数値を返すことが多いために混同されてきた——その混同の上に、ベクトル解析という巨大な体系が築かれている。本章の目標は、この区別を明確にした上で、内積の自然な一般化として計量 $g$ を導き、そこからホッジ・スター $\ast$ の正体を暴くことである。</p>
 <hr />
-<h3 id="61-g">§6.1 パラメータ空間の内積——計量 $g$ の正体</h3>
+<h3 id="61-mathblock2818placeholder">§6.1 パラメータ空間の内積——計量 $g$ の正体</h3>
 <h4 id="611">6.1.1 実空間の内積</h4>
 <p>実空間 $(x,y,z)$ における二つの縦ベクトルを成分で書こう。</p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix} x_1 \ y_1 \ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \ y_2 \ z_2 \end{pmatrix}$$</p>
+<p>$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$</p>
 <p>同じ添字の成分同士を掛けて総和をとる操作を、本書では<strong>内積</strong>（ドット積）と定義し、記号 $\cdot$ で表す。</p>
 <p>$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$</p>
 <p>$xyz$ 座標での内積は、対応する成分同士を掛けて足し合わせるだけで計算できる。</p>
 <h4 id="612">6.1.2 内積を測定器として読み直す</h4>
 <p>ここで、同じ計算を「測定器」の言葉で読み直しておこう。内積は一見すると、これまで扱ってきた測定器とは別系統の演算に見える。しかし実は、内積もまた「あるものを測定器に変え、別のものに作用させてスカラーを得る」操作として読むことができる。</p>
 <p>その入り口が転置である。$\mathbf{v}_1$ を転置すると、縦ベクトルは横ベクトルになる。</p>
-<p>$$\mathbf{v}_1^T = \begin{pmatrix} x_1 &amp; y_1 &amp; z_1 \end{pmatrix}$$</p>
+<p>$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$</p>
 <p>これは、ペアになる縦ベクトル $\mathbf{v}_2$ を食べて、「$\mathbf{v}_1$ との内積はいくらか」を測る測定器である。</p>
 <p>$$\mathbf{v}_1^T\mathbf{v}_2
-= \begin{pmatrix} x_1 &amp; y_1 &amp; z_1 \end{pmatrix}
-\begin{pmatrix} x_2 \ y_2 \ z_2 \end{pmatrix}
+= \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
 = x_1x_2 + y_1y_2 + z_1z_2$$</p>
 <p>つまり、実空間の直交デカルト座標では、縦ベクトル $\mathbf{v}_1$ を転置するだけで、そのベクトルと内積をとるための横ベクトル——測定器——が得られる。</p>
 <blockquote>
@@ -2470,43 +2468,43 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p>では、パラメータ空間の縦ベクトルを、実空間の内積を正しく測る横ベクトルに変えるには、何を挟めばよいか。</p>
 <p>第1章 §1.4 で我々は、パラメータ空間の変位を実空間の変位に変換する規則を知っている——ヤコビ行列 $J$ を掛ければよい。</p>
 <p>$$J = \begin{pmatrix}
-\frac{\partial x}{\partial r} &amp; \frac{\partial x}{\partial \theta} &amp; \frac{\partial x}{\partial z} \
-\frac{\partial y}{\partial r} &amp; \frac{\partial y}{\partial \theta} &amp; \frac{\partial y}{\partial z} \
-\frac{\partial z}{\partial r} &amp; \frac{\partial z}{\partial \theta} &amp; \frac{\partial z}{\partial z}
+\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
+\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
+\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
 \end{pmatrix}$$</p>
 <p>円柱座標の換算式 $x = r\cos\theta,\; y = r\sin\theta,\; z = z$ から偏微分を計算すれば：</p>
 <p>$$J = \begin{pmatrix}
-\cos\theta &amp; -r\sin\theta &amp; 0 \
-\sin\theta &amp; r\cos\theta &amp; 0 \
-0 &amp; 0 &amp; 1
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$</p>
 <p>パラメータ空間のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を成分で書く。</p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \ \Delta\theta_1 \ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \ \Delta\theta_2 \ \Delta z_2 \end{pmatrix}$$</p>
+<p>$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$</p>
 <p>これらを実空間へ引き戻すと、それぞれ $J\mathbf{v}_1, J\mathbf{v}_2$ になる。実空間で「$J\mathbf{v}_1$ との内積」を測る測定器は、前節の読み方では $(J\mathbf{v}_1)^T$ である。したがって、求めたい内積は次の形で書ける。</p>
 <p>$$\text{内積} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$</p>
 <p>ここで転置の規則を使うと、$(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$ だから、</p>
 <p>$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$</p>
 <p>ここで $J^T J$ を実際に計算してみよう。$J^T$ は $J$ の行と列を入れ替えたものだ。</p>
 <p>$$J^T = \begin{pmatrix}
-\cos\theta &amp; \sin\theta &amp; 0 \
--r\sin\theta &amp; r\cos\theta &amp; 0 \
-0 &amp; 0 &amp; 1
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$</p>
 <p>したがって、</p>
 <p>$$J^T J = \begin{pmatrix}
-\cos\theta &amp; \sin\theta &amp; 0 \
--r\sin\theta &amp; r\cos\theta &amp; 0 \
-0 &amp; 0 &amp; 1
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}
 \begin{pmatrix}
-\cos\theta &amp; -r\sin\theta &amp; 0 \
-\sin\theta &amp; r\cos\theta &amp; 0 \
-0 &amp; 0 &amp; 1
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}
 = \begin{pmatrix}
-1 &amp; 0 &amp; 0 \
-0 &amp; r^2 &amp; 0 \
-0 &amp; 0 &amp; 1
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$</p>
 <p>$\cos^2\theta + \sin^2\theta = 1$ という代数的恒等式がすべての幾何を代行し、対角成分に $1, r^2, 1$ が残る。$\theta$ 方向の弧の長さなど一度も考えていない——行列の積と転置の性質だけを使った、純粋に代数的な変形だ。</p>
 <p><strong>これで、新しい測定器が出てきた。</strong> パラメータ空間の縦ベクトル $\mathbf{v}_1$ から、実空間での内積を正しく測る横ベクトルを作るには、単に転置するのではなく、右側に $J^T J$ を掛ければよい。</p>
@@ -2517,29 +2515,29 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p>$xyz$ 座標では、そもそも「引き戻す」という操作を通らず、成分の積和だけで内積を計算していた。パラメータ空間に来ると、まず $J$ で実空間へ戻し、その後で成分の積和をとる。この二段階を行列の形に畳み込むと、中央に $\mathbf{g}=J^T J$ が現れる——そしてその中身は、ヤコビ行列 $J$ さえ知っていれば、偏微分と行列の積だけで機械的に求まる。新しい幾何学の公理など、どこにも入り込む余地はない。</p>
 <p>念のため、具体的な数値で確認しておこう。$r=2,\; \theta=\pi/3$ の地点を考える。このとき $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$ だから、</p>
 <p>$$J = \begin{pmatrix}
-1/2 &amp; -\sqrt{3} &amp; 0 \
-\sqrt{3}/2 &amp; 1 &amp; 0 \
-0 &amp; 0 &amp; 1
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$</p>
-<p>パラメータ空間で $\mathbf{v} = \begin{pmatrix}0 \ 1 \ 0\end{pmatrix}$ という $\theta$ 方向の単位変位を考える。$\mathbf{g} = \begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; r^2 &amp; 0 \ 0 &amp; 0 &amp; 1 \end{pmatrix}$ であり、いま $r=2$ だから $\mathbf{g} = \begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; 4 &amp; 0 \ 0 &amp; 0 &amp; 1 \end{pmatrix}$。パラメータ空間で内積（長さの二乗）を計算すると：</p>
-<p>$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 &amp; 1 &amp; 0 \end{pmatrix}
-\begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; 4 &amp; 0 \ 0 &amp; 0 &amp; 1 \end{pmatrix}
-\begin{pmatrix} 0 \ 1 \ 0 \end{pmatrix} = 4$$</p>
+<p>パラメータ空間で $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ という $\theta$ 方向の単位変位を考える。$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$ であり、いま $r=2$ だから $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$。パラメータ空間で内積（長さの二乗）を計算すると：</p>
+<p>$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$</p>
 <p>一方、同じ $\mathbf{v}$ を実空間に引き戻すと：</p>
 <p>$$J\mathbf{v} = \begin{pmatrix}
-1/2 &amp; -\sqrt{3} &amp; 0 \
-\sqrt{3}/2 &amp; 1 &amp; 0 \
-0 &amp; 0 &amp; 1
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
 \end{pmatrix}
-\begin{pmatrix} 0 \ 1 \ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \ 1 \ 0 \end{pmatrix}$$</p>
-<p>実空間での内積（長さの二乗）は $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$。確かに一致している。$\mathbf{v} = \begin{pmatrix}1 \ 0 \ 0\end{pmatrix}$（$r$ 方向の単位変位）でも同様に、$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$、$(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ で一致する。$\mathbf{g} = J^T J$ はこうして、パラメータ空間と実空間の内積を矛盾なく繫いでいる。</p>
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$</p>
+<p>実空間での内積（長さの二乗）は $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$。確かに一致している。$\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$（$r$ 方向の単位変位）でも同様に、$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$、$(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ で一致する。$\mathbf{g} = J^T J$ はこうして、パラメータ空間と実空間の内積を矛盾なく繫いでいる。</p>
 <p>なお、ここでは円柱座標 $(r,\theta,z)$ で計算したが、球座標 $(r,\theta,\phi)$ の場合も同様に $J$ から $\mathbf{g}$ が求まる。</p>
-<p>$$\mathbf{g}_{\text{球座標}} = \begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; r^2 &amp; 0 \ 0 &amp; 0 &amp; r^2\sin^2\theta \end{pmatrix}$$</p>
+<p>$$\mathbf{g}_{\text{球座標}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$</p>
 <p>対角成分に $r^2$ と $r^2\sin^2\theta$ が現れるが、これらもすべて連鎖律だけから機械的に導かれる換算係数である。</p>
 <p>この $g$ を仲立ちにすることで、どの座標系でも一貫して内積（長さ・角度）を計算できる。また、後半で扱うホッジ・スター $\ast$ の仕様も、この内積のルールから自然に読み解ける。</p>
 <hr />
-<h3 id="62-g">§6.2 $g$ による縦ベクトルと横ベクトルの変換</h3>
-<h4 id="621-mathbfvt-mathbfg">6.2.1 $\mathbf{v}^T \mathbf{g}$ は横ベクトルである</h4>
+<h3 id="62-mathblock2878placeholder">§6.2 $g$ による縦ベクトルと横ベクトルの変換</h3>
+<h4 id="621-mathblock2879placeholder">6.2.1 $\mathbf{v}^T \mathbf{g}$ は横ベクトルである</h4>
 <p>§6.1 で導いた内積の式 $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ を、もう一度見てみよう。行列の積は左から順に実行できるから、この式は「まず $\mathbf{v}_1^T \mathbf{g}$ を計算し、その結果に $\mathbf{v}_2$ を掛ける」と読むことができる。</p>
 <p>$\mathbf{v}_1$ は縦ベクトルだが、転置された $\mathbf{v}_1^T$ は横ベクトルだ。横ベクトルに正方行列を掛けると、結果は再び横ベクトルになる。つまり、$\mathbf{v}_1^T \mathbf{g}$ という部分だけを取り出せば、</p>
 <p>$$\omega = \mathbf{v}^T \mathbf{g}$$</p>
@@ -2548,9 +2546,9 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p><strong>注</strong> （第2章で密輸していたもの）第2章で $2$-form の行列表現を探したとき、我々はすでに $\mathbf{v}_1^T M \mathbf{v}_2$ という形を使っていた。あのときは「縦ベクトルを横に寝かせる操作は数学的には行儀が悪い」とだけ断って、深入りせずに押し通した。いま見ている $\mathbf{v}^T\mathbf{g}$ は、そのとき密輸していた操作の正体である。実空間では $\mathbf{g}=I$ なので、転置だけで縦ベクトルが横ベクトルに見えてしまう。しかしパラメータ空間では、実空間の内積を再現するように縦ベクトルを測定器としての横ベクトルへ変えるには、計量 $\mathbf{g}$ を明示的に通す必要がある。</p>
 </blockquote>
 <p>この変換の意味を考えよう。第1章以来、我々は「測られる図形（縦ベクトル $\mathbf{v}$）」と「測る装置（横ベクトル $\omega$）」を区別してきた。両者は異なる世界の住人だった。しかし $g$ を経由することで、図形の側にいた縦ベクトルが、はかりの側——横ベクトル——へと姿を変える。同じ矢印でも、場所によって「はかりとしての感度」が変わるのは、$\mathbf{g}$ がその場所ごとの目盛りの違いをすべて吸収してくれるからだ。</p>
-<p>実空間（$\mathbf{g}=I$）では $\omega = \mathbf{v}^T$ であり、縦ベクトルの成分がそのまま横ベクトルの成分になる。パラメータ空間では $\mathbf{g} = \begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; r^2 &amp; 0 \ 0 &amp; 0 &amp; 1 \end{pmatrix}$ なので、$\omega = \begin{pmatrix} \Delta r &amp; r^2\Delta\theta &amp; \Delta z \end{pmatrix}$。$\theta$ 成分だけ $r^2$ 倍されるのは、$\theta$ 方向の目盛りが $r$ 倍に伸びていることの反映だ。</p>
+<p>実空間（$\mathbf{g}=I$）では $\omega = \mathbf{v}^T$ であり、縦ベクトルの成分がそのまま横ベクトルの成分になる。パラメータ空間では $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$ なので、$\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$。$\theta$ 成分だけ $r^2$ 倍されるのは、$\theta$ 方向の目盛りが $r$ 倍に伸びていることの反映だ。</p>
 <p>$g$ がなければ、「測られる図形」と「測る装置」は互いに変換不能である。$g$ は両者を繫ぐ唯一の仲介者なのだ。</p>
-<h4 id="622-k">6.2.2 計量が与えるもの——平行 $k$ 面体の幾何学的な大きさ</h4>
+<h4 id="622-mathblock2907placeholder">6.2.2 計量が与えるもの——平行 $k$ 面体の幾何学的な大きさ</h4>
 <p>計量 $g$ の最も基本的な役割は、$k$ 本のベクトルが貼る<strong>平行 $k$ 面体の実際の幾何学的な大きさ</strong>（長さ・面積・体積）を定義することである。</p>
 <p>本書のこれまでの章では、$k$-form に $k$ 本のベクトルを食わせることで「向き付きの数え上げ」を行ってきた。$dx(\mathbf{v})$ は $\mathbf{v}$ の $x$ 成分という数、$dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ は $\mathbf{v}_1, \mathbf{v}_2$ が張る平行四辺形の向き付き面積という数である。しかしこれらはあくまで影の測量であり、ベクトルたちが実際に何メートルの線分を張り、何平方メートルの平行四辺形を張っているか——<strong>幾何学的な本当の大きさ</strong>——は、計量 $g$ が与えられて初めて決まる。</p>
 <p>$k=1$（1本のベクトル $\mathbf{v}$ が張る線分）の場合、その長さの二乗は自分自身との内積で定義される。これは §6.1 ですでに導いた通りだ。</p>
@@ -2572,7 +2570,7 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p><strong>線形性</strong>（双線形性）：$(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$。各引数について線形。これは $(a\mathbf{v}_1 + b\mathbf{v}_2)^T \mathbf{g} \,\mathbf{v}_3 = a\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_3 + b\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_3$ という、行列の積の分配法則そのものである。</p>
 </li>
 <li>
-<p><strong>正定値性</strong>：$\mathbf{v} \cdot \mathbf{v} &gt; 0$（$\mathbf{v} \neq \mathbf{0}$）。「長さの二乗」が正であることを保証する。特殊相対論のように符号が混ざる場合はこの限りではないが、本書の舞台である3次元実空間ではつねに成り立つ。</p>
+<p><strong>正定値性</strong>：$\mathbf{v} \cdot \mathbf{v} > 0$（$\mathbf{v} \neq \mathbf{0}$）。「長さの二乗」が正であることを保証する。特殊相対論のように符号が混ざる場合はこの限りではないが、本書の舞台である3次元実空間ではつねに成り立つ。</p>
 </li>
 </ol>
 <blockquote>
@@ -2592,7 +2590,7 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 - 内積の性質（対称性・線形性・正定値性）から $g$ の対称性が導かれる。これは面積測定器 $\wedge$ の反対称性と対をなす。</p>
 </blockquote>
 <hr />
-<h3 id="63-ast">§6.3 ホッジ・スター $\ast$ ——二つの方法を繫ぐ対応</h3>
+<h3 id="63-mathblock2978placeholder">§6.3 ホッジ・スター $\ast$ ——二つの方法を繫ぐ対応</h3>
 <h4 id="631">6.3.1 スカラーを得る二つの方法</h4>
 <p>ここまでで $g = J^T J$ の正体が明らかになり、内積をどの座標系でも計算できるようになった。ここで、より大きな構図を見ておこう。</p>
 <p>物理の式を眺めると、スカラー量を作るやり方が一つではないことに気づく。ある場を線や面に沿って積分するときは、「測るもの」が「測られるもの」に作用して数を返す、という書き方が自然に現れる。一方で、仕事率やエネルギー密度のような量は、しばしば $\mathbf{E}\cdot\mathbf{J}$ や $\mathbf{A}\cdot(\nabla\times\mathbf{A})$ のように、同じ種類の矢印同士の内積として書かれる。</p>
@@ -2613,31 +2611,31 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 <p><strong>注</strong> （二つの方法のあいだで）方法①と方法②のどちらか一方だけを使う必要はない。筆者の理想は、両方を自由に行き来できることだ。本書が方法①（微分形式）から出発したのは、空間の歪みに依存しない強固な土台を築くためである。その上で、必要に応じて方法②の言葉でも同じ量を読めるようにする——その橋渡しをするのが $\ast$ だ。</p>
 <p><strong>注</strong> （ベクトル解析を知っている読者へ）通常のベクトル解析で面の向きや外積として扱われる操作の多くは、この $\ast$ が与える対応として読み直せる。ただし本章では、それらを既知の公式として使うのではなく、$g$ と第2章の基底 $2$-form から作り直す。</p>
 </blockquote>
-<h4 id="632-ast">6.3.2 行列から $\ast$ を構成する</h4>
+<h4 id="632-mathblock3010placeholder">6.3.2 行列から $\ast$ を構成する</h4>
 <p>付録Aで、我々は $2$-form を行列表示する方法を学んだ。$dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ という $3$ つの基底 $2$-form は、それぞれ $3 \times 3$ の反対称行列で表現できるのだった。</p>
-<p>さて、ここで素朴な問いを立てよう。任意の $1$-form $\omega = P\,dx + Q\,dy + R\,dz$ は、本書の流儀により係数の横ベクトル $\begin{pmatrix} P &amp; Q &amp; R \end{pmatrix}$ として書ける。この横ベクトルの各成分を、対応する基底 $2$-form の行列の係数として分配する——つまり、$P$ を $dy \wedge dz$ の行列に、$Q$ を $dz \wedge dx$ の行列に、$R$ を $dx \wedge dy$ の行列に掛けて足し合わせる——操作を考えよう。</p>
+<p>さて、ここで素朴な問いを立てよう。任意の $1$-form $\omega = P\,dx + Q\,dy + R\,dz$ は、本書の流儀により係数の横ベクトル $\begin{pmatrix} P & Q & R \end{pmatrix}$ として書ける。この横ベクトルの各成分を、対応する基底 $2$-form の行列の係数として分配する——つまり、$P$ を $dy \wedge dz$ の行列に、$Q$ を $dz \wedge dx$ の行列に、$R$ を $dx \wedge dy$ の行列に掛けて足し合わせる——操作を考えよう。</p>
 <p>行列で書けば、</p>
 <p>$$
 \ast\omega
 = P
 \begin{pmatrix}
-0 &amp; 0 &amp; 0 \
-0 &amp; 0 &amp; 1 \
-0 &amp; -1 &amp; 0
+0 & 0 & 0 \\
+0 & 0 & 1 \\
+0 & -1 & 0
 \end{pmatrix}
 +
 Q
 \begin{pmatrix}
-0 &amp; 0 &amp; -1 \
-0 &amp; 0 &amp; 0 \
-1 &amp; 0 &amp; 0
+0 & 0 & -1 \\
+0 & 0 & 0 \\
+1 & 0 & 0
 \end{pmatrix}
 +
 R
 \begin{pmatrix}
-0 &amp; 1 &amp; 0 \
--1 &amp; 0 &amp; 0 \
-0 &amp; 0 &amp; 0
+0 & 1 & 0 \\
+-1 & 0 & 0 \\
+0 & 0 & 0
 \end{pmatrix}
 $$</p>
 <p>これは、横ベクトルの成分を3枚の反対称行列へそのまま分配する、単純な線形結合に他ならない。これを $\ast$ という記号で書こう。</p>
@@ -2645,29 +2643,29 @@ $$</p>
 <p>$$
 \ast\omega =
 \begin{pmatrix}
-0 &amp; R &amp; -Q \
--R &amp; 0 &amp; P \
-Q &amp; -P &amp; 0
+0 & R & -Q \\
+-R & 0 & P \\
+Q & -P & 0
 \end{pmatrix}
 $$</p>
 <p>この $3 \times 3$ の反対称行列が、$\ast\omega$ の行列表現である。元の $1$-form の係数 $P, Q, R$ が、行列の決まった位置にそのまま収まっている。第2章 §2.4.9 で見たクロス積の成分と同じ並びがここにも現れている。</p>
 <blockquote>
 <p><strong>注</strong> （$\ast$ の幾何学的意味）$\ast\omega$ が表す $2$-form は、$\omega$ の係数ベクトル $(P, Q, R)$ に直交する平面を測る面積測定器である。$x$ 軸方向の線分（$dx$）に対応するのは $x$ 軸に垂直な面（$dy \wedge dz$）。ベクトル解析で $3$ 成分の矢印として扱われる量は、本書の言葉ではこの面積測定器の情報を読み替えたものだ。</p>
 </blockquote>
-<h4 id="633-ast">6.3.3 実空間での $\ast$ 辞書</h4>
+<h4 id="633-mathblock3043placeholder">6.3.3 実空間での $\ast$ 辞書</h4>
 <p>§6.3.2 で行ったのは、$1$-form の係数を $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ という三つの面積測定器へ分配することだった。同じ手順を基底 $1$-form に対して繰り返す。すなわち、$dx$ なら第1成分だけを、$dy$ なら第2成分だけを、$dz$ なら第3成分だけを取り出せばよい。</p>
 <p>成分をすべて追いたい読者は付録Dの行列表示を確認してほしい。ここでは結果だけを $dx,dy,dz$ の言葉で書けば、次の簡潔な辞書になる。</p>
 <p>$$\begin{aligned}
-\ast(1) &amp;= dx \wedge dy \wedge dz, \qquad &amp;\ast(dx \wedge dy \wedge dz) &amp;= 1 \
-\ast(dx) &amp;= dy \wedge dz, \qquad &amp;\ast(dy \wedge dz) &amp;= dx \
-\ast(dy) &amp;= dz \wedge dx, \qquad &amp;\ast(dz \wedge dx) &amp;= dy \
-\ast(dz) &amp;= dx \wedge dy, \qquad &amp;\ast(dx \wedge dy) &amp;= dz
+\ast(1) &= dx \wedge dy \wedge dz, \qquad &\ast(dx \wedge dy \wedge dz) &= 1 \\
+\ast(dx) &= dy \wedge dz, \qquad &\ast(dy \wedge dz) &= dx \\
+\ast(dy) &= dz \wedge dx, \qquad &\ast(dz \wedge dx) &= dy \\
+\ast(dz) &= dx \wedge dy, \qquad &\ast(dx \wedge dy) &= dz
 \end{aligned}$$</p>
 <p>この辞書の意味するところは単純だ。$x$ 軸方向の線分（$dx$）に対応するのは、$x$ 軸に垂直な面（$dy \wedge dz$）である。同様に $y \leftrightarrow dz \wedge dx$、$z \leftrightarrow dx \wedge dy$。そしてスカラー $1$（$0$-form）と体積要素 $dx \wedge dy \wedge dz$（$3$-form）が互いに対応する。これがまさに、第2章で見た独立成分数 $1, 3, 3, 1$ の対称性の現れである。</p>
 <blockquote>
 <p><strong>注</strong> （なぜこの辞書でよいのか）$\ast dx = dy \wedge dz$ となるのは、$dx,dy,dz$ が正規直交基底（互いに直交し、長さ $1$）であり、かつ空間の向きを $dx \wedge dy \wedge dz$ が正となる右手系にとっているからだ。この条件のもとでは、上の辞書が一意的に定まる。パラメータ空間まで考慮すると、$\ast$ の辞書は計量 $g$ と空間の向きの選び方に依存する——言い換えると、$g$ が $I$ でなければ、辞書の係数はもっと複雑になる。</p>
 </blockquote>
-<h4 id="634-astast-mathrmid">6.3.4 $\ast\ast = \mathrm{id}$</h4>
+<h4 id="634-mathblock3072placeholder">6.3.4 $\ast\ast = \mathrm{id}$</h4>
 <p>上の辞書から直ちにわかるように、$\ast$ を二度続けて作用させると元に戻る：</p>
 <p>$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx$$</p>
 <p>一般に、3次元デカルト実空間では $\ast\ast = \mathrm{id}$（恒等演算子）が成り立つ。$\ast$ を $1$ 回適用すれば形式の次数が反転し、$2$ 回適用すれば元に戻る。</p>
@@ -2678,7 +2676,7 @@ $$</p>
 - ホッジ・スター $\ast$ は、$1$-form の係数をそのまま $2$-form の基底行列に分配する演算として構成できる。行列表現は外積行列に一致する。
 - 実空間での $\ast$ 辞書：$\ast dx = dy \wedge dz$ など。$\ast\ast = \mathrm{id}$。</p>
 </blockquote>
-<h4 id="635-ast">6.3.5 $\ast$ の性質</h4>
+<h4 id="635-mathblock3088placeholder">6.3.5 $\ast$ の性質</h4>
 <p>§6.2.3 で内積の性質を、第5章で外微分 $d$ の性質をまとめたのに倣い、$\ast$ についてもここまでの構成から浮かび上がる性質を整理しておく。</p>
 <ol>
 <li>
@@ -2697,7 +2695,7 @@ $$</p>
 <p>これらの性質は、$\ast$ が単なる「辞書」ではなく、計量と向きを備えた空間における<strong>次数の折り返し構造</strong>そのものであることを示している。</p>
 <hr />
 <h3 id="64">§6.4 対応の実例——微分形式とベクトル解析</h3>
-<h4 id="641-pvi">6.4.1 ジュール熱 $P=VI$ ——二つの経路</h4>
+<h4 id="641-mathblock3109placeholder">6.4.1 ジュール熱 $P=VI$ ——二つの経路</h4>
 <p>$\ast$ が具体的にどのように微分形式と同種ベクトルの内積表示を繫いでいるか、実際の計算で確かめよう。</p>
 <blockquote>
 <p><strong>注</strong> （電磁気学を知らなくてよい）ここから先、説明のために電磁気学の用語を天下り的に使う。まだ物理を学んでいない読者や、ベクトル解析で電磁気学を学んだ読者も、数式の意味を完全に理解する必要はない。$\ast$ が計算の構造の中でどう働くかを見てほしい。</p>
@@ -2718,7 +2716,7 @@ $$</p>
 <p>$$\ast(E \wedge J)$$</p>
 <p>カッコの中身 $E \wedge J$ は、方法①で得た $3$-form と全く同じものだ。外側の $\ast$ は、$3$-form から体積要素 $dx \wedge dy \wedge dz$ を剥ぎ取り、スカラー値を取り出している。スカラー $E \cdot J$ に微小体積 $dV$ を掛け直して積分する書き方は、この $3$-form が持っていた体積要素を後から補っている、と読める。</p>
 <p><strong>つまり、$\ast$ は方法①の $3$-form と方法②のスカラー表示を矛盾なく繫いでいる。</strong> $\ast\ast = \mathrm{id}$ があるからこそ、どちらの経路を通っても同じ結果に至るのだ。</p>
-<h4 id="642-a-cdot-nabla-times-a-ast">6.4.2 ヘリシティ $A \cdot (\nabla \times A)$ ——$\ast$ の往復</h4>
+<h4 id="642-mathblock3155placeholder-mathblock3156placeholder">6.4.2 ヘリシティ $A \cdot (\nabla \times A)$ ——$\ast$ の往復</h4>
 <p>もう一つの例で、$\ast$ の働きをさらに見てみよう。$1$-form $\alpha$ と、その外微分 $d\alpha$ を組み合わせた次の $3$-form を考える：</p>
 <p>$$\alpha \wedge d\alpha$$</p>
 <p>この形は、方法②の言葉で書けば、ベクトル場 $\mathbf{A}$ とその回転の内積として現れる。</p>
@@ -2749,13 +2747,13 @@ $$</p>
 <p><strong>注</strong> （ベクトル解析を知っている読者へ）ここで定義する grad, rot, div は、ベクトル解析で $\nabla f,\; \nabla \times \mathbf{F},\; \nabla \cdot \mathbf{F}$ と書かれるものと同一である。ベクトル解析をまだ学んでいない読者は、単に $d$ と $\ast$ の組み合わせとして理解すれば十分だ。</p>
 </blockquote>
 <p>以降、ベクトル場 $\mathbf{F} = (F_x, F_y, F_z)$ に対応する $1$-form を $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ と書く。</p>
-<h4 id="651-mathrmgradf-df">6.5.1 勾配 $\mathrm{grad}\,f = df$</h4>
+<h4 id="651-mathblock3225placeholder">6.5.1 勾配 $\mathrm{grad}\,f = df$</h4>
 <p>これはすでに知っている。$0$-form（スカラー場）$f$ の外微分 $df$ は $1$-form であり、その係数は偏微分係数である：</p>
 <p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$</p>
 <p>この横ベクトルの成分 $(\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ を<strong>勾配</strong>と呼び、$\mathrm{grad}\,f$ と書く。</p>
 <p>$$\mathrm{grad}\,f = df$$</p>
 <p>$d$ は次数を $0 \to 1$ に上げる。これが勾配の正体である。勾配では、$0$-form から $1$-form への外微分だけが現れる。</p>
-<h4 id="652-mathrmrotmathbff-astdomega">6.5.2 回転 $\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$</h4>
+<h4 id="652-mathblock3236placeholder">6.5.2 回転 $\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$</h4>
 <p>$1$-form $\omega$ に $d$ を作用させると $2$-form $d\omega$ が得られる。その係数は第5章で導いたとおり：</p>
 <p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</p>
 <p>ここに $\ast$ を作用させると、$2$-form が $1$-form に変換される。§6.3.3 の辞書を使えば：</p>
@@ -2763,7 +2761,7 @@ $$</p>
 <p>この $1$-form の係数 $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ を<strong>回転</strong>と呼び、$\mathrm{rot}\,\mathbf{F}$ と書く。</p>
 <p>$$\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$$</p>
 <p>$\ast\,d$ は $1$-form $\to$ $2$-form $\to$ $1$-form という、次数を上げてから下げる操作である。この「上げて下げる」が、まさに回転の代数構造だ。</p>
-<h4 id="653-mathrmdivmathbff-astdastomega">6.5.3 発散 $\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$</h4>
+<h4 id="653-mathblock3254placeholder">6.5.3 発散 $\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$</h4>
 <p>さらに $\ast\,d\,\ast$ と三つの演算子を連ねる。まず $\ast\,\omega$ で $1$-form を $2$-form に変換し、$d$ で $3$-form に上げ、最後に $\ast$ で $0$-form（スカラー場）に落とす：</p>
 <p>$$\ast(d(\ast\omega)) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</p>
 <p>このスカラー場を<strong>発散</strong>と呼び、$\mathrm{div}\,\mathbf{F}$ と書く。</p>
@@ -2772,7 +2770,7 @@ $$</p>
 <blockquote>
 <p><strong>注</strong> （ベクトル解析を知っている読者へ）円柱座標や球座標での rot や div の公式が長くなる理由は、ここで明らかになったはずだ。rot は $\ast$ を $1$ 回、div は $\ast$ を $2$ 回使っている。$\ast$ の辞書は計量 $g$ に依存し、$g$ は $g = J^T J$ という場所の関数である。公式の複雑さは、裏で $\ast$ と $g$ が繰り返し適用されていることの結果に過ぎない。</p>
 </blockquote>
-<h4 id="654-d2-0">6.5.4 $d^2 = 0$ の当然の帰結</h4>
+<h4 id="654-mathblock3282placeholder">6.5.4 $d^2 = 0$ の当然の帰結</h4>
 <p>第5章で学んだ $d^2 = 0$ を思い出そう。この一つの事実から、二つの恒等式が自動的に導かれる。</p>
 <p>$\mathrm{rot}(\mathrm{grad}\,f) = 0$ は、$\ast\,d\,(df) = \ast\,(d^2 f) = 0$ に他ならない。</p>
 <p>$\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$ も同様に、$\ast\,d\,\ast(\ast\,d\,\omega) = \ast\,d\,(d\,\omega) = \ast\,(d^2 \omega) = 0$ である。</p>
@@ -2816,7 +2814,7 @@ $$</p>
 </blockquote>
 <p>第III部では、この視点をさらに推し進める。第8章では第5章で得たストークスの定理 $\int_{\partial M} \omega = \int_M d\omega$ を、$\ast$ の辞書を通じて再考し、微積分学の基本定理・ケルビン–ストークスの定理・ガウスの発散定理がこの一本に集約されることを確認する。第9章では、円柱座標や球座標といったパラメータ空間での $\ast$ の辞書を具体的に構成し、実戦的な計算の道具立てを整える。</p>
 <blockquote>
-<p><strong>注</strong> （計量の符号を一つ変えるだけで）本章では正定値計量（$\mathbf{v}^T \mathbf{g} \,\mathbf{v} &gt; 0$ for $\mathbf{v} \neq 0$）を前提とした。しかし特殊相対性理論の舞台である $4$ 次元時空では、時間成分だけ符号が反転した $\mathbf{g} = \begin{pmatrix} -1 &amp; 0 &amp; 0 &amp; 0 \ 0 &amp; 1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 &amp; 0 \ 0 &amp; 0 &amp; 0 &amp; 1 \end{pmatrix}$ のような不定計量が登場する。本書は $3$ 次元デカルト実空間に固定しているためこれ以上踏み込まないが、本章で学んだ「行列 $\mathbf{g}$ を挟む」という発想は、そのまま $4$ 次元時空へと拡張可能である。必要になったとき、読者はこの章に立ち返ってほしい。</p>
+<p><strong>注</strong> （計量の符号を一つ変えるだけで）本章では正定値計量（$\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$）を前提とした。しかし特殊相対性理論の舞台である $4$ 次元時空では、時間成分だけ符号が反転した $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$ のような不定計量が登場する。本書は $3$ 次元デカルト実空間に固定しているためこれ以上踏み込まないが、本章で学んだ「行列 $\mathbf{g}$ を挟む」という発想は、そのまま $4$ 次元時空へと拡張可能である。必要になったとき、読者はこの章に立ち返ってほしい。</p>
 </blockquote>
 <hr />
 <blockquote>
@@ -2843,66 +2841,66 @@ $$</p>
 <p><strong>注</strong> （係数 $1/2$ について）フロベニウス積には $\operatorname{tr}(A^T B)$（$1/2$ なし）を採用する流儀もある。しかし反対称行列では $M_{23}$ と $M_{32} = -M_{23}$ のようなペア成分の両方を拾ってしまい、内積が $2$ 倍される。本書では $1/2$ を定義に織り込む。これにより、$2$-form $M$ の自分自身との内積 $M \cdot M = M_{23}^2 + M_{31}^2 + M_{12}^2$ がそのまま §6.2.2 の「平行四辺形の符号なし面積の二乗」に一致する。</p>
 <p><strong>注</strong> （抽象化の引力）§6.2.3 で「数学者はすぐに抽象化したがる」とぼやいたが、こうして実際に手を動かしてみると彼らの言い分も分からなくもない。縦ベクトルの内積には $\mathbf{v}_1^T \mathbf{v}_2$ を、行列の内積には $\frac{1}{2}\operatorname{tr}(A^T B)$ を——表示が変わるたびに内積を一から定義し直すのは、考えてみれば相当に大変だ。これらをまとめて「内積とは、ある公理を満たす演算である」と一言で済ませたい欲求に飲まれそうな自分に気付く。それでも本書は最後まで表示を明示する方針を崩さない。ここまで来ると意地である。</p>
 </blockquote>
-<h3 id="d2-ast_1to2">D.2 $\ast_{1\to2}$ ——行列の縦ベクトル</h3>
+<h3 id="d2-mathblock3366placeholder">D.2 $\ast_{1\to2}$ ——行列の縦ベクトル</h3>
 <p>基底 $2$-form に対応する3枚の反対称行列を $E_1, E_2, E_3$ と名付ける。添字 $1,2,3$ は $dx,dy,dz$ の順である。</p>
 <p>$$
 E_1 = \begin{pmatrix}
-0 &amp; 0 &amp; 0 \
-0 &amp; 0 &amp; 1 \
-0 &amp; -1 &amp; 0
+0 & 0 & 0 \\
+0 & 0 & 1 \\
+0 & -1 & 0
 \end{pmatrix},\quad
 E_2 = \begin{pmatrix}
-0 &amp; 0 &amp; -1 \
-0 &amp; 0 &amp; 0 \
-1 &amp; 0 &amp; 0
+0 & 0 & -1 \\
+0 & 0 & 0 \\
+1 & 0 & 0
 \end{pmatrix},\quad
 E_3 = \begin{pmatrix}
-0 &amp; 1 &amp; 0 \
--1 &amp; 0 &amp; 0 \
-0 &amp; 0 &amp; 0
+0 & 1 & 0 \\
+-1 & 0 & 0 \\
+0 & 0 & 0
 \end{pmatrix}
 $$</p>
 <p>この3枚の行列を縦に積み上げる。</p>
 <p>$$
 \ast_{1\to2} = \begin{pmatrix}
-\begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix} \[1em]
-\begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix} \[1em]
-\begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}
+\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} \\[1em]
+\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} \\[1em]
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
 $$</p>
-<p>$\ast_{1\to2}$ は<strong>行列の縦ベクトル</strong>である。$1$-form $\omega = \begin{pmatrix} P &amp; Q &amp; R \end{pmatrix}$（横ベクトル）を左から掛ければ、第 $k$ 成分が $E_k$ を係数倍した線形結合となって $3\times 3$ 行列が得られる。</p>
+<p>$\ast_{1\to2}$ は<strong>行列の縦ベクトル</strong>である。$1$-form $\omega = \begin{pmatrix} P & Q & R \end{pmatrix}$（横ベクトル）を左から掛ければ、第 $k$ 成分が $E_k$ を係数倍した線形結合となって $3\times 3$ 行列が得られる。</p>
 <p>$$
 \ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}
 = P E_1 + Q E_2 + R E_3
 = \begin{pmatrix}
-0 &amp; R &amp; -Q \
--R &amp; 0 &amp; P \
-Q &amp; -P &amp; 0
+0 & R & -Q \\
+-R & 0 & P \\
+Q & -P & 0
 \end{pmatrix}
 $$</p>
 <blockquote>
 <p><strong>注</strong> （第2章の $\widehat{\epsilon}$ との関係）この $E_1, E_2, E_3$ は、付録Aで $\epsilon_{1,\cdot,\cdot}, \epsilon_{2,\cdot,\cdot}, \epsilon_{3,\cdot,\cdot}$ として書き下した行列と同一である。$\ast_{1\to2}$ の本質は、エディントンのイプシロン $\epsilon_{ijk}$ の第一添字を縦ベクトルの成分方向に、残りの二添字を $3\times 3$ 行列の方向に配置したものだ。第2章で体積測定器 $\widehat{\epsilon}$ として導入したあの3枚組が、ここでホッジ・スターとして再登場している。</p>
 </blockquote>
-<h3 id="d3-ast_2to1">D.3 $\ast_{2\to1}$ ——フロベニウス積による係数抽出</h3>
+<h3 id="d3-mathblock3384placeholder">D.3 $\ast_{2\to1}$ ——フロベニウス積による係数抽出</h3>
 <p>逆向きの変換 $\ast_{2\to1}$ は、$E_1, E_2, E_3$ とのフロベニウス積で構成する。$M$ を任意の $3\times 3$ 行列（反対称とは限らない）とする。</p>
-<p>$$\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M &amp; E_2 \cdot M &amp; E_3 \cdot M \end{pmatrix}$$</p>
+<p>$$\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$$</p>
 <p>$E_k \cdot M = \operatorname{tr}(E_k^T M)$ は C.1 のフロベニウス積である。</p>
 <h3 id="d4">D.4 転置関係</h3>
 <p>$\ast_{1\to2}$ と $\ast_{2\to1}$ が互いに転置であることは、C.2 と C.3 の定義から直ちに従う。任意の $1$-form $\omega$ と任意の $3\times 3$ 行列 $M$ に対し、</p>
 <p>$$
 \begin{aligned}
 \ast_{1\to2}(\omega) \cdot M
-&amp;= (P E_1 + Q E_2 + R E_3) \cdot M \
-&amp;= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
+&= (P E_1 + Q E_2 + R E_3) \cdot M \\
+&= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
 \end{aligned}
 $$</p>
 <p>一方、</p>
 <p>$$
 \begin{aligned}
 \omega \cdot \ast_{2\to1}(M)
-&amp;= \begin{pmatrix} P &amp; Q &amp; R \end{pmatrix} \cdot
-\begin{pmatrix} E_1 \cdot M &amp; E_2 \cdot M &amp; E_3 \cdot M \end{pmatrix} \
-&amp;= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
+&= \begin{pmatrix} P & Q & R \end{pmatrix} \cdot
+\begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix} \\
+&= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
 \end{aligned}
 $$</p>
 <p>両辺は等しい。左辺の $\cdot$ はフロベニウス積、右辺の $\cdot$ はベクトルの内積である。<strong>すなわち、$\ast_{2\to1}$ は $\ast_{1\to2}$ の転置である。</strong></p>
@@ -2912,52 +2910,52 @@ $$</p>
 <p>実際、すべての成分を書き下せばその関係は一目瞭然だ。$\ast_{1\to2}$ が $3$ 枚の行列からなる縦ベクトルなら、その転置である $\ast_{2\to1}$ は同じ $3$ 枚の行列からなる横ベクトルである。</p>
 <p>$$
 \ast_{2\to1} = \begin{pmatrix}
-\begin{pmatrix} 0 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 1 \ 0 &amp; -1 &amp; 0 \end{pmatrix} &amp;
-\begin{pmatrix} 0 &amp; 0 &amp; -1 \ 0 &amp; 0 &amp; 0 \ 1 &amp; 0 &amp; 0 \end{pmatrix} &amp;
-\begin{pmatrix} 0 &amp; 1 &amp; 0 \ -1 &amp; 0 &amp; 0 \ 0 &amp; 0 &amp; 0 \end{pmatrix}
+\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
 $$</p>
-<p>$\ast_{1\to2}$ では縦に積まれていた $E_1, E_2, E_3$ が、ここでは横に並んでいる。作用の仕方も対称的だ。$\ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}$ は横ベクトル $\omega$ と縦ベクトル $\ast_{1\to2}$ の積であり、各 $E_k$ を係数倍して足し合わせる。一方 $\ast_{2\to1}$ は横ベクトルであるから、$M$ に作用させるときは各成分 $E_k$ と $M$ のフロベニウス積をとる——これが C.3 の定義 $\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M &amp; E_2 \cdot M &amp; E_3 \cdot M \end{pmatrix}$ に他ならない。縦と横、加重和と内積抽出——この対称性が $\ast$ のすべてを支配している。</p>
-<h3 id="d5-e_k-cdot-m">D.5 $E_k \cdot M$ の成分</h3>
+<p>$\ast_{1\to2}$ では縦に積まれていた $E_1, E_2, E_3$ が、ここでは横に並んでいる。作用の仕方も対称的だ。$\ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}$ は横ベクトル $\omega$ と縦ベクトル $\ast_{1\to2}$ の積であり、各 $E_k$ を係数倍して足し合わせる。一方 $\ast_{2\to1}$ は横ベクトルであるから、$M$ に作用させるときは各成分 $E_k$ と $M$ のフロベニウス積をとる——これが C.3 の定義 $\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$ に他ならない。縦と横、加重和と内積抽出——この対称性が $\ast$ のすべてを支配している。</p>
+<h3 id="d5-mathblock3422placeholder">D.5 $E_k \cdot M$ の成分</h3>
 <p>C.3 の定義が実際に $M$ から何を取り出すかは、$E_k$ の非ゼロ成分を数えればわかる。フロベニウス積は成分ごとの積の総和に $1/2$ を掛けたものだから、非ゼロ成分だけ見れば十分だ。</p>
 <p>$E_1$ の非ゼロ成分は $(2,3)=1$ と $(3,2)=-1$ のみ。したがって</p>
 <p>$$E_1 \cdot M = \frac{1}{2}\bigl(1 \cdot M_{23} + (-1) \cdot M_{32}\bigr) = \frac{1}{2}(M_{23} - M_{32})$$</p>
 <p>同様に、$E_2$ は $(1,3)=-1$ と $(3,1)=1$、$E_3$ は $(1,2)=1$ と $(2,1)=-1$ であるから、</p>
 <p>$$
 \begin{aligned}
-E_2 \cdot M &amp;= \frac{1}{2}\bigl((-1) \cdot M_{13} + 1 \cdot M_{31}\bigr) = \frac{1}{2}(M_{31} - M_{13}) \
-E_3 \cdot M &amp;= \frac{1}{2}\bigl(1 \cdot M_{12} + (-1) \cdot M_{21}\bigr) = \frac{1}{2}(M_{12} - M_{21})
+E_2 \cdot M &= \frac{1}{2}\bigl((-1) \cdot M_{13} + 1 \cdot M_{31}\bigr) = \frac{1}{2}(M_{31} - M_{13}) \\
+E_3 \cdot M &= \frac{1}{2}\bigl(1 \cdot M_{12} + (-1) \cdot M_{21}\bigr) = \frac{1}{2}(M_{12} - M_{21})
 \end{aligned}
 $$</p>
 <p>$M$ が<strong>反対称行列</strong>（$2$-form）ならば $M_{21} = -M_{12},\; M_{31} = -M_{13},\; M_{32} = -M_{23}$ だから、</p>
-<p>$$\ast_{2\to1}(M) = \begin{pmatrix} M_{23} &amp; M_{31} &amp; M_{12} \end{pmatrix}$$</p>
+<p>$$\ast_{2\to1}(M) = \begin{pmatrix} M_{23} & M_{31} & M_{12} \end{pmatrix}$$</p>
 <p>$1/2$ が反対称ペアの二重拾いを打ち消し、ちょうど係数そのものが抜き出される。これは §6.3.3 の簡略版辞書 $\ast(dy \wedge dz) = dx$ 等と完全に一致する。</p>
-<h3 id="d6-ast">D.6 $\ast$ の二回作用</h3>
+<h3 id="d6-mathblock3440placeholder">D.6 $\ast$ の二回作用</h3>
 <p>C.2 と C.3 の定義のもとで $\ast$ を二回作用させるとどうなるか。$\ast_{1\to2}(\omega) = P E_1 + Q E_2 + R E_3$ に $\ast_{2\to1}$ を作用させると、</p>
 <p>$$
 \ast_{2\to1}(\ast_{1\to2}(\omega))
 = \begin{pmatrix}
-E_1 \cdot (P E_1 + Q E_2 + R E_3) &amp;
-E_2 \cdot (P E_1 + Q E_2 + R E_3) &amp;
+E_1 \cdot (P E_1 + Q E_2 + R E_3) &
+E_2 \cdot (P E_1 + Q E_2 + R E_3) &
 E_3 \cdot (P E_1 + Q E_2 + R E_3)
 \end{pmatrix}
 $$</p>
 <p>フロベニウス積の線形性より、</p>
 <p>$$= \begin{pmatrix}
-P(E_1 \cdot E_1) + Q(E_1 \cdot E_2) + R(E_1 \cdot E_3) &amp;
-P(E_2 \cdot E_1) + Q(E_2 \cdot E_2) + R(E_2 \cdot E_3) &amp;
+P(E_1 \cdot E_1) + Q(E_1 \cdot E_2) + R(E_1 \cdot E_3) &
+P(E_2 \cdot E_1) + Q(E_2 \cdot E_2) + R(E_2 \cdot E_3) &
 P(E_3 \cdot E_1) + Q(E_3 \cdot E_2) + R(E_3 \cdot E_3)
 \end{pmatrix}$$</p>
 <p>$E_i \cdot E_j$ を C.5 と同様に非ゼロ成分だけで調べる。</p>
 <p>$$
 \begin{aligned}
-E_1 \cdot E_1 &amp;= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1 \
-E_2 \cdot E_2 &amp;= \frac{1}{2}\bigl((-1)^2 + 1^2\bigr) = 1 \
-E_3 \cdot E_3 &amp;= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1
+E_1 \cdot E_1 &= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1 \\
+E_2 \cdot E_2 &= \frac{1}{2}\bigl((-1)^2 + 1^2\bigr) = 1 \\
+E_3 \cdot E_3 &= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1
 \end{aligned}
 $$</p>
 <p>$i \neq j$ では $E_i$ と $E_j$ に非ゼロ成分の重なりがまったくないため、$E_i \cdot E_j = 0$。したがって $E_i \cdot E_j = \delta_{ij}$ であり、</p>
-<p>$$\ast_{2\to1}(\ast_{1\to2}(\omega)) = \begin{pmatrix} P &amp; Q &amp; R \end{pmatrix} = \omega$$</p>
+<p>$$\ast_{2\to1}(\ast_{1\to2}(\omega)) = \begin{pmatrix} P & Q & R \end{pmatrix} = \omega$$</p>
 <p>$\ast\ast = \mathrm{id}$ が、§6.3.3 の辞書とも完全に整合する形で導かれた。$1/2$ を定義に織り込んだことで、$\ast_{1\to2}$ と $\ast_{2\to1}$ は文字どおり互いに逆演算子になっている。</p>
 <blockquote>
 <p><strong>【ここまでのチェックポイント — 付録D】</strong>
@@ -2986,26 +2984,26 @@ $$</p>
 <h4 id="712">7.1.2 クロス積</h4>
 <p>二つの縦ベクトル $\mathbf{a}, \mathbf{b}$ の<strong>クロス積</strong>（外積）を次で定義する。</p>
 <p>$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
-a_y b_z - a_z b_y \
-a_z b_x - a_x b_z \
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
 a_x b_y - a_y b_x
 \end{pmatrix}$$</p>
 <p>この結果は再び縦ベクトルである。クロス積の成分の並びには規則性があり、次の反対称行列を使うと簡潔に書ける。</p>
 <p>$$\mathbf{a} \times = \begin{pmatrix}
-0 &amp; -a_z &amp; a_y \
-a_z &amp; 0 &amp; -a_x \
--a_y &amp; a_x &amp; 0
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
 \end{pmatrix}$$</p>
 <p>この $3\times 3$ 行列をベクトル $\mathbf{b}$ に左から掛ければ、</p>
 <p>$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
-0 &amp; -a_z &amp; a_y \
-a_z &amp; 0 &amp; -a_x \
--a_y &amp; a_x &amp; 0
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
 \end{pmatrix}\begin{pmatrix}
-b_x \ b_y \ b_z
+b_x \\ b_y \\ b_z
 \end{pmatrix} = \begin{pmatrix}
-a_y b_z - a_z b_y \
-a_z b_x - a_x b_z \
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
 a_x b_y - a_y b_x
 \end{pmatrix}$$</p>
 <p>となる。この $(\mathbf{a} \times)$ を $\mathbf{a}$ の<strong>外積行列</strong>と呼ぶ。第2章 §2.4.9 で $2$-form の行列表現として現れ、§5.3.2 では $\ast$ の出力として再登場した行列と、まったく同じ形である。本章ではこれを純粋に「ベクトルにベクトルを掛けてベクトルを得る演算」として使う。</p>
@@ -3023,20 +3021,20 @@ a_x b_y - a_y b_x
 - クロス積は反可換、自分自身とはゼロ、結果は二つのベクトルに直交する。</p>
 </blockquote>
 <hr />
-<h3 id="72-nabla">§7.2 $\nabla$ と勾配</h3>
-<h4 id="721-nabla">7.2.1 $\nabla$ の定義</h4>
+<h3 id="72-mathblock3502placeholder">§7.2 $\nabla$ と勾配</h3>
+<h4 id="721-mathblock3503placeholder">7.2.1 $\nabla$ の定義</h4>
 <p>ナブラ $\nabla$ を、偏微分演算子を縦に並べた形式的なベクトルとして定義する。</p>
 <p>$$\nabla = \begin{pmatrix}
-\frac{\partial}{\partial x} \[0.5em]
-\frac{\partial}{\partial y} \[0.5em]
+\frac{\partial}{\partial x} \\[0.5em]
+\frac{\partial}{\partial y} \\[0.5em]
 \frac{\partial}{\partial z}
 \end{pmatrix}$$</p>
 <p>$\nabla$ は「ベクトル」だが、その成分は数ではなく<strong>微分演算子</strong>である。$\nabla$ は単独では意味を持たず、何かに作用して初めて値が定まる。</p>
 <h4 id="722">7.2.2 勾配</h4>
 <p>スカラー場 $f(x,y,z)$ に $\nabla$ を作用させたものを<strong>勾配</strong>と呼び、$\mathrm{grad}\,f$ または $\nabla f$ と書く。</p>
 <p>$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
-\frac{\partial f}{\partial x} \[0.5em]
-\frac{\partial f}{\partial y} \[0.5em]
+\frac{\partial f}{\partial x} \\[0.5em]
+\frac{\partial f}{\partial y} \\[0.5em]
 \frac{\partial f}{\partial z}
 \end{pmatrix}$$</p>
 <p>勾配の各成分は、$f$ の各座標方向の変化率である。幾何学的には、$\nabla f$ は $f$ が最も急に増加する方向を指すベクトル場になる。</p>
@@ -3044,7 +3042,7 @@ a_x b_y - a_y b_x
 <p><strong>注</strong> （勾配は横ベクトルか縦ベクトルか）§5.5 では $\mathrm{grad}\,f = df$ と書き、$df$ は係数の横ベクトルだった。本章では $\nabla f$ を縦ベクトルとして扱う。これは単なる転置の違いではない。$\nabla f$（縦）は「空間の各点に矢印を立てる」見方——実空間が変化しているとみなす立場——に立ち、$df$（横）は「微分そのもの（form）が変化している」とみなす立場に立つ。出発点の絵は異なるが、線積分で集計すれば同じスカラー量を与える。この一致は偶然ではない。</p>
 </blockquote>
 <p><strong>例</strong>：$f(x,y,z) = x^2 + y^2 + z^2$ の勾配。</p>
-<p>$$\nabla f = \begin{pmatrix} 2x \ 2y \ 2z \end{pmatrix}$$</p>
+<p>$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$</p>
 <p>このベクトル場は原点から放射状に外向きで、原点から離れるほど大きくなる。</p>
 <hr />
 <h3 id="73">§7.3 発散</h3>
@@ -3053,9 +3051,9 @@ a_x b_y - a_y b_x
 <p>形式的には「$\nabla$ と $\mathbf{F}$ のドット積」だが、$\nabla$ の各成分が微分演算子であるため、結果はスカラー場になる。</p>
 <p>発散は行列の言葉でも書ける。$\mathbf{F}$ のヤコビ行列 $\mathbf{J}_\mathbf{F}$ を考える。</p>
 <p>$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
-\frac{\partial F_x}{\partial x} &amp; \frac{\partial F_x}{\partial y} &amp; \frac{\partial F_x}{\partial z} \[0.3em]
-\frac{\partial F_y}{\partial x} &amp; \frac{\partial F_y}{\partial y} &amp; \frac{\partial F_y}{\partial z} \[0.3em]
-\frac{\partial F_z}{\partial x} &amp; \frac{\partial F_z}{\partial y} &amp; \frac{\partial F_z}{\partial z}
+\frac{\partial F_x}{\partial x} & \frac{\partial F_x}{\partial y} & \frac{\partial F_x}{\partial z} \\[0.3em]
+\frac{\partial F_y}{\partial x} & \frac{\partial F_y}{\partial y} & \frac{\partial F_y}{\partial z} \\[0.3em]
+\frac{\partial F_z}{\partial x} & \frac{\partial F_z}{\partial y} & \frac{\partial F_z}{\partial z}
 \end{pmatrix}$$</p>
 <p>この行列の<strong>トレース</strong>（対角成分の和）が発散に一致する。</p>
 <p>$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</p>
@@ -3069,34 +3067,34 @@ a_x b_y - a_y b_x
 <h3 id="74">§7.4 回転</h3>
 <p>ベクトル場 $\mathbf{F}$ に対して、$\nabla$ とのクロス積をとったものを<strong>回転</strong>（ローテーション）と呼ぶ。</p>
 <p>$$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \[0.5em]
-\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \[0.5em]
+\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
+\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.5em]
 \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}
 \end{pmatrix}$$</p>
 <p>外積行列を使えば次のようにも書ける。</p>
 <p>$$\mathrm{rot}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
-0 &amp; -\frac{\partial}{\partial z} &amp; \frac{\partial}{\partial y} \[0.3em]
-\frac{\partial}{\partial z} &amp; 0 &amp; -\frac{\partial}{\partial x} \[0.3em]
--\frac{\partial}{\partial y} &amp; \frac{\partial}{\partial x} &amp; 0
+0 & -\frac{\partial}{\partial z} & \frac{\partial}{\partial y} \\[0.3em]
+\frac{\partial}{\partial z} & 0 & -\frac{\partial}{\partial x} \\[0.3em]
+-\frac{\partial}{\partial y} & \frac{\partial}{\partial x} & 0
 \end{pmatrix}\begin{pmatrix}
-F_x \ F_y \ F_z
+F_x \\ F_y \\ F_z
 \end{pmatrix}$$</p>
 <p>物理的には、$\mathrm{rot}\,\mathbf{F}$ はその点での「渦」の強さと向きを表す。渦の軸方向を向き、大きさが渦の強さに対応する。</p>
 <p><strong>例</strong>：$\mathbf{F} = (-y, x, 0)^T$ の回転。</p>
 <p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \[0.3em]
-\frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \[0.3em]
+\frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \\[0.3em]
+\frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \\[0.3em]
 \frac{\partial x}{\partial x} - \frac{\partial (-y)}{\partial y}
 \end{pmatrix} = \begin{pmatrix}
-0 - 0 \ 0 - 0 \ 1 - (-1)
-\end{pmatrix} = \begin{pmatrix} 0 \ 0 \ 2 \end{pmatrix}$$</p>
+0 - 0 \\ 0 - 0 \\ 1 - (-1)
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$</p>
 <p>この場は $z$ 軸まわりに一様に回転しており、渦の強さは $2$ である。</p>
 <p><strong>例</strong>：$\mathbf{F} = (x, y, z)^T$ の回転。</p>
 <p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \[0.3em]
-\frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \[0.3em]
+\frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \\[0.3em]
+\frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \\[0.3em]
 \frac{\partial y}{\partial x} - \frac{\partial x}{\partial y}
-\end{pmatrix} = \begin{pmatrix} 0 \ 0 \ 0 \end{pmatrix}$$</p>
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$</p>
 <p>放射状の場には渦がない——直感とも一致する。</p>
 <blockquote>
 <p><strong>【ここまでのチェックポイント — §7.2–§7.4】</strong>
@@ -3113,23 +3111,23 @@ F_x \ F_y \ F_z
 <p><strong>例</strong>：$f(x,y,z) = x^2 + y^2 + z^2$ のラプラシアン。</p>
 <p>$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$</p>
 <p>ベクトル場 $\mathbf{F}$ に対しても、成分ごとにラプラシアンを作用させたものを<strong>ベクトルラプラシアン</strong>と呼ぶ。</p>
-<p>$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \ \nabla^2 F_y \ \nabla^2 F_z \end{pmatrix}$$</p>
+<p>$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$</p>
 <p>ラプラシアンは物理の至るところに現れる。熱伝導方程式、波動方程式、ポアソン方程式——いずれも $\nabla^2$ を中心に据えた方程式である。</p>
 <hr />
 <h3 id="76">§7.6 恒等式</h3>
 <p>ここまでに定義した三つの演算の間には、二つの重要な恒等式が成り立つ。どちらも「二度作用させるとゼロになる」という形をしている。</p>
-<h4 id="761-mathrmrotmathrmgradf-mathbf0">7.6.1 $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</h4>
+<h4 id="761-mathblock3547placeholder">7.6.1 $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</h4>
 <p>勾配でベクトル場を得て、その回転をとると必ずゼロベクトルになる。</p>
 <p>$$\nabla \times (\nabla f) = \begin{pmatrix}
-\frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \[0.5em]
-\frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \[0.5em]
+\frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \\[0.5em]
+\frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \\[0.5em]
 \frac{\partial}{\partial x}\frac{\partial f}{\partial y} - \frac{\partial}{\partial y}\frac{\partial f}{\partial x}
-\end{pmatrix} = \begin{pmatrix} 0 \ 0 \ 0 \end{pmatrix}$$</p>
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$</p>
 <p>各成分で、偏微分の順序交換 $\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$ により打ち消し合う。これは $f$ がなめらか（二階連続微分可能）であれば常に成り立つ。</p>
 <p>物理的意味：「勾配場には渦がない」。重力場や静電場がこれに当たる。</p>
-<h4 id="762-mathrmdivmathrmrotmathbff-0">7.6.2 $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</h4>
+<h4 id="762-mathblock3550placeholder">7.6.2 $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</h4>
 <p>回転でベクトル場を得て、その発散をとると必ずゼロになる。</p>
-<p>$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$</p>
+<p>$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$</p>
 <p>展開すると、$\frac{\partial^2 F_z}{\partial x\partial y}$ と $-\frac{\partial^2 F_z}{\partial y\partial x}$ のように、やはり偏微分の順序交換により項がペアで打ち消し合い、総和は $0$ になる。</p>
 <p>物理的意味：「渦場に湧き出しはない」。磁場がこれに当たる（モノポールが存在しないことの数学的表現）。</p>
 <blockquote>
@@ -3250,26 +3248,26 @@ F_x \ F_y \ F_z
 <p>本章は、この本の<strong>ハイライト</strong>である。しかし、その実あっさりと、これまでのどの章よりも短くなる。そのために第1章から第7章までの入念な準備があった——行列、ウェッジ積、外微分、計量、ホッジ・スター、そしてベクトル解析。これらの道具がすべて揃っているからこそ、本章ではただ「翻訳する」だけで、二つの世界が一つの絵に収まる。我々は二つの言語を手に入れた——測定器の微分（$d$）と、場の微分（$\nabla$）。この二つは、やっていることが根本的に違う。しかし積分を通じて繋がるとき、まったく同じ結果を与える。その仕組みを、これから徹底的に掘り下げる。</p>
 <hr />
 <h3 id="81">§8.1 二つの微分、二つの世界</h3>
-<h4 id="811-d">8.1.1 測定器に微分を乗せる——$d$ の立場</h4>
-<p>第1章以来、我々は $dx = \begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$, $dy = \begin{pmatrix}0&amp;1&amp;0\end{pmatrix}$, $dz = \begin{pmatrix}0&amp;0&amp;1\end{pmatrix}$ を横ベクトルの測定器として扱ってきた。これらは縦ベクトル（変位）を食わせると、その方向の変位量をスカラーで返す。</p>
+<h4 id="811-mathblock3652placeholder">8.1.1 測定器に微分を乗せる——$d$ の立場</h4>
+<p>第1章以来、我々は $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ を横ベクトルの測定器として扱ってきた。これらは縦ベクトル（変位）を食わせると、その方向の変位量をスカラーで返す。</p>
 <p>外微分 $d$ は、この測定器に<strong>微分を乗せる</strong>操作である。</p>
 <p>$f(x,y,z)$ がスカラー場のとき、$df$ は $f$ の変化を測る新しい測定器だ。各偏微分係数を成分として持つ横ベクトルになる。</p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} &amp; \frac{\partial f}{\partial y} &amp; \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
+<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
 <p>$\omega = P\,dx + Q\,dy + R\,dz$ が $1$-form のとき、$d\omega$ は $\omega$ の局所的なズレを測る $2$-form（反対称行列）になる。</p>
 <p>$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$</p>
 <p>$\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ が $2$-form のとき、$d\eta$ は $3$-form（三階反対称テンソル）になる。</p>
 <p>$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$</p>
 <p>このように、$d$ が作用するたびに測定器の次数が $0\to1\to2\to3$ と一つずつ上がっていく。核心は<strong>場はそのまま、測定器の側が変化する</strong>ことだ。$f$ はスカラー場のままだが、$d$ が作用するたびに新しい測定器——$df$（$1$-form）、$d\omega$（$2$-form）、$d\eta$（$3$-form）——が生み出される。</p>
-<h4 id="812-nabla">8.1.2 測定器はそのまま、新たな場を考える——$\nabla$ の立場</h4>
-<p>一方、第7章で導入した $\nabla = \begin{pmatrix} \frac{\partial}{\partial x} &amp; \frac{\partial}{\partial y} &amp; \frac{\partial}{\partial z} \end{pmatrix}^T$ の世界では、<strong>測定器（$\nabla$）は変わらず、作用する相手に応じて新たな場が生まれる</strong>。$\nabla$ はつねに同じ演算子だが、スカラー場 $f$ に作用すればベクトル場 $\nabla f$ を、ベクトル場 $\mathbf{F}$ に作用すればスカラー場 $\nabla\cdot\mathbf{F}$ やベクトル場 $\nabla\times\mathbf{F}$ を返す。</p>
+<h4 id="812-mathblock3679placeholder">8.1.2 測定器はそのまま、新たな場を考える——$\nabla$ の立場</h4>
+<p>一方、第7章で導入した $\nabla = \begin{pmatrix} \frac{\partial}{\partial x} & \frac{\partial}{\partial y} & \frac{\partial}{\partial z} \end{pmatrix}^T$ の世界では、<strong>測定器（$\nabla$）は変わらず、作用する相手に応じて新たな場が生まれる</strong>。$\nabla$ はつねに同じ演算子だが、スカラー場 $f$ に作用すればベクトル場 $\nabla f$ を、ベクトル場 $\mathbf{F}$ に作用すればスカラー場 $\nabla\cdot\mathbf{F}$ やベクトル場 $\nabla\times\mathbf{F}$ を返す。</p>
 <p>スカラー場 $f(x,y,z)$ に $\nabla$ を作用させると、各方向の変化率を成分とする縦ベクトル場が得られる。</p>
-<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \[0.3em] \frac{\partial f}{\partial y} \[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
+<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$</p>
 <p>これは空間の各点に立つ矢印であり、もはや測定器ではない。$f$ が最も急に増加する方向とその強さを表す。</p>
 <p>ベクトル場 $\mathbf{F} = (F_x, F_y, F_z)^T$ に $\nabla\cdot$ を作用させると、スカラー場が得られる。</p>
 <p>$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</p>
 <p>各方向の変化率の和——湧き出しの強さ——を返す。</p>
 <p>同じ $\mathbf{F}$ に $\nabla\times$ を作用させると、再び縦ベクトル場が得られる。</p>
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$</p>
+<p>$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$</p>
 <p>渦の軸方向と強さを表す。</p>
 <p>$\nabla$ の世界では、結果はつねに実空間の中の矢印かスカラーとして返される。$\nabla f$ も $\nabla\times\mathbf{F}$ も画面上では同じ「矢印」であり、型による区別はつかない。</p>
 <blockquote>
@@ -3351,7 +3349,7 @@ $$</p>
 <hr />
 <h3 id="83">§8.3 ストークスの定理を翻訳する</h3>
 <p>第5章 §4.6 で、我々はすでに $\int_{\partial S}\omega = \int_S d\omega$ という形のストークスの定理を導いた。第7章 §6.8.1 では、同じ定理を $\nabla$ の言葉で $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ と書いた。この二つが同じものであることを、§8.2 の辞書を使って確認する。</p>
-<h4 id="831-nabla-d">8.3.1 $\nabla$ から $d$ へ</h4>
+<h4 id="831-mathblock3764placeholder-mathblock3765placeholder">8.3.1 $\nabla$ から $d$ へ</h4>
 <p>$\nabla$ 表記のストークスの定理を出発点とする。</p>
 <p>$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$</p>
 <p>左辺の $\oint_C \mathbf{F}\cdot d\mathbf{r}$ は、ベクトル場 $\mathbf{F}$ を曲線 $C$ に沿って線積分したものだ。$\mathbf{F}$ に対応する $1$-form を $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ とすれば、第3章の定義によりこれは $\int_C \omega$ に等しい。</p>
@@ -3484,12 +3482,12 @@ $$</p>
 <p>§8.2 の辞書はデカルト座標 $(x,y,z)$ で $\mathbf{g}=I$ を前提としていた。一般の座標系では計量 $g = J^T J$ が単位行列ではなくなり、$\ast$ の辞書も変わる。ここでは円柱座標を例に、辞書の変化を確認したあと、§8.5 で語った二つの方法論を目の前で回してみる。</p>
 <h4 id="861">8.6.1 辞書は計量で変わる</h4>
 <p>第6章 §5.1.3 で円柱座標の計量を導出した。</p>
-<p>$$\mathbf{g} = \begin{pmatrix} 1 &amp; 0 &amp; 0 \ 0 &amp; r^2 &amp; 0 \ 0 &amp; 0 &amp; 1 \end{pmatrix}$$</p>
+<p>$$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$$</p>
 <p>この $\mathbf{g} \neq I$ が $\ast$ の辞書にどう影響するか。デカルト座標では $\ast(dx) = dy \wedge dz$ だった。円柱座標の基底 $1$-form を $(dr, d\theta, dz)$ とすると、$\ast$ の辞書は次のように変わる。</p>
 <p>$$\begin{aligned}
-\ast(dr) &amp;= r\,d\theta \wedge dz \
-\ast(d\theta) &amp;= \frac{1}{r}\,dz \wedge dr \
-\ast(dz) &amp;= r\,dr \wedge d\theta
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
 \end{aligned}$$</p>
 <p>$r$ や $1/r$ という係数は $\mathbf{g} = J^T J$ の対角成分 $1, r^2, 1$ から決まる。$\ast$ の辞書は、その場所の計量を反映して場所ごとに異なる係数を持つ。</p>
 <h4 id="862">8.6.2 二つの方法を回してみる</h4>
@@ -3503,13 +3501,13 @@ $$</p>
 <p>$$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$</p>
 <p>が得られる。</p>
 <blockquote>
-<p><strong>注</strong> （正規直交成分と form 係数）ベクトル解析では $\mathbf{F}$ を「長さ1の矢印」に対する成分 $(F_r, F_\theta)$ で表す。しかし微分形式の自然な基底は座標微分 $(dr, d\theta)$ であり、$d\theta$ 方向の目盛り間隔は場所によって $r$ 倍異なる。したがって $\tilde{\omega} = F_r\,dr + \tilde{F}<em>\theta\,d\theta$ と書いたときの form 係数 $\tilde{F}</em>\theta$ は $r F_\theta$ であり、ベクトル解析の成分 $F_\theta$ とは次元も値も異なる。この違いが、方法①と方法②の公式の見た目の差を生んでいる。</p>
+<p><strong>注</strong> （正規直交成分と form 係数）ベクトル解析では $\mathbf{F}$ を「長さ1の矢印」に対する成分 $(F_r, F_\theta)$ で表す。しかし微分形式の自然な基底は座標微分 $(dr, d\theta)$ であり、$d\theta$ 方向の目盛り間隔は場所によって $r$ 倍異なる。したがって $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$ と書いたときの form 係数 $\tilde{F}_\theta$ は $r F_\theta$ であり、ベクトル解析の成分 $F_\theta$ とは次元も値も異なる。この違いが、方法①と方法②の公式の見た目の差を生んでいる。</p>
 </blockquote>
-<p>ここから先は $\ast d\ast$ の機械的な計算だ。極座標の計量 $\mathbf{g} = \begin{pmatrix} 1 &amp; 0 \ 0 &amp; r^2 \end{pmatrix}$ から $\ast$ の辞書は $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ となる（§8.6.1 の二次元版）。$d$ は偏微分の係数をそのまま拾うだけ——途中に $\frac{1}{r}$ などを挟み込む必要は一切ない。</p>
+<p>ここから先は $\ast d\ast$ の機械的な計算だ。極座標の計量 $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$ から $\ast$ の辞書は $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ となる（§8.6.1 の二次元版）。$d$ は偏微分の係数をそのまま拾うだけ——途中に $\frac{1}{r}$ などを挟み込む必要は一切ない。</p>
 <p>$$\begin{aligned}
-\ast\tilde{\omega} &amp;= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \[0.3em]
-d\ast\tilde{\omega} &amp;= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \[0.3em]
-\ast d\ast\tilde{\omega} &amp;= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
+\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
+\ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$</p>
 <p>$\frac{1}{r}$ が現れたのは最後の $\ast(dr\wedge d\theta) = \frac{1}{r}$ の一箇所だけだ。途中の $r$ と $\frac{1}{r}$ は、$d\theta$ の係数に付いていた $r$ と $\ast(d\theta)$ の $\frac{1}{r}$ が打ち消し合った結果である。$\ast$ が計量の情報を一手に引き受け、$d$ は純粋に偏微分だけを担当する——この分業こそが方法①の最大の強みだ。</p>
 <p>測るのはつねに均一な正方形グリッド。場所ごとの換算係数の違いは pullback が織り込み、$\ast$ が整理する。グリッドは有限でよい——極限は最後の一手で十分だ。</p>
@@ -3526,8 +3524,8 @@ d\ast\tilde{\omega} &amp;= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\par
 <p>§8.6.1 の辞書と §8.6.2 の方法①を組み合わせれば、円柱座標での発散と回転の公式が機械的に導出できる。結果だけを示す（$\mathbf{F} = (F_r, F_\theta, F_z)^T$）。</p>
 <p>$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$</p>
 <p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \[0.3em]
-\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \[0.3em]
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
 \frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
 \end{pmatrix}$$</p>
 <p>これらの公式を暗記するのは骨が折れる。しかし $\ast d\ast\omega$ という $d$ と $\ast$ の組み合わせで考えれば、$g = J^T J$ から $\ast$ の辞書をその場で導出し、機械的に計算できる。第9章では、この「辞書をその場で作る」技術を実践する。</p>
@@ -3564,31 +3562,31 @@ d\ast\tilde{\omega} &amp;= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\par
 </ol>
 <p>以下、この手順を円柱座標と球座標で実演する。</p>
 <hr />
-<h3 id="92-rthetaz">§9.2 円柱座標 $(r,\theta,z)$</h3>
+<h3 id="92-mathblock3996placeholder">§9.2 円柱座標 $(r,\theta,z)$</h3>
 <h4 id="921">9.2.1 辞書の導出</h4>
 <p>円柱座標への変換は $x = r\cos\theta$, $y = r\sin\theta$, $z = z$。</p>
 <p>$$J = \begin{pmatrix}
-\cos\theta &amp; -r\sin\theta &amp; 0 \
-\sin\theta &amp; r\cos\theta &amp; 0 \
-0 &amp; 0 &amp; 1
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}, \qquad
 \mathbf{g} = J^T J = \begin{pmatrix}
-1 &amp; 0 &amp; 0 \
-0 &amp; r^2 &amp; 0 \
-0 &amp; 0 &amp; 1
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$</p>
 <p>$\mathbf{g}$ から $\ast$ の辞書を導く。第6章 §5.3.3 でデカルト座標の $\ast$ 辞書が $\mathbf{g}=I$ から決まったのと同じ原理で、$\mathbf{g}$ の対角成分の平方根が $\ast$ の係数に現れる。</p>
 <p>$$\begin{aligned}
-\ast(dr) &amp;= r\,d\theta \wedge dz \
-\ast(d\theta) &amp;= \frac{1}{r}\,dz \wedge dr \
-\ast(dz) &amp;= r\,dr \wedge d\theta
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
 \end{aligned}$$</p>
 <p>また $\ast(1) = r\,dr\wedge d\theta\wedge dz$, $\ast(dr\wedge d\theta\wedge dz) = 1/r$。</p>
 <h4 id="922">9.2.2 勾配</h4>
 <p>$\mathrm{grad}\,f = df$ は $\ast$ を使わない。単に偏微分係数を基底 $1$-form に載せるだけだ。</p>
 <p>$$df = \frac{\partial f}{\partial r}\,dr + \frac{\partial f}{\partial \theta}\,d\theta + \frac{\partial f}{\partial z}\,dz$$</p>
 <p>ベクトル解析の表記（縦ベクトル）では、</p>
-<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial r} &amp; \frac{1}{r}\frac{\partial f}{\partial \theta} &amp; \frac{\partial f}{\partial z} \end{pmatrix}^T$$</p>
+<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial r} & \frac{1}{r}\frac{\partial f}{\partial \theta} & \frac{\partial f}{\partial z} \end{pmatrix}^T$$</p>
 <p>$\theta$ 成分に $\frac{1}{r}$ がつくのは、$\nabla f$ が正規直交基底に対する成分だからだ。$df$ の $d\theta$ の係数 $\frac{\partial f}{\partial\theta}$ は「角度あたりの変化率」だが、$\nabla f$ の $\mathbf{e}_\theta$ 成分は「長さあたりの変化率」であり、$d\theta$ が弧長 $r\,d\theta$ に対応するための換算 $\frac{1}{r}$ が必要になる。</p>
 <h4 id="923">9.2.3 発散</h4>
 <p>$\mathbf{F} = (F_r, F_\theta, F_z)^T$ に対応する $1$-form は $\tilde{\omega} = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$ である（§7.6.2 で確認したように、$d\theta$ の係数は $rF_\theta$）。</p>
@@ -3596,42 +3594,42 @@ d\ast\tilde{\omega} &amp;= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\par
 <p><strong>注</strong> （$\tilde{\omega}$ のチルダについて）第8章 §7.6.2 で、正規直交成分 $F_\theta$ と form 係数 $rF_\theta$ を区別するために $\tilde{\omega}$ という記法を使った。しかし本来、数学ではこの二つをいちいち区別しないことも多い。文脈からどちらの $\omega$ を指しているか明らかだからだ。以下でもチルダを省く。どちらを指しているかは、係数に $r$ や $\rho$ が現れているかどうかで判断してほしい。</p>
 </blockquote>
 <p>$$\begin{aligned}
-\ast\omega &amp;= F_r(r\,d\theta\wedge dz) + rF_\theta!\left(\frac{1}{r}\,dz\wedge dr\right) + F_z(r\,dr\wedge d\theta) \
-&amp;= rF_r\,d\theta\wedge dz + F_\theta\,dz\wedge dr + rF_z\,dr\wedge d\theta \[0.3em]
-d\ast\omega &amp;= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta}{\partial\theta} + \frac{\partial}{\partial z}(rF_z)\right) dr\wedge d\theta\wedge dz \[0.3em]
-\ast d\ast\omega &amp;= \frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta} + \frac{\partial F_z}{\partial z}
+\ast\omega &= F_r(r\,d\theta\wedge dz) + rF_\theta\!\left(\frac{1}{r}\,dz\wedge dr\right) + F_z(r\,dr\wedge d\theta) \\
+&= rF_r\,d\theta\wedge dz + F_\theta\,dz\wedge dr + rF_z\,dr\wedge d\theta \\[0.3em]
+d\ast\omega &= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta}{\partial\theta} + \frac{\partial}{\partial z}(rF_z)\right) dr\wedge d\theta\wedge dz \\[0.3em]
+\ast d\ast\omega &= \frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta} + \frac{\partial F_z}{\partial z}
 \end{aligned}$$</p>
 <p>これが円柱座標での発散の公式である。</p>
 <h4 id="924">9.2.4 回転</h4>
 <p>回転は $\mathrm{rot}\,\mathbf{F} \leftrightarrow \ast d\omega$。</p>
 <p>$$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right) dr\wedge d\theta + \left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right) d\theta\wedge dz + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz\wedge dr$$</p>
-<p>$$\ast d\omega = \frac{1}{r}!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)! dr + \frac{1}{r}!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)! d\theta + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz$$</p>
+<p>$$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! d\theta + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz$$</p>
 <p>$1$-form の $dr, d\theta, dz$ の係数を読み取り、正規直交成分に焼き直すと $d\theta$ 係数はさらに $\frac{1}{r}$ される。最終的に、</p>
 <p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \[0.3em]
-\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \[0.3em]
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
 \frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
 \end{pmatrix}$$</p>
 <p>$r$ が $\frac{\partial}{\partial r}$ の内側と外側に現れる構造は、§7.6.2 の方法②で扇形の面積要素を数えたときの $\frac{1}{r}$ とまったく同じ起源を持つ。</p>
 <hr />
-<h3 id="93-rhothetaphi">§9.3 球座標 $(\rho,\theta,\phi)$</h3>
+<h3 id="93-mathblock4042placeholder">§9.3 球座標 $(\rho,\theta,\phi)$</h3>
 <h4 id="931">9.3.1 辞書の導出</h4>
 <p>球座標への変換は $x = \rho\sin\theta\cos\phi$, $y = \rho\sin\theta\sin\phi$, $z = \rho\cos\theta$（$\theta$ は $z$ 軸からの角度、$\phi$ は $xy$ 平面内の方位角）。</p>
 <p>$$J = \begin{pmatrix}
-\sin\theta\cos\phi &amp; \rho\cos\theta\cos\phi &amp; -\rho\sin\theta\sin\phi \
-\sin\theta\sin\phi &amp; \rho\cos\theta\sin\phi &amp; \rho\sin\theta\cos\phi \
-\cos\theta &amp; -\rho\sin\theta &amp; 0
+\sin\theta\cos\phi & \rho\cos\theta\cos\phi & -\rho\sin\theta\sin\phi \\
+\sin\theta\sin\phi & \rho\cos\theta\sin\phi & \rho\sin\theta\cos\phi \\
+\cos\theta & -\rho\sin\theta & 0
 \end{pmatrix},\qquad
 \mathbf{g} = J^T J = \begin{pmatrix}
-1 &amp; 0 &amp; 0 \
-0 &amp; \rho^2 &amp; 0 \
-0 &amp; 0 &amp; \rho^2\sin^2\theta
+1 & 0 & 0 \\
+0 & \rho^2 & 0 \\
+0 & 0 & \rho^2\sin^2\theta
 \end{pmatrix}$$</p>
 <p>$\ast$ の辞書は対角成分 $\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$ すなわち $1, \rho, \rho\sin\theta$ から決まる。</p>
 <p>$$\begin{aligned}
-\ast(d\rho) &amp;= \rho^2\sin\theta\; d\theta \wedge d\phi \
-\ast(d\theta) &amp;= \sin\theta\; d\phi \wedge d\rho \
-\ast(d\phi) &amp;= \frac{1}{\sin\theta}\; d\rho \wedge d\theta
+\ast(d\rho) &= \rho^2\sin\theta\; d\theta \wedge d\phi \\
+\ast(d\theta) &= \sin\theta\; d\phi \wedge d\rho \\
+\ast(d\phi) &= \frac{1}{\sin\theta}\; d\rho \wedge d\theta
 \end{aligned}$$</p>
 <h4 id="932">9.3.2 発散</h4>
 <p>$\mathbf{F} = (F_\rho, F_\theta, F_\phi)^T$ の $1$-form への変換では、$d\rho$ の係数は $F_\rho$（$\rho$ はすでに長さ）、$d\theta$ の係数は $\rho F_\theta$、$d\phi$ の係数は $\rho\sin\theta\,F_\phi$ となる（それぞれ弧長 $\rho\,d\theta$, $\rho\sin\theta\,d\phi$ に対応）。</p>
@@ -3644,8 +3642,8 @@ d\ast\omega &amp;= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\t
 <h4 id="933">9.3.3 回転</h4>
 <p>同様に $\ast d\omega$ から、</p>
 <p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \[0.3em]
-\frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \[0.3em]
+\frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+\frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
 \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
 \end{pmatrix}$$</p>
 <hr />
@@ -3662,32 +3660,32 @@ d\ast\omega &amp;= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\t
 <p>$$\ast d\ast\omega = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</p>
 <p>これを $S$ とおく。$S$ はスカラー場だから、その勾配は $dS = \frac{\partial S}{\partial\rho}\,d\rho + \frac{\partial S}{\partial\theta}\,d\theta + \frac{\partial S}{\partial\phi}\,d\phi$ である。正規直交成分に焼き直すと、</p>
 <p>$$\nabla(\nabla\cdot\mathbf{F}) = \begin{pmatrix}
-\frac{\partial S}{\partial\rho} \[0.5em]
-\frac{1}{\rho}\frac{\partial S}{\partial\theta} \[0.5em]
+\frac{\partial S}{\partial\rho} \\[0.5em]
+\frac{1}{\rho}\frac{\partial S}{\partial\theta} \\[0.5em]
 \frac{1}{\rho\sin\theta}\frac{\partial S}{\partial\phi}
 \end{pmatrix}$$</p>
 <h4 id="942">9.4.2 第二項——回転の回転</h4>
 <p>§9.3.3 の回転の結果を $C_\rho, C_\theta, C_\phi$ とおく。</p>
 <p>$$\begin{aligned}
-C_\rho &amp;= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \[0.3em]
-C_\theta &amp;= \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \[0.3em]
-C_\phi &amp;= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
+C_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+C_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
+C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
 \end{aligned}$$</p>
 <p>$\mathbf{C} = \nabla\times\mathbf{F}$ に再度 $\nabla\times$ を作用させるには、$C_\rho, C_\theta, C_\phi$ を §9.3.3 の公式の $F_\rho, F_\theta, F_\phi$ の位置に代入すればよい。</p>
 <p>$$\begin{aligned}
-(\nabla\times(\nabla\times\mathbf{F}))<em>\rho &amp;= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C</em>\phi) - \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi} \[0.5em]
-(\nabla\times(\nabla\times\mathbf{F}))<em>\theta &amp;= \frac{1}{\rho\sin\theta}\frac{\partial C</em>\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\phi) \[0.5em]
-(\nabla\times(\nabla\times\mathbf{F}))<em>\phi &amp;= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C</em>\theta) - \frac{1}{\rho}\frac{\partial C_\rho}{\partial\theta}
+(\nabla\times(\nabla\times\mathbf{F}))_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi} \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial C_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\phi) \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\theta) - \frac{1}{\rho}\frac{\partial C_\rho}{\partial\theta}
 \end{aligned}$$</p>
 <h4 id="943">9.4.3 差をとる——ベクトルラプラシアン</h4>
 <p>$\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ だから、各成分は第一項から第二項を引けばよい。$\rho$ 成分を展開する。</p>
-<p>$$(\nabla^2\mathbf{F})<em>\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C</em>\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$</p>
+<p>$$(\nabla^2\mathbf{F})_\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$</p>
 <p>$S$ と $C_\theta, C_\phi$ の表式を代入し、偏微分を展開して整理すると、</p>
-<p>$$(\nabla^2\mathbf{F})<em>\rho = \nabla^2 F</em>\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</p>
-<p>ここで $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$ である。</p>
+<p>$$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</p>
+<p>ここで $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$ である。</p>
 <p>同様に $\theta$ 成分と $\phi$ 成分も、</p>
-<p>$$(\nabla^2\mathbf{F})<em>\theta = \nabla^2 F</em>\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$</p>
-<p>$$(\nabla^2\mathbf{F})<em>\phi = \nabla^2 F</em>\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$</p>
+<p>$$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$</p>
+<p>$$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$</p>
 <p>以上で全成分の導出が完了した。ベクトル解析の流儀で一から導出すれば1ページを優に超える計算量だが、辞書を経由すれば各ステップは偏微分と係数の掛け算の繰り返しに過ぎない。暗記する必要はどこにもない——$d\ast d\ast\omega - \ast d\ast d\omega$ の一本と、§9.3 の $\ast$ 辞書さえあれば、すべてその場で再構成できる。</p>
 <h3 id="95">§9.5 電磁気学の難問——点電荷の電場と発散</h3>
 <p>最後に、電磁気学からの例題を一つ。第10章への橋渡しでもある。</p>
@@ -3732,10 +3730,10 @@ C_\phi &amp;= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac
 <h3 id="101-2">§10.1 マクスウェル方程式——2本で書く</h3>
 <p>電磁気学の基本法則は、SI単位系で次の4本の式として書かれる。</p>
 <p>$$\begin{aligned}
-\mathrm{div}\,\mathbf{E} &amp;= \frac{\rho}{\varepsilon_0} &amp;
-\mathrm{div}\,\mathbf{B} &amp;= 0 \[0.5em]
-\mathrm{rot}\,\mathbf{B} &amp;= \mu_0\mathbf{J} + \frac{1}{c^2}\frac{\partial \mathbf{E}}{\partial t} &amp;
-\mathrm{rot}\,\mathbf{E} &amp;= -\frac{\partial \mathbf{B}}{\partial t}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B} &= 0 \\[0.5em]
+\mathrm{rot}\,\mathbf{B} &= \mu_0\mathbf{J} + \frac{1}{c^2}\frac{\partial \mathbf{E}}{\partial t} &
+\mathrm{rot}\,\mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t}
 \end{aligned}$$</p>
 <p>このままでは、これから $4\times4$ 行列に押し込むための「型」が揃っていない。電場 $\mathbf{E}$（次元 $\mathrm{V/m}$）と磁束密度 $\mathbf{B}$（次元 $\mathrm{T}$）は単位が違い、さらに空間の微分（$\mathrm{rot}$ や $\mathrm{div}$）と時間 $t$ の微分も次元が異なる。</p>
 <p>そこで、すべてを「長さ」の次元に変換する。</p>
@@ -3748,13 +3746,13 @@ C_\phi &amp;= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac
 </li>
 </ol>
 <p>これらを上の4式に代入する。ファラデーの法則は、</p>
-<p>$$\mathrm{rot}\,\mathbf{E} = -\frac{\partial}{\partial t}!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$</p>
+<p>$$\mathrm{rot}\,\mathbf{E} = -\frac{\partial}{\partial t}\!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}\!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$</p>
 <p>アンペールの法則も同様に整理すると、</p>
 <p>$$\begin{aligned}
-\mathrm{div}\,\mathbf{E} &amp;= \frac{\rho}{\varepsilon_0} &amp;
-\mathrm{div}\,\mathbf{B}' &amp;= 0 \[0.5em]
-\mathrm{rot}\,\mathbf{B}' &amp;= c\mu_0\mathbf{J} + \frac{\partial \mathbf{E}}{\partial w} &amp;
-\mathrm{rot}\,\mathbf{E} &amp;= -\frac{\partial \mathbf{B}'}{\partial w}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B}' &= 0 \\[0.5em]
+\mathrm{rot}\,\mathbf{B}' &= c\mu_0\mathbf{J} + \frac{\partial \mathbf{E}}{\partial w} &
+\mathrm{rot}\,\mathbf{E} &= -\frac{\partial \mathbf{B}'}{\partial w}
 \end{aligned}$$</p>
 <p>時間微分が $\frac{\partial}{\partial w}$ になり、空間微分（$\mathrm{rot}, \mathrm{div}$）と分母の次元（長さ）が揃った。</p>
 <p>以降、$\mathbf{B}'$ のことを改めて $\mathbf{B}$ と呼び、$w$ を改めて $t$ と書く。つまり、これ以降の $\mathbf{B}$ は本来の磁束密度ではなく $c$ 倍された「次元を揃えた磁場」であり、$t$ は本来の時間ではなく $c$ 倍された「長さの次元を持つ時間座標」である。</p>
@@ -3763,14 +3761,14 @@ C_\phi &amp;= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac
 <p>以上である。4本が2本に——この簡潔さをもって「美しい」と讃えるのが、微分形式の教科書の定番の幕引きだ。</p>
 <p>しかし、本書はここで終わらない。$F$ の中身は何なのか。$dF=0$ を成分で展開すると、本当に $\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ と $\mathrm{div}\,\mathbf{B} = 0$ が出てくるのか。それを、この章で全部書き下す。</p>
 <hr />
-<h3 id="102-f">§10.2 $F$ の中身——行列で全部書く</h3>
+<h3 id="102-mathblock4167placeholder">§10.2 $F$ の中身——行列で全部書く</h3>
 <p>電磁場 $F$ は $2$-form である。第2章以来、$2$-form は反対称行列で表示できることを知っている。$F$ も例外ではない——ただし、時間も含めた4次元時空で考えるため、$F$ は $4\times4$ の反対称行列になる。</p>
 <p>時間座標を $t$（ただしこれは §10.1 で変換した $w=ct$ を改名したものであり、元のSI単位系の $t$ ではない）、空間座標を $x,y,z$ とする。§10.1 の変換により、$F$ の成分は次のようになる。</p>
 <p>$$F = \begin{pmatrix}
-0 &amp; -E_x &amp; -E_y &amp; -E_z \
-E_x &amp; 0 &amp; B_z &amp; -B_y \
-E_y &amp; -B_z &amp; 0 &amp; B_x \
-E_z &amp; B_y &amp; -B_x &amp; 0
+0 & -E_x & -E_y & -E_z \\
+E_x & 0 & B_z & -B_y \\
+E_y & -B_z & 0 & B_x \\
+E_z & B_y & -B_x & 0
 \end{pmatrix}$$</p>
 <p>行と列の順は $(t,x,y,z)$。$E_x, E_y, E_z$ は電場（元のSI単位系の値）、$B_x, B_y, B_z$ は $c$ 倍された磁場である。両者は §10.1 の正規化により同一の次元 $\mathrm{V/m}$ を持ち、行列にそのまま並べられる。$F$ は反対称行列（$F^T = -F$）であり、独立な成分はちょうど6個だ。</p>
 <p>基底 $2$-form で書けば、</p>
@@ -3779,67 +3777,67 @@ E_z &amp; B_y &amp; -B_x &amp; 0
 <blockquote>
 <p><strong>注</strong> （符号の規約）上の行列表示は、4元ポテンシャル $A$ から作る
 $$
-F_{\mu\nu}
-=
-\frac{\partial A_\nu}{\partial x^\mu}
--
-\frac{\partial A_\mu}{\partial x^\nu}
-$$
+> F_{\mu\nu}
+> =
+> \frac{\partial A_\nu}{\partial x^\mu}
+> -
+> \frac{\partial A_\mu}{\partial x^\nu}
+> $$
 という反対称な成分の並べ方に対応する（§10.6 ではこれを $F=-dA$ として扱う）。ここで
 $$
-(x^0,x^1,x^2,x^3)=(t,x,y,z)
-$$
+> (x^0,x^1,x^2,x^3)=(t,x,y,z)
+> $$
 である。通常は $\partial_\mu A_\nu-\partial_\nu A_\mu$ と略記されるが、本書では不要な略記法を避ける。符号が逆の流儀もあるが、本章ではこの規約に従う。</p>
 </blockquote>
 <hr />
-<h3 id="103-mathbbr3-4">§10.3 ミンコフスキー計量——$\mathbb{R}^3$ から4次元へ</h3>
+<h3 id="103-mathblock4195placeholder-4">§10.3 ミンコフスキー計量——$\mathbb{R}^3$ から4次元へ</h3>
 <p>本書は一貫して $\mathbb{R}^3$ のデカルト座標 $(x,y,z)$ を舞台にしてきた。しかし $F$ を扱うには、時間 $t$ を加えた4次元時空 $(t,x,y,z)$ が必要になる。</p>
 <p>幸い、ここまでに積み上げた知識があれば、拡張は容易だ。第6章で $\mathbf{g} = J^T J$ を導出し、第9章で $\mathbf{g}$ から $\ast$ の辞書を作る手順を練習した。時空でも同じことをすればよい。計量は次のようになる（時間成分の符号が空間成分と異なる点が唯一の新しい要素だ）。</p>
 <p>$$\mathbf{g} = \begin{pmatrix}
--1 &amp; 0 &amp; 0 &amp; 0 \
-0 &amp; 1 &amp; 0 &amp; 0 \
-0 &amp; 0 &amp; 1 &amp; 0 \
-0 &amp; 0 &amp; 0 &amp; 1
+-1 & 0 & 0 & 0 \\
+0 & 1 & 0 & 0 \\
+0 & 0 & 1 & 0 \\
+0 & 0 & 0 & 1
 \end{pmatrix}$$</p>
 <blockquote>
-<p><strong>注</strong> （正定値性からの離脱）本書の計量はこれまでつねに正定値（$\mathbf{v}^T\mathbf{g}\,\mathbf{v} &gt; 0$ for $\mathbf{v}\neq\mathbf{0}$）だった。ミンコフスキー計量は正定値ではなく、これまでの $\mathbf{g}=J^T J$ 型の計量とは異なる。ここでは「計量行列から $\ast$ の辞書を作る」という手順だけを引き継いでいる。この違いは $\ast$ の辞書に符号の変化として現れるが、計算手順そのものは変わらない。第11章でこの点に簡単に触れる。</p>
+<p><strong>注</strong> （正定値性からの離脱）本書の計量はこれまでつねに正定値（$\mathbf{v}^T\mathbf{g}\,\mathbf{v} > 0$ for $\mathbf{v}\neq\mathbf{0}$）だった。ミンコフスキー計量は正定値ではなく、これまでの $\mathbf{g}=J^T J$ 型の計量とは異なる。ここでは「計量行列から $\ast$ の辞書を作る」という手順だけを引き継いでいる。この違いは $\ast$ の辞書に符号の変化として現れるが、計算手順そのものは変わらない。第11章でこの点に簡単に触れる。</p>
 </blockquote>
 <p>行と列の順は $(t,x,y,z)$。空間部分（右下の$3\times3$）は単位行列であり、これまでの $\mathbb{R}^3$ の計量そのものだ。時間成分の $-1$ が $\ast$ の辞書に符号の変化をもたらすが、それは §10.5 で $\ast F$ の行列表示として結果を受け取れば十分である。</p>
 <hr />
-<h3 id="104-df0">§10.4 $dF=0$ を全部書き下す</h3>
+<h3 id="104-mathblock4215placeholder">§10.4 $dF=0$ を全部書き下す</h3>
 <p>$F$ は $2$-form だから、$dF$ は $3$-form になる。4次元空間での $3$-form の独立成分は4つ。$F$ の全6項について $d$ を作用させ、同じ基底 $3$-form の係数をまとめる。</p>
 <p>$F$ の6項を形式で書く。</p>
 <p>$$F = E_x\,dt\wedge dx + E_y\,dt\wedge dy + E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$</p>
 <p>各項に $d$ を作用させる。$E_x, E_y, E_z, B_x, B_y, B_z$ はすべて $(t,x,y,z)$ の関数である。</p>
 <p>$$\begin{aligned}
-d!\left(E_x\,dt\wedge dx\right) &amp;= \frac{\partial E_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial E_x}{\partial z}\,dz\wedge dt\wedge dx \
-d!\left(E_y\,dt\wedge dy\right) &amp;= \frac{\partial E_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial E_y}{\partial z}\,dz\wedge dt\wedge dy \
-d!\left(E_z\,dt\wedge dz\right) &amp;= \frac{\partial E_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial E_z}{\partial y}\,dy\wedge dt\wedge dz
+d\!\left(E_x\,dt\wedge dx\right) &= \frac{\partial E_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial E_x}{\partial z}\,dz\wedge dt\wedge dx \\
+d\!\left(E_y\,dt\wedge dy\right) &= \frac{\partial E_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial E_y}{\partial z}\,dz\wedge dt\wedge dy \\
+d\!\left(E_z\,dt\wedge dz\right) &= \frac{\partial E_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial E_z}{\partial y}\,dy\wedge dt\wedge dz
 \end{aligned}$$</p>
 <p>$B$ の項は $t$ 微分も含む。</p>
 <p>$$\begin{aligned}
-d(B_x\,dy\wedge dz) &amp;= \frac{\partial B_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial B_x}{\partial x}\,dx\wedge dy\wedge dz \
-d(B_y\,dz\wedge dx) &amp;= \frac{\partial B_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial B_y}{\partial y}\,dy\wedge dz\wedge dx \
-d(B_z\,dx\wedge dy) &amp;= \frac{\partial B_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial B_z}{\partial z}\,dz\wedge dx\wedge dy
+d(B_x\,dy\wedge dz) &= \frac{\partial B_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial B_x}{\partial x}\,dx\wedge dy\wedge dz \\
+d(B_y\,dz\wedge dx) &= \frac{\partial B_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial B_y}{\partial y}\,dy\wedge dz\wedge dx \\
+d(B_z\,dx\wedge dy) &= \frac{\partial B_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial B_z}{\partial z}\,dz\wedge dx\wedge dy
 \end{aligned}$$</p>
 <p>これらをすべて足し合わせる。基底 $3$-form の種類は $(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$ の4つ。ウェッジ積の反対称性を使って項を整理する（たとえば $dy\wedge dt\wedge dx = -dt\wedge dy\wedge dx = dt\wedge dx\wedge dy$）。</p>
 <p>各基底 $3$-form の係数をゼロとおくと、$dF=0$ は次と同値になる。</p>
 <p>$$dF = 0 \Longleftrightarrow \begin{cases}
-\displaystyle \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z} = 0 \[1em]
-\displaystyle \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t} = 0 \[0.5em]
-\displaystyle \frac{\partial E_x}{\partial z} - \frac{\partial E_z}{\partial x} + \frac{\partial B_y}{\partial t} = 0 \[0.5em]
+\displaystyle \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z} = 0 \\[1em]
+\displaystyle \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t} = 0 \\[0.5em]
+\displaystyle \frac{\partial E_x}{\partial z} - \frac{\partial E_z}{\partial x} + \frac{\partial B_y}{\partial t} = 0 \\[0.5em]
 \displaystyle \frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t} = 0
 \end{cases}$$</p>
 <p>1行目は $\mathrm{div}\,\mathbf{B} = 0$、2〜4行目は $\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ の各成分にほかならない。</p>
 <hr />
-<h3 id="105-ast-f-2">§10.5 $\ast F$ と残りの2本</h3>
+<h3 id="105-mathblock4237placeholder-2">§10.5 $\ast F$ と残りの2本</h3>
 <p>もう一つの式 $d(\ast F) = \mu_0(\ast\mathcal{J})$ も、§10.4 と同じ手順で全部書き下す。</p>
 <p>まず $\ast F$ を求める。$\ast$ は4次元時空の計量に依存するが、特殊相対論の平坦な時空（計量は時間成分だけ符号が異なる）では、$\ast F$ は §10.2 の $F$ で $\mathbf{E}$ と $\mathbf{B}$ を入れ替えた形になる。行列表示は次の通りだ。</p>
 <p>$$\ast F = \begin{pmatrix}
-0 &amp; B_x &amp; B_y &amp; B_z \
--B_x &amp; 0 &amp; E_z &amp; -E_y \
--B_y &amp; -E_z &amp; 0 &amp; E_x \
--B_z &amp; E_y &amp; -E_x &amp; 0
+0 & B_x & B_y & B_z \\
+-B_x & 0 & E_z & -E_y \\
+-B_y & -E_z & 0 & E_x \\
+-B_z & E_y & -E_x & 0
 \end{pmatrix}$$</p>
 <p>$F$ と見比べてほしい。$E$ と $B$ の位置が入れ替わっている。この規約と正規化のもとでは、$\ast$ はほとんど「$\mathbf{E}$ と $\mathbf{B}$ を入れ替える装置」として働く。</p>
 <p>基底 $2$-form で書けば、§10.2 の $F$ と対応する形になる。</p>
@@ -3847,25 +3845,25 @@ d(B_z\,dx\wedge dy) &amp;= \frac{\partial B_z}{\partial t}\,dt\wedge dx\wedge dy
 <p>次に、$d(\ast F)$ を展開する。$\ast F$ も $2$-form だから、$d(\ast F)$ は $3$-form だ。</p>
 <p>まず $B$ の項（$dt\wedge dx, dt\wedge dy, dt\wedge dz$）に $d$ を作用させる。これらの時間微分は $dt\wedge dt = 0$ で消え、空間微分だけが残る。§10.4 の $E$ の項と同じ構造だ。</p>
 <p>$$\begin{aligned}
-d!\left(B_x\,dt\wedge dx\right) &amp;= \frac{\partial B_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial B_x}{\partial z}\,dz\wedge dt\wedge dx \
-d!\left(B_y\,dt\wedge dy\right) &amp;= \frac{\partial B_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial B_y}{\partial z}\,dz\wedge dt\wedge dy \
-d!\left(B_z\,dt\wedge dz\right) &amp;= \frac{\partial B_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial B_z}{\partial y}\,dy\wedge dt\wedge dz
+d\!\left(B_x\,dt\wedge dx\right) &= \frac{\partial B_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial B_x}{\partial z}\,dz\wedge dt\wedge dx \\
+d\!\left(B_y\,dt\wedge dy\right) &= \frac{\partial B_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial B_y}{\partial z}\,dz\wedge dt\wedge dy \\
+d\!\left(B_z\,dt\wedge dz\right) &= \frac{\partial B_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial B_z}{\partial y}\,dy\wedge dt\wedge dz
 \end{aligned}$$</p>
 <p>次に $E$ の項（$dy\wedge dz, dz\wedge dx, dx\wedge dy$）に $d$ を作用させる。こちらは時間微分も含む。§10.4 の $B$ の項と同じ構造だ。</p>
 <p>$$\begin{aligned}
-d!\left(E_x\,dy\wedge dz\right) &amp;= \frac{\partial E_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial E_x}{\partial x}\,dx\wedge dy\wedge dz \
-d!\left(E_y\,dz\wedge dx\right) &amp;= \frac{\partial E_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial E_y}{\partial y}\,dy\wedge dz\wedge dx \
-d!\left(E_z\,dx\wedge dy\right) &amp;= \frac{\partial E_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial E_z}{\partial z}\,dz\wedge dx\wedge dy
+d\!\left(E_x\,dy\wedge dz\right) &= \frac{\partial E_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial E_x}{\partial x}\,dx\wedge dy\wedge dz \\
+d\!\left(E_y\,dz\wedge dx\right) &= \frac{\partial E_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial E_y}{\partial y}\,dy\wedge dz\wedge dx \\
+d\!\left(E_z\,dx\wedge dy\right) &= \frac{\partial E_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial E_z}{\partial z}\,dz\wedge dx\wedge dy
 \end{aligned}$$</p>
 <p>これらをすべて足し合わせる。基底 $3$-form の種類は §10.4 と同じ $(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$ の4つ。ウェッジ積の反対称性を使って項を整理する。</p>
 <p>各基底 $3$-form の係数をまとめると、$d(\ast F)$ は次になる。</p>
 <p>$$\begin{aligned}
-d(\ast F) = &amp;\left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right) dt\wedge dx\wedge dy \
-{+} &amp;\left(\frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t}\right) dt\wedge dy\wedge dz \
-{+} &amp;\left(\frac{\partial B_z}{\partial x} - \frac{\partial B_x}{\partial z} + \frac{\partial E_y}{\partial t}\right) dt\wedge dz\wedge dx \
-{+} &amp;\left(\frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}\right) dx\wedge dy\wedge dz
+d(\ast F) = &\left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right) dt\wedge dx\wedge dy \\
+{+} &\left(\frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t}\right) dt\wedge dy\wedge dz \\
+{+} &\left(\frac{\partial B_z}{\partial x} - \frac{\partial B_x}{\partial z} + \frac{\partial E_y}{\partial t}\right) dt\wedge dz\wedge dx \\
+{+} &\left(\frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}\right) dx\wedge dy\wedge dz
 \end{aligned}$$</p>
-<p>$dx\wedge dy\wedge dz$ の係数は $\mathrm{div}\,\mathbf{E}$ にほかならない。$dt\wedge dx\wedge dy$ の係数は $\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t} = -(\mathrm{rot}\,\mathbf{B})<em>z + \frac{\partial E_z}{\partial t}$ であり、2〜3行目も同様に $-(\mathrm{rot}\,\mathbf{B})</em>{x,y} + \frac{\partial E_{x,y}}{\partial t}$ の各成分だ。</p>
+<p>$dx\wedge dy\wedge dz$ の係数は $\mathrm{div}\,\mathbf{E}$ にほかならない。$dt\wedge dx\wedge dy$ の係数は $\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t} = -(\mathrm{rot}\,\mathbf{B})_z + \frac{\partial E_z}{\partial t}$ であり、2〜3行目も同様に $-(\mathrm{rot}\,\mathbf{B})_{x,y} + \frac{\partial E_{x,y}}{\partial t}$ の各成分だ。</p>
 <p>一方、右辺の $\ast\mathcal{J}$ は電荷・電流を表す $3$-form である。正規化された系では、次の形をとる。</p>
 <p>$$\ast\mathcal{J} = \frac{\rho}{\varepsilon_0\mu_0}\,dx\wedge dy\wedge dz - cJ_x\,dt\wedge dy\wedge dz - cJ_y\,dt\wedge dz\wedge dx - cJ_z\,dt\wedge dx\wedge dy$$</p>
 <p>（$\rho$ は電荷密度、$J_x,J_y,J_z$ は電流密度。$\varepsilon_0\mu_0 = 1/c^2$ より、第1項の係数は $c^2\rho$ に等しい。）</p>
@@ -3884,17 +3882,17 @@ d(\ast F) = &amp;\left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\pa
 <p><strong>注</strong> （なぜここで終わるのか）多くの教科書は $dF=0$ を示した時点で「かくしてマクスウェル方程式は幾何学である」と締める。しかし本書の流儀は違う。行列の成分を全部書き下し、$d$ と $\ast$ の辞書を通じてベクトル解析の式を再現する——その往復ができることこそ、第1章から積み上げてきた「測定器」の枠組みの到達点だ。</p>
 </blockquote>
 <hr />
-<h3 id="106-f-da">§10.6 ポテンシャル構成——$F=-dA$ から始める</h3>
+<h3 id="106-mathblock4304placeholder">§10.6 ポテンシャル構成——$F=-dA$ から始める</h3>
 <p>§10.2 では $F$ を「$\mathbf{E}$ と $\mathbf{B}$ の寄せ集め」として天下り的に定義した。しかし実は、$F$ はもっと根源的な量——<strong>4元ポテンシャル $A$</strong>——から機械的に導かれる。こちらが出発点として自然なのは、<strong>$dF=0$ が「$dd=0$」の一言で証明される</strong>からだ。</p>
 <p>4元ポテンシャル $A$ は $1$-form である。電磁気学ではスカラーポテンシャル $\phi$ とベクトルポテンシャル $\mathbf{A} = (A_x, A_y, A_z)$ が組になる。時間成分の符号に注意して（§10.3 の計量の時間成分が $-1$ であることの反映）、</p>
 <p>$$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$$</p>
 <p>と書く。$\phi, A_x, A_y, A_z$ はいずれも $(t,x,y,z)$ の関数である。</p>
 <p>$dA$ の計算は第5章以来の手順そのものだ。$A$ の4項それぞれに $d$ を作用させる。</p>
 <p>$$\begin{aligned}
-d(-\phi\,dt) &amp;= -\frac{\partial\phi}{\partial x}\,dx\wedge dt - \frac{\partial\phi}{\partial y}\,dy\wedge dt - \frac{\partial\phi}{\partial z}\,dz\wedge dt \
-d(A_x\,dx) &amp;= \frac{\partial A_x}{\partial t}\,dt\wedge dx + \frac{\partial A_x}{\partial y}\,dy\wedge dx + \frac{\partial A_x}{\partial z}\,dz\wedge dx \
-d(A_y\,dy) &amp;= \frac{\partial A_y}{\partial t}\,dt\wedge dy + \frac{\partial A_y}{\partial x}\,dx\wedge dy + \frac{\partial A_y}{\partial z}\,dz\wedge dy \
-d(A_z\,dz) &amp;= \frac{\partial A_z}{\partial t}\,dt\wedge dz + \frac{\partial A_z}{\partial x}\,dx\wedge dz + \frac{\partial A_z}{\partial y}\,dy\wedge dz
+d(-\phi\,dt) &= -\frac{\partial\phi}{\partial x}\,dx\wedge dt - \frac{\partial\phi}{\partial y}\,dy\wedge dt - \frac{\partial\phi}{\partial z}\,dz\wedge dt \\
+d(A_x\,dx) &= \frac{\partial A_x}{\partial t}\,dt\wedge dx + \frac{\partial A_x}{\partial y}\,dy\wedge dx + \frac{\partial A_x}{\partial z}\,dz\wedge dx \\
+d(A_y\,dy) &= \frac{\partial A_y}{\partial t}\,dt\wedge dy + \frac{\partial A_y}{\partial x}\,dx\wedge dy + \frac{\partial A_y}{\partial z}\,dz\wedge dy \\
+d(A_z\,dz) &= \frac{\partial A_z}{\partial t}\,dt\wedge dz + \frac{\partial A_z}{\partial x}\,dx\wedge dz + \frac{\partial A_z}{\partial y}\,dy\wedge dz
 \end{aligned}$$</p>
 <p>（$\phi$ の時間微分は $dt\wedge dt = 0$ で消える。$A_x$ の $x$ 微分も $dx\wedge dx = 0$ で消える。以下同様。）</p>
 <p>これらを足し合わせ、ウェッジ積の反対称性（$dx\wedge dt = -dt\wedge dx$ など）で基底 $2$-form ごとに整理する。</p>
@@ -3902,21 +3900,21 @@ d(A_z\,dz) &amp;= \frac{\partial A_z}{\partial t}\,dt\wedge dz + \frac{\partial 
 <p>$dy\wedge dz$ の係数は、$d(A_y\,dy)$ から $\frac{\partial A_y}{\partial z}\,dz\wedge dy = -\frac{\partial A_y}{\partial z}\,dy\wedge dz$。$d(A_z\,dz)$ から $\frac{\partial A_z}{\partial y}\,dy\wedge dz$。よって $dA$ の $dy\wedge dz$ 係数は $\displaystyle \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$。</p>
 <p>全6基底について同様に整理すると、$dA$ は次のようになる。</p>
 <p>$$\begin{aligned}
-dA &amp;= \left(\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}\right)dt\wedge dx + \left(\frac{\partial\phi}{\partial y} + \frac{\partial A_y}{\partial t}\right)dt\wedge dy + \left(\frac{\partial\phi}{\partial z} + \frac{\partial A_z}{\partial t}\right)dt\wedge dz \
-&amp;\quad+ \left(\frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial A_x}{\partial z} - \frac{\partial A_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial A_y}{\partial x} - \frac{\partial A_x}{\partial y}\right)dx\wedge dy
+dA &= \left(\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}\right)dt\wedge dx + \left(\frac{\partial\phi}{\partial y} + \frac{\partial A_y}{\partial t}\right)dt\wedge dy + \left(\frac{\partial\phi}{\partial z} + \frac{\partial A_z}{\partial t}\right)dt\wedge dz \\
+&\quad+ \left(\frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial A_x}{\partial z} - \frac{\partial A_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial A_y}{\partial x} - \frac{\partial A_x}{\partial y}\right)dx\wedge dy
 \end{aligned}$$</p>
 <p>ここで $dA$ の $dt\wedge dx$ 係数は $\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}$ だが、§10.2 の $F$ では同基底の係数は $E_x$。両者の符号を見比べると、$E_x = -\frac{\partial\phi}{\partial x} - \frac{\partial A_x}{\partial t}$ とする必要がある。つまり、$F = -dA$ と置けばよい。まとめると、</p>
 <p>$$F = -dA$$</p>
 <p>である。$\mathbf{E}$ の全成分と $\mathbf{B}$ の全成分を、ポテンシャルで書き下すと次のとおり。</p>
 <p>$$\begin{aligned}
-\mathbf{E} &amp;= -\nabla\phi - \frac{\partial\mathbf{A}}{\partial t} \[0.3em]
-\mathbf{B} &amp;= -\left(\nabla\times\mathbf{A}\right)
+\mathbf{E} &= -\nabla\phi - \frac{\partial\mathbf{A}}{\partial t} \\[0.3em]
+\mathbf{B} &= -\left(\nabla\times\mathbf{A}\right)
 \end{aligned}$$</p>
 <p>$dt\wedge dx$ の係数 $E_x$ が $-\partial\phi/\partial x - \partial A_x/\partial t$、$dy\wedge dz$ の係数 $B_x$ が $-\frac{\partial A_z}{\partial y} + \frac{\partial A_y}{\partial z}$——電磁気学の教科書では $B_x = \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$ と書かれるが、ここでの負号は本章の規約（$F=-dA$）に由来する。この負号は $\mathbf{A}$ の符号を反転させれば吸収できる、形式的な違いにすぎない。</p>
 <blockquote>
 <p><strong>注</strong> （$F$ の符号規約）$F = -dA$ という定義は、§10.2 の $F$ の行列表示（$F_{tx}=-E_x$）と整合するように選んだものである。$F = +dA$、$A = +\phi\,dt + \cdots$ など、異なる符号の組み合わせを使う流儀も存在する。本章では、§10.2 の $F$ の行列と $\mathbf{E} = -\nabla\phi - \partial\mathbf{A}/\partial t$ が整合する規約として $F=-dA$ を採用している。</p>
 </blockquote>
-<h4 id="dd0-df0">$dd=0$ が $dF=0$ を証明する</h4>
+<h4 id="mathblock4373placeholder-mathblock4374placeholder">$dd=0$ が $dF=0$ を証明する</h4>
 <p>§10.4 の主結果——$dF=0$ が $\mathrm{div}\,\mathbf{B}=0$ と $\mathrm{rot}\,\mathbf{E}=-\partial\mathbf{B}/\partial t$ に等しい——の証明は一瞬である。$F=-dA$ だから、</p>
 <p>$$dF = d(-dA) = -d(dA) = 0$$</p>
 <p>$dd=0$ は第5章 §4.4 で証明した外微分の基本性質だ。$F$ が「何かの外微分」（定数倍を除いて）で書ける以上、その外微分は自動的にゼロになる。§10.4 で4つの基底 $3$-form の係数をゼロとおいて得た4本の式は、すべてこの一行に集約されている。</p>
@@ -3937,9 +3935,9 @@ dA &amp;= \left(\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t
 - <strong>ポテンシャル構成</strong>：$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$ から $F=-dA$（§10.2 の行列規約と整合）。$dF=0$ は $dd=0$ より自動的。$\mathbf{E}=-\nabla\phi-\partial\mathbf{A}/\partial t$ が自然に出る。</p>
 </blockquote>
 <hr />
-<h2 id="edf-dast-f-4times4times4">付録E：$dF$ と $d(\ast F)$ のスライス行列表示 —— $4\times4\times4$ 配列で見るマクスウェル方程式</h2>
+<h2 id="emathblock4420placeholder-mathblock4421placeholder-mathblock4422placeholder">付録E：$dF$ と $d(\ast F)$ のスライス行列表示 —— $4\times4\times4$ 配列で見るマクスウェル方程式</h2>
 <p>§10.4・§10.5 では $dF$ と $d(\ast F)$ を基底 $3$-form の係数として展開した。付録Eでは、同じ計算を <strong>$4\times4$ スライス行列の束</strong>——実質的には $4\times4\times4$ の3階テンソル——で可視化する。付録Aの延長線上にあり、本書の「全部行列に載せる」流儀の到達点でもある。</p>
-<h3 id="e1-3-form-16">E.1 基底 $3$-form とそのスライス行列 —— 全16枚</h3>
+<h3 id="e1-mathblock4428placeholder-form-16">E.1 基底 $3$-form とそのスライス行列 —— 全16枚</h3>
 <p>4次元の基底 $3$-form は次の4つである（§10.4 の並びと比べると、$\omega_2$ と $\omega_3$ の符号・順序が異なるが、内容は同じ4つである）。</p>
 <p>$$
 \omega_1 = dt\wedge dx\wedge dy,\qquad
@@ -3947,69 +3945,69 @@ dA &amp;= \left(\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t
 \omega_3 = dt\wedge dy\wedge dz,\qquad
 \omega_4 = dx\wedge dy\wedge dz
 $$</p>
-<p>各 $\omega_i$ について、座標方向 $t,x,y,z$ の<strong>スライス行列</strong> $\mathbf{S}<em>{t}^{(\omega_i)}, \mathbf{S}</em>{x}^{(\omega_i)}, \mathbf{S}<em>{y}^{(\omega_i)}, \mathbf{S}</em>{z}^{(\omega_i)}$ を定義する。スライス行列とは「その方向の座標を除いた残りの $3$ 方向が作る $3$-form」を $4\times4$ 反対称行列に焼き直したものである。行・列の順は $(t,x,y,z)$。非ゼロ成分には $\pm1$ が入る。$4$ 基底 $\times 4$ スライス $=$ 全 $16$ 枚。</p>
+<p>各 $\omega_i$ について、座標方向 $t,x,y,z$ の<strong>スライス行列</strong> $\mathbf{S}_{t}^{(\omega_i)}, \mathbf{S}_{x}^{(\omega_i)}, \mathbf{S}_{y}^{(\omega_i)}, \mathbf{S}_{z}^{(\omega_i)}$ を定義する。スライス行列とは「その方向の座標を除いた残りの $3$ 方向が作る $3$-form」を $4\times4$ 反対称行列に焼き直したものである。行・列の順は $(t,x,y,z)$。非ゼロ成分には $\pm1$ が入る。$4$ 基底 $\times 4$ スライス $=$ 全 $16$ 枚。</p>
 <p><strong>（1）</strong> $\omega_1 = dt\wedge dx\wedge dy$ のスライス：</p>
 <p>$$
-\mathbf{S}<em>{t}^{(\omega_1)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;1&amp;0\[2pt]0&amp;-1&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{x}^{(\omega_1)}=\begin{pmatrix}0&amp;0&amp;-1&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]1&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}<em>{y}^{(\omega_1)}=\begin{pmatrix}0&amp;1&amp;0&amp;0\[2pt]-1&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{z}^{(\omega_1)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(\omega_1)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&1&0\\[2pt]0&-1&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{x}^{(\omega_1)}=\begin{pmatrix}0&0&-1&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{y}^{(\omega_1)}=\begin{pmatrix}0&1&0&0\\[2pt]-1&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{z}^{(\omega_1)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 $$</p>
 <p><strong>（2）</strong> $\omega_2 = dt\wedge dx\wedge dz$ のスライス：</p>
 <p>$$
-\mathbf{S}<em>{t}^{(\omega_2)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;-1&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{x}^{(\omega_2)}=\begin{pmatrix}0&amp;0&amp;0&amp;-1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]1&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}<em>{y}^{(\omega_2)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{z}^{(\omega_2)}=\begin{pmatrix}0&amp;1&amp;0&amp;0\[2pt]-1&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(\omega_2)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&0&0\\[2pt]0&-1&0&0\end{pmatrix},\;
+\mathbf{S}_{x}^{(\omega_2)}=\begin{pmatrix}0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\end{pmatrix},\;
+\mathbf{S}_{y}^{(\omega_2)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{z}^{(\omega_2)}=\begin{pmatrix}0&1&0&0\\[2pt]-1&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 $$</p>
 <p><strong>（3）</strong> $\omega_3 = dt\wedge dy\wedge dz$ のスライス：</p>
 <p>$$
-\mathbf{S}<em>{t}^{(\omega_3)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;-1&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{x}^{(\omega_3)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}<em>{y}^{(\omega_3)}=\begin{pmatrix}0&amp;0&amp;0&amp;-1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]1&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{z}^{(\omega_3)}=\begin{pmatrix}0&amp;0&amp;-1&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]1&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(\omega_3)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix},\;
+\mathbf{S}_{x}^{(\omega_3)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{y}^{(\omega_3)}=\begin{pmatrix}0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\end{pmatrix},\;
+\mathbf{S}_{z}^{(\omega_3)}=\begin{pmatrix}0&0&-1&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 $$</p>
 <p><strong>（4）</strong> $\omega_4 = dx\wedge dy\wedge dz$ のスライス：</p>
 <p>$$
-\mathbf{S}<em>{t}^{(\omega_4)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{x}^{(\omega_4)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;-1&amp;0\end{pmatrix},\;
-\mathbf{S}<em>{y}^{(\omega_4)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;-1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;1&amp;0&amp;0\end{pmatrix},\;
-\mathbf{S}</em>{z}^{(\omega_4)}=\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;-1&amp;0\[2pt]0&amp;1&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
+\mathbf{S}_{x}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix},\;
+\mathbf{S}_{y}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&1&0&0\end{pmatrix},\;
+\mathbf{S}_{z}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&-1&0\\[2pt]0&1&0&0\\[2pt]0&0&0&0\end{pmatrix}
 $$</p>
-<p>16枚のうち、$\mathbf{S}<em>{z}^{(\omega_1)}, \mathbf{S}</em>{y}^{(\omega_2)}, \mathbf{S}<em>{x}^{(\omega_3)}, \mathbf{S}</em>{t}^{(\omega_4)}$ の4枚はゼロ行列である。残る12枚に $\pm1$ が一つずつ（と反対称のペアが一つずつ）入っている。これが $4\times4\times4$ テンソルの正体だ。</p>
-<h3 id="e2-df">E.2 $dF$ をスライス行列で書く</h3>
+<p>16枚のうち、$\mathbf{S}_{z}^{(\omega_1)}, \mathbf{S}_{y}^{(\omega_2)}, \mathbf{S}_{x}^{(\omega_3)}, \mathbf{S}_{t}^{(\omega_4)}$ の4枚はゼロ行列である。残る12枚に $\pm1$ が一つずつ（と反対称のペアが一つずつ）入っている。これが $4\times4\times4$ テンソルの正体だ。</p>
+<h3 id="e2-mathblock4451placeholder">E.2 $dF$ をスライス行列で書く</h3>
 <p>§10.4 の展開により、$dF$ の各基底係数は次で与えられる（$c$ を含まない正規化された系）。</p>
 <p>$$
 \begin{aligned}
-A_{txy} &amp;= \frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}
-\quad (\omega_1 = dt\wedge dx\wedge dy\text{ の係数}) \[6pt]
-A_{txz} &amp;= \frac{\partial E_z}{\partial x} - \frac{\partial E_x}{\partial z} - \frac{\partial B_y}{\partial t}
-\quad (\omega_2 = dt\wedge dx\wedge dz\text{ の係数}) \[6pt]
-A_{tyz} &amp;= \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t}
-\quad (\omega_3 = dt\wedge dy\wedge dz\text{ の係数}) \[6pt]
-A_{xyz} &amp;= \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z}
+A_{txy} &= \frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}
+\quad (\omega_1 = dt\wedge dx\wedge dy\text{ の係数}) \\[6pt]
+A_{txz} &= \frac{\partial E_z}{\partial x} - \frac{\partial E_x}{\partial z} - \frac{\partial B_y}{\partial t}
+\quad (\omega_2 = dt\wedge dx\wedge dz\text{ の係数}) \\[6pt]
+A_{tyz} &= \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t}
+\quad (\omega_3 = dt\wedge dy\wedge dz\text{ の係数}) \\[6pt]
+A_{xyz} &= \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z}
 \quad (\omega_4 = dx\wedge dy\wedge dz\text{ の係数})
 \end{aligned}
 $$</p>
 <p>$dF$ の各スライスは、4つの基底スライス行列を係数 $A_{\cdots}$ で線形結合したものである。たとえば $t$-スライスは</p>
 <p>$$
-\mathbf{S}<em>{t}^{(dF)} = A</em>{txy}\,\mathbf{S}<em>{t}^{(\omega_1)}
-{+} A</em>{txz}\,\mathbf{S}<em>{t}^{(\omega_2)}
-{+} A</em>{tyz}\,\mathbf{S}<em>{t}^{(\omega_3)}
-{+} A</em>{xyz}\,\mathbf{S}_{t}^{(\omega_4)}
+\mathbf{S}_{t}^{(dF)} = A_{txy}\,\mathbf{S}_{t}^{(\omega_1)}
+{+} A_{txz}\,\mathbf{S}_{t}^{(\omega_2)}
+{+} A_{tyz}\,\mathbf{S}_{t}^{(\omega_3)}
+{+} A_{xyz}\,\mathbf{S}_{t}^{(\omega_4)}
 $$</p>
 <p>となる。各 $A_{\cdots}$ を偏微分に展開し、それぞれの基底スライス行列に係数として掛けて並べると次のようになる。</p>
 <p>$$
 \begin{aligned}
-\mathbf{S}<em>{t}^{(dF)}
-&amp;= \left(\frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;1&amp;0\[2pt]0&amp;-1&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix} \[10pt]
-&amp;\quad+ \left(\frac{\partial E_z}{\partial x} - \frac{\partial E_x}{\partial z} - \frac{\partial B_y}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;-1&amp;0&amp;0\end{pmatrix} \[10pt]
-&amp;\quad+ \left(\frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;-1&amp;0\end{pmatrix}
-{+} A</em>{xyz}
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(dF)}
+&= \left(\frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&1&0\\[2pt]0&-1&0&0\\[2pt]0&0&0&0\end{pmatrix} \\[10pt]
+&\quad+ \left(\frac{\partial E_z}{\partial x} - \frac{\partial E_x}{\partial z} - \frac{\partial B_y}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&0&0\\[2pt]0&-1&0&0\end{pmatrix} \\[10pt]
+&\quad+ \left(\frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix}
+{+} A_{xyz}
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 \end{aligned}
 $$</p>
 <p>同じ位置の成分を<strong>一枚の行列に足し合わせる</strong>と、$t$-スライスは $16$ 成分すべてが明示された単一の $4\times4$ 反対称行列にまとまる。</p>
@@ -4017,22 +4015,22 @@ $$</p>
 \mathbf{S}_{t}^{(dF)}
 {=}
 \left(\begin{array}{c|cccc}
- &amp; t &amp; x &amp; y &amp; z \\hline
-t &amp; 0 &amp; 0 &amp; 0 &amp; 0 \[6pt]
-x &amp; 0 &amp; 0 &amp;
-\displaystyle\frac{\partial E_y}{\partial x} {-} \frac{\partial E_x}{\partial y} {+} \frac{\partial B_z}{\partial t} &amp;
-\displaystyle\frac{\partial E_z}{\partial x} {-} \frac{\partial E_x}{\partial z} {-} \frac{\partial B_y}{\partial t} \[14pt]
-y &amp; 0 &amp;
-\displaystyle{-}\frac{\partial E_y}{\partial x} {+} \frac{\partial E_x}{\partial y} {-} \frac{\partial B_z}{\partial t} &amp;
-0 &amp;
-\displaystyle\frac{\partial E_z}{\partial y} {-} \frac{\partial E_y}{\partial z} {+} \frac{\partial B_x}{\partial t} \[14pt]
-z &amp; 0 &amp;
-\displaystyle{-}\frac{\partial E_z}{\partial x} {+} \frac{\partial E_x}{\partial z} {+} \frac{\partial B_y}{\partial t} &amp;
-\displaystyle{-}\frac{\partial E_z}{\partial y} {+} \frac{\partial E_y}{\partial z} {-} \frac{\partial B_x}{\partial t} &amp;
+ & t & x & y & z \\\hline
+t & 0 & 0 & 0 & 0 \\[6pt]
+x & 0 & 0 &
+\displaystyle\frac{\partial E_y}{\partial x} {-} \frac{\partial E_x}{\partial y} {+} \frac{\partial B_z}{\partial t} &
+\displaystyle\frac{\partial E_z}{\partial x} {-} \frac{\partial E_x}{\partial z} {-} \frac{\partial B_y}{\partial t} \\[14pt]
+y & 0 &
+\displaystyle{-}\frac{\partial E_y}{\partial x} {+} \frac{\partial E_x}{\partial y} {-} \frac{\partial B_z}{\partial t} &
+0 &
+\displaystyle\frac{\partial E_z}{\partial y} {-} \frac{\partial E_y}{\partial z} {+} \frac{\partial B_x}{\partial t} \\[14pt]
+z & 0 &
+\displaystyle{-}\frac{\partial E_z}{\partial x} {+} \frac{\partial E_x}{\partial z} {+} \frac{\partial B_y}{\partial t} &
+\displaystyle{-}\frac{\partial E_z}{\partial y} {+} \frac{\partial E_y}{\partial z} {-} \frac{\partial B_x}{\partial t} &
 0
 \end{array}\right)
 $$</p>
-<p>$x,y,z$ のスライス $\mathbf{S}<em>{x}^{(dF)}, \mathbf{S}</em>{y}^{(dF)}, \mathbf{S}_{z}^{(dF)}$ も同様に4項の線形結合から得られる。$dF$ 全体は、これら4枚のスライス行列の束である。</p>
+<p>$x,y,z$ のスライス $\mathbf{S}_{x}^{(dF)}, \mathbf{S}_{y}^{(dF)}, \mathbf{S}_{z}^{(dF)}$ も同様に4項の線形結合から得られる。$dF$ 全体は、これら4枚のスライス行列の束である。</p>
 <h3 id="e3">E.3 フロベニウス積で係数を抜き出す</h3>
 <p>第6章付録D で導入したフロベニウス積は、$4\times4$ 行列にもそのまま拡張できる。</p>
 <blockquote>
@@ -4043,48 +4041,48 @@ A \cdot B = \frac{1}{2}\operatorname{tr}(A^T B) = \frac{1}{2}\sum_{i=1}^{4}\sum_
 $$</p>
 <p>この内積を使うと、各スライスから係数を<strong>一行で抽出</strong>できる。たとえば $A_{txy}$ は</p>
 <p>$$
-A_{txy} = \mathbf{S}<em>{t}^{(\omega_1)} \cdot \mathbf{S}</em>{t}^{(dF)}
+A_{txy} = \mathbf{S}_{t}^{(\omega_1)} \cdot \mathbf{S}_{t}^{(dF)}
 $$</p>
-<p>である。$\mathbf{S}<em>{t}^{(\omega_1)}$ の非ゼロ成分は $(x,y)=+1, (y,x)=-1$ だけなので、フロベニウス積は $(1 \cdot S</em>{xy} + (-1) \cdot S_{yx})/2 = (S_{xy} - S_{yx})/2 = S_{xy}$（$\mathbf{S}<em>{t}^{(dF)}$ が反対称だから $S</em>{yx}=-S_{xy}$）。一発で係数が抜ける。</p>
-<p>同様に、<strong>すべての係数は対応する基底スライスとのフロベニウス積で得られる</strong>。この構造は、第6章付録D で $\ast_{2\to1}(\mathbf{M}) = (E_1!\cdot!\mathbf{M},\;E_2!\cdot!\mathbf{M},\;E_3!\cdot!\mathbf{M})$ が $2$-form $\mathbf{M}$ の各成分を抽出したのと完全に相似である。次数が $1\to2$ から $2\to3$ に上がり、内積をとる相手が縦ベクトルから $4\times4$ 行列の束に変わっただけだ。</p>
-<h3 id="e4-df0">E.4 $dF=0$ をスライスで読む</h3>
+<p>である。$\mathbf{S}_{t}^{(\omega_1)}$ の非ゼロ成分は $(x,y)=+1, (y,x)=-1$ だけなので、フロベニウス積は $(1 \cdot S_{xy} + (-1) \cdot S_{yx})/2 = (S_{xy} - S_{yx})/2 = S_{xy}$（$\mathbf{S}_{t}^{(dF)}$ が反対称だから $S_{yx}=-S_{xy}$）。一発で係数が抜ける。</p>
+<p>同様に、<strong>すべての係数は対応する基底スライスとのフロベニウス積で得られる</strong>。この構造は、第6章付録D で $\ast_{2\to1}(\mathbf{M}) = (E_1\!\cdot\!\mathbf{M},\;E_2\!\cdot\!\mathbf{M},\;E_3\!\cdot\!\mathbf{M})$ が $2$-form $\mathbf{M}$ の各成分を抽出したのと完全に相似である。次数が $1\to2$ から $2\to3$ に上がり、内積をとる相手が縦ベクトルから $4\times4$ 行列の束に変わっただけだ。</p>
+<h3 id="e4-mathblock4478placeholder">E.4 $dF=0$ をスライスで読む</h3>
 <p>$dF=0$ とは、4枚のスライス行列すべてがゼロ行列になることである。</p>
 <p>$$
-\mathbf{S}<em>{t}^{(dF)} = \mathbf{0},\quad
-\mathbf{S}</em>{x}^{(dF)} = \mathbf{0},\quad
-\mathbf{S}<em>{y}^{(dF)} = \mathbf{0},\quad
-\mathbf{S}</em>{z}^{(dF)} = \mathbf{0}
+\mathbf{S}_{t}^{(dF)} = \mathbf{0},\quad
+\mathbf{S}_{x}^{(dF)} = \mathbf{0},\quad
+\mathbf{S}_{y}^{(dF)} = \mathbf{0},\quad
+\mathbf{S}_{z}^{(dF)} = \mathbf{0}
 $$</p>
 <p>$t$-スライス（上記）の非ゼロ成分を読めば、
 - $(x,y)$ 成分 $=0$ から $\mathrm{rot}_z\,\mathbf{E} + \partial B_z/\partial t = 0$
 - $(x,z)$ 成分 $=0$ から $-\mathrm{rot}_y\,\mathbf{E} - \partial B_y/\partial t = 0$
 - $(y,z)$ 成分 $=0$ から $\mathrm{rot}_x\,\mathbf{E} + \partial B_x/\partial t = 0$</p>
 <p>これら3つは $\mathrm{rot}\,\mathbf{E} = -\partial\mathbf{B}/\partial t$ にほかならない。$z$-スライス（$\mathbf{S}_{z}^{(\omega_4)}$ 由来）の非ゼロ成分からは $\mathrm{div}\,\mathbf{B} = 0$ が現れる。見かけは巨大だが、中身は §10.4 の4本の係数比較式の繰り返しにすぎない。</p>
-<h3 id="e5-dast-f-mu_0astmathcalj">E.5 $d(\ast F) = \mu_0(\ast\mathcal{J})$ のスライス表示</h3>
+<h3 id="e5-mathblock4494placeholder">E.5 $d(\ast F) = \mu_0(\ast\mathcal{J})$ のスライス表示</h3>
 <p>有源側も同型の構造を持つ。$\ast F$ と $\ast\mathcal{J}$ は §10.5 で展開済みであり、$d(\ast F)$ は $dF$ と同型のスライス行列になる——$\mathbf{E}$ と $\mathbf{B}$ の係数位置が入れ替わるだけだ。</p>
 <p>$d(\ast F)$ の $\omega_1\sim\omega_4$ 係数を $B_{txy}, B_{txz}, B_{tyz}, B_{xyz}$ と書く。</p>
 <p>$$
 \begin{aligned}
-B_{txy} &amp;= \frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}
-\quad (\text{§10.5 の } dt\wedge dx\wedge dy \text{ 係数}) \[6pt]
-B_{txz} &amp;= \frac{\partial B_x}{\partial z} - \frac{\partial B_z}{\partial x} - \frac{\partial E_y}{\partial t} \[6pt]
-B_{tyz} &amp;= \frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t} \[6pt]
-B_{xyz} &amp;= \frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}
+B_{txy} &= \frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}
+\quad (\text{§10.5 の } dt\wedge dx\wedge dy \text{ 係数}) \\[6pt]
+B_{txz} &= \frac{\partial B_x}{\partial z} - \frac{\partial B_z}{\partial x} - \frac{\partial E_y}{\partial t} \\[6pt]
+B_{tyz} &= \frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t} \\[6pt]
+B_{xyz} &= \frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}
 \quad (= \mathrm{div}\,\mathbf{E})
 \end{aligned}
 $$</p>
 <p>$d(\ast F)$ の各スライスも $dF$ と同様に、4つの係数 $B_{\cdots}$ で基底スライス行列を線形結合すればよい。$t$-スライスを項別に書く。</p>
 <p>$$
 \begin{aligned}
-\mathbf{S}<em>{t}^{(d(\ast F))}
-&amp;= \left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;1&amp;0\[2pt]0&amp;-1&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix} \[10pt]
-&amp;\quad+ \left(\frac{\partial B_x}{\partial z} - \frac{\partial B_z}{\partial x} - \frac{\partial E_y}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;-1&amp;0&amp;0\end{pmatrix} \[10pt]
-&amp;\quad+ \left(\frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t}\right)
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;1\[2pt]0&amp;0&amp;-1&amp;0\end{pmatrix}
-{+} B</em>{xyz}
-\begin{pmatrix}0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\[2pt]0&amp;0&amp;0&amp;0\end{pmatrix}
+\mathbf{S}_{t}^{(d(\ast F))}
+&= \left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&1&0\\[2pt]0&-1&0&0\\[2pt]0&0&0&0\end{pmatrix} \\[10pt]
+&\quad+ \left(\frac{\partial B_x}{\partial z} - \frac{\partial B_z}{\partial x} - \frac{\partial E_y}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&0&0\\[2pt]0&-1&0&0\end{pmatrix} \\[10pt]
+&\quad+ \left(\frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t}\right)
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix}
+{+} B_{xyz}
+\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 \end{aligned}
 $$</p>
 <p>同じ位置の成分を一枚の行列に足し合わせる。$dF$ の $t$-スライスと見比べてほしい——$\mathbf{E}$ と $\mathbf{B}$（および添字の巡回）がきれいに入れ替わっている。</p>
@@ -4092,27 +4090,27 @@ $$</p>
 \mathbf{S}_{t}^{(d(\ast F))}
 {=}
 \left(\begin{array}{c|cccc}
- &amp; t &amp; x &amp; y &amp; z \\hline
-t &amp; 0 &amp; 0 &amp; 0 &amp; 0 \[6pt]
-x &amp; 0 &amp; 0 &amp;
-\displaystyle\frac{\partial B_x}{\partial y} {-} \frac{\partial B_y}{\partial x} {+} \frac{\partial E_z}{\partial t} &amp;
-\displaystyle\frac{\partial B_x}{\partial z} {-} \frac{\partial B_z}{\partial x} {-} \frac{\partial E_y}{\partial t} \[14pt]
-y &amp; 0 &amp;
-\displaystyle{-}\frac{\partial B_x}{\partial y} {+} \frac{\partial B_y}{\partial x} {-} \frac{\partial E_z}{\partial t} &amp;
-0 &amp;
-\displaystyle\frac{\partial B_y}{\partial z} {-} \frac{\partial B_z}{\partial y} {+} \frac{\partial E_x}{\partial t} \[14pt]
-z &amp; 0 &amp;
-\displaystyle{-}\frac{\partial B_x}{\partial z} {+} \frac{\partial B_z}{\partial x} {+} \frac{\partial E_y}{\partial t} &amp;
-\displaystyle{-}\frac{\partial B_y}{\partial z} {+} \frac{\partial B_z}{\partial y} {-} \frac{\partial E_x}{\partial t} &amp;
+ & t & x & y & z \\\hline
+t & 0 & 0 & 0 & 0 \\[6pt]
+x & 0 & 0 &
+\displaystyle\frac{\partial B_x}{\partial y} {-} \frac{\partial B_y}{\partial x} {+} \frac{\partial E_z}{\partial t} &
+\displaystyle\frac{\partial B_x}{\partial z} {-} \frac{\partial B_z}{\partial x} {-} \frac{\partial E_y}{\partial t} \\[14pt]
+y & 0 &
+\displaystyle{-}\frac{\partial B_x}{\partial y} {+} \frac{\partial B_y}{\partial x} {-} \frac{\partial E_z}{\partial t} &
+0 &
+\displaystyle\frac{\partial B_y}{\partial z} {-} \frac{\partial B_z}{\partial y} {+} \frac{\partial E_x}{\partial t} \\[14pt]
+z & 0 &
+\displaystyle{-}\frac{\partial B_x}{\partial z} {+} \frac{\partial B_z}{\partial x} {+} \frac{\partial E_y}{\partial t} &
+\displaystyle{-}\frac{\partial B_y}{\partial z} {+} \frac{\partial B_z}{\partial y} {-} \frac{\partial E_x}{\partial t} &
 0
 \end{array}\right)
 $$</p>
-<p>右辺 $\mu_0(\ast\mathcal{J})$ も同じ4枚のスライス行列の線形結合で書ける。$\ast\mathcal{J}$ を本付録の基底順に展開し直すと（§10.5 参照）、$\omega_1!\sim!\omega_4$ の係数は順に $-\mu_0 c J_z,\; +\mu_0 c J_y,\; -\mu_0 c J_x,\; \rho/\varepsilon_0$ となる。すなわち</p>
+<p>右辺 $\mu_0(\ast\mathcal{J})$ も同じ4枚のスライス行列の線形結合で書ける。$\ast\mathcal{J}$ を本付録の基底順に展開し直すと（§10.5 参照）、$\omega_1\!\sim\!\omega_4$ の係数は順に $-\mu_0 c J_z,\; +\mu_0 c J_y,\; -\mu_0 c J_x,\; \rho/\varepsilon_0$ となる。すなわち</p>
 <p>$$
-\mathbf{S}<em>{t}^{(d(\ast F))} = \mathbf{S}</em>{t}^{(\mu_0\ast\mathcal{J})},\quad
-\mathbf{S}<em>{x}^{(d(\ast F))} = \mathbf{S}</em>{x}^{(\mu_0\ast\mathcal{J})},\quad
-\mathbf{S}<em>{y}^{(d(\ast F))} = \mathbf{S}</em>{y}^{(\mu_0\ast\mathcal{J})},\quad
-\mathbf{S}<em>{z}^{(d(\ast F))} = \mathbf{S}</em>{z}^{(\mu_0\ast\mathcal{J})}
+\mathbf{S}_{t}^{(d(\ast F))} = \mathbf{S}_{t}^{(\mu_0\ast\mathcal{J})},\quad
+\mathbf{S}_{x}^{(d(\ast F))} = \mathbf{S}_{x}^{(\mu_0\ast\mathcal{J})},\quad
+\mathbf{S}_{y}^{(d(\ast F))} = \mathbf{S}_{y}^{(\mu_0\ast\mathcal{J})},\quad
+\mathbf{S}_{z}^{(d(\ast F))} = \mathbf{S}_{z}^{(\mu_0\ast\mathcal{J})}
 $$</p>
 <p>$t$-スライスの非ゼロ成分を読めば $-\mathrm{rot}\,\mathbf{B} + \partial\mathbf{E}/\partial t = -c\mu_0\mathbf{J}$、すなわち $\mathrm{rot}\,\mathbf{B} = c\mu_0\mathbf{J} + \partial\mathbf{E}/\partial t$ の各成分。$z$-スライスの $(x,y)$ 成分からは $\mathrm{div}\,\mathbf{E} = \rho/\varepsilon_0$ が現れる。</p>
 <hr />
@@ -4141,7 +4139,7 @@ $$</p>
 つまり本書は、「微分形式の幾何学的直感」と「テンソル解析の計算力」の両方を手に入れるための、中間的なアプローチだったのだ。
 ——ただし、どちらの伝統から見ても中途半端な側面は否めない。</p>
 </blockquote>
-<h3 id="111-mathbfgx">§11.1 多様体 —— $\mathbf{g}(x)$ から始める</h3>
+<h3 id="111-mathblock4533placeholder">§11.1 多様体 —— $\mathbf{g}(x)$ から始める</h3>
 <p>本書では第6章で計量 $\mathbf{g}$ を導入し、第9章で $\mathbf{g}$ から $\ast$ の辞書を作る手順を練習した。いずれも $\mathbf{g}$ は場所に依存しない定数行列だった。では、計量が場所ごとに異なる行列 $\mathbf{g}(x,y,z)$ になったら何が起きるか。</p>
 <p>$\ast$ の辞書は $\mathbf{g}$ から作られる。$\mathbf{g}$ が場所ごとに変われば、$\ast$ の辞書も場所ごとに変わる。$dx \mapsto \ast(dx) = \cdots\,dy\wedge dz$ という対応表が、空間の各点で異なる係数を持つようになるのだ。</p>
 <p>この「各点で計量 $\mathbf{g}(p)$ を持ち、その計量から各点の $\ast$ を作る」という見方は、リーマン多様体へ進むための最初の模型である。平たい $\mathbb{R}^3$ では $\mathbf{g}$ が単位行列だったから $\ast$ の辞書は至って単純だった。一般の座標表示では、$\mathbf{g}$ はもはや単位行列とは限らず、場所の関数として現れる。それでも $\mathbf{g}$ から $\ast$ の辞書を書き下す手順そのものは、第9章でやったのと同じだ——ただ毎回、各点で辞書を引き直す必要があるだけである。</p>
@@ -4155,17 +4153,17 @@ $$</p>
 </blockquote>
 <h4 id="1111">11.1.1 定義 —— チャートとアトラス</h4>
 <p>$n$ 次元<strong>位相多様体</strong> $M$ とは、ハウスドルフかつ第二可算公理を満たす位相空間であって、任意の点 $p \in M$ に対し、$p$ を含む開集合 $U \subset M$ と、$U$ から $\mathbb{R}^n$ の開集合への同相写像 $\varphi: U \to \varphi(U) \subset \mathbb{R}^n$ が存在するものである。この組 $(U, \varphi)$ を<strong>チャート</strong>（座標近傍）と呼ぶ。$\varphi(p) = (x^1(p), \dots, x^n(p))$ と書いたとき、$x^i$ を<strong>局所座標</strong>という。</p>
-<p>$M$ を覆うチャートの族 ${(U_\alpha, \varphi_\alpha)}$ であって、任意の重なるチャート対に対して<strong>座標変換</strong></p>
+<p>$M$ を覆うチャートの族 $\{(U_\alpha, \varphi_\alpha)\}$ であって、任意の重なるチャート対に対して<strong>座標変換</strong></p>
 <p>$$\varphi_\beta \circ \varphi_\alpha^{-1}: \varphi_\alpha(U_\alpha \cap U_\beta) \to \varphi_\beta(U_\alpha \cap U_\beta)$$</p>
 <p>が $C^\infty$ 級であるとき、これを<strong>滑らかなアトラス</strong>と呼び、$M$ は<strong>滑らかな多様体（$C^\infty$ 多様体）</strong> になる。座標変換が滑らかであること——この一点が、多様体上で微積分を可能にする根幹である。</p>
 <p>本書がこれまで舞台としてきた $\mathbb{R}^3$ は、恒等写像 $\mathrm{id}: \mathbb{R}^3 \to \mathbb{R}^3$ という一枚のチャートで全体を覆える、最も自明な多様体の例だ。</p>
-<p>よく知られた別の例として、$n$ 次元球面 $S^n = {x \in \mathbb{R}^{n+1} \mid |x| = 1}$ がある。$S^n$ は一枚のチャートでは覆えないが、北極と南極を除いた二枚のチャート（立体射影）でアトラスが構成できる。一般相対性理論の時空はローレンツ多様体——計量の符号が $(-,+,+,+)$ である4次元多様体——として定式化される。</p>
+<p>よく知られた別の例として、$n$ 次元球面 $S^n = \{x \in \mathbb{R}^{n+1} \mid \|x\| = 1\}$ がある。$S^n$ は一枚のチャートでは覆えないが、北極と南極を除いた二枚のチャート（立体射影）でアトラスが構成できる。一般相対性理論の時空はローレンツ多様体——計量の符号が $(-,+,+,+)$ である4次元多様体——として定式化される。</p>
 <h4 id="1112">11.1.2 接空間 —— 「曲がった空間での微分」の定義</h4>
 <p>$\mathbb{R}^n$ では「ベクトル」を「原点から伸びる矢印」として素朴に定義できた。多様体上ではそうはいかない。球面の表面に矢印を描こうとしても、矢印は曲面からはみ出してしまう。</p>
 <p>接空間の構成には二つの同値な方法がある。</p>
 <p><strong>曲線の同値類による定義。</strong> $p$ を通る滑らかな曲線 $\gamma: (-\varepsilon, \varepsilon) \to M$（$\gamma(0)=p$）に対し、チャート $(U, \varphi)$ を一つ選び、$\mathbb{R}^n$ における速度ベクトル $(\varphi \circ \gamma)'(0)$ を計算する。別のチャート $(V, \psi)$ を選んでも、$(\psi \circ \gamma)'(0) = D(\psi \circ \varphi^{-1})_{\varphi(p)} \cdot (\varphi \circ \gamma)'(0)$ とヤコビ行列で変換されるから、ある一つのチャートで速度ベクトルが一致すれば、座標変換の微分により任意のチャートでも一致する。したがって、この一致関係はチャートの選び方に依存せず、接ベクトルの同値類を定める。この同値類 $[\gamma]$ が $p$ における<strong>接ベクトル</strong>である。</p>
 <p><strong>方向微分（derivation）による定義。</strong> 接ベクトル $v \in T_p M$ を、$p$ の近傍の滑らかな関数 $f$ に実数 $v(f)$ を対応させる線形写像であって、ライプニッツ則 $v(fg) = v(f)\,g(p) + f(p)\,v(g)$ を満たすものとして定義する。この定義はチャートに依存しない内在的なものであり、代数幾何などへの一般化にも耐える。チャート $(U, \varphi)$ と局所座標 $x^i$ が与えられれば、</p>
-<p>$$\left.\frac{\partial}{\partial x^i}\right|<em>p (f) = \left.\frac{\partial (f \circ \varphi^{-1})}{\partial x^i}\right|</em>{\varphi(p)}$$</p>
+<p>$$\left.\frac{\partial}{\partial x^i}\right|_p (f) = \left.\frac{\partial (f \circ \varphi^{-1})}{\partial x^i}\right|_{\varphi(p)}$$</p>
 <p>が $T_p M$ の基底をなす。$\dim T_p M = \dim M = n$ である。</p>
 <p>二つのベクトル場 $X, Y$ が与えられたとき、その<strong>リー括弧（Lie bracket）</strong> $[X, Y] = XY - YX$ は再びベクトル場になる。$[X,Y]^i = \sum_j (X^j \partial_j Y^i - Y^j \partial_j X^i)$ であり、本書では陽に扱わなかったが、フロベニウスの定理（分布の積分可能性）やリー群論の根幹をなす演算である。</p>
 <p>すべての点における接空間の非交和が<strong>接束</strong> $TM = \bigsqcup_{p \in M} T_p M$ である。$TM$ 自身も $2n$ 次元の多様体になる。$M$ 上の<strong>ベクトル場</strong> $X$ とは、各点 $p \in M$ に接ベクトル $X_p \in T_p M$ を滑らかに割り当てる写像、すなわち接束の<strong>切断</strong> $X: M \to TM$ にほかならない。</p>
@@ -4173,20 +4171,20 @@ $$</p>
 <p>$$\frac{\partial}{\partial y^j} = \sum_i \frac{\partial x^i}{\partial y^j}\,\frac{\partial}{\partial x^i}$$</p>
 <p>と変換される。この変換行列 $\partial x^i/\partial y^j$ は、本書第3章で座標変換のヤコビ行列として繰り返し登場したものだ。接ベクトルの成分はこのヤコビ行列の逆行列で変換される（反変ベクトル）。これに対し、1-form の成分はヤコビ行列そのもので変換される（共変ベクトル）。この「反変」と「共変」の区別——本書ではベクトルが「縦」、1-form が「横」として視覚化されてきた——が、多様体論におけるテンソル解析の出発点である。</p>
 <h4 id="1113">11.1.3 微分形式 —— 余接束とテンソル場</h4>
-<p>接空間 $T_p M$ の双対空間を<strong>余接空間</strong> $T_p^<em> M$ と呼ぶ。$\omega_p \in T_p^</em> M$ は接ベクトルを食べて実数を返す線形写像 $\omega_p: T_p M \to \mathbb{R}$、すなわち<strong>1-form</strong>である。本書第1章で $dx$ を「変位ベクトルから $x$ 成分を抽出する横ベクトル」と定義したのは、まさにこの双対性の具現化だった。</p>
+<p>接空間 $T_p M$ の双対空間を<strong>余接空間</strong> $T_p^* M$ と呼ぶ。$\omega_p \in T_p^* M$ は接ベクトルを食べて実数を返す線形写像 $\omega_p: T_p M \to \mathbb{R}$、すなわち<strong>1-form</strong>である。本書第1章で $dx$ を「変位ベクトルから $x$ 成分を抽出する横ベクトル」と定義したのは、まさにこの双対性の具現化だった。</p>
 <blockquote>
-<p><strong>注</strong>（本編との対応）  これは、第1章で $dx=\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ と書いた約束を、標準デカルト座標における余接基底 $dx^1|_p$ の成分表示として言い直したものである。第1章では点 $p$ への依存を抑えて書いたが、多様体論では各点の余接空間 $T_p^* M$ に属する対象として扱う。</p>
+<p><strong>注</strong>（本編との対応）  これは、第1章で $dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と書いた約束を、標準デカルト座標における余接基底 $dx^1|_p$ の成分表示として言い直したものである。第1章では点 $p$ への依存を抑えて書いたが、多様体論では各点の余接空間 $T_p^* M$ に属する対象として扱う。</p>
 </blockquote>
-<p>局所座標 $x^i$ に対し、$dx^i|_p \in T_p^<em> M$ を $dx^i|_p(\partial/\partial x^j|_p) = \delta^i_j$ で定めると、${dx^i|_p}$ は $T_p^</em> M$ の ${\partial/\partial x^i|_p}$ に対する双対基底になる。任意の1-form $\omega$ は局所的に $\omega = \sum_i \omega_i\,dx^i$ と展開できる。</p>
+<p>局所座標 $x^i$ に対し、$dx^i|_p \in T_p^* M$ を $dx^i|_p(\partial/\partial x^j|_p) = \delta^i_j$ で定めると、$\{dx^i|_p\}$ は $T_p^* M$ の $\{\partial/\partial x^i|_p\}$ に対する双対基底になる。任意の1-form $\omega$ は局所的に $\omega = \sum_i \omega_i\,dx^i$ と展開できる。</p>
 <p>これを $k$ 重に拡張したものが <strong>$k$-form</strong> である。多様体上の $k$-form とは、各点 $p$ に $\Lambda^k T_p^* M$ の元を滑らかに割り当てる切断である。つまり、各点では $k$ 個の接ベクトルを引数にとる交代多重線形写像</p>
 <p>$$\omega_p: \underbrace{T_p M \times \cdots \times T_p M}_{k\ \text{個}} \to \mathbb{R}$$</p>
 <p>であり、その成分が局所座標で滑らかに変化するものをいう。ウェッジ積 $\wedge$ は、二つの形式の引数を「すべての順列にわたって符号付きで和をとる」操作として定義される。本書第2章で反対称行列の成分計算として導入したウェッジ積が、この抽象的な定義のもとで自然に再現される。</p>
 <p><strong>引き戻し（pullback）</strong>も多様体間の写像へと一般化される。滑らかな写像 $f: M \to N$ に対し、$N$ 上の $k$-form $\omega$ の引き戻し $f^*\omega$ は $M$ 上の $k$-form であり、</p>
-<p>$$(f^*\omega)<em>p(v_1, \dots, v_k) = \omega</em>{f(p)}(df_p(v_1), \dots, df_p(v_k))$$</p>
+<p>$$(f^*\omega)_p(v_1, \dots, v_k) = \omega_{f(p)}(df_p(v_1), \dots, df_p(v_k))$$</p>
 <p>で定義される。$df_p: T_p M \to T_{f(p)} N$ は $f$ の微分（接写像）である。本書第3章で座標変換のヤコビアンとして計算した引き戻しは、この一般公式において $f$ をチャート間の座標変換とし、局所座標で成分表示したものに一致する。</p>
-<p>本書が一貫して使ってきた「$dx$ は横ベクトル」という記法は、実は多様体論の標準言語では $dx^i$ たちが余接空間の基底であるという事実にほかならない。$\omega = \sum_i \omega_i\,dx^i$ と書いたとき、係数 $\omega_i$ は本書の言葉では「横ベクトルの第 $i$ 成分」であり、多様体論の言葉では「1-form の局所座標に関する成分」である。$\omega(v) = \sum_i \omega_i\,dx^i(v) = \sum_i \omega_i v^i$ という計算は、本書第1章の行列の積 $\begin{pmatrix}\omega_1&amp;\omega_2&amp;\omega_3\end{pmatrix}\begin{pmatrix}v^1\v^2\v^3\end{pmatrix}$ に完全に対応する。</p>
+<p>本書が一貫して使ってきた「$dx$ は横ベクトル」という記法は、実は多様体論の標準言語では $dx^i$ たちが余接空間の基底であるという事実にほかならない。$\omega = \sum_i \omega_i\,dx^i$ と書いたとき、係数 $\omega_i$ は本書の言葉では「横ベクトルの第 $i$ 成分」であり、多様体論の言葉では「1-form の局所座標に関する成分」である。$\omega(v) = \sum_i \omega_i\,dx^i(v) = \sum_i \omega_i v^i$ という計算は、本書第1章の行列の積 $\begin{pmatrix}\omega_1&\omega_2&\omega_3\end{pmatrix}\begin{pmatrix}v^1\\v^2\\v^3\end{pmatrix}$ に完全に対応する。</p>
 <p>この双対性は高次の形式にも拡張される。本書第2章で $k$-form を行列（$k=1$ では横ベクトル、$k=2$ では反対称行列、$k=3$ では反対称3階テンソル）で表示したのは、交代多重線形写像としての $k$-form の成分表示にほかならない。付録Eで $4\times4\times4$ のスライス行列を扱ったとき、我々はすでに多様体上の3-form の成分計算を実践していたのだ。</p>
-<h4 id="1114-d">11.1.4 外微分 $d$ —— 多様体上で変わらないもの</h4>
+<h4 id="1114-mathblock4665placeholder">11.1.4 外微分 $d$ —— 多様体上で変わらないもの</h4>
 <p>外微分 $d$ は、多様体上で<strong>計量を一切使わずに</strong>定義できる数少ない微分演算子の一つである。$k$-form $\omega$ に対し、$d\omega$ は $(k+1)$-form であり、その定義は本書第5章で偏微分とウェッジ積の組み合わせとして学んだものと完全に一致する。</p>
 <p>外微分 $d$ は、$\Omega^k(M)$ から $\Omega^{k+1}(M)$ への線形作用素であり、関数に対して通常の全微分を与え、次数付きライプニッツ則を満たし、局所座標では偏微分とウェッジ積によって与えられる。この作用素について $d^2 = 0$ が成り立つ。計量はどこにも登場しない。曲がっていようがいまいが、$d$ は本書で慣れ親しんだ計算規則をそのまま使える。</p>
 <p>この普遍性こそが微分形式の最大の武器であり、<strong>ストークスの定理</strong></p>
@@ -4267,7 +4265,7 @@ $$</p>
 <strong>共変ベクトル</strong> $\omega_i$ は $\bar{\omega}_i = \sum_j \frac{\partial x^j}{\partial \bar{x}^i} \omega_j$ と変換される。</p>
 <p>この区別は本書第3章で既に出会っている。変位ベクトル $\mathbf{v}$ の成分 $v^i$ は反変（ヤコビ行列の逆行列で変換）、1-form $\omega$ の係数 $\omega_i$ は共変（ヤコビ行列で変換）だった。一般の $(r,s)$-テンソル $T^{i_1\cdots i_r}_{j_1\cdots j_s}$ は、$r$ 個の反変添字と $s$ 個の共変添字を持ち、添字ごとに上記の変換則を適用する。</p>
 <p>本書で計量を表す行列 $\mathbf{g}$ の成分 $g_{ij}$ は $(0,2)$-テンソル（二階共変テンソル）である。座標変換に対して $g_{ij}$ は</p>
-<p>$$\bar{g}<em>{ij} = \sum</em>{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$</p>
+<p>$$\bar{g}_{ij} = \sum_{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$</p>
 <p>と変換される。本書第6章で導出した $\mathbf{g} = J^T J$ という関係式は、デカルト座標で $g_{ij} = \delta_{ij}$ であるときに曲線座標での $\bar{g}_{ij}$ を計算する公式にほかならない。一般のリーマン計量は、必ずしも一つの座標変換のヤコビ行列 $J$ から $J^T J$ として得られるわけではない。第6章の $J^T J$ は、あくまでユークリッド空間内で誘導計量を計算する最も具体的な例である。</p>
 <h4 id="1122">11.2.2 クリストッフェル記号 —— 微分がテンソルでなくなる問題</h4>
 <p>ベクトル場 $V^i$ の偏微分 $\partial_j V^i$ は、そのままではテンソルとして振る舞わない。座標変換すると余分な項が現れてしまう。計量 $g$ と整合的で捩れのないレヴィ＝チヴィタ接続を選ぶと、その接続係数、すなわち<strong>クリストッフェル記号（Christoffel symbols）</strong>は</p>
@@ -4293,8 +4291,8 @@ $$R_{abcd}=-R_{bacd},\qquad R_{abcd}=-R_{abdc},\qquad R_{abcd}=R_{cdab}$$
 <p><strong>注</strong>（曲率テンソルの符号と添字順序）
 曲率テンソルの符号と添字順序には複数の規約がある。本項では一つの代表的な規約を示したが、他の文献では添字の順序や符号が異なる場合がある。</p>
 <p>$$
-\nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
-$$</p>
+> \nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
+> $$</p>
 <p>この恒等式は、外微分の $d^2=0$ と同じ「二度境界を取ると消える」型の構造を思わせるが、厳密には接続を含む外共変微分 $D$ に関する恒等式であり、単なる $d^2=0$ ではない。</p>
 </blockquote>
 <p>リッチテンソルは曲率テンソルの一組の添字を縮約して得られる。縮約の具体的な位置や符号は曲率テンソルの規約に依存する。ここでは詳細な規約の固定には立ち入らない。これと<strong>スカラー曲率</strong> $R = \sum_i\sum_j g^{ij} \mathrm{Ric}_{ij}$ が、アインシュタイン方程式の左辺を構成する。方程式は</p>
@@ -4340,16 +4338,16 @@ $$</p>
 <h4 id="1221">12.2.1 パウリ行列の定義と掛け算</h4>
 <p>パウリ行列 $\sigma_1, \sigma_2, \sigma_3$ は次の $2\times2$ 行列である。</p>
 <p>$$
-\sigma_1 = \begin{pmatrix}0 &amp; 1 \ 1 &amp; 0\end{pmatrix},\quad
-\sigma_2 = \begin{pmatrix}0 &amp; -i \ i &amp; 0\end{pmatrix},\quad
-\sigma_3 = \begin{pmatrix}1 &amp; 0 \ 0 &amp; -1\end{pmatrix}
+\sigma_1 = \begin{pmatrix}0 & 1 \\ 1 & 0\end{pmatrix},\quad
+\sigma_2 = \begin{pmatrix}0 & -i \\ i & 0\end{pmatrix},\quad
+\sigma_3 = \begin{pmatrix}1 & 0 \\ 0 & -1\end{pmatrix}
 $$</p>
 <p>これらの掛け算規則を調べてみよう。単独では $\sigma_1^2 = \sigma_2^2 = \sigma_3^2 = I$（単位行列）であり、異なるもの同士では $\sigma_1\sigma_2 = -\sigma_2\sigma_1$ という<strong>反可換性</strong>が成り立つ。積は全部で9通りある。</p>
 <p>$$
 \begin{aligned}
-\sigma_1\sigma_1 = I,\quad &amp;\sigma_1\sigma_2 = i\sigma_3,\quad &amp;\sigma_1\sigma_3 = -i\sigma_2 \
-\sigma_2\sigma_1 = -i\sigma_3,\quad &amp;\sigma_2\sigma_2 = I,\quad &amp;\sigma_2\sigma_3 = i\sigma_1 \
-\sigma_3\sigma_1 = i\sigma_2,\quad &amp;\sigma_3\sigma_2 = -i\sigma_1,\quad &amp;\sigma_3\sigma_3 = I
+\sigma_1\sigma_1 = I,\quad &\sigma_1\sigma_2 = i\sigma_3,\quad &\sigma_1\sigma_3 = -i\sigma_2 \\
+\sigma_2\sigma_1 = -i\sigma_3,\quad &\sigma_2\sigma_2 = I,\quad &\sigma_2\sigma_3 = i\sigma_1 \\
+\sigma_3\sigma_1 = i\sigma_2,\quad &\sigma_3\sigma_2 = -i\sigma_1,\quad &\sigma_3\sigma_3 = I
 \end{aligned}
 $$</p>
 <p>この9通りの積を、対称部分と反対称部分に分解してみよう。第2章でウェッジ積 $\wedge$ を反対称化によって導入したのと同じ発想である。</p>
@@ -4362,14 +4360,14 @@ $$</p>
 <p>パウリ行列の積は、つねに「内積（対称部分）$+$ ウェッジ積（反対称部分）」に分解される。この一点が、パウリ行列のすべての魔法の源である。</p>
 <h4 id="1222">12.2.2 ベクトルをパウリ行列で書く</h4>
 <p>3次元ベクトル $\mathbf{v} = (v_1, v_2, v_3)$ をパウリ行列で表してみよう。</p>
-<p>$$V = v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3 = \mathbf{v}!\cdot!\bm{\sigma}$$</p>
-<p>二つのベクトル $\mathbf{v}, \mathbf{w}$ に対応するパウリ行列 $V = \mathbf{v}!\cdot!\bm{\sigma}$, $W = \mathbf{w}!\cdot!\bm{\sigma}$ の積を計算する。</p>
+<p>$$V = v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3 = \mathbf{v}\!\cdot\!\bm{\sigma}$$</p>
+<p>二つのベクトル $\mathbf{v}, \mathbf{w}$ に対応するパウリ行列 $V = \mathbf{v}\!\cdot\!\bm{\sigma}$, $W = \mathbf{w}\!\cdot\!\bm{\sigma}$ の積を計算する。</p>
 <p>$$
 \begin{aligned}
-VW &amp;= (v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3)(w_1\sigma_1 + w_2\sigma_2 + w_3\sigma_3) \[4pt]
-&amp;= v_1w_1\sigma_1\sigma_1 + v_1w_2\sigma_1\sigma_2 + v_1w_3\sigma_1\sigma_3 \
-&amp;\quad + v_2w_1\sigma_2\sigma_1 + v_2w_2\sigma_2\sigma_2 + v_2w_3\sigma_2\sigma_3 \
-&amp;\quad + v_3w_1\sigma_3\sigma_1 + v_3w_2\sigma_3\sigma_2 + v_3w_3\sigma_3\sigma_3
+VW &= (v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3)(w_1\sigma_1 + w_2\sigma_2 + w_3\sigma_3) \\[4pt]
+&= v_1w_1\sigma_1\sigma_1 + v_1w_2\sigma_1\sigma_2 + v_1w_3\sigma_1\sigma_3 \\
+&\quad + v_2w_1\sigma_2\sigma_1 + v_2w_2\sigma_2\sigma_2 + v_2w_3\sigma_2\sigma_3 \\
+&\quad + v_3w_1\sigma_3\sigma_1 + v_3w_2\sigma_3\sigma_2 + v_3w_3\sigma_3\sigma_3
 \end{aligned}
 $$</p>
 <p>上記の9通りの積を各項に適用する。非ゼロの置き換えだけ書けば</p>
@@ -4380,14 +4378,14 @@ $$</p>
 <p>と、これらの添字を逆順にした $\sigma_2\sigma_1 = -i\sigma_3$, $\sigma_3\sigma_2 = -i\sigma_1$, $\sigma_1\sigma_3 = -i\sigma_2$ の計9通りである。$I$ の係数（対称部分＝内積）と $\sigma_1,\sigma_2,\sigma_3$ の係数（反対称部分＝ウェッジ積）をそれぞれ集める。</p>
 <p>$$
 \begin{aligned}
-I\text{ の係数（内積）} &amp;: v_1w_1 + v_2w_2 + v_3w_3 \;=\; \mathbf{v}!\cdot!\mathbf{w} \
-\sigma_1\text{ の係数（$\wedge$）} &amp;: i\,(v_2w_3 - v_3w_2) \
-\sigma_2\text{ の係数（$\wedge$）} &amp;: i\,(v_3w_1 - v_1w_3) \
-\sigma_3\text{ の係数（$\wedge$）} &amp;: i\,(v_1w_2 - v_2w_1)
+I\text{ の係数（内積）} &: v_1w_1 + v_2w_2 + v_3w_3 \;=\; \mathbf{v}\!\cdot\!\mathbf{w} \\
+\sigma_1\text{ の係数（$\wedge$）} &: i\,(v_2w_3 - v_3w_2) \\
+\sigma_2\text{ の係数（$\wedge$）} &: i\,(v_3w_1 - v_1w_3) \\
+\sigma_3\text{ の係数（$\wedge$）} &: i\,(v_1w_2 - v_2w_1)
 \end{aligned}
 $$</p>
 <p>$\sigma_1,\sigma_2,\sigma_3$ の係数カッコ内は、第2章で定義したウェッジ積 $\mathbf{v}\wedge\mathbf{w}$ の各成分そのものである。したがって</p>
-<p>$$VW = (\mathbf{v}!\cdot!\mathbf{w})\,I \;+\; i\,(\mathbf{v}\times\mathbf{w})!\cdot!\bm{\sigma}$$</p>
+<p>$$VW = (\mathbf{v}\!\cdot\!\mathbf{w})\,I \;+\; i\,(\mathbf{v}\times\mathbf{w})\!\cdot\!\bm{\sigma}$$</p>
 <p>と、内積 $+$ ウェッジ積の形にまとまる。内積と外積が、<strong>一つの積 $VW$ から同時に</strong>現れた。</p>
 <p>これが「魔法の箱」の正体だ。パウリ行列の積は、内積（$0$-form に相当するスカラー）と外積（$2$-form に相当するウェッジ積）を、<strong>一つの演算で同時に</strong>生み出す。通常の微分形式では別々の次数に属していたものが、パウリ行列の代数の中では一つの $2\times2$ 行列として共存している。</p>
 <blockquote>
@@ -4400,52 +4398,52 @@ $$</p>
 <p>の形をしている。$\varphi$ はスカラー（$0$-form）、$A_1,A_2,A_3$ はベクトルの成分（$1$-form）である。さらに $\psi$ に左から $\sigma_i$ を掛ければ、$2$-form に相当する $i\sigma_k$ の項まで現れる。つまり、パウリ行列の代数は $0,1,2,3$-form の<strong>すべての次数</strong>を一つの枠組みで扱えるのだ。</p>
 <blockquote>
 <p><strong>注</strong> （何ができるようになったのか）微分形式でも異なる次数の形式を直和として形式的に並べることはできる。しかし、内積（縮約）と外積（反対称化）を<strong>一つの積として同時に</strong>扱うには、通常のウェッジ積だけでは足りない。パウリ行列の代数では、それらが一つの積 $VW$ の中で自然に分離・共存する。これが幾何代数の核心である。</p>
-<p><strong>注</strong> （全次数の対応）パウリ行列の代数における次数対応を整理しておく。$I$ が $0$-form（スカラー）、$\sigma_1,\sigma_2,\sigma_3$ が $1$-form（ベクトル）、$i\sigma_1,i\sigma_2,i\sigma_3$ が $2$-form（バイベクトル）、$iI$ が $3$-form（擬スカラー）に対応する。最も一般的な元は $\psi = aI + \mathbf{v}!\cdot!\bm{\sigma} + i\,\mathbf{w}!\cdot!\bm{\sigma} + ibI$ の形で、4つの次数すべてを複素係数で含んでいる。</p>
+<p><strong>注</strong> （全次数の対応）パウリ行列の代数における次数対応を整理しておく。$I$ が $0$-form（スカラー）、$\sigma_1,\sigma_2,\sigma_3$ が $1$-form（ベクトル）、$i\sigma_1,i\sigma_2,i\sigma_3$ が $2$-form（バイベクトル）、$iI$ が $3$-form（擬スカラー）に対応する。最も一般的な元は $\psi = aI + \mathbf{v}\!\cdot\!\bm{\sigma} + i\,\mathbf{w}\!\cdot\!\bm{\sigma} + ibI$ の形で、4つの次数すべてを複素係数で含んでいる。</p>
 <p><strong>注</strong> （四元数——すでにあった魔法の箱）実はこの「スカラーとベクトルを一つの数に混ぜる」という発想は、パウリ行列よりもずっと古い。行列代数よりも古い。1843年にハミルトンが発見した<strong>四元数（quaternion）</strong> $q = a + bi + cj + dk$ がまさにそれだ。マクスウェルは自身の電磁気学を四元数で定式化していた。しかしその後、ギブズとヘヴィサイドが四元数からスカラー部分とベクトル部分を<strong>分離</strong>し、現代のベクトル解析（内積とクロス積）が誕生した。パウリ行列は、ギブズが分離したスカラーとベクトルを、約80年後に量子力学の文脈で再び<strong>統合</strong>したものである。歴史は一周したのだ。</p>
 <p><strong>注</strong> （行列なき時代のベクトル解析）ギブズとヘヴィサイドがベクトル解析を整備した1880年代には、まだ行列代数が存在しなかった。行列式はあったが、行列そのものの代数——積の非可換性、固有値、線形変換としての統一的理解——は、ケイリーの先駆的研究を経て、20世紀初頭のヒルベルトらによってようやく整備される。ギブズは線形変換を表すために<strong>ダイアド（dyad）</strong> $\mathbf{a}\mathbf{b}$ という独自の記法を発明したが、これは現代の行列 $\mathbf{a}\mathbf{b}^T$ に相当する。要するに、ベクトル解析は行列代数が存在しない時代に、四元数を切り刻み、ダイアドを継ぎ接ぎして作られた<strong>キメラ</strong>だったのだ。本書が「ナブラ解体新書」と題して $\nabla$ を $d$ と $\ast$ に解体し、最終章でパウリ行列による再統合を見せたことには、この百年越しの負債を清算する意味もある。</p>
 <p><strong>注</strong> （行列代数が物理学者の標準語でなかったこと）なお、行列代数が物理学者の標準語でなかったことは、1925年の行列力学にもよく現れている。ハイゼンベルク自身は当初、自分の計算が行列の非可換積であることを知らず、それを行列として読んだのはボルンだった。</p>
 </blockquote>
 <hr />
 <h3 id="123">§12.3 ディラック演算子と真のナブラ</h3>
-<h4 id="1231-bmsigmacdotnabla">12.3.1 $\bm{\sigma}!\cdot!\nabla$ —— すべてを統合する演算子</h4>
+<h4 id="1231-mathblock4928placeholder">12.3.1 $\bm{\sigma}\!\cdot\!\nabla$ —— すべてを統合する演算子</h4>
 <p>パウリ行列とナブラ $\nabla = (\frac{\partial}{\partial x}, \frac{\partial}{\partial y}, \frac{\partial}{\partial z})$ を組み合わせて、次の演算子を定義する。</p>
-<p>$$D = \sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z} = \bm{\sigma}!\cdot!\nabla$$</p>
+<p>$$D = \sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z} = \bm{\sigma}\!\cdot\!\nabla$$</p>
 <p>$D$ は $2\times2$ 行列の形をした微分演算子である。これをスカラー場 $\varphi$ に作用させてみよう。</p>
-<p>$$D\varphi = \sigma_1\frac{\partial\varphi}{\partial x} + \sigma_2\frac{\partial\varphi}{\partial y} + \sigma_3\frac{\partial\varphi}{\partial z} = (\nabla\varphi)!\cdot!\bm{\sigma}$$</p>
+<p>$$D\varphi = \sigma_1\frac{\partial\varphi}{\partial x} + \sigma_2\frac{\partial\varphi}{\partial y} + \sigma_3\frac{\partial\varphi}{\partial z} = (\nabla\varphi)\!\cdot\!\bm{\sigma}$$</p>
 <p>これは $\mathrm{grad}\,\varphi$ をパウリ行列で表したものだ。</p>
-<p>次に、ベクトル場 $\mathbf{A} = (A_1, A_2, A_3)$ をパウリ行列で $A = \mathbf{A}!\cdot!\bm{\sigma}$ と書いて $D$ を作用させる。11.2.2 の積の公式を思い出そう。</p>
+<p>次に、ベクトル場 $\mathbf{A} = (A_1, A_2, A_3)$ をパウリ行列で $A = \mathbf{A}\!\cdot\!\bm{\sigma}$ と書いて $D$ を作用させる。11.2.2 の積の公式を思い出そう。</p>
 <p>$$
 \begin{aligned}
-D A &amp;= (\sigma_1\tfrac{\partial}{\partial x} + \sigma_2\tfrac{\partial}{\partial y} + \sigma_3\tfrac{\partial}{\partial z})(A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3) \[4pt]
-&amp;= \tfrac{\partial A_1}{\partial x}\,\sigma_1\sigma_1 + \tfrac{\partial A_2}{\partial x}\,\sigma_1\sigma_2 + \tfrac{\partial A_3}{\partial x}\,\sigma_1\sigma_3 \
-&amp;\quad + \tfrac{\partial A_1}{\partial y}\,\sigma_2\sigma_1 + \tfrac{\partial A_2}{\partial y}\,\sigma_2\sigma_2 + \tfrac{\partial A_3}{\partial y}\,\sigma_2\sigma_3 \
-&amp;\quad + \tfrac{\partial A_1}{\partial z}\,\sigma_3\sigma_1 + \tfrac{\partial A_2}{\partial z}\,\sigma_3\sigma_2 + \tfrac{\partial A_3}{\partial z}\,\sigma_3\sigma_3
+D A &= (\sigma_1\tfrac{\partial}{\partial x} + \sigma_2\tfrac{\partial}{\partial y} + \sigma_3\tfrac{\partial}{\partial z})(A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3) \\[4pt]
+&= \tfrac{\partial A_1}{\partial x}\,\sigma_1\sigma_1 + \tfrac{\partial A_2}{\partial x}\,\sigma_1\sigma_2 + \tfrac{\partial A_3}{\partial x}\,\sigma_1\sigma_3 \\
+&\quad + \tfrac{\partial A_1}{\partial y}\,\sigma_2\sigma_1 + \tfrac{\partial A_2}{\partial y}\,\sigma_2\sigma_2 + \tfrac{\partial A_3}{\partial y}\,\sigma_2\sigma_3 \\
+&\quad + \tfrac{\partial A_1}{\partial z}\,\sigma_3\sigma_1 + \tfrac{\partial A_2}{\partial z}\,\sigma_3\sigma_2 + \tfrac{\partial A_3}{\partial z}\,\sigma_3\sigma_3
 \end{aligned}
 $$</p>
 <p>11.2.2 と同じ $\sigma_i\sigma_j$ の置き換えを9項に適用し、$I$ の係数（内積＝発散）と $\sigma_1,\sigma_2,\sigma_3$ の係数（ウェッジ積＝回転）を集める。</p>
 <p>$$
 \begin{aligned}
-I\text{ の係数} &amp;: \frac{\partial A_1}{\partial x} + \frac{\partial A_2}{\partial y} + \frac{\partial A_3}{\partial z} = \mathrm{div}\,\mathbf{A} \
-\sigma_1\text{ の係数（$\wedge$）} &amp;: i\,\left(\frac{\partial A_3}{\partial y} - \frac{\partial A_2}{\partial z}\right) \
-\sigma_2\text{ の係数（$\wedge$）} &amp;: i\,\left(\frac{\partial A_1}{\partial z} - \frac{\partial A_3}{\partial x}\right) \
-\sigma_3\text{ の係数（$\wedge$）} &amp;: i\,\left(\frac{\partial A_2}{\partial x} - \frac{\partial A_1}{\partial y}\right)
+I\text{ の係数} &: \frac{\partial A_1}{\partial x} + \frac{\partial A_2}{\partial y} + \frac{\partial A_3}{\partial z} = \mathrm{div}\,\mathbf{A} \\
+\sigma_1\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_3}{\partial y} - \frac{\partial A_2}{\partial z}\right) \\
+\sigma_2\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_1}{\partial z} - \frac{\partial A_3}{\partial x}\right) \\
+\sigma_3\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_2}{\partial x} - \frac{\partial A_1}{\partial y}\right)
 \end{aligned}
 $$</p>
 <p>$\sigma_k$ の係数カッコ内は $\mathrm{rot}\,\mathbf{A}$ の各成分——外微分 $d$ が $1$-form $\mathbf{A}$ から生み出す $2$-form $d\mathbf{A}$ の成分——にほかならない。したがって</p>
-<p>$$D(\mathbf{A}!\cdot!\bm{\sigma}) = (\mathrm{div}\,\mathbf{A})\,I \;+\; i\,(\mathrm{rot}\,\mathbf{A})!\cdot!\bm{\sigma}$$</p>
+<p>$$D(\mathbf{A}\!\cdot\!\bm{\sigma}) = (\mathrm{div}\,\mathbf{A})\,I \;+\; i\,(\mathrm{rot}\,\mathbf{A})\!\cdot\!\bm{\sigma}$$</p>
 <p><strong>一つの演算子 $D$ が、$\mathrm{grad}$（$D\varphi$）、$\mathrm{div}$（$DA$ の実部）、$\mathrm{rot}$（$DA$ の虚部）をすべて産み出す。</strong> これこそが、$\nabla$ を $d$ と $\ast$ に解体した旅の、逆方向の結論——統合——にほかならない。</p>
 <blockquote>
 <p><strong>注</strong> （$d$ と $\ast$ で書くと）$D$ は本書の言葉でも表現できる。符号規約を別にすれば、$D$ は $d$（次数を上げる）と $\ast d\ast$（次数を下げる）を合わせた演算子として理解できる。$\ast d\ast$ は<strong>余微分（codifferential）</strong> $\delta$ と呼ばれ、$\delta = \pm\ast d\ast$（符号は次元と次数に依存）と定義される。ここでは厳密な符号には立ち入らず、$D \sim d + \delta$ という構造だけを押さえておく。$d$ が次数を上げ、$\delta$ が次数を下げる——この二つを足した $D$ が、grad・rot・div を一つの演算子に束ねているのだ。</p>
 </blockquote>
-<h4 id="1232-d2">12.3.2 $D^2$ —— ラプラシアン</h4>
+<h4 id="1232-mathblock4970placeholder">12.3.2 $D^2$ —— ラプラシアン</h4>
 <p>さらに $D$ を二度作用させるとどうなるか。</p>
-<p>$$D^2 = (\bm{\sigma}!\cdot!\nabla)(\bm{\sigma}!\cdot!\nabla) = (\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})(\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})$$</p>
+<p>$$D^2 = (\bm{\sigma}\!\cdot\!\nabla)(\bm{\sigma}\!\cdot\!\nabla) = (\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})(\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})$$</p>
 <p>9項に展開する。</p>
 <p>$$
 \begin{aligned}
-D^2 &amp;= \sigma_1\sigma_1\,\frac{\partial^2}{\partial x^2} + \sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y} + \sigma_1\sigma_3\,\frac{\partial^2}{\partial x\partial z} \
-&amp;\quad + \sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x} + \sigma_2\sigma_2\,\frac{\partial^2}{\partial y^2} + \sigma_2\sigma_3\,\frac{\partial^2}{\partial y\partial z} \
-&amp;\quad + \sigma_3\sigma_1\,\frac{\partial^2}{\partial z\partial x} + \sigma_3\sigma_2\,\frac{\partial^2}{\partial z\partial y} + \sigma_3\sigma_3\,\frac{\partial^2}{\partial z^2}
+D^2 &= \sigma_1\sigma_1\,\frac{\partial^2}{\partial x^2} + \sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y} + \sigma_1\sigma_3\,\frac{\partial^2}{\partial x\partial z} \\
+&\quad + \sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x} + \sigma_2\sigma_2\,\frac{\partial^2}{\partial y^2} + \sigma_2\sigma_3\,\frac{\partial^2}{\partial y\partial z} \\
+&\quad + \sigma_3\sigma_1\,\frac{\partial^2}{\partial z\partial x} + \sigma_3\sigma_2\,\frac{\partial^2}{\partial z\partial y} + \sigma_3\sigma_3\,\frac{\partial^2}{\partial z^2}
 \end{aligned}
 $$</p>
 <p>$\sigma_i\sigma_j$ の反対称部分（$i\neq j$ の項、すなわち $\sigma_1\sigma_2 = i\sigma_3$ など）を含む項は、偏微分の可換性 $\frac{\partial^2}{\partial x\partial y} = \frac{\partial^2}{\partial y\partial x}$ により、符号が逆のペア同士で打ち消し合う。たとえば $\sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y}$ と $\sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x}$ は、$\sigma_2\sigma_1 = -\sigma_1\sigma_2$ かつ $\frac{\partial^2}{\partial y\partial x} = \frac{\partial^2}{\partial x\partial y}$ だから、足してゼロ。残るのは $\sigma_i\sigma_i = I$ の対角項だけである。</p>
@@ -4455,42 +4453,42 @@ $$</p>
 <p>§12.1 では $F + i\ast F$ によって4次元でマクスウェル方程式を一本化した。$D$ を使えば、同じことが3次元の言葉だけで書ける。</p>
 <p>電場 $\mathbf{E}$ と磁場 $\mathbf{B}$ を一つの複素ベクトルに束ねる。これは<strong>リーマン－ジルバーシュタイン・ベクトル</strong>と呼ばれる。</p>
 <p>$$\mathbf{F} = \mathbf{E} + i\mathbf{B}$$</p>
-<p>パウリ行列で書けば $F = \mathbf{E}!\cdot!\bm{\sigma} + i\,\mathbf{B}!\cdot!\bm{\sigma}$ である。$F$ はスカラー部を持たない純粋な複素パウリ・ベクトルだ。時間微分を含めた演算子 $D + \frac{\partial}{\partial t}$ を作用させる。</p>
-<p>$$(D + \frac{\partial}{\partial t})F = (\bm{\sigma}!\cdot!\nabla + \frac{\partial}{\partial t})(\mathbf{E}!\cdot!\bm{\sigma} + i\,\mathbf{B}!\cdot!\bm{\sigma})$$</p>
-<p>§12.3.1 の $D(\mathbf{A}!\cdot!\bm{\sigma})$ の公式を $\mathbf{E}$ と $\mathbf{B}$ の両方に適用する。</p>
+<p>パウリ行列で書けば $F = \mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma}$ である。$F$ はスカラー部を持たない純粋な複素パウリ・ベクトルだ。時間微分を含めた演算子 $D + \frac{\partial}{\partial t}$ を作用させる。</p>
+<p>$$(D + \frac{\partial}{\partial t})F = (\bm{\sigma}\!\cdot\!\nabla + \frac{\partial}{\partial t})(\mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma})$$</p>
+<p>§12.3.1 の $D(\mathbf{A}\!\cdot\!\bm{\sigma})$ の公式を $\mathbf{E}$ と $\mathbf{B}$ の両方に適用する。</p>
 <p>$$
 \begin{aligned}
-(D + \frac{\partial}{\partial t})F &amp;= (\mathrm{div}\,\mathbf{E})\,I + i\,(\mathrm{rot}\,\mathbf{E})!\cdot!\bm{\sigma} + \frac{\partial}{\partial t}\mathbf{E}!\cdot!\bm{\sigma} \
-&amp;\quad + i\,(\mathrm{div}\,\mathbf{B})\,I - (\mathrm{rot}\,\mathbf{B})!\cdot!\bm{\sigma} + i\,\frac{\partial}{\partial t}\mathbf{B}!\cdot!\bm{\sigma}
+(D + \frac{\partial}{\partial t})F &= (\mathrm{div}\,\mathbf{E})\,I + i\,(\mathrm{rot}\,\mathbf{E})\!\cdot\!\bm{\sigma} + \frac{\partial}{\partial t}\mathbf{E}\!\cdot\!\bm{\sigma} \\
+&\quad + i\,(\mathrm{div}\,\mathbf{B})\,I - (\mathrm{rot}\,\mathbf{B})\!\cdot\!\bm{\sigma} + i\,\frac{\partial}{\partial t}\mathbf{B}\!\cdot\!\bm{\sigma}
 \end{aligned}
 $$</p>
 <p>実部と虚部、そして $I$（スカラー）と $\bm{\sigma}$（ベクトル）の各成分に整理する。</p>
 <p>$$
 \begin{aligned}
-\text{実部・}I &amp;: \mathrm{div}\,\mathbf{E} - 0 \
-\text{実部・}\bm{\sigma} &amp;: \frac{\partial}{\partial t}\mathbf{E} - \mathrm{rot}\,\mathbf{B} \
-\text{虚部・}I &amp;: 0 + \mathrm{div}\,\mathbf{B} \
-\text{虚部・}\bm{\sigma} &amp;: \mathrm{rot}\,\mathbf{E} + \frac{\partial}{\partial t}\mathbf{B}
+\text{実部・}I &: \mathrm{div}\,\mathbf{E} - 0 \\
+\text{実部・}\bm{\sigma} &: \frac{\partial}{\partial t}\mathbf{E} - \mathrm{rot}\,\mathbf{B} \\
+\text{虚部・}I &: 0 + \mathrm{div}\,\mathbf{B} \\
+\text{虚部・}\bm{\sigma} &: \mathrm{rot}\,\mathbf{E} + \frac{\partial}{\partial t}\mathbf{B}
 \end{aligned}
 $$</p>
-<p>これらをゼロとおけば、真空のマクスウェル方程式4本がすべて現れる。電流 $\mathbf{J}$ と電荷 $\rho$ がある場合は、右辺に $\rho + \mathbf{J}!\cdot!\bm{\sigma}$ を置けばよい。</p>
-<p>$$(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}!\cdot!\bm{\sigma}$$</p>
+<p>これらをゼロとおけば、真空のマクスウェル方程式4本がすべて現れる。電流 $\mathbf{J}$ と電荷 $\rho$ がある場合は、右辺に $\rho + \mathbf{J}\!\cdot\!\bm{\sigma}$ を置けばよい。</p>
+<p>$$(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$$</p>
 <p>$dF=0$ と $d(\ast F)=\mu_0(\ast\mathcal{J})$ の2本が、$D$ の前ではたった一本の複素方程式に統合された。§12.1 の4次元トリックが特殊な次元に依存していたのに対し、こちらは $D$ という統合された演算子そのものが統合を実現している。</p>
-<h4 id="1234-cancelpartial-f-j-4">12.3.4 $\cancel{\partial} F = J$ —— 4次元時空のディラック演算子</h4>
-<p>§12.3.3 の $(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}!\cdot!\bm{\sigma}$ には、時間と空間が分離して現れている。これは3次元のパウリ行列 $\sigma_1,\sigma_2,\sigma_3$ をベースに組み立てたからだ。4次元時空を最初から扱えば、この分離すら消える。</p>
+<h4 id="1234-mathblock5002placeholder-4">12.3.4 $\cancel{\partial} F = J$ —— 4次元時空のディラック演算子</h4>
+<p>§12.3.3 の $(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$ には、時間と空間が分離して現れている。これは3次元のパウリ行列 $\sigma_1,\sigma_2,\sigma_3$ をベースに組み立てたからだ。4次元時空を最初から扱えば、この分離すら消える。</p>
 <p>パウリ行列を $4\times4$ に拡張したものが<strong>ガンマ行列</strong> $\gamma^0,\gamma^1,\gamma^2,\gamma^3$ である。これらは反可換性 $\gamma^\mu\gamma^\nu + \gamma^\nu\gamma^\mu = 2g^{\mu\nu}I$ を満たす（$g^{\mu\nu}$ はミンコフスキー計量）。このガンマ行列を用いて、4次元のディラック演算子を</p>
 <p>$$\cancel{\partial} = \gamma^0\frac{\partial}{\partial t} + \gamma^1\frac{\partial}{\partial x} + \gamma^2\frac{\partial}{\partial y} + \gamma^3\frac{\partial}{\partial z}$$</p>
-<p>と定義する。第10章の電磁場 $F$（$4\times4$ 反対称行列）をガンマ行列のウェッジ積 $\gamma^\mu!\wedge!\gamma^\nu$ で展開したものと同一視すれば、マクスウェル方程式は</p>
+<p>と定義する。第10章の電磁場 $F$（$4\times4$ 反対称行列）をガンマ行列のウェッジ積 $\gamma^\mu\!\wedge\!\gamma^\nu$ で展開したものと同一視すれば、マクスウェル方程式は</p>
 <p>$$\cancel{\partial} F = J$$</p>
 <p>の一行になる。$F$ は電磁場、$J$ は4元電流（$\gamma^\mu$ で展開されたもの）。真空では $\cancel{\partial} F = 0$。</p>
 <blockquote>
-<p><strong>注</strong> （$\cancel{\partial} F$ の積について）ここでの積は通常の行列積ではなく、ガンマ行列が生成する幾何代数の積である。第10章の反対称行列 $F$ は、ここでは $\gamma^\mu!\wedge!\gamma^\nu$ で展開された2-vectorとして再解釈される。細部は幾何代数の教科書に譲るが、$\sigma_i\sigma_j = \delta_{ij}I + i\varepsilon_{ijk}\sigma_k$（11.2.1）の4次元版がここでも成り立っていると考えればよい。</p>
+<p><strong>注</strong> （$\cancel{\partial} F$ の積について）ここでの積は通常の行列積ではなく、ガンマ行列が生成する幾何代数の積である。第10章の反対称行列 $F$ は、ここでは $\gamma^\mu\!\wedge\!\gamma^\nu$ で展開された2-vectorとして再解釈される。細部は幾何代数の教科書に譲るが、$\sigma_i\sigma_j = \delta_{ij}I + i\varepsilon_{ijk}\sigma_k$（11.2.1）の4次元版がここでも成り立っていると考えればよい。</p>
 </blockquote>
 <p>§12.1 の $F + i\ast F$ も、§12.3.3 の $(D + \frac{\partial}{\partial t})F$ も、すべてこの一行に吸収される。これが、$\nabla$ の解体から始まった旅の、最も遠くにある風景である。ディラックが1928年に電子の方程式を導くために発見したこの演算子は、時空の幾何と物理法則を一つの代数で記述する<strong>幾何代数（Geometric Algebra）</strong>の核であり、Doran &amp; Lasenby の Geometric Algebra for Physicists に詳しい。</p>
-<h3 id="124-nabla">§12.4 演算子$\nabla$</h3>
+<h3 id="124-mathblock5023placeholder">§12.4 演算子$\nabla$</h3>
 <p>さあ、ここで最初の問いに戻ろう。$\nabla$ とは何だったのか。</p>
 <p>ベクトル解析では、$\nabla$ は「偏微分を並べた形式的なベクトル」として導入され、grad・rot・div の三つの顔を持つ謎めいた記号だった。本書はそれを $d$ と $\ast$ に<strong>解体</strong>することで、各演算の正体を明らかにしてきた。</p>
-<p>そして今、これを逆方向に辿り、$d$ と $\ast$ というバラバラだった部品が、幾何代数の中で3次元のディラック演算子$D = \bm{\sigma}!\cdot!\nabla$ として<strong>統合</strong>され、更にその4次元版のディラック演算子$\cancel{\partial}$が究極のマクスウェル方程式$\cancel{\partial} F = J$を与えた。</p>
+<p>そして今、これを逆方向に辿り、$d$ と $\ast$ というバラバラだった部品が、幾何代数の中で3次元のディラック演算子$D = \bm{\sigma}\!\cdot\!\nabla$ として<strong>統合</strong>され、更にその4次元版のディラック演算子$\cancel{\partial}$が究極のマクスウェル方程式$\cancel{\partial} F = J$を与えた。</p>
 <p>ところで、幾何代数の文脈では、この演算子を必ずしも$\cancel{\partial}$ とは書かない。むしろ、この種のベクトル微分演算子を</p>
 <p>$$
 \nabla
@@ -4644,8 +4642,8 @@ $$</p>
   → 第10章 §9.1 で $w=ct$ と $\mathbf{B}'=c\mathbf{B}$ による次元の正規化を明示し、§9.3 でミンコフスキー計量の符号規約を定義し、§9.2 の注で $F_{\mu\nu}$ の符号規約を明記し、§9.6 で $F=-dA$ の規約を宣言している。§9.5 の注では $\mathcal{J}$ の正規化が標準的な相対論的記法と係数が異なる場合があることも注記している。</p>
 </li>
 <li>
-<p><strong>$dx$ の行列表現 $\begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ は座標変換後に同じ行列として残るわけではない</strong>
-  → 第1章 §1.4 で明示的に扱っている。デカルト座標での $dx = \begin{pmatrix}1&amp;0&amp;0\end{pmatrix}$ は、円柱座標の目盛りでは $\begin{pmatrix}\cos\theta &amp; -r\sin\theta &amp; 0\end{pmatrix}$ に変わる。これが「引き戻し」の具体化であり、座標変換による行列の成分変化を隠さずに正面から見せている。</p>
+<p><strong>$dx$ の行列表現 $\begin{pmatrix}1&0&0\end{pmatrix}$ は座標変換後に同じ行列として残るわけではない</strong>
+  → 第1章 §1.4 で明示的に扱っている。デカルト座標での $dx = \begin{pmatrix}1&0&0\end{pmatrix}$ は、円柱座標の目盛りでは $\begin{pmatrix}\cos\theta & -r\sin\theta & 0\end{pmatrix}$ に変わる。これが「引き戻し」の具体化であり、座標変換による行列の成分変化を隠さずに正面から見せている。</p>
 </li>
 </ul>
 <p>\newpage</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,53 +8,29 @@
 <style>
   :root { --sidebar-width: 300px; }
   body { margin: 0; display: flex; background: #fff; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
-  
-  /* サイドバーのスタイル */
-  .sidebar {
-    width: var(--sidebar-width);
-    height: 100vh;
-    position: sticky;
-    top: 0;
-    background: #f8f9fa;
-    border-right: 1px solid #d0d7de;
-    overflow-y: auto;
-    padding: 1rem;
-    box-sizing: border-box;
-  }
-  .sidebar h2 { font-size: 1.2rem; margin-bottom: 1rem; border: none; }
-  .sidebar .toc { font-size: 0.9rem; }
+  .sidebar { width: var(--sidebar-width); height: 100vh; position: sticky; top: 0; background: #f8f9fa; border-right: 1px solid #d0d7de; overflow-y: auto; padding: 1.5rem; box-sizing: border-box; }
+  .sidebar h2 { font-size: 1.2rem; margin-bottom: 1.5rem; border: none; color: #24292f; }
+  .sidebar .toc { font-size: 0.85rem; line-height: 1.6; }
   .sidebar .toc ul { list-style: none; padding-left: 1rem; }
-  .sidebar .toc li { margin: 0.5rem 0; }
   .sidebar a { text-decoration: none; color: #0969da; }
   .sidebar a:hover { text-decoration: underline; }
-
-  /* メインコンテンツ */
-  .main-content {
-    flex: 1;
-    padding: 2rem 3rem;
-    max-width: calc(100vw - var(--sidebar-width));
-    box-sizing: border-box;
-  }
-  .markdown-body { max-width: 900px; margin: 0 auto; }
-  
-  /* スマホ対応 */
-  @media (max-width: 768px) {
-    body { flex-direction: column; }
-    .sidebar { width: 100%; height: auto; position: relative; border-right: none; border-bottom: 1px solid #d0d7de; }
-    .main-content { max-width: 100%; padding: 1.5rem; }
-  }
-
-  blockquote { border-left: 4px solid #d0d7de; color: #57606a; background: #f6f8fa; padding: 0.5em 1em; margin: 1em 0; }
-  .math-display { overflow-x: auto; padding: 1rem 0; }
+  .main-content { flex: 1; padding: 2rem 3rem; max-width: calc(100vw - var(--sidebar-width)); box-sizing: border-box; overflow-x: hidden; }
+  .markdown-body { max-width: 850px; margin: 0 auto; font-size: 16px; }
+  @media (max-width: 768px) { body { flex-direction: column; } .sidebar { width: 100%; height: auto; position: relative; border-right: none; } .main-content { max-width: 100%; padding: 1.5rem; } }
+  blockquote { border-left: 4px solid #d0d7de; color: #57606a; background: #f6f8fa; padding: 0.5em 1em; margin: 1.5em 0; border-radius: 0 6px 6px 0; }
+  /* 数式がはみ出さないように調整 */
+  .mjx-container { overflow-x: auto !important; overflow-y: hidden !important; max-width: 100%; }
 </style>
 <script>
 window.MathJax = {
   tex: {
     inlineMath: [['$', '$'], ['\\(', '\\)']],
-    displayMath: [['$$', '$$'], ['\\[', '\\]']],
-    processEscapes: true
+    displayMath: [['$$', '$$']],
+    processEscapes: true,
+    packages: {'[+]': ['base', 'ams', 'noerrors', 'noundefined']}
   },
-  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
+  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] },
+  loader: {load: ['[tex]/ams', '[tex]/noerrors', '[tex]/noundefined']}
 };
 </script>
 <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
@@ -486,7 +462,7 @@ window.MathJax = {
 </ul>
 </div>
 </div>
-    <hr>
+    <hr style="border:none; border-top:1px solid #d0d7de; margin: 2rem 0;">
     <p style="font-size:0.8rem; color:#666;">著者: yokiikoy<br>License: CC BY-NC 4.0</p>
   </nav>
   <main class="main-content">
@@ -578,7 +554,7 @@ $$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \ 0 \ 0 \end{pmatrix}$$
 <h4 id="113-dx">1.1.3 $dx$ の登場 — 本書最大の特徴としての「断言」</h4>
 <p>さて、本書では $dx$ という記号に次のような意味を与える。<strong>大胆で奇妙に思えるかもしれないが、これが本書最大の特徴でもある——ここでは $dx$ を次の $1\times 3$ 行列だと断言する。</strong></p>
 <p>すなわち、<strong>横ベクトル</strong>（$1\times 3$ <strong>行列</strong>として成分を横に並べて書く）として
-\begin{center}\scalebox{1.8}{$\displaystyle dx = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$}\end{center}
+$$\displaystyle dx = \begin{pmatrix} 1 &amp; 0 &amp; 0 \end{pmatrix}$$
 と<strong>定義する</strong>。これは、入力された縦ベクトルから $x$ 成分だけを抜き出して返す線形演算子の行列表現である。</p>
 <blockquote>
 <p><strong>注</strong>（これはトンデモか？）<br />


### PR DESCRIPTION
## 修正内容\n- 数式ブロックをMarkdown変換から保護するロジックを導入\n- \mathbf{v}i などのタイポを自動補正\n- MathJaxの設定を強化