### PR TITLE
Fix MathJax rendering issue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,10 +25,23 @@ window.MathJax = {
   tex: {
     inlineMath: [['$', '$']],
     displayMath: [['$$', '$$']],
-    processEscapes: false,
-    packages: { '[+]': ['bm'] }
+    processEscapes: true,
+    packages: {'[+]': ['bm']}
   },
-  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
+  options: {
+    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+    ignoreHtmlClass: 'tex2jax_ignore',
+    processHtmlClass: 'tex2jax_process'
+  },
+  startup: {
+    ready: () => {
+      console.log('MathJax is loaded and ready');
+      MathJax.startup.defaultReady();
+      MathJax.startup.promise.then(() => {
+        console.log('MathJax initial typesetting complete');
+      });
+    }
+  }
 };
 
 </script>
@@ -400,13 +413,13 @@ window.MathJax = {
 </p>
 <p>\newpage
 </p>
-<h1 id="第1章-とは何か--ベクトルを食べる測定器あるいは横ベクトル">第1章：$dx$ とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</h1>
+<h1 id="第1章span-classtex2jaxprocessspan-とは何か--ベクトルを食べる測定器あるいは横ベクトル">第1章：<span class="tex2jax_process">$dx$</span> とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</h1>
 <h3 id="10-数学者の1次元物理学者の1次元">§1.0 数学者の1次元、物理学者の1次元</h3>
-<p>高校で $\int f(x) dx$ という1次元の積分を習ったとき、教科書の記述では「$x$軸という1本の線」が置かれる。数学の教科書としてはそれで妥当だ。<strong>数学者</strong>は1次元空間 $\mathbb{R}^1$ という自己完結した抽象世界を仮定し、その上で論理を積み上げる。点は実数 $x$、変位は実数 $\Delta x$、積分は「関数×微小幅」の極限として定義される。すべてが完結している。
+<p>高校で <span class="tex2jax_process">$\int f(x) dx$</span> という1次元の積分を習ったとき、教科書の記述では「<span class="tex2jax_process">$x$</span>軸という1本の線」が置かれる。数学の教科書としてはそれで妥当だ。<strong>数学者</strong>は1次元空間 <span class="tex2jax_process">$\mathbb{R}^1$</span> という自己完結した抽象世界を仮定し、その上で論理を積み上げる。点は実数 <span class="tex2jax_process">$x$</span>、変位は実数 <span class="tex2jax_process">$\Delta x$</span>、積分は「関数×微小幅」の極限として定義される。すべてが完結している。
 </p>
 <strong>しかし、我々は物理学者である。</strong>
-<p>我々が扱う<strong>現実の物理空間は、常に3次元だ。</strong>質点が直線上を運動しているように見えても、それは「架空の1次元空間」にいるのではなく、「3次元空間 $\mathbb{R}^3$ の中で、たまたま $y$ 方向と $z$ 方向への変位が観測されない（あるいは無視できる）断面」を見ているに過ぎない。
-例えば、摩擦のない直線レール上を滑る台車を考えよう。我々は「これは $x$ 軸方向の1次元運動だ」と言うが、実際には：
+<p>我々が扱う<strong>現実の物理空間は、常に3次元だ。</strong>質点が直線上を運動しているように見えても、それは「架空の1次元空間」にいるのではなく、「3次元空間 <span class="tex2jax_process">$\mathbb{R}^3$</span> の中で、たまたま <span class="tex2jax_process">$y$</span> 方向と <span class="tex2jax_process">$z$</span> 方向への変位が観測されない（あるいは無視できる）断面」を見ているに過ぎない。
+例えば、摩擦のない直線レール上を滑る台車を考えよう。我々は「これは <span class="tex2jax_process">$x$</span> 軸方向の1次元運動だ」と言うが、実際には：
 <ul>
 <li>レールは3次元空間内に設置されている</li>
 </ol>
@@ -417,17 +430,17 @@ window.MathJax = {
 <li>空気抵抗による横方向の微小変動もある</li>
 </ol>
 <p>物理学者の「1次元運動」とは、<strong>3次元空間内で特定の方向への変位が支配的であり、他の方向の変位が無視できるほど小さいか、系の対称性によって厳密にゼロに拘束されている状況</strong>を指す。
-したがって、物理学者が「1次元の微小変位」と呼ぶものの真の姿は、単なるスカラー $\Delta x$ ではなく、次のような<strong>縦ベクトル（列ベクトル）</strong>で表すのがふさわしい：
-$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$
+したがって、物理学者が「1次元の微小変位」と呼ぶものの真の姿は、単なるスカラー <span class="tex2jax_process">$\Delta x$</span> ではなく、次のような<strong>縦ベクトル（列ベクトル）</strong>で表すのがふさわしい：
 </p>
+<div class="math-block tex2jax_process">$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$</div>
 <blockquote><p>**注** （標準的でない呼び方）本書全体を通して**縦ベクトル・横ベクトル**という言い方をする（縦が列、横が行、と対応させて読んでほしい）。筆者は行と列という語の区別が苦手だからだ。</p>
 </p></blockquote>
-<p>我々はこのように、3次元空間内の一点からの変位を3成分で表したものを<strong>変位ベクトル</strong>と呼ぶ。成分の並びは慣習に従い、<strong>第1成分が $x$ 軸方向、第2が $y$ 軸方向、第3が $z$ 軸方向</strong>の変位に対応するものとする。
+<p>我々はこのように、3次元空間内の一点からの変位を3成分で表したものを<strong>変位ベクトル</strong>と呼ぶ。成分の並びは慣習に従い、<strong>第1成分が <span class="tex2jax_process">$x$</span> 軸方向、第2が <span class="tex2jax_process">$y$</span> 軸方向、第3が <span class="tex2jax_process">$z$</span> 軸方向</strong>の変位に対応するものとする。
 </p>
-<p>この第2成分・第3成分のゼロは、「無視されている」あるいは「存在しない」という消極的な意味ではない。<strong>「我々が今、$x$軸方向の運動だけに注目し、他の成分を測定対象から意図的に除外している」という積極的な選択の結果</strong>なのである。
-この「物理学者としての3次元前提」こそが、積分記号の末尾にへばりついている $dx$ という記号の真の姿を暴き出す鍵となる。次節では、この視点から <strong>$dx$ を「微小量」から「行列」へと解体していく。</strong>
+<p>この第2成分・第3成分のゼロは、「無視されている」あるいは「存在しない」という消極的な意味ではない。<strong>「我々が今、<span class="tex2jax_process">$x$</span>軸方向の運動だけに注目し、他の成分を測定対象から意図的に除外している」という積極的な選択の結果</strong>なのである。
+この「物理学者としての3次元前提」こそが、積分記号の末尾にへばりついている <span class="tex2jax_process">$dx$</span> という記号の真の姿を暴き出す鍵となる。次節では、この視点から <strong><span class="tex2jax_process">$dx$</span> を「微小量」から「行列」へと解体していく。</strong>
 </p>
-<strong>本書はあくまで初等微分積分学とベクトル解析の教科書であり、一般次元の微分形式を展開しようとするものではない。したがって最後まで3次元デカルト座標 $(x,y,z)$ に固定し、線形代数学として最も素直な表現——行列表現——を採用する。</strong>よって、本書で用いる $dx,dy,dz$ は、この座標系において成分を取り出す具体的な行列として定義し、まずは「3次元・デカルト・行列」という素直な道具立ての中で、誤魔化しのないベクトル解析を身体に染み込ませることが狙いである。
+<strong>本書はあくまで初等微分積分学とベクトル解析の教科書であり、一般次元の微分形式を展開しようとするものではない。したがって最後まで3次元デカルト座標 <span class="tex2jax_process">$(x,y,z)$</span> に固定し、線形代数学として最も素直な表現——行列表現——を採用する。</strong>よって、本書で用いる <span class="tex2jax_process">$dx,dy,dz$</span> は、この座標系において成分を取り出す具体的な行列として定義し、まずは「3次元・デカルト・行列」という素直な道具立ての中で、誤魔化しのないベクトル解析を身体に染み込ませることが狙いである。
 <blockquote><p>**注**（デカルト座標の呼称について）本書の「デカルト座標」とは、**正規直交座標系**（原点が一致し、各軸が互いに直交し、間隔が等間隔である座標系）を指す。数学や他書籍では「ユークリッド空間上の直交直線座標」「デカルト座標系」などとも呼ばれるが、本書では単に「デカルト座標」と呼ぶ。</p>
 </p></blockquote>
 <blockquote><p>**注** （第III部での拡張）ただし第III部では、必要に応じて曲線座標や高次元への拡張にも触れる。</p>
@@ -436,117 +449,128 @@ $$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$
 </p></blockquote>
 <hr />
 <h3 id="11-リーマン積分は行列の積である">§1.1 リーマン積分は行列の積である</h3>
-<p>前節で、物理的な微小変位を縦ベクトル $\mathbf{v}$ として捉え直した。§1.0 と同じく
-$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$
-である。この視点を持って、今度は高校以来慣れ親しんだリーマン積分のプロセスを徹底的に解体し、その中に潜む「行列としての $dx$」を炙り出してみよう。
+<p>前節で、物理的な微小変位を縦ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> として捉え直した。§1.0 と同じく
 </p>
-<blockquote><p>**注** （転置の記法について）数学や他文献では、縦ベクトルの成分を横に並べ、右上に ${}^T$ を添えて略記することもある。本書では縦ベクトルはすべて $\begin{pmatrix}\cdots\end{pmatrix}$ の形で書く。${}^T$ が出てきたときは、行列の転置演算の記号として読んでほしい。</p>
+<div class="math-block tex2jax_process">$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>である。この視点を持って、今度は高校以来慣れ親しんだリーマン積分のプロセスを徹底的に解体し、その中に潜む「行列としての <span class="tex2jax_process">$dx$</span>」を炙り出してみよう。
+</p>
+<blockquote><p>**注** （転置の記法について）数学や他文献では、縦ベクトルの成分を横に並べ、右上に <span class="tex2jax_process">${}^T$</span> を添えて略記することもある。本書では縦ベクトルはすべて <span class="tex2jax_process">$\begin{pmatrix}\cdots\end{pmatrix}$</span> の形で書く。<span class="tex2jax_process">${}^T$</span> が出てきたときは、行列の転置演算の記号として読んでほしい。</p>
 </p></blockquote>
 <h4 id="111-リーマン和の標準的構成復習">1.1.1 リーマン和の標準的構成（復習）</h4>
-<p>関数 $f(x)$ の区間 $[a, b]$ における定積分は、次のように定義される：
+<p>関数 <span class="tex2jax_process">$f(x)$</span> の区間 <span class="tex2jax_process">$[a, b]$</span> における定積分は、次のように定義される：
 </p>
-<blockquote><p>**注** （閉区間とは）記号 $[a,b]$ は、端点 $a$ と $b$ を両方含む**閉区間**（$a \le x \le b$ の実数 $x$ の集合）を表す。数学者の流儀に慣れていない読者のために明示しておく。</p>
+<blockquote><p>**注** （閉区間とは）記号 <span class="tex2jax_process">$[a,b]$</span> は、端点 <span class="tex2jax_process">$a$</span> と <span class="tex2jax_process">$b$</span> を両方含む**閉区間**（<span class="tex2jax_process">$a \le x \le b$</span> の実数 <span class="tex2jax_process">$x$</span> の集合）を表す。数学者の流儀に慣れていない読者のために明示しておく。</p>
 </p></blockquote>
 <ol>
-<li>区間を $n$ 個の小区間に分割： $a = x_0 < x_1 < \cdots < x_n = b$</li>
+<li>区間を <span class="tex2jax_process">$n$</span> 個の小区間に分割： <span class="tex2jax_process">$a = x_0 < x_1 < \cdots < x_n = b$</span></li>
 </ol>
-<p>2. 小区間の幅を $\Delta x_i = x_i - x_{i-1}$
+<p>2. 小区間の幅を <span class="tex2jax_process">$\Delta x_i = x_i - x_{i-1}$</span>
 <ol>
-<li>各小区間 $[x_{i-1}, x_i]$ の**中から**代表点 $\xi_i$ を1つ選ぶ</li>
+<li>各小区間 <span class="tex2jax_process">$[x_{i-1}, x_i]$</span> の**中から**代表点 <span class="tex2jax_process">$\xi_i$</span> を1つ選ぶ</li>
 </ol>
-<p>4. リーマン和 $R_n = \sum_{i=1}^n f(\xi_i) \Delta x_i$ を作る（この $n$ 分割に対する和を $R_n$ と書く）
+<p>4. リーマン和 <span class="tex2jax_process">$R_n = \sum_{i=1}^n f(\xi_i) \Delta x_i$</span> を作る（この <span class="tex2jax_process">$n$</span> 分割に対する和を <span class="tex2jax_process">$R_n$</span> と書く）
 <ol>
-<li>分割を細かくする極限をとる（厳密には、小区間の幅の**最大値**が $0$ に近づく。分割数 $n$ だけを大きくしても幅が残る取り方がありうるので、数学ではこちらを重視する。以下の $\lim_{n\to\infty} R_n$ は、この条件を満たす分割の取り方を前提にしている）： $\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n$</li>
+<li>分割を細かくする極限をとる（厳密には、小区間の幅の**最大値**が <span class="tex2jax_process">$0$</span> に近づく。分割数 <span class="tex2jax_process">$n$</span> だけを大きくしても幅が残る取り方がありうるので、数学ではこちらを重視する。以下の <span class="tex2jax_process">$\lim_{n\to\infty} R_n$</span> は、この条件を満たす分割の取り方を前提にしている）： <span class="tex2jax_process">$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n$</span></li>
 </ol>
-<p>この教科書的な説明では、$\Delta x_i$ は「微小な幅」という一次元の量だ。しかし、我々はもう一歩踏み込めるはずだ。
+<p>この教科書的な説明では、<span class="tex2jax_process">$\Delta x_i$</span> は「微小な幅」という一次元の量だ。しかし、我々はもう一歩踏み込めるはずだ。
 </p>
 <h4 id="112-小区間ごとの変位">1.1.2 小区間ごとの変位</h4>
-<p>第 $i$ 小区間 $[x_{i-1}, x_i]$ における変位は、§1.0 の<strong>変位ベクトル</strong>を、その区間の幅に合わせて
-$$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$$
-と書く。添字 $i$ は「第 $i$ 小区間の分」という意味だけで、$\mathbf{v}_i$ もまた変位ベクトルである。今は直線運動を考えているので $y,z$ 成分はゼロだが、それは条件ではなく結果としてゼロになっているだけだ。
+<p>第 <span class="tex2jax_process">$i$</span> 小区間 <span class="tex2jax_process">$[x_{i-1}, x_i]$</span> における変位は、§1.0 の<strong>変位ベクトル</strong>を、その区間の幅に合わせて
+</p>
+<div class="math-block tex2jax_process">$$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>と書く。添字 <span class="tex2jax_process">$i$</span> は「第 <span class="tex2jax_process">$i$</span> 小区間の分」という意味だけで、<span class="tex2jax_process">$\mathbf{v}_i$</span> もまた変位ベクトルである。今は直線運動を考えているので <span class="tex2jax_process">$y,z$</span> 成分はゼロだが、それは条件ではなく結果としてゼロになっているだけだ。
 </p>
 <p>\clearpage
 </p>
-<h4 id="113-の登場--本書最大の特徴としての断言">1.1.3 $dx$ の登場 — 本書最大の特徴としての「断言」</h4>
-<p>さて、本書では $dx$ という記号に次のような意味を与える。<strong>大胆で奇妙に思えるかもしれないが、これが本書最大の特徴でもある——ここでは $dx$ を次の $1\times 3$ 行列だと断言する。</strong>
+<h4 id="113-span-classtex2jaxprocessspan-の登場--本書最大の特徴としての断言">1.1.3 <span class="tex2jax_process">$dx$</span> の登場 — 本書最大の特徴としての「断言」</h4>
+<p>さて、本書では <span class="tex2jax_process">$dx$</span> という記号に次のような意味を与える。<strong>大胆で奇妙に思えるかもしれないが、これが本書最大の特徴でもある——ここでは <span class="tex2jax_process">$dx$</span> を次の <span class="tex2jax_process">$1\times 3$</span> 行列だと断言する。</strong>
 </p>
-<p>すなわち、<strong>横ベクトル</strong>（$1\times 3$ <strong>行列</strong>として成分を横に並べて書く）として
-\begin{center}\scalebox{1.8}{$\displaystyle dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$}\end{center}
-と<strong>定義する</strong>。これは、入力された縦ベクトルから $x$ 成分だけを抜き出して返す線形演算子の行列表現である。
+<p>すなわち、<strong>横ベクトル</strong>（<span class="tex2jax_process">$1\times 3$</span> <strong>行列</strong>として成分を横に並べて書く）として
+\begin{center}\scalebox{1.8}{<span class="tex2jax_process">$\displaystyle dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$</span>}\end{center}
+と<strong>定義する</strong>。これは、入力された縦ベクトルから <span class="tex2jax_process">$x$</span> 成分だけを抜き出して返す線形演算子の行列表現である。
 </p>
 <blockquote><p>**注**（これはトンデモか？）</p>
-双対ベクトルを横ベクトルで表すこと自体は、テンソル解析や線形代数、量子力学のブラケット記法などの文脈で普通に行われる。たとえば標準基底 $e_1,e_2,e_3$ に対する双対基底のひとつ $e^1$ は、行列表現では
-$$
+双対ベクトルを横ベクトルで表すこと自体は、テンソル解析や線形代数、量子力学のブラケット記法などの文脈で普通に行われる。たとえば標準基底 <span class="tex2jax_process">$e_1,e_2,e_3$</span> に対する双対基底のひとつ <span class="tex2jax_process">$e^1$</span> は、行列表現では
+
+</p></blockquote>
+<div class="math-block tex2jax_process">$$
 > e^1=\begin{pmatrix}1&0&0\end{pmatrix}
-> $$
-と書ける。テンソル解析でいう共変成分を、行ベクトルとして配列に起こしたものに対応する。本書では、標準デカルト座標のもとで、$dx$ をこの $e^1$ と同一視する。
+> $$</div>
+<blockquote><p>と書ける。テンソル解析でいう共変成分を、行ベクトルとして配列に起こしたものに対応する。本書では、標準デカルト座標のもとで、<span class="tex2jax_process">$dx$</span> をこの <span class="tex2jax_process">$e^1$</span> と同一視する。</p>
 
-もちろんこれは、多様体論における座標自由な幾何学的実体としての $dx$ を否定するものではない。その立場では、$dx$ そのものと、その標準基底に関する行列表現は区別される。すなわち、
-$$
+もちろんこれは、多様体論における座標自由な幾何学的実体としての <span class="tex2jax_process">$dx$</span> を否定するものではない。その立場では、<span class="tex2jax_process">$dx$</span> そのものと、その標準基底に関する行列表現は区別される。すなわち、
+
+</p></blockquote>
+<div class="math-block tex2jax_process">$$
 > dx \longleftrightarrow \begin{pmatrix}1&0&0\end{pmatrix}
-> $$
-という「表示の対応」として理解するのがより慎重だ。
+> $$</div>
+<blockquote><p>という「表示の対応」として理解するのがより慎重だ。</p>
 
-しかし本文では、等号 $=$ を採用する。理由は、日本の高校数学を通ってきた初学者にとって、$\longleftrightarrow$ や $\mapsto$ と $=$ の違いへ初手から立ち入ることが、余計な認知的負荷になると考えるからである。重要なのは、$=$ か $\mapsto$ かという記号そのものではなく、どの同一視を読者と約束しているかだ。本書では、「標準デカルト座標を固定した表示として、$dx$ を $\begin{pmatrix}1&0&0\end{pmatrix}$ と書く」という約束のもとで、この省略記法を用いる。この同一視の裏側やテンソル解析・多様体論への発展は第11章で改めて述べる。
+しかし本文では、等号 <span class="tex2jax_process">$=$</span> を採用する。理由は、日本の高校数学を通ってきた初学者にとって、<span class="tex2jax_process">$\longleftrightarrow$</span> や <span class="tex2jax_process">$\mapsto$</span> と <span class="tex2jax_process">$=$</span> の違いへ初手から立ち入ることが、余計な認知的負荷になると考えるからである。重要なのは、<span class="tex2jax_process">$=$</span> か <span class="tex2jax_process">$\mapsto$</span> かという記号そのものではなく、どの同一視を読者と約束しているかだ。本書では、「標準デカルト座標を固定した表示として、<span class="tex2jax_process">$dx$</span> を <span class="tex2jax_process">$\begin{pmatrix}1&0&0\end{pmatrix}$</span> と書く」という約束のもとで、この省略記法を用いる。この同一視の裏側やテンソル解析・多様体論への発展は第11章で改めて述べる。
 </p></blockquote>
 <blockquote><p>**注**（なぜこんなに必死なのか）</p>
 この種の発見的・構築的な導入は、しばしば「不正確だ」「一般論を矮小化している」と誤解される。したがって、本書の射程をあらかじめ明示しておく。本書の主戦場は、物理数学としての三次元ベクトル解析であり、一般多様体上の微分形式論やド・ラームコホモロジーではない。詳しくは「付録：本書で語らなかったもの」を参照のこと。
 </p></blockquote>
 <p>\clearpage
 </p>
-<p>変位ベクトル $\mathbf{v}_i$ に左から掛けると
-$$dx\,\mathbf{v}_i = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \Delta x_i$$
-となる。ここで「$dx$ が変位ベクトル $\mathbf{v}_i$ を食べてスカラー $\Delta x_i$ を吐く」というイメージを、<strong>関数の値のように書く</strong>ことにする：
-$$dx(\mathbf{v}_i) = dx\,\mathbf{v}_i = \Delta x_i$$
+<p>変位ベクトル <span class="tex2jax_process">$\mathbf{v}_i$</span> に左から掛けると
 </p>
-<strong>本書では、しばしばこの $dx(\mathbf{v})$ の形で「横ベクトル $dx$ が縦ベクトル $\mathbf{v}$ に作用する」と強調する。何度繰り返しても強調しすぎることはない。</strong>
-<blockquote><p>**注** （演算子・作用素・関数・写像の呼び分け）この $dx(\mathbf{v})$ を**演算子**と呼ぶか**作用素**と呼ぶか**関数**と呼ぶか**写像**と呼ぶかは、文献によってさまざまな流儀がある。筆者は**演算子**と呼ぶことを好むので、この先も演算子と呼ぶことが多いだろう。</p>
+<div class="math-block tex2jax_process">$$dx\,\mathbf{v}_i = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \Delta x_i$$</div>
+<p>となる。ここで「<span class="tex2jax_process">$dx$</span> が変位ベクトル <span class="tex2jax_process">$\mathbf{v}_i$</span> を食べてスカラー <span class="tex2jax_process">$\Delta x_i$</span> を吐く」というイメージを、<strong>関数の値のように書く</strong>ことにする：
+</p>
+<div class="math-block tex2jax_process">$$dx(\mathbf{v}_i) = dx\,\mathbf{v}_i = \Delta x_i$$</div>
+<strong>本書では、しばしばこの <span class="tex2jax_process">$dx(\mathbf{v})$</span> の形で「横ベクトル <span class="tex2jax_process">$dx$</span> が縦ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> に作用する」と強調する。何度繰り返しても強調しすぎることはない。</strong>
+<blockquote><p>**注** （演算子・作用素・関数・写像の呼び分け）この <span class="tex2jax_process">$dx(\mathbf{v})$</span> を**演算子**と呼ぶか**作用素**と呼ぶか**関数**と呼ぶか**写像**と呼ぶかは、文献によってさまざまな流儀がある。筆者は**演算子**と呼ぶことを好むので、この先も演算子と呼ぶことが多いだろう。</p>
 </p></blockquote>
 <blockquote><p>**注**（座標不変な \(dx\) とデカルト表示）上で述べた通り、ここでの \(\begin{pmatrix}1&0&0\end{pmatrix}\) は標準デカルト座標での表示である。§1.4 で、座標を替えるとこの表示がどう変わるかを見る。</p>
 </p></blockquote>
-<p>リーマン和に現れる $\Delta x_i$ は、「1次元の謎の微小量」ではない。<strong>3次元空間の中での変位ベクトル $\mathbf{v}_i$ に対し、上の行列としての $dx$ が $x$ 成分だけを抜き出した結果</strong>である。
+<p>リーマン和に現れる <span class="tex2jax_process">$\Delta x_i$</span> は、「1次元の謎の微小量」ではない。<strong>3次元空間の中での変位ベクトル <span class="tex2jax_process">$\mathbf{v}_i$</span> に対し、上の行列としての <span class="tex2jax_process">$dx$</span> が <span class="tex2jax_process">$x$</span> 成分だけを抜き出した結果</strong>である。
 </p>
 <strong>これが決定的な瞬間だ</strong>：
 <ul>
-<li>左辺：$dx(\mathbf{v}_i)$ は、行列 $dx$ が**変位ベクトル $\mathbf{v}_i$ に**作用する代数的操作</li>
+<li>左辺：<span class="tex2jax_process">$dx(\mathbf{v}_i)$</span> は、行列 <span class="tex2jax_process">$dx$</span> が**変位ベクトル <span class="tex2jax_process">$\mathbf{v}_i$</span> に**作用する代数的操作</li>
 </ol>
 <ul>
-<li>右辺：従来のリーマン和に現れる「小区間の幅 $\Delta x_i$」</li>
+<li>右辺：従来のリーマン和に現れる「小区間の幅 <span class="tex2jax_process">$\Delta x_i$</span>」</li>
 </ol>
-<p>つまり $\Delta x_i$ は、<strong>1次元の謎の微小変位ではなく、3次元の微小変位 $\mathbf{v}_i$ から $x$ 方向の成分だけを取り出した $dx(\mathbf{v}_i)$ である</strong>。
+<p>つまり <span class="tex2jax_process">$\Delta x_i$</span> は、<strong>1次元の謎の微小変位ではなく、3次元の微小変位 <span class="tex2jax_process">$\mathbf{v}_i$</span> から <span class="tex2jax_process">$x$</span> 方向の成分だけを取り出した <span class="tex2jax_process">$dx(\mathbf{v}_i)$</span> である</strong>。
 </p>
-<blockquote><p>**注** （成分並びの約束）横ベクトル（行）や行成分の略記は **$(1\ 0\ 0)$** のように**コンマを打たず**、成分の間だけを区切って書く。**$(1, 0, 0)$** のように**コンマのあとにスペース**を入れる書き方は**座標**（点の位置など）を強調するときに用い、**行列・横ベクトルの略記には使わない**。</p>
+<blockquote><p>**注** （成分並びの約束）横ベクトル（行）や行成分の略記は **<span class="tex2jax_process">$(1\ 0\ 0)$</span>** のように**コンマを打たず**、成分の間だけを区切って書く。**<span class="tex2jax_process">$(1, 0, 0)$</span>** のように**コンマのあとにスペース**を入れる書き方は**座標**（点の位置など）を強調するときに用い、**行列・横ベクトルの略記には使わない**。</p>
 </p></blockquote>
 <h4 id="114-リーマン和のベクトル再解釈と積分記号">1.1.4 リーマン和のベクトル再解釈と積分記号</h4>
 <p>この視点でリーマン和を書き直すと：
-$$R_n = \sum_{i=1}^n f(\xi_i) \cdot dx(\mathbf{v}_i)$$
 </p>
+<div class="math-block tex2jax_process">$$R_n = \sum_{i=1}^n f(\xi_i) \cdot dx(\mathbf{v}_i)$$</div>
 <p>さらに、各小区間で
-$$f(\xi_i)\,dx = \begin{pmatrix} f(\xi_i) & 0 & 0 \end{pmatrix}$$
-とおけば（スカラー $f(\xi_i)$ が各行をスケールする）、
-$$\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i) = f(\xi_i) \cdot dx(\mathbf{v}_i) = f(\xi_i)\,\Delta x_i$$
-であり、リーマン和の各項そのものが得られる：
-$$R_n = \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$
 </p>
-<p>分割を無限に細かくする極限では（手順5と同じく、幅の最大値が $0$ に近づく意味で）、リーマン積分の定義より
-$$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n = \lim_{n\to\infty} \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$
-左辺の $\int_a^b f(x)\,dx$ は、高校以来おなじみの積分記号そのものである——すなわち、上の手順5で書いた $\lim_{n\to\infty} R_n$ と同じ量だ。右辺は、<strong>各小区間で「行列 $f(\xi_i)\,dx$ を変位ベクトルに作用させた値」を足し上げたものの極限</strong>という、同じ積分の別顔だ。
+<div class="math-block tex2jax_process">$$f(\xi_i)\,dx = \begin{pmatrix} f(\xi_i) & 0 & 0 \end{pmatrix}$$</div>
+<p>とおけば（スカラー <span class="tex2jax_process">$f(\xi_i)$</span> が各行をスケールする）、
+</p>
+<div class="math-block tex2jax_process">$$\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i) = f(\xi_i) \cdot dx(\mathbf{v}_i) = f(\xi_i)\,\Delta x_i$$</div>
+<p>であり、リーマン和の各項そのものが得られる：
+</p>
+<div class="math-block tex2jax_process">$$R_n = \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$</div>
+<p>分割を無限に細かくする極限では（手順5と同じく、幅の最大値が <span class="tex2jax_process">$0$</span> に近づく意味で）、リーマン積分の定義より
+</p>
+<div class="math-block tex2jax_process">$$\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n = \lim_{n\to\infty} \sum_{i=1}^n \bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)$$</div>
+<p>左辺の <span class="tex2jax_process">$\int_a^b f(x)\,dx$</span> は、高校以来おなじみの積分記号そのものである——すなわち、上の手順5で書いた <span class="tex2jax_process">$\lim_{n\to\infty} R_n$</span> と同じ量だ。右辺は、<strong>各小区間で「行列 <span class="tex2jax_process">$f(\xi_i)\,dx$</span> を変位ベクトルに作用させた値」を足し上げたものの極限</strong>という、同じ積分の別顔だ。
 </p>
 <h4 id="115-物理的解釈--仕事の計算を例に">1.1.5 物理的解釈 — 仕事の計算を例に</h4>
-<blockquote><p>**注** （力学になじみがない読者へ）ここで力学の講義をしようとするわけではない。下に出す $W=\int F\,dx$ は、**積分を行列作用の極限としてどう読むか**を示すための、馴染みのある例として借りるだけである。力の厳密な定義や単位の細部まで押さえなくとも、本節の主眼を追ううえで支障はない。想定読者の多くは高校程度の力学に触れているであろうが、これから初学者の読者も、上の趣旨だけ押さえていれば、同様に支障はない。</p>
+<blockquote><p>**注** （力学になじみがない読者へ）ここで力学の講義をしようとするわけではない。下に出す <span class="tex2jax_process">$W=\int F\,dx$</span> は、**積分を行列作用の極限としてどう読むか**を示すための、馴染みのある例として借りるだけである。力の厳密な定義や単位の細部まで押さえなくとも、本節の主眼を追ううえで支障はない。想定読者の多くは高校程度の力学に触れているであろうが、これから初学者の読者も、上の趣旨だけ押さえていれば、同様に支障はない。</p>
 </p></blockquote>
-<p>直線上の質点に力 $F(x)$ が作用する場合の仕事を考えよう。力学を学んだ読者であれば
-$$W = \int_a^b F(x)\,dx$$
-という表現を知っているだろう。本書の流儀で行列表現すると、
-$$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \lim_{n\to\infty} \sum_{i=1}^n \bigl(F(\xi_i)\,dx\bigr)(\mathbf{v}_i) = \int_a^b F(x)\,dx$$
-である。左から順に、<strong>成分を明示したリーマン和の極限</strong>、<strong>演算子記法による同じ極限</strong>、<strong>慣用の積分記号</strong>であり、<strong>同じ量</strong>を三通りに表している。ここで $\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$ である。
+<p>直線上の質点に力 <span class="tex2jax_process">$F(x)$</span> が作用する場合の仕事を考えよう。力学を学んだ読者であれば
 </p>
-<p>$F(x)\,dx = \begin{pmatrix} F(x) & 0 & 0 \end{pmatrix}$ は演算子であり、$\bigl(F(x)\,dx\bigr)(\mathbf{v}) = F(x)\,\Delta x$ が一次近似としての微小仕事になる。
+<div class="math-block tex2jax_process">$$W = \int_a^b F(x)\,dx$$</div>
+<p>という表現を知っているだろう。本書の流儀で行列表現すると、
 </p>
-<h4 id="116-一次形式-form">1.1.6 一次形式（$1$-form）</h4>
-<p>ここまで、我々は $dx$ を「変位ベクトルに作用して特定の成分を抽出し、スカラー（実数）を返す横ベクトル」として定義してきた。このような、ベクトルを食べてスカラーを吐き出す<strong>線形</strong>な測定器のことを、専門的には<strong>一次形式（$1$-form）</strong>と呼ぶ。本稿で「行列としての $dx$」と呼んできたものは、まさにこの一次形式に他ならない。
+<div class="math-block tex2jax_process">$$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix} = \lim_{n\to\infty} \sum_{i=1}^n \bigl(F(\xi_i)\,dx\bigr)(\mathbf{v}_i) = \int_a^b F(x)\,dx$$</div>
+<p>である。左から順に、<strong>成分を明示したリーマン和の極限</strong>、<strong>演算子記法による同じ極限</strong>、<strong>慣用の積分記号</strong>であり、<strong>同じ量</strong>を三通りに表している。ここで <span class="tex2jax_process">$\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}$</span> である。
 </p>
-<blockquote><p>**注** （余ベクトルという用語）数学者は **一次形式（$1$-form）** の別名として **余ベクトル（covector）**と呼ぶ流儀をとることもよくある。他書を読むときの辞書として、頭の片隅に置いておけばよい。</p>
+<span class="tex2jax_process">$F(x)\,dx = \begin{pmatrix} F(x) & 0 & 0 \end{pmatrix}$</span> は演算子であり、<span class="tex2jax_process">$\bigl(F(x)\,dx\bigr)(\mathbf{v}) = F(x)\,\Delta x$</span> が一次近似としての微小仕事になる。
+<h4 id="116-一次形式span-classtex2jaxprocessspan-form">1.1.6 一次形式（<span class="tex2jax_process">$1$</span>-form）</h4>
+<p>ここまで、我々は <span class="tex2jax_process">$dx$</span> を「変位ベクトルに作用して特定の成分を抽出し、スカラー（実数）を返す横ベクトル」として定義してきた。このような、ベクトルを食べてスカラーを吐き出す<strong>線形</strong>な測定器のことを、専門的には<strong>一次形式（<span class="tex2jax_process">$1$</span>-form）</strong>と呼ぶ。本稿で「行列としての <span class="tex2jax_process">$dx$</span>」と呼んできたものは、まさにこの一次形式に他ならない。
+</p>
+<blockquote><p>**注** （余ベクトルという用語）数学者は **一次形式（<span class="tex2jax_process">$1$</span>-form）** の別名として **余ベクトル（covector）**と呼ぶ流儀をとることもよくある。他書を読むときの辞書として、頭の片隅に置いておけばよい。</p>
 </p></blockquote>
 <p>命名の由来は単純だ：
 </p>
@@ -556,303 +580,315 @@ $$W = \lim_{n\to\infty} \sum_{i=1}^n \begin{pmatrix} F(\xi_i) & 0 & 0 \end{pmatr
 <ul>
 <li>**「形式」**：「測定の形式」「作用の形式」を意味する</li>
 </ol>
-<p>これ以降、この測定器のことを「行列」とも「一次形式（$1$-form）」とも呼ぶことにする。どちらの呼び方も、同じ実体を指している。
+<p>これ以降、この測定器のことを「行列」とも「一次形式（<span class="tex2jax_process">$1$</span>-form）」とも呼ぶことにする。どちらの呼び方も、同じ実体を指している。
 </p>
 <strong>本書の記号契約</strong>
-<strong>$dx$ を単独で「微小な変位」や「微小変化」の意味には用いない</strong>——変位の幅と測定器（横ベクトル）を混同しないために、次のように約束する。$x$ 方向の（微小）変位の大きさは <strong>$\Delta x$</strong> を使うか、変位ベクトル $\mathbf{v}$ を明示して <strong>$dx(\mathbf{v})$</strong> と書く。
-<p>一方、<strong>単独で現れる $dx$</strong> は、<strong>$x$ 成分を抜き出す横ベクトル（一次形式）としての演算子</strong>を指す。式 $df = f'(x)\,dx$ のように並ぶ $dx$ も、<strong>常に演算子として読む</strong>。<strong>この区別を徹底することが、以降のすべての理解の土台となる。</strong>
+<strong><span class="tex2jax_process">$dx$</span> を単独で「微小な変位」や「微小変化」の意味には用いない</strong>——変位の幅と測定器（横ベクトル）を混同しないために、次のように約束する。<span class="tex2jax_process">$x$</span> 方向の（微小）変位の大きさは <strong><span class="tex2jax_process">$\Delta x$</span></strong> を使うか、変位ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> を明示して <strong><span class="tex2jax_process">$dx(\mathbf{v})$</span></strong> と書く。
+<p>一方、<strong>単独で現れる <span class="tex2jax_process">$dx$</span></strong> は、<strong><span class="tex2jax_process">$x$</span> 成分を抜き出す横ベクトル（一次形式）としての演算子</strong>を指す。式 <span class="tex2jax_process">$df = f'(x)\,dx$</span> のように並ぶ <span class="tex2jax_process">$dx$</span> も、<strong>常に演算子として読む</strong>。<strong>この区別を徹底することが、以降のすべての理解の土台となる。</strong>
 </p>
-<p>積分記号 $\int_a^b f(x)\,dx$ の末尾の $dx$ は、高校以来の<strong>慣用記法</strong>として残す（積分変数 $x$ とセットの「ひとかたまり」）。本書ではここを毎回 $dx(\mathbf{v})$ まで展開しないことも多いが、<strong>変位や微小幅を語る本文では $\Delta x$ か $dx(\mathbf{v})$ に揃え、裸の $dx$ には幅や変化量のイメージを載せない</strong>。
+<p>積分記号 <span class="tex2jax_process">$\int_a^b f(x)\,dx$</span> の末尾の <span class="tex2jax_process">$dx$</span> は、高校以来の<strong>慣用記法</strong>として残す（積分変数 <span class="tex2jax_process">$x$</span> とセットの「ひとかたまり」）。本書ではここを毎回 <span class="tex2jax_process">$dx(\mathbf{v})$</span> まで展開しないことも多いが、<strong>変位や微小幅を語る本文では <span class="tex2jax_process">$\Delta x$</span> か <span class="tex2jax_process">$dx(\mathbf{v})$</span> に揃え、裸の <span class="tex2jax_process">$dx$</span> には幅や変化量のイメージを載せない</strong>。
 </p>
-<blockquote><p>**注** （文献における $dx$ の用法）物理学者は変位の成分そのものを $dx$ と書く慣習もよく使う。しかし、本書の記法に慣れると、**測定器としての $dx$ と変位のスカラーを切り分けた**読みがしやすくなる——より進んだ本では、その区別がそのまま効いてくる。</p>
+<blockquote><p>**注** （文献における <span class="tex2jax_process">$dx$</span> の用法）物理学者は変位の成分そのものを <span class="tex2jax_process">$dx$</span> と書く慣習もよく使う。しかし、本書の記法に慣れると、**測定器としての <span class="tex2jax_process">$dx$</span> と変位のスカラーを切り分けた**読みがしやすくなる——より進んだ本では、その区別がそのまま効いてくる。</p>
 </p></blockquote>
-<p>次節では、この視点を関数の微分へと拡張し、全微分 $df$ を行列として定義していく。
+<p>次節では、この視点を関数の微分へと拡張し、全微分 <span class="tex2jax_process">$df$</span> を行列として定義していく。
 </p>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 微小変位は縦ベクトル $\mathbf{v}$。$\Delta x$ はスカラー幅であり、単独の $dx$ は横ベクトル（一次形式）としての演算子である。
-- デカルトの $dy$, $dz$ は**次節 §1.2.3**で置く（§1.1.6 の $dx$ と**同じ考え方の**一次形式）。$\Delta y$, $\Delta z$ や $dy(\mathbf{v})$, $dz(\mathbf{v})$ との区別は §1.1.6 の**記号契約**に沿う。
-- リーマン和の各項は $(f\,dx)(\mathbf{v}_i)$ の形で、積分はその極限として理解できる。
-- 積分記号 $\int_a^b f(x)\,dx$ の末尾の $dx$ は慣用記法であり、変位そのものは $\Delta x$ や $dx(\mathbf{v})$ で書く（§1.1.6 の契約）。
+- 微小変位は縦ベクトル <span class="tex2jax_process">$\mathbf{v}$</span>。<span class="tex2jax_process">$\Delta x$</span> はスカラー幅であり、単独の <span class="tex2jax_process">$dx$</span> は横ベクトル（一次形式）としての演算子である。
+- デカルトの <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> は**次節 §1.2.3**で置く（§1.1.6 の <span class="tex2jax_process">$dx$</span> と**同じ考え方の**一次形式）。<span class="tex2jax_process">$\Delta y$</span>, <span class="tex2jax_process">$\Delta z$</span> や <span class="tex2jax_process">$dy(\mathbf{v})$</span>, <span class="tex2jax_process">$dz(\mathbf{v})$</span> との区別は §1.1.6 の**記号契約**に沿う。
+- リーマン和の各項は <span class="tex2jax_process">$(f\,dx)(\mathbf{v}_i)$</span> の形で、積分はその極限として理解できる。
+- 積分記号 <span class="tex2jax_process">$\int_a^b f(x)\,dx$</span> の末尾の <span class="tex2jax_process">$dx$</span> は慣用記法であり、変位そのものは <span class="tex2jax_process">$\Delta x$</span> や <span class="tex2jax_process">$dx(\mathbf{v})$</span> で書く（§1.1.6 の契約）。
 </p></blockquote>
 <hr />
-<h3 id="12-全微分--変化率を行列にまとめた演算子">§1.2 全微分 $df$ — 変化率を行列にまとめた演算子</h3>
-<p>前節では、リーマン積分を「行列 $f(x)\,dx$ の変位ベクトルへの作用の和の極限」として解剖した。この節では、その考え方を関数自体の微分へと拡張し、<strong>全微分 $df$ を横ベクトル（行列）として定義する</strong>。「微分」は、単なる数値の変化率ではなく、<strong>変位ベクトルに掛けて初めて「変化量の一次部分」が出てくる演算子</strong>として扱う。
+<h3 id="12-全微分-span-classtex2jaxprocessspan--変化率を行列にまとめた演算子">§1.2 全微分 <span class="tex2jax_process">$df$</span> — 変化率を行列にまとめた演算子</h3>
+<p>前節では、リーマン積分を「行列 <span class="tex2jax_process">$f(x)\,dx$</span> の変位ベクトルへの作用の和の極限」として解剖した。この節では、その考え方を関数自体の微分へと拡張し、<strong>全微分 <span class="tex2jax_process">$df$</span> を横ベクトル（行列）として定義する</strong>。「微分」は、単なる数値の変化率ではなく、<strong>変位ベクトルに掛けて初めて「変化量の一次部分」が出てくる演算子</strong>として扱う。
 <h4 id="121-微分可能性の行列表現">1.2.1 微分可能性の行列表現</h4>
-<p>関数 $f(x)$ が点 $x$ で微分可能であるとは、次の一次近似が成り立つことである：
-$$\Delta f = f(x + \Delta x) - f(x) = f'(x) \Delta x + o(|\Delta x|) \quad (|\Delta x| \to 0)$$
+<p>関数 <span class="tex2jax_process">$f(x)$</span> が点 <span class="tex2jax_process">$x$</span> で微分可能であるとは、次の一次近似が成り立つことである：
 </p>
-<blockquote><p>**注** （ランダウのオーダー記法）**$o(|\Delta x|)$** は**ランダウのオーダー記法**である。$\Delta x \to 0$ のとき、$o(|\Delta x|)$ でまとめて書いた量は **$|\Delta x|$ よりずっと速くゼロに近づく余り**を意味し、主項 $f'(x)\Delta x$ に比べれば**無視してよいほど小さい**、という約束である。理工系の専門書ではよく出るが、初めて見る読者もいるかもしれない。</p>
+<div class="math-block tex2jax_process">$$\Delta f = f(x + \Delta x) - f(x) = f'(x) \Delta x + o(|\Delta x|) \quad (|\Delta x| \to 0)$$</div>
+<blockquote><p>**注** （ランダウのオーダー記法）**<span class="tex2jax_process">$o(|\Delta x|)$</span>** は**ランダウのオーダー記法**である。<span class="tex2jax_process">$\Delta x \to 0$</span> のとき、<span class="tex2jax_process">$o(|\Delta x|)$</span> でまとめて書いた量は **<span class="tex2jax_process">$|\Delta x|$</span> よりずっと速くゼロに近づく余り**を意味し、主項 <span class="tex2jax_process">$f'(x)\Delta x$</span> に比べれば**無視してよいほど小さい**、という約束である。理工系の専門書ではよく出るが、初めて見る読者もいるかもしれない。</p>
 </p></blockquote>
-<p>ここで $\Delta x$ はスカラーだが、我々はこれを前節同様、3次元の変位ベクトルとして捉え直す：
-$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$
+<p>ここで <span class="tex2jax_process">$\Delta x$</span> はスカラーだが、我々はこれを前節同様、3次元の変位ベクトルとして捉え直す：
 </p>
-<p>すると、関数の変化 $\Delta f$ は、この $\mathbf{v}$ によって引き起こされる効果と見なせる。
+<div class="math-block tex2jax_process">$$\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>すると、関数の変化 <span class="tex2jax_process">$\Delta f$</span> は、この <span class="tex2jax_process">$\mathbf{v}$</span> によって引き起こされる効果と見なせる。
 </p>
-<h4 id="122-の行列としての定義と">1.2.2 $df$ の行列としての定義と $df(\mathbf{v})$</h4>
-<p>点 $x$ における関数 $f$ の<strong>全微分</strong> $df$ を、次の $1 \times 3$ 横ベクトルとして定義する：
-$$df = f'(x) \, dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$$
+<h4 id="122-span-classtex2jaxprocessspan-の行列としての定義と-span-classtex2jaxprocessspan">1.2.2 <span class="tex2jax_process">$df$</span> の行列としての定義と <span class="tex2jax_process">$df(\mathbf{v})$</span></h4>
+<p>点 <span class="tex2jax_process">$x$</span> における関数 <span class="tex2jax_process">$f$</span> の<strong>全微分</strong> <span class="tex2jax_process">$df$</span> を、次の <span class="tex2jax_process">$1 \times 3$</span> 横ベクトルとして定義する：
 </p>
-<p>この $df$ を変位 $\mathbf{v}$ に作用させた結果を、前節と同様に <strong>$df(\mathbf{v})$</strong> と書く：
-$$df(\mathbf{v}) = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix} = f'(x)\,\Delta x$$
+<div class="math-block tex2jax_process">$$df = f'(x) \, dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$$</div>
+<p>この <span class="tex2jax_process">$df$</span> を変位 <span class="tex2jax_process">$\mathbf{v}$</span> に作用させた結果を、前節と同様に <strong><span class="tex2jax_process">$df(\mathbf{v})$</span></strong> と書く：
 </p>
+<div class="math-block tex2jax_process">$$df(\mathbf{v}) = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix} \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix} = f'(x)\,\Delta x$$</div>
 <strong>重要な認識の転換</strong>（<strong>常に次のように読む</strong>）：
 <ul>
-<li>式 $df = f'(x)\,dx$ は、微積分でおなじみの**全微分の記法**だが、本書では **$df$ も $dx$ も演算子としての横ベクトル**であり、**単体では微小変化量ではない**、と読む。</li>
+<li>式 <span class="tex2jax_process">$df = f'(x)\,dx$</span> は、微積分でおなじみの**全微分の記法**だが、本書では **<span class="tex2jax_process">$df$</span> も <span class="tex2jax_process">$dx$</span> も演算子としての横ベクトル**であり、**単体では微小変化量ではない**、と読む。</li>
 </ol>
 <ul>
-<li>**$df(\mathbf{v})$** と書いたときは、**有限の（ただし十分小さい）変位 $\mathbf{v}$ に対する一次近似としての変化量**を意味する。</li>
+<li>**<span class="tex2jax_process">$df(\mathbf{v})$</span>** と書いたときは、**有限の（ただし十分小さい）変位 <span class="tex2jax_process">$\mathbf{v}$</span> に対する一次近似としての変化量**を意味する。</li>
 </ol>
-<p>$df$ それ自体は変化量ではない。<strong>変化量の一次部分を生成する「装置」</strong>なのである。
-</p>
-<blockquote><p>**注** （$df$ は演算子、$df(\mathbf{v})$ が変化量）§1.1.6 の記号契約と同じ区別を、ここでもう一度述べる。くどいと感じるかもしれないが、**ここを誤読すると以降すべてがずれる**ので、繰り返しに価値がある。</p>
+<span class="tex2jax_process">$df$</span> それ自体は変化量ではない。<strong>変化量の一次部分を生成する「装置」</strong>なのである。
+<blockquote><p>**注** （<span class="tex2jax_process">$df$</span> は演算子、<span class="tex2jax_process">$df(\mathbf{v})$</span> が変化量）§1.1.6 の記号契約と同じ区別を、ここでもう一度述べる。くどいと感じるかもしれないが、**ここを誤読すると以降すべてがずれる**ので、繰り返しに価値がある。</p>
 </p></blockquote>
-<h4 id="123-方向と-方向の物差し-">1.2.3 $y$ 方向と $z$ 方向の物差し $dy$, $dz$</h4>
-<p>この視点の強みを、§1.1.5 の力学の例に戻せば、<strong>力が $y$ 方向にも成分を持つ一般的な場合に自然に拡張できる</strong>点だ。
+<h4 id="123-span-classtex2jaxprocessspan-方向と-span-classtex2jaxprocessspan-方向の物差し-span-classtex2jaxprocessspan-span-classtex2jaxprocessspan">1.2.3 <span class="tex2jax_process">$y$</span> 方向と <span class="tex2jax_process">$z$</span> 方向の物差し <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span></h4>
+<p>この視点の強みを、§1.1.5 の力学の例に戻せば、<strong>力が <span class="tex2jax_process">$y$</span> 方向にも成分を持つ一般的な場合に自然に拡張できる</strong>点だ。
 </p>
-<strong>いま定める $dy$</strong>を使えば、$F_x dx + F_y dy$ という形で2次元の仕事を統一的に扱える。
-<p>$dx$ が $x$ 成分を抜き出すのと同様に、実空間では <strong>$dy$ は $y$ 成分</strong>、<strong>$dz$ は $z$ 成分</strong>を抜き出す横ベクトル（一次形式）と定める。行列表現は
-$$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}, \qquad dz = \begin{pmatrix} 0 & 0 & 1 \end{pmatrix}$$
-である。変位 $\mathbf{v} = \begin{pmatrix} \Delta x \\ \Delta y \\ \Delta z \end{pmatrix}$ に対して $dy(\mathbf{v}) = \Delta y$, $dz(\mathbf{v}) = \Delta z$ となる。
+<strong>いま定める <span class="tex2jax_process">$dy$</span></strong>を使えば、<span class="tex2jax_process">$F_x dx + F_y dy$</span> という形で2次元の仕事を統一的に扱える。
+<span class="tex2jax_process">$dx$</span> が <span class="tex2jax_process">$x$</span> 成分を抜き出すのと同様に、実空間では <strong><span class="tex2jax_process">$dy$</span> は <span class="tex2jax_process">$y$</span> 成分</strong>、<strong><span class="tex2jax_process">$dz$</span> は <span class="tex2jax_process">$z$</span> 成分</strong>を抜き出す横ベクトル（一次形式）と定める。行列表現は
+<div class="math-block tex2jax_process">$$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}, \qquad dz = \begin{pmatrix} 0 & 0 & 1 \end{pmatrix}$$</div>
+<p>である。変位 <span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix} \Delta x \\ \Delta y \\ \Delta z \end{pmatrix}$</span> に対して <span class="tex2jax_process">$dy(\mathbf{v}) = \Delta y$</span>, <span class="tex2jax_process">$dz(\mathbf{v}) = \Delta z$</span> となる。
 </p>
-<blockquote><p>**注** （$dy$, $dz$ の契約）単独の $dy$, $dz$ は演算子であり、$y$ や $z$ の微小幅を語るときは $\Delta y$, $\Delta z$ または $dy(\mathbf{v})$, $dz(\mathbf{v})$ と書く。積分記号の末尾に並ぶ $dy$, $dz$ も、高校以来の慣用記法として **$dx$ と同じ仕方で読めばよい**。細部の約束は、§1.1.6 で $dx$ についてまとめた**記号契約**と**同じ考え方**を適用する。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> の契約）単独の <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> は演算子であり、<span class="tex2jax_process">$y$</span> や <span class="tex2jax_process">$z$</span> の微小幅を語るときは <span class="tex2jax_process">$\Delta y$</span>, <span class="tex2jax_process">$\Delta z$</span> または <span class="tex2jax_process">$dy(\mathbf{v})$</span>, <span class="tex2jax_process">$dz(\mathbf{v})$</span> と書く。積分記号の末尾に並ぶ <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> も、高校以来の慣用記法として **<span class="tex2jax_process">$dx$</span> と同じ仕方で読めばよい**。細部の約束は、§1.1.6 で <span class="tex2jax_process">$dx$</span> についてまとめた**記号契約**と**同じ考え方**を適用する。</p>
 </p></blockquote>
-<p>3次元の空間には、<strong>三つの物差し</strong>がそろった。本章では説明の主線として $x$ 方向の断面に寄せてきたが、座標 $y,z$ と測定子 $dy,dz$ は最初からそろっている、と考えてほしい。
-いま、一変数の $df=f'(x)\,dx$ に $dy$, $dz$ を同じ型の物差しとして足しそろえた。以下の具体例と §1.2.6 での三次元への拡張で、この三つがどう効いてくるかを追う。
+<p>3次元の空間には、<strong>三つの物差し</strong>がそろった。本章では説明の主線として <span class="tex2jax_process">$x$</span> 方向の断面に寄せてきたが、座標 <span class="tex2jax_process">$y,z$</span> と測定子 <span class="tex2jax_process">$dy,dz$</span> は最初からそろっている、と考えてほしい。
+いま、一変数の <span class="tex2jax_process">$df=f'(x)\,dx$</span> に <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> を同じ型の物差しとして足しそろえた。以下の具体例と §1.2.6 での三次元への拡張で、この三つがどう効いてくるかを追う。
 </p>
-<h4 id="124-具体例-の場合">1.2.4 具体例： $f(x) = x^2$ の場合</h4>
-<p>$f(x) = x^2$ とする。$f'(x) = 2x$ である。
+<h4 id="124-具体例-span-classtex2jaxprocessspan-の場合">1.2.4 具体例： <span class="tex2jax_process">$f(x) = x^2$</span> の場合</h4>
+<span class="tex2jax_process">$f(x) = x^2$</span> とする。<span class="tex2jax_process">$f'(x) = 2x$</span> である。
+<p>たとえば <strong><span class="tex2jax_process">$x=3$</span> において</strong>全微分を具体的に書き下ろす。横ベクトルと縦ベクトルを並べて、
 </p>
-<p>たとえば <strong>$x=3$ において</strong>全微分を具体的に書き下ろす。横ベクトルと縦ベクトルを並べて、
-$$df = 6\,dx = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix}, \qquad \mathbf{v} = \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix}$$
-であるから、行列の積は
-$$df(\mathbf{v}) = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix} \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix} = 6\cdot 0.1 + 0\cdot 0 + 0\cdot 0 = 0.6$$
+<div class="math-block tex2jax_process">$$df = 6\,dx = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix}, \qquad \mathbf{v} = \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>であるから、行列の積は
 </p>
-<p>実際、$f(3.1) - f(3) = 9.61 - 9 = 0.61$ であり、一次近似 $0.6$ はよく一致している。
+<div class="math-block tex2jax_process">$$df(\mathbf{v}) = \begin{pmatrix} 6 & 0 & 0 \end{pmatrix} \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix} = 6\cdot 0.1 + 0\cdot 0 + 0\cdot 0 = 0.6$$</div>
+<p>実際、<span class="tex2jax_process">$f(3.1) - f(3) = 9.61 - 9 = 0.61$</span> であり、一次近似 <span class="tex2jax_process">$0.6$</span> はよく一致している。
 </p>
 <h4 id="125-置換積分の行列解釈">1.2.5 置換積分の行列解釈</h4>
-<blockquote><p>**注** （読み進め方）本節は §1.1 で整えた「一次形式が変位に作用する」視点の応用例である。§1.2.6 以降の本線（$df$ の多次元拡張）に進むうえで必須ではないため、興味がなければ §1.2.6 へ進んでかまわない。</p>
+<blockquote><p>**注** （読み進め方）本節は §1.1 で整えた「一次形式が変位に作用する」視点の応用例である。§1.2.6 以降の本線（<span class="tex2jax_process">$df$</span> の多次元拡張）に進むうえで必須ではないため、興味がなければ §1.2.6 へ進んでかまわない。</p>
 </p></blockquote>
-<p>置換積分は、積分変数を取り換えて被積分関数を書き換える操作である（高校数学で扱う）。本節の目的はそれ<strong>単体の公式暗記ではない</strong>。§1.1 までに整えた言葉で言えば、<strong>「空間側の一次形式 $F\,dx$ が各ステップの変位 $\Delta\mathbf{r}$ に作用する」リーマン和</strong>と、<strong>「時間パラメータ $t$ 上のステップ幅 $\Delta t$」</strong>を、<strong>同じステップの中で対応づける</strong>と、置換後の積分 $\int F(x(t))\,\frac{dx}{dt}\,dt$ の形に自然に落ちる、という骨格を見せることである。
+<p>置換積分は、積分変数を取り換えて被積分関数を書き換える操作である（高校数学で扱う）。本節の目的はそれ<strong>単体の公式暗記ではない</strong>。§1.1 までに整えた言葉で言えば、<strong>「空間側の一次形式 <span class="tex2jax_process">$F\,dx$</span> が各ステップの変位 <span class="tex2jax_process">$\Delta\mathbf{r}$</span> に作用する」リーマン和</strong>と、<strong>「時間パラメータ <span class="tex2jax_process">$t$</span> 上のステップ幅 <span class="tex2jax_process">$\Delta t$</span>」</strong>を、<strong>同じステップの中で対応づける</strong>と、置換後の積分 <span class="tex2jax_process">$\int F(x(t))\,\frac{dx}{dt}\,dt$</span> の形に自然に落ちる、という骨格を見せることである。
 </p>
 <p>仕事を例に取る。仕事は
-$$W = \int_a^b F(x)\,dx$$
-と書ける（§1.1.5 でも同じ量を行列作用の極限として見た）。位置が時間 $t$ とともに動き、$t_0<t_1$ で $x(t_0)=a,\; x(t_1)=b$ となるようにパラメータ表示すると、空間内の点は
-$$\mathbf{r}(t) = \begin{pmatrix} x(t) \\ 0 \\ 0 \end{pmatrix}$$
-と書ける。
+</p>
+<div class="math-block tex2jax_process">$$W = \int_a^b F(x)\,dx$$</div>
+<p>と書ける（§1.1.5 でも同じ量を行列作用の極限として見た）。位置が時間 <span class="tex2jax_process">$t$</span> とともに動き、<span class="tex2jax_process">$t_0<t_1$</span> で <span class="tex2jax_process">$x(t_0)=a,\; x(t_1)=b$</span> となるようにパラメータ表示すると、空間内の点は
+</p>
+<div class="math-block tex2jax_process">$$\mathbf{r}(t) = \begin{pmatrix} x(t) \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>と書ける。
 </p>
 <strong>時間軸側の1ステップ</strong>を、縦1成分のベクトル
-<p>$$\mathbf{w} = \begin{pmatrix} \Delta t \end{pmatrix}$$
-で表す。$dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と<strong>並べて考えるなら</strong>、$t$ 成分だけを抜き出す「測定器」を $1\times 1$ 行列
-$$dt = \begin{pmatrix} 1 \end{pmatrix}$$
-とおき、$dt(\mathbf{w})=\Delta t$ と読む。これは §1.1.6 の「横が測定器・縦がステップ・作用でスカラー」という<strong>型</strong>を、時間だけに縮めたものである。
+<div class="math-block tex2jax_process">$$\mathbf{w} = \begin{pmatrix} \Delta t \end{pmatrix}$$</div>
+<p>で表す。<span class="tex2jax_process">$dx=\begin{pmatrix}1&0&0\end{pmatrix}$</span> と<strong>並べて考えるなら</strong>、<span class="tex2jax_process">$t$</span> 成分だけを抜き出す「測定器」を <span class="tex2jax_process">$1\times 1$</span> 行列
 </p>
-<blockquote><p>**注** （時間軸の $dt$ — 空間の$1$-formとの違い）すまない——$dt$ は $1\times 1$ の横ベクトルであり、空間 $\mathbb{R}^3$ 上で定義した $3$ 次元の $dx$ とは**異なる空間の測定器**である。幾何学的には、$dx$ は3次元空間の余接空間に属する$1$-form、$dt$ は時間という1次元パラメータ軸の余接空間に属する$1$-formであり、**厳密には本書のここまでの導入だけでは両者の関係をカバーしきれていない**。**しかし物理学者として、時間は空間の3次元の中にすっぽり埋め込めるものではない——空間だけの話に丸めてごまかすわけにもいかなかったのだ。** だから $t$ の軸は $1\times1$ として切り出して正面から置く。横が測定器、縦が微小ステップ、作用でスカラー——という $dx$ と**同じ型**にそろえてあるので、理解は容易であろう。</p>
+<div class="math-block tex2jax_process">$$dt = \begin{pmatrix} 1 \end{pmatrix}$$</div>
+<p>とおき、<span class="tex2jax_process">$dt(\mathbf{w})=\Delta t$</span> と読む。これは §1.1.6 の「横が測定器・縦がステップ・作用でスカラー」という<strong>型</strong>を、時間だけに縮めたものである。
+</p>
+<blockquote><p>**注** （時間軸の <span class="tex2jax_process">$dt$</span> — 空間の<span class="tex2jax_process">$1$</span>-formとの違い）すまない——<span class="tex2jax_process">$dt$</span> は <span class="tex2jax_process">$1\times 1$</span> の横ベクトルであり、空間 <span class="tex2jax_process">$\mathbb{R}^3$</span> 上で定義した <span class="tex2jax_process">$3$</span> 次元の <span class="tex2jax_process">$dx$</span> とは**異なる空間の測定器**である。幾何学的には、<span class="tex2jax_process">$dx$</span> は3次元空間の余接空間に属する<span class="tex2jax_process">$1$</span>-form、<span class="tex2jax_process">$dt$</span> は時間という1次元パラメータ軸の余接空間に属する<span class="tex2jax_process">$1$</span>-formであり、**厳密には本書のここまでの導入だけでは両者の関係をカバーしきれていない**。**しかし物理学者として、時間は空間の3次元の中にすっぽり埋め込めるものではない——空間だけの話に丸めてごまかすわけにもいかなかったのだ。** だから <span class="tex2jax_process">$t$</span> の軸は <span class="tex2jax_process">$1\times1$</span> として切り出して正面から置く。横が測定器、縦が微小ステップ、作用でスカラー——という <span class="tex2jax_process">$dx$</span> と**同じ型**にそろえてあるので、理解は容易であろう。</p>
 </p></blockquote>
 <strong>空間側と時間側の対応を整理する</strong>と、次の表の通りになる。まったく同じ型が、異なる次元で繰り返されているだけだ。
 <p>|  | 空間側 | 時間側 |
 |---|---|---|
-| <strong>横ベクトル（測定器）</strong> | $F(x)\,dx$（$1\times 3$） | $dt$（$1\times 1$） |
-| <strong>縦ベクトル（変位）</strong> | $\mathbf{v}_i = \Delta\mathbf{r}$ | $\mathbf{w} = \Delta t$ |
-| <strong>作用の結果</strong> | $(F\,dx)(\mathbf{v}_i) = F\,\Delta x$ | $dt(\mathbf{w}) = \Delta t$ |
+| <strong>横ベクトル（測定器）</strong> | <span class="tex2jax_process">$F(x)\,dx$</span>（<span class="tex2jax_process">$1\times 3$</span>） | <span class="tex2jax_process">$dt$</span>（<span class="tex2jax_process">$1\times 1$</span>） |
+| <strong>縦ベクトル（変位）</strong> | <span class="tex2jax_process">$\mathbf{v}_i = \Delta\mathbf{r}$</span> | <span class="tex2jax_process">$\mathbf{w} = \Delta t$</span> |
+| <strong>作用の結果</strong> | <span class="tex2jax_process">$(F\,dx)(\mathbf{v}_i) = F\,\Delta x$</span> | <span class="tex2jax_process">$dt(\mathbf{w}) = \Delta t$</span> |
 </p>
-<p>この $\Delta t$ に対応する<strong>空間での実際の変位</strong>は
-$$\Delta \mathbf{r} = \mathbf{r}(t+\Delta t) - \mathbf{r}(t) = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}, \qquad \Delta x = x(t+\Delta t)-x(t)$$
-である。ここで $\Delta t \neq 0$ とする。商 $\Delta x/\Delta t$ は<strong>そのステップにおける $x$ の平均変化率</strong>であり、中学生でも知っている恒等式
-$$\Delta x = \frac{\Delta x}{\Delta t}\,\Delta t$$
-が成り立つ。したがって
-$$\begin{aligned}
+<p>この <span class="tex2jax_process">$\Delta t$</span> に対応する<strong>空間での実際の変位</strong>は
+</p>
+<div class="math-block tex2jax_process">$$\Delta \mathbf{r} = \mathbf{r}(t+\Delta t) - \mathbf{r}(t) = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}, \qquad \Delta x = x(t+\Delta t)-x(t)$$</div>
+<p>である。ここで <span class="tex2jax_process">$\Delta t \neq 0$</span> とする。商 <span class="tex2jax_process">$\Delta x/\Delta t$</span> は<strong>そのステップにおける <span class="tex2jax_process">$x$</span> の平均変化率</strong>であり、中学生でも知っている恒等式
+</p>
+<div class="math-block tex2jax_process">$$\Delta x = \frac{\Delta x}{\Delta t}\,\Delta t$$</div>
+<p>が成り立つ。したがって
+</p>
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \Delta \mathbf{r} &= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \\ 0 \\ 0 \end{pmatrix}\,\Delta t \\
 &= \begin{pmatrix} \dfrac{\Delta x}{\Delta t} \\ 0 \\ 0 \end{pmatrix}\,dt(\mathbf{w})
-\end{aligned}$$
-と書ける。<strong>これは近似でも微積の魔法でもなく、$\Delta x$ を $\Delta t$ で割った商を途中に挟んだだけの書き換えである。</strong>左の縦ベクトルは「そのステップでの $x$ 方向の平均変化率」、右の $dt(\mathbf{w})=\Delta t$ は時間ステップの幅である。
+\end{aligned}$$</div>
+<p>と書ける。<strong>これは近似でも微積の魔法でもなく、<span class="tex2jax_process">$\Delta x$</span> を <span class="tex2jax_process">$\Delta t$</span> で割った商を途中に挟んだだけの書き換えである。</strong>左の縦ベクトルは「そのステップでの <span class="tex2jax_process">$x$</span> 方向の平均変化率」、右の <span class="tex2jax_process">$dt(\mathbf{w})=\Delta t$</span> は時間ステップの幅である。
 </p>
-<p>さて $F\,dx$ は横ベクトル（演算子）なので、各ステップで
-$$\bigl(F(x)\,dx\bigr)(\Delta \mathbf{r}) = F(x)\,\Delta x = F(x)\,\frac{\Delta x}{\Delta t}\,\Delta t = F(x)\,\frac{\Delta x}{\Delta t}\,dt(\mathbf{w})$$
-という<strong>スカラー</strong>が得られる。積分記号 $\int_{t_0}^{t_1} g(t)\,dt$ の末尾の $dt$ は、§1.1.6 の $\int f(x)\,dx$ の $dx$ と同じく<strong>積分変数とセットの慣用記法</strong>であり、リーマン和の段階では <strong>$\Delta t$ と $dt(\mathbf{w})$ が対応する</strong>と読めばよい。
+<p>さて <span class="tex2jax_process">$F\,dx$</span> は横ベクトル（演算子）なので、各ステップで
 </p>
-<p>分割を細かくし $\Delta t \to 0$ の極限をとると、各ステップで平均変化率 $\Delta x/\Delta t$ は接線の傾き $\dfrac{dx}{dt}$ に近づく。したがって高校数学の置換積分の形
-$$W = \int_a^b F(x)\,dx = \int_{t_0}^{t_1} F(x(t))\,\frac{dx}{dt}\,dt$$
-に帰着する（$\dfrac{dx}{dt}$ は $\Delta x/\Delta t$ の極限）。直前まで平均変化率 $\Delta x/\Delta t$ による<strong>恒等</strong>の書き換えだったが、<strong>各ステップの $\Delta t$ が十分小さいときの一次近似として</strong>、平均変化率を接線の傾き $\dfrac{dx}{dt}$ に置き換えて評価すると、極限の内側の典型的なリーマン項は
-$$\bigl(F(x(t))\,dx\bigr)(\Delta \mathbf{r}) \approx F(x(t))\,\frac{dx}{dt}\,\Delta t$$
-と読め、<strong>空間側の一次形式 $F\,dx$ が $\Delta\mathbf{r}$ に作用した値</strong>と、<strong>時間側のステップ $\Delta t$（すなわち $dt(\mathbf{w})$）を積み上げる構造</strong>が対応している。
+<div class="math-block tex2jax_process">$$\bigl(F(x)\,dx\bigr)(\Delta \mathbf{r}) = F(x)\,\Delta x = F(x)\,\frac{\Delta x}{\Delta t}\,\Delta t = F(x)\,\frac{\Delta x}{\Delta t}\,dt(\mathbf{w})$$</div>
+<p>という<strong>スカラー</strong>が得られる。積分記号 <span class="tex2jax_process">$\int_{t_0}^{t_1} g(t)\,dt$</span> の末尾の <span class="tex2jax_process">$dt$</span> は、§1.1.6 の <span class="tex2jax_process">$\int f(x)\,dx$</span> の <span class="tex2jax_process">$dx$</span> と同じく<strong>積分変数とセットの慣用記法</strong>であり、リーマン和の段階では <strong><span class="tex2jax_process">$\Delta t$</span> と <span class="tex2jax_process">$dt(\mathbf{w})$</span> が対応する</strong>と読めばよい。
+</p>
+<p>分割を細かくし <span class="tex2jax_process">$\Delta t \to 0$</span> の極限をとると、各ステップで平均変化率 <span class="tex2jax_process">$\Delta x/\Delta t$</span> は接線の傾き <span class="tex2jax_process">$\dfrac{dx}{dt}$</span> に近づく。したがって高校数学の置換積分の形
+</p>
+<div class="math-block tex2jax_process">$$W = \int_a^b F(x)\,dx = \int_{t_0}^{t_1} F(x(t))\,\frac{dx}{dt}\,dt$$</div>
+<p>に帰着する（<span class="tex2jax_process">$\dfrac{dx}{dt}$</span> は <span class="tex2jax_process">$\Delta x/\Delta t$</span> の極限）。直前まで平均変化率 <span class="tex2jax_process">$\Delta x/\Delta t$</span> による<strong>恒等</strong>の書き換えだったが、<strong>各ステップの <span class="tex2jax_process">$\Delta t$</span> が十分小さいときの一次近似として</strong>、平均変化率を接線の傾き <span class="tex2jax_process">$\dfrac{dx}{dt}$</span> に置き換えて評価すると、極限の内側の典型的なリーマン項は
+</p>
+<div class="math-block tex2jax_process">$$\bigl(F(x(t))\,dx\bigr)(\Delta \mathbf{r}) \approx F(x(t))\,\frac{dx}{dt}\,\Delta t$$</div>
+<p>と読め、<strong>空間側の一次形式 <span class="tex2jax_process">$F\,dx$</span> が <span class="tex2jax_process">$\Delta\mathbf{r}$</span> に作用した値</strong>と、<strong>時間側のステップ <span class="tex2jax_process">$\Delta t$</span>（すなわち <span class="tex2jax_process">$dt(\mathbf{w})$</span>）を積み上げる構造</strong>が対応している。
 </p>
 <h4 id="126-三次元への拡張">1.2.6 三次元への拡張</h4>
-<p>空間の各点 $(x,y,z)$ にスカラー（実数）を対応させる関数 $f$ は、実空間の開集合上の<strong>実数値関数</strong>として扱えばよい。
+<p>空間の各点 <span class="tex2jax_process">$(x,y,z)$</span> にスカラー（実数）を対応させる関数 <span class="tex2jax_process">$f$</span> は、実空間の開集合上の<strong>実数値関数</strong>として扱えばよい。
 </p>
 <blockquote><p>**注** （スカラー場）物理学ではこのような関数を**スカラー場**と呼ぶことが多い。</p>
 </p></blockquote>
-<p>その $f(x,y,z)$ が点 $(x,y,z)$ で<strong>（全）微分可能である</strong>とは、変位 $\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ に対して
-$$\Delta f = f(x+\Delta x,\,y+\Delta y,\,z+\Delta z) - f(x,y,z) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z + o(\|\mathbf{v}\|) \quad (\|\mathbf{v}\|\to 0)$$
-が成り立つことである。§1.2.1 の1変数の定義と形式がそろっている。$o(\|\mathbf{v}\|)$ は余り項の略記（$o(|\Delta x|)$ と同趣旨）であり、ここでは深追いしないが、理解に支障はないであろう。
+<p>その <span class="tex2jax_process">$f(x,y,z)$</span> が点 <span class="tex2jax_process">$(x,y,z)$</span> で<strong>（全）微分可能である</strong>とは、変位 <span class="tex2jax_process">$\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> に対して
 </p>
-<p>§1.2.3 の物差し $dx,dy,dz$ を使い、§1.2.2 と同じ型の演算子として
-$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
-と定義する。いちばん初めの式にあった $o(\|\mathbf{v}\|)$ は、ここから数行では省略し、<strong>記号の骨格だけ</strong>を追う。$\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ のとき、微分可能性の定義より $\Delta f = df(\mathbf{v}) + o(\|\mathbf{v}\|)$ である——すなわち <strong>$df(\mathbf{v})$ は厳密な変化量 $\Delta f$ そのものではなく、剰余を除いた一次（主）項</strong>である。以下ではその主項を行列の積で書き下ろす：
-$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\begin{pmatrix}1&0&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial y}\begin{pmatrix}0&1&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial z}\begin{pmatrix}0&0&1\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$$
-$$= \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z.$$
-第一行は、§1.2.3 の物差し $dx,dy,dz$ が行ベクトルとして $\mathbf{v}$ から $x,y,z$ 成分を抜き出し、偏導関数が係数としてかかる様子を<strong>行列の積</strong>で見せたものである。第二行はその評価結果であり、先の $\Delta f$ の定義式における<strong>線形主項</strong>と同じ形である。<strong>横ベクトル（演算子）× 縦ベクトル（変位）→ スカラー</strong>という §1.2.2 の読みが、三次元でも変わらない。
+<div class="math-block tex2jax_process">$$\Delta f = f(x+\Delta x,\,y+\Delta y,\,z+\Delta z) - f(x,y,z) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z + o(\|\mathbf{v}\|) \quad (\|\mathbf{v}\|\to 0)$$</div>
+<p>が成り立つことである。§1.2.1 の1変数の定義と形式がそろっている。<span class="tex2jax_process">$o(\|\mathbf{v}\|)$</span> は余り項の略記（<span class="tex2jax_process">$o(|\Delta x|)$</span> と同趣旨）であり、ここでは深追いしないが、理解に支障はないであろう。
 </p>
-<p>座標が二つまでしか現れない $f(x,y)$ も、$z$ に依らなければ $\partial f/\partial z=0$ として上の枠に含めればよい——<strong>三次元に載せた枠組みが、そのまま低次元に退化する</strong>。
+<p>§1.2.3 の物差し <span class="tex2jax_process">$dx,dy,dz$</span> を使い、§1.2.2 と同じ型の演算子として
+</p>
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</div>
+<p>と定義する。いちばん初めの式にあった <span class="tex2jax_process">$o(\|\mathbf{v}\|)$</span> は、ここから数行では省略し、<strong>記号の骨格だけ</strong>を追う。<span class="tex2jax_process">$\mathbf{v}=\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> のとき、微分可能性の定義より <span class="tex2jax_process">$\Delta f = df(\mathbf{v}) + o(\|\mathbf{v}\|)$</span> である——すなわち <strong><span class="tex2jax_process">$df(\mathbf{v})$</span> は厳密な変化量 <span class="tex2jax_process">$\Delta f$</span> そのものではなく、剰余を除いた一次（主）項</strong>である。以下ではその主項を行列の積で書き下ろす：
+</p>
+<div class="math-block tex2jax_process">$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\begin{pmatrix}1&0&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial y}\begin{pmatrix}0&1&0\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix} + \frac{\partial f}{\partial z}\begin{pmatrix}0&0&1\end{pmatrix}\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$$</div>
+<div class="math-block tex2jax_process">$$= \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z.$$</div>
+<p>第一行は、§1.2.3 の物差し <span class="tex2jax_process">$dx,dy,dz$</span> が行ベクトルとして <span class="tex2jax_process">$\mathbf{v}$</span> から <span class="tex2jax_process">$x,y,z$</span> 成分を抜き出し、偏導関数が係数としてかかる様子を<strong>行列の積</strong>で見せたものである。第二行はその評価結果であり、先の <span class="tex2jax_process">$\Delta f$</span> の定義式における<strong>線形主項</strong>と同じ形である。<strong>横ベクトル（演算子）× 縦ベクトル（変位）→ スカラー</strong>という §1.2.2 の読みが、三次元でも変わらない。
+</p>
+<p>座標が二つまでしか現れない <span class="tex2jax_process">$f(x,y)$</span> も、<span class="tex2jax_process">$z$</span> に依らなければ <span class="tex2jax_process">$\partial f/\partial z=0$</span> として上の枠に含めればよい——<strong>三次元に載せた枠組みが、そのまま低次元に退化する</strong>。
 </p>
 <p>見比べてみよう。
-1変数では： $df = f'(x) dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$
-2変数関数 $f(x, y)$ では（§1.2.3 の $dy$ を用いる）： $df = \frac{\partial f}{\partial x} dx + \frac{\partial f}{\partial y} dy = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & 0 \end{pmatrix}$
-3変数 $f(x,y,z)$ では、§1.2.6 の式のとおり、横ベクトルの成分が三つそろうだけである。
+1変数では： <span class="tex2jax_process">$df = f'(x) dx = \begin{pmatrix} f'(x) & 0 & 0 \end{pmatrix}$</span>
+2変数関数 <span class="tex2jax_process">$f(x, y)$</span> では（§1.2.3 の <span class="tex2jax_process">$dy$</span> を用いる）： <span class="tex2jax_process">$df = \frac{\partial f}{\partial x} dx + \frac{\partial f}{\partial y} dy = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & 0 \end{pmatrix}$</span>
+3変数 <span class="tex2jax_process">$f(x,y,z)$</span> では、§1.2.6 の式のとおり、横ベクトルの成分が三つそろうだけである。
 </p>
-<p>このように、<strong>形式は同じで、ただ成分の個数が増える</strong>。これが行列表示の威力である。$df$ を行列と見なすことで、微分は「変位に対する線形近似を与える演算子」として統一的に扱える。
+<p>このように、<strong>形式は同じで、ただ成分の個数が増える</strong>。これが行列表示の威力である。<span class="tex2jax_process">$df$</span> を行列と見なすことで、微分は「変位に対する線形近似を与える演算子」として統一的に扱える。
 </p>
 <h4 id="127-線積分の先取り">1.2.7 線積分の先取り</h4>
-<p>空間内の曲線をパラメータ $t$ で $\mathbf{r}(t)=\begin{pmatrix}x(t)\\y(t)\\z(t)\end{pmatrix}$ と表し、細かいステップの変位を $\Delta\mathbf{r}$ と書くとき、各ステップで $\bigl(df\bigr)(\Delta\mathbf{r})$ を足し上げる操作の極限を、記号では
-$$\int_\gamma df$$
-の形で表す（$\gamma$ は曲線）。§1.2.5 で見た $\int f'(x)\,dx$ と同じく、<strong>一次形式 $df$ が各ステップの変位に作用するリーマン和の極限</strong>という骨格である。閉曲線・向き・パラメータの取り換えなど、厳密な定式化は<strong>後の章に譲る</strong>。
+<p>空間内の曲線をパラメータ <span class="tex2jax_process">$t$</span> で <span class="tex2jax_process">$\mathbf{r}(t)=\begin{pmatrix}x(t)\\y(t)\\z(t)\end{pmatrix}$</span> と表し、細かいステップの変位を <span class="tex2jax_process">$\Delta\mathbf{r}$</span> と書くとき、各ステップで <span class="tex2jax_process">$\bigl(df\bigr)(\Delta\mathbf{r})$</span> を足し上げる操作の極限を、記号では
 </p>
-<blockquote><p>**注** （線積分とストークスは後章）線積分・$1$-form の曲線への制限・ストークスの定理の枠組みは、本書では主として第3章以降で改めて置く。第2章ではまず面積・体積の測定器（$2$-form, $3$-form）を構築する。ここは動機と記号の予告にすぎない。</p>
+<div class="math-block tex2jax_process">$$\int_\gamma df$$</div>
+<p>の形で表す（<span class="tex2jax_process">$\gamma$</span> は曲線）。§1.2.5 で見た <span class="tex2jax_process">$\int f'(x)\,dx$</span> と同じく、<strong>一次形式 <span class="tex2jax_process">$df$</span> が各ステップの変位に作用するリーマン和の極限</strong>という骨格である。閉曲線・向き・パラメータの取り換えなど、厳密な定式化は<strong>後の章に譲る</strong>。
+</p>
+<blockquote><p>**注** （線積分とストークスは後章）線積分・<span class="tex2jax_process">$1$</span>-form の曲線への制限・ストークスの定理の枠組みは、本書では主として第3章以降で改めて置く。第2章ではまず面積・体積の測定器（<span class="tex2jax_process">$2$</span>-form, <span class="tex2jax_process">$3$</span>-form）を構築する。ここは動機と記号の予告にすぎない。</p>
 </p></blockquote>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 微分可能性は $\Delta f = f'(x)\Delta x + o(|\Delta x|)$（$o$ はランダウのオーダー記法）で表される一次近似として捉えられる。
-- $df = f'(x)\,dx$ は横ベクトル；数値の変化量は $df(\mathbf{v})$ として読む。
-- 置換積分は、一次形式 $F\,dx$ が空間の変位に作用する構造と、時間軸上の $dt$ を積み上げる構造の対応としても見られる。
+- 微分可能性は <span class="tex2jax_process">$\Delta f = f'(x)\Delta x + o(|\Delta x|)$</span>（<span class="tex2jax_process">$o$</span> はランダウのオーダー記法）で表される一次近似として捉えられる。
+- <span class="tex2jax_process">$df = f'(x)\,dx$</span> は横ベクトル；数値の変化量は <span class="tex2jax_process">$df(\mathbf{v})$</span> として読む。
+- 置換積分は、一次形式 <span class="tex2jax_process">$F\,dx$</span> が空間の変位に作用する構造と、時間軸上の <span class="tex2jax_process">$dt$</span> を積み上げる構造の対応としても見られる。
 </p></blockquote>
 <hr />
 <h3 id="13-ライプニッツの記法と代数的直感">§1.3 ライプニッツの記法と代数的直感</h3>
-<p>ライプニッツが $dx$, $dy$ という記号を導入したとき、彼はこれらを「無限小」として直感的に扱った。
+<p>ライプニッツが <span class="tex2jax_process">$dx$</span>, <span class="tex2jax_process">$dy$</span> という記号を導入したとき、彼はこれらを「無限小」として直感的に扱った。
 </p>
-<blockquote><p>**注** （ライプニッツと記号）**ライプニッツ**（Gottfried Wilhelm Leibniz, 1646–1716）は、$dx$, $dy$ など微積分の記号体系を整えた数学者である。以下では歴史の経緯には立ち入らず、記号を導入した人物として名前だけに触れる（記号 $dx$ 自体は慣れている読者も多いが、人名に心当たりがなければ、この一行で足りる）。</p>
+<blockquote><p>**注** （ライプニッツと記号）**ライプニッツ**（Gottfried Wilhelm Leibniz, 1646–1716）は、<span class="tex2jax_process">$dx$</span>, <span class="tex2jax_process">$dy$</span> など微積分の記号体系を整えた数学者である。以下では歴史の経緯には立ち入らず、記号を導入した人物として名前だけに触れる（記号 <span class="tex2jax_process">$dx$</span> 自体は慣れている読者も多いが、人名に心当たりがなければ、この一行で足りる）。</p>
 </p></blockquote>
 <p>現代の我々は、その直感を<strong>線形代数の言葉</strong>で再配置したと言える。
-ライプニッツの記法 $df = f'(x)dx$ は、単なる形式的等式ではない：
+ライプニッツの記法 <span class="tex2jax_process">$df = f'(x)dx$</span> は、単なる形式的等式ではない：
 <ul>
-<li>$dx$：ライプニッツの無限小の直感 → 本書では **演算子**としての $x$ 成分抽出（微小変位そのものを語るときは $\Delta x$ や $dx(\mathbf{v})$）。$dy$, $dz$ も §1.2.3 で $dx$ と同様に定義する。</li>
+<li><span class="tex2jax_process">$dx$</span>：ライプニッツの無限小の直感 → 本書では **演算子**としての <span class="tex2jax_process">$x$</span> 成分抽出（微小変位そのものを語るときは <span class="tex2jax_process">$\Delta x$</span> や <span class="tex2jax_process">$dx(\mathbf{v})$</span>）。<span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> も §1.2.3 で <span class="tex2jax_process">$dx$</span> と同様に定義する。</li>
 </ol>
 <ul>
-<li>$df$：ライプニッツの無限小変化の直感 → 本書では **演算子**としての全微分（数値の変化量は $df(\mathbf{v})$ などで）</li>
+<li><span class="tex2jax_process">$df$</span>：ライプニッツの無限小変化の直感 → 本書では **演算子**としての全微分（数値の変化量は <span class="tex2jax_process">$df(\mathbf{v})$</span> などで）</li>
 </ol>
 <strong>ライプニッツの天才は、微分・積分が本質的に代数的操作であることを見抜いていた</strong>。我々は、彼の直感に行列という具体的な骨格を与えたに過ぎない。
 <p>次節では、この枠組みが依存している暗黙の前提——デカルト座標系の「使いやすさ」——を明らかにし、より一般的な座標への接続を示唆する。
 </p>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- ライプニッツの $dx$、$df$ の直感は、本書ではいずれも「変位に作用する横ベクトル（演算子）」として再配置されている。
-- 微小変化量を語るときは $\Delta x$ や $df(\mathbf{v})$ とし、記号の役割を混同しない。
+- ライプニッツの <span class="tex2jax_process">$dx$</span>、<span class="tex2jax_process">$df$</span> の直感は、本書ではいずれも「変位に作用する横ベクトル（演算子）」として再配置されている。
+- 微小変化量を語るときは <span class="tex2jax_process">$\Delta x$</span> や <span class="tex2jax_process">$df(\mathbf{v})$</span> とし、記号の役割を混同しない。
 </p></blockquote>
 <hr />
 <h3 id="14-座標変換物差しの目盛りを書き換える">§1.4 座標変換——「物差し」の目盛りを書き換える</h3>
-<p>本章を通じて、我々は $dx$ の<strong>行列表現</strong>を $\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ と置いて議論してきた。これが場所によらず一定なのは、我々が物理空間を<strong>デカルト座標（直交直線座標）</strong>という最も素直な目盛りで測っているからだ。
+<p>本章を通じて、我々は <span class="tex2jax_process">$dx$</span> の<strong>行列表現</strong>を <span class="tex2jax_process">$\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$</span> と置いて議論してきた。これが場所によらず一定なのは、我々が物理空間を<strong>デカルト座標（直交直線座標）</strong>という最も素直な目盛りで測っているからだ。
 </p>
-<p>しかし物理学の現実はいつでも四角いとは限らない。円形パイプ内の流れや、直線電流の周りの磁場——こうした問題では、点を $(r,\theta,z)$ という数の組で指定する<strong>円柱座標</strong>を使ったほうが格段に扱いやすい。では、「成分を抜き出す物差し」である $dx$ は、別の座標系ではどう書けるのだろうか。
+<p>しかし物理学の現実はいつでも四角いとは限らない。円形パイプ内の流れや、直線電流の周りの磁場——こうした問題では、点を <span class="tex2jax_process">$(r,\theta,z)$</span> という数の組で指定する<strong>円柱座標</strong>を使ったほうが格段に扱いやすい。では、「成分を抜き出す物差し」である <span class="tex2jax_process">$dx$</span> は、別の座標系ではどう書けるのだろうか。
 </p>
 <h4 id="141-連鎖律は物差しの成分表示を与える">1.4.1 連鎖律は「物差し」の成分表示を与える</h4>
 <p>座標変換の式を思い出そう。
 </p>
-<p>$$x = r\cos\theta,\qquad y = r\sin\theta,\qquad z = z$$
+<div class="math-block tex2jax_process">$$x = r\cos\theta,\qquad y = r\sin\theta,\qquad z = z$$</div>
+<p>この変換則を、§1.2.2 で定義した<strong>全微分（演算子としての <span class="tex2jax_process">$d$</span>）</strong>の枠組みに入れる。座標関数 <span class="tex2jax_process">$x(r,\theta,z)=r\cos\theta$</span> の<strong>全微分 <span class="tex2jax_process">$dx$</span></strong>（あくまで一次形式としての演算子であり、§1.1.6 の「微小変化」ではない）は、連鎖律によって次のように展開される。
 </p>
-<p>この変換則を、§1.2.2 で定義した<strong>全微分（演算子としての $d$）</strong>の枠組みに入れる。座標関数 $x(r,\theta,z)=r\cos\theta$ の<strong>全微分 $dx$</strong>（あくまで一次形式としての演算子であり、§1.1.6 の「微小変化」ではない）は、連鎖律によって次のように展開される。
+<div class="math-block tex2jax_process">$$dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz = \cos\theta\,dr - r\sin\theta\,d\theta$$</div>
+<p>ここで <span class="tex2jax_process">$dx, dr, d\theta, dz$</span> はいずれも<strong>演算子（一次形式）</strong>だ。右辺の式が告げているのは、<strong>「実空間の物差し <span class="tex2jax_process">$dx$</span> を、<span class="tex2jax_process">$(dr,d\theta,dz)$</span> を目盛りとして表現し直すと、場所ごとに変わる係数 <span class="tex2jax_process">$(\cos\theta,\,-r\sin\theta,\,0)$</span> を持つ行列になる」</strong>という事実である。
 </p>
-<p>$$dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz = \cos\theta\,dr - r\sin\theta\,d\theta$$
+<div class="math-block tex2jax_process">$$dx \;\xrightarrow{\text{円柱座標の目盛りで書くと}} \;\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$$</div>
+<p>実空間の <span class="tex2jax_process">$(x,y,z)$</span> では定数成分 <span class="tex2jax_process">$\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$</span> だった <span class="tex2jax_process">$dx$</span> が、目盛りを取り替えた途端、場所 <span class="tex2jax_process">$(r,\theta)$</span> に依存する関数を成分に持つ行列へと姿を変える。対象そのものは不変であっても、「別の座標で書けば、その成分表示も変わる」——これが座標変換の代数的な正体である。
 </p>
-<p>ここで $dx, dr, d\theta, dz$ はいずれも<strong>演算子（一次形式）</strong>だ。右辺の式が告げているのは、<strong>「実空間の物差し $dx$ を、$(dr,d\theta,dz)$ を目盛りとして表現し直すと、場所ごとに変わる係数 $(\cos\theta,\,-r\sin\theta,\,0)$ を持つ行列になる」</strong>という事実である。
-</p>
-<p>$$dx \;\xrightarrow{\text{円柱座標の目盛りで書くと}} \;\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$$
-</p>
-<p>実空間の $(x,y,z)$ では定数成分 $\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ だった $dx$ が、目盛りを取り替えた途端、場所 $(r,\theta)$ に依存する関数を成分に持つ行列へと姿を変える。対象そのものは不変であっても、「別の座標で書けば、その成分表示も変わる」——これが座標変換の代数的な正体である。
-</p>
-<blockquote><p>**注** （連鎖律と変数変換——第3章への伏線）上では多変数関数の連鎖律 $dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz$ を計算ルールとして使った。本書ではまだ**微分形式の変数変換を正式には定式化していない**——この公式の厳密な意味づけ、すなわち「別の座標で書く」ことの一般論は、第3章 §3.5 の**引き戻し（pullback）**で改めて扱う。読者の既知の計算経験と、本章の「横ベクトル $dx$ が変位に作用する」という流儀がのちほど接続できそうだという動機だけ先に示す。いまは「行列の成分が機械的に出てくる」という感覚だけ掴めば十分である。</p>
+<blockquote><p>**注** （連鎖律と変数変換——第3章への伏線）上では多変数関数の連鎖律 <span class="tex2jax_process">$dx = \frac{\partial x}{\partial r}dr + \frac{\partial x}{\partial \theta}d\theta + \frac{\partial x}{\partial z}dz$</span> を計算ルールとして使った。本書ではまだ**微分形式の変数変換を正式には定式化していない**——この公式の厳密な意味づけ、すなわち「別の座標で書く」ことの一般論は、第3章 §3.5 の**引き戻し（pullback）**で改めて扱う。読者の既知の計算経験と、本章の「横ベクトル <span class="tex2jax_process">$dx$</span> が変位に作用する」という流儀がのちほど接続できそうだという動機だけ先に示す。いまは「行列の成分が機械的に出てくる」という感覚だけ掴めば十分である。</p>
 </p></blockquote>
-<blockquote><p>**注** （行列の積で読むときの約束）横ベクトル $\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$ を左から掛ける相手は、デカルト成分 $\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ ではなく、円柱座標のパラメータの変化量を並べた縦ベクトル $\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$ である。測定器（一次形式）を円柱座標の目盛りで書き換えた以上、測られる側の変位も同じ目盛りで入力しなければならない、という当たり前の理屈だ。§1.5 の演習で、その積が $dx(\mathbf{v})$ と一致することを手で確かめる。</p>
+<blockquote><p>**注** （行列の積で読むときの約束）横ベクトル <span class="tex2jax_process">$\begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$</span> を左から掛ける相手は、デカルト成分 <span class="tex2jax_process">$\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> ではなく、円柱座標のパラメータの変化量を並べた縦ベクトル <span class="tex2jax_process">$\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$</span> である。測定器（一次形式）を円柱座標の目盛りで書き換えた以上、測られる側の変位も同じ目盛りで入力しなければならない、という当たり前の理屈だ。§1.5 の演習で、その積が <span class="tex2jax_process">$dx(\mathbf{v})$</span> と一致することを手で確かめる。</p>
 </p></blockquote>
 <h4 id="142-行列の一歩一歩に幾何を宿らせる">1.4.2 行列の一歩一歩に幾何を宿らせる</h4>
-<p>多くの教科書では、実空間に $(r,\theta)$ の「曲がったグリッド」を描き込み、「$\theta$ 方向の弧の長さは約 $r\Delta\theta$」と幾何学的に説明する。この直感自体は正しい——問題は、その絵を「証明」の土台に据えることだ。座標系が複雑になるほど、曲がった図形を相手にした幾何学的な「見積もり」はすぐに限界を迎える。
+<p>多くの教科書では、実空間に <span class="tex2jax_process">$(r,\theta)$</span> の「曲がったグリッド」を描き込み、「<span class="tex2jax_process">$\theta$</span> 方向の弧の長さは約 <span class="tex2jax_process">$r\Delta\theta$</span>」と幾何学的に説明する。この直感自体は正しい——問題は、その絵を「証明」の土台に据えることだ。座標系が複雑になるほど、曲がった図形を相手にした幾何学的な「見積もり」はすぐに限界を迎える。
 </p>
-<p>本書がやりたいことは、幾何を代数で置き換えることではない。<strong>大きな幾何を、行列の一つひとつの成分という小さい幾何に分割すること</strong>だ。係数 $-r\sin\theta$ は「$\theta$ 方向の一歩が実空間の $x$ 方向にどれだけ効くか」という、それ自体で完結した幾何的情報を一つの数値として担っている。同様に $\cos\theta$ は $r$ 方向→$x$ 方向の効きを、$0$ は $z$ 方向が $x$ に効かないことを示す。つまり $dx = \begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$ という一行が、$x$ 成分の変位に関する幾何を<strong>3つの独立した小問題</strong>に分解した姿なのである。幾何的直感と代数的な見通しの良さは、行列の上で両立する。
+<p>本書がやりたいことは、幾何を代数で置き換えることではない。<strong>大きな幾何を、行列の一つひとつの成分という小さい幾何に分割すること</strong>だ。係数 <span class="tex2jax_process">$-r\sin\theta$</span> は「<span class="tex2jax_process">$\theta$</span> 方向の一歩が実空間の <span class="tex2jax_process">$x$</span> 方向にどれだけ効くか」という、それ自体で完結した幾何的情報を一つの数値として担っている。同様に <span class="tex2jax_process">$\cos\theta$</span> は <span class="tex2jax_process">$r$</span> 方向→<span class="tex2jax_process">$x$</span> 方向の効きを、<span class="tex2jax_process">$0$</span> は <span class="tex2jax_process">$z$</span> 方向が <span class="tex2jax_process">$x$</span> に効かないことを示す。つまり <span class="tex2jax_process">$dx = \begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}$</span> という一行が、<span class="tex2jax_process">$x$</span> 成分の変位に関する幾何を<strong>3つの独立した小問題</strong>に分解した姿なのである。幾何的直感と代数的な見通しの良さは、行列の上で両立する。
 </p>
 <h4 id="143-二つのデカルト座標">1.4.3 二つのデカルト座標</h4>
-<p>ここで、いま扱っている二つの数の組——実空間の $(x,y,z)$ と円柱座標の $(r,\theta,z)$——の関係をはっきりさせておこう。計算用紙の上では、<strong>どちらも互いに直交し等間隔な軸を持つデカルト座標</strong>である。$\theta$ 軸は物理的には「角度」だが、数式の上では単なる一つの真っ直ぐな数直線にすぎない。
+<p>ここで、いま扱っている二つの数の組——実空間の <span class="tex2jax_process">$(x,y,z)$</span> と円柱座標の <span class="tex2jax_process">$(r,\theta,z)$</span>——の関係をはっきりさせておこう。計算用紙の上では、<strong>どちらも互いに直交し等間隔な軸を持つデカルト座標</strong>である。<span class="tex2jax_process">$\theta$</span> 軸は物理的には「角度」だが、数式の上では単なる一つの真っ直ぐな数直線にすぎない。
 </p>
-<p>実空間も円柱座標のパラメータ空間も、どちらも「平坦な方眼紙」だ。両者の違いは、そのあいだに $\cos\theta$ や $-r\sin\theta$ といった偏微分係数（換算係数）が挟まっているかどうか、それだけである。計算のあいだは「実空間の中に曲がった座標軸がある」のではなく「二つの空間のあいだに翻訳規則があるだけ」と割り切って考えると、見通しがよい。
+<p>実空間も円柱座標のパラメータ空間も、どちらも「平坦な方眼紙」だ。両者の違いは、そのあいだに <span class="tex2jax_process">$\cos\theta$</span> や <span class="tex2jax_process">$-r\sin\theta$</span> といった偏微分係数（換算係数）が挟まっているかどうか、それだけである。計算のあいだは「実空間の中に曲がった座標軸がある」のではなく「二つの空間のあいだに翻訳規則があるだけ」と割り切って考えると、見通しがよい。
 </p>
-<blockquote><p>**注** （$dr$, $d\theta$ の行列表現）では $dr$ や $d\theta$ についても、「数ベクトルとしての行列表現は何か」と気になるだろう。パラメータ空間もまたデカルト座標なのだから、答えは単純だ——$dr$ はパラメータ空間の第1成分を抜く $(1\ 0\ 0)$ であり、$d\theta$ は $(0\ 1\ 0)$、$dz$ は $(0\ 0\ 1)$ である。デカルトの実空間で書いた $dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と同じ見た目をしているが、載っている座標系が違う。数学者ならば「$\omega \in \Omega^1(M)$、局所では $\omega = \omega_i(x)\,dx^i$、座標系の取り替え、$\phi^*\omega$、開集合の重なりでの整合……」と衒学的な呪文を唱えるだろう。**なるほど、頭が痛くなってきた。私も読者も疲れてしまう。深追いはしないでおく。**</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$dr$</span>, <span class="tex2jax_process">$d\theta$</span> の行列表現）では <span class="tex2jax_process">$dr$</span> や <span class="tex2jax_process">$d\theta$</span> についても、「数ベクトルとしての行列表現は何か」と気になるだろう。パラメータ空間もまたデカルト座標なのだから、答えは単純だ——<span class="tex2jax_process">$dr$</span> はパラメータ空間の第1成分を抜く <span class="tex2jax_process">$(1\ 0\ 0)$</span> であり、<span class="tex2jax_process">$d\theta$</span> は <span class="tex2jax_process">$(0\ 1\ 0)$</span>、<span class="tex2jax_process">$dz$</span> は <span class="tex2jax_process">$(0\ 0\ 1)$</span> である。デカルトの実空間で書いた <span class="tex2jax_process">$dx=\begin{pmatrix}1&0&0\end{pmatrix}$</span> と同じ見た目をしているが、載っている座標系が違う。数学者ならば「<span class="tex2jax_process">$\omega \in \Omega^1(M)$</span>、局所では <span class="tex2jax_process">$\omega = \omega_i(x)\,dx^i$</span>、座標系の取り替え、<span class="tex2jax_process">$\phi^*\omega$</span>、開集合の重なりでの整合……」と衒学的な呪文を唱えるだろう。**なるほど、頭が痛くなってきた。私も読者も疲れてしまう。深追いはしないでおく。**</p>
 </p></blockquote>
 <h4 id="144-第3章への伏線引き戻し">1.4.4 第3章への伏線——引き戻し</h4>
 <p>このように、元の世界の測定器を別の目盛り用に焼き直す操作を、数学の専門用語で<strong>引き戻し（pullback）</strong>と呼ぶ。いまは「偏微分を使えば行列の成分が機械的に書き換えられる」という感覚さえ掴めれば十分だ。第3章において、面積や体積の物差しを一気に引き戻す際、この代数的アプローチの圧倒的な強さを確信することになるだろう。
 </p>
-<blockquote><p>**注** （計量という言葉はまだ使わない）本書では第6章まで**計量**という概念の形式的な導入を後回しにする。ここで出てきた換算係数 $\cos\theta$ や $-r\sin\theta$ は、のちに第6章で計量 $g$ として体系的に整理されるが、現時点では単に「連鎖律から出てきた偏微分係数」として扱えば十分である。実空間に曲がった図形を描いてその辺の長さを「弧の長さ $r\Delta\theta$」などと幾何学的に見積もる発想に頼るのではなく、パラメータ空間の格子と変換式だけからすべてを導く——この代数優先の構えが、本書の一貫した姿勢である。</p>
+<blockquote><p>**注** （計量という言葉はまだ使わない）本書では第6章まで**計量**という概念の形式的な導入を後回しにする。ここで出てきた換算係数 <span class="tex2jax_process">$\cos\theta$</span> や <span class="tex2jax_process">$-r\sin\theta$</span> は、のちに第6章で計量 <span class="tex2jax_process">$g$</span> として体系的に整理されるが、現時点では単に「連鎖律から出てきた偏微分係数」として扱えば十分である。実空間に曲がった図形を描いてその辺の長さを「弧の長さ <span class="tex2jax_process">$r\Delta\theta$</span>」などと幾何学的に見積もる発想に頼るのではなく、パラメータ空間の格子と変換式だけからすべてを導く——この代数優先の構えが、本書の一貫した姿勢である。</p>
 </p></blockquote>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $dx$ という測定器自体は不変だが、座標系を取り替えると行列表現（成分）が変わる。
+- <span class="tex2jax_process">$dx$</span> という測定器自体は不変だが、座標系を取り替えると行列表現（成分）が変わる。
 - 座標変換の係数は、図形的なイメージからではなく、連鎖律（偏微分）から機械的に求まる。
 - 座標の取り替えの影響はすべて行列の成分に現れるため、我々は常に「真っ直ぐな変数」として計算を進めればよい。
-- **確認：**実空間の $(x,y,z)$ では $dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$ だが、円柱座標の目盛り $(dr,d\theta,dz)$ ではどう書けるか、§1.4.1 を振り返れ。
+- **確認：**実空間の <span class="tex2jax_process">$(x,y,z)$</span> では <span class="tex2jax_process">$dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$</span> だが、円柱座標の目盛り <span class="tex2jax_process">$(dr,d\theta,dz)$</span> ではどう書けるか、§1.4.1 を振り返れ。
 </p></blockquote>
 <hr />
 <h3 id="15-別の座標で書く演習">§1.5 別の座標で書く——演習</h3>
-<p>本章の終盤で、読者自身の手で「別の座標で書くこと」を一度、計算として体験してもらう。ここではまだ<strong>座標系の取り替えを一般論として定義したわけではない</strong>が、§1.4.3 で見たように、<strong>同じ $dx$ でも座標の取り方で行列表現が変わる</strong>ことは既に述べた。この演習は、その感覚を手で確かめるためのものである。<strong>いま座標系の取り替えの厳密な言語を全部そろえるより先に、なぜ計算をしておきたいのか</strong>——それは、後の章で式が一気に忙しくなるときに、「成分が変わるのは当たり前」という腹落ちを持っておくためだ。
+<p>本章の終盤で、読者自身の手で「別の座標で書くこと」を一度、計算として体験してもらう。ここではまだ<strong>座標系の取り替えを一般論として定義したわけではない</strong>が、§1.4.3 で見たように、<strong>同じ <span class="tex2jax_process">$dx$</span> でも座標の取り方で行列表現が変わる</strong>ことは既に述べた。この演習は、その感覚を手で確かめるためのものである。<strong>いま座標系の取り替えの厳密な言語を全部そろえるより先に、なぜ計算をしておきたいのか</strong>——それは、後の章で式が一気に忙しくなるときに、「成分が変わるのは当たり前」という腹落ちを持っておくためだ。
 </p>
 <h4 id="151-演習問題円柱座標での測定">1.5.1 演習問題：円柱座標での測定</h4>
 <strong>問題設定</strong>  
-<p>前節で見た通り、円柱座標 $(r, \theta, z)$ における $dx$ の行列表示は以下のようになる：
-$$
+<p>前節で見た通り、円柱座標 <span class="tex2jax_process">$(r, \theta, z)$</span> における <span class="tex2jax_process">$dx$</span> の行列表示は以下のようになる：
+</p>
+<div class="math-block tex2jax_process">$$
 dx = \begin{pmatrix} \cos\theta & -r\sin\theta & 0 \end{pmatrix}
-$$
-（上の行は §1.4.3 の $(dr,d\theta,dz)$ 展開の係数を並べたものであり、§1.1.3 のデカルト表示 $\begin{pmatrix}1&0&0\end{pmatrix}$ とは<strong>右に立てる縦ベクトルの意味が違う</strong>。）
+$$</div>
+<p>（上の行は §1.4.3 の <span class="tex2jax_process">$(dr,d\theta,dz)$</span> 展開の係数を並べたものであり、§1.1.3 のデカルト表示 <span class="tex2jax_process">$\begin{pmatrix}1&0&0\end{pmatrix}$</span> とは<strong>右に立てる縦ベクトルの意味が違う</strong>。）
 </p>
 <p>このとき、次の問いに答えよ。
 </p>
 <strong>問1</strong>  
-<p>円柱座標空間内の点 $P(r=2, \theta=\pi/6, z=0)$ に質点があるとする。この質点が、$r$ 方向に $0.1$ だけ微小変位した。<strong>この節では記号 $\mathbf{v}$ を、$r,\theta,z$ のパラメータの変化量を並べた $\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$ とする</strong>（§1.0–§1.2 のデカルト列 $\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ とは別の並べ方である）。この変位ベクトル $\mathbf{v}$ を、その成分で表せ。
+<p>円柱座標空間内の点 <span class="tex2jax_process">$P(r=2, \theta=\pi/6, z=0)$</span> に質点があるとする。この質点が、<span class="tex2jax_process">$r$</span> 方向に <span class="tex2jax_process">$0.1$</span> だけ微小変位した。<strong>この節では記号 <span class="tex2jax_process">$\mathbf{v}$</span> を、<span class="tex2jax_process">$r,\theta,z$</span> のパラメータの変化量を並べた <span class="tex2jax_process">$\begin{pmatrix}\Delta r\\\Delta\theta\\\Delta z\end{pmatrix}$</span> とする</strong>（§1.0–§1.2 のデカルト列 <span class="tex2jax_process">$\begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> とは別の並べ方である）。この変位ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> を、その成分で表せ。
 </p>
 <strong>問2</strong>  
-<p>問1の変位ベクトル $\mathbf{v}$ に対して、点 $P$ における行列 $dx$ を作用させよ。（$\cos(\pi/6) = \sqrt{3}/2$ を用いよ）
+<p>問1の変位ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> に対して、点 <span class="tex2jax_process">$P$</span> における行列 <span class="tex2jax_process">$dx$</span> を作用させよ。（<span class="tex2jax_process">$\cos(\pi/6) = \sqrt{3}/2$</span> を用いよ）
 </p>
 <strong>問3</strong>  
-<p>問2で計算した結果 $dx(\mathbf{v})$ は、物理的に何を意味しているか説明せよ。
+<p>問2で計算した結果 <span class="tex2jax_process">$dx(\mathbf{v})$</span> は、物理的に何を意味しているか説明せよ。
 </p>
 <h4 id="152-解答と解説">1.5.2 解答と解説</h4>
 <strong>問1の解答</strong>  
-<p>変位は $r$ 方向に $0.1$、$\theta$ 方向と $z$ 方向にはゼロなので、<strong>円柱座標のパラメータの変化量</strong>を縦に並べたベクトルとして次のように書ける：
-$$
+<p>変位は <span class="tex2jax_process">$r$</span> 方向に <span class="tex2jax_process">$0.1$</span>、<span class="tex2jax_process">$\theta$</span> 方向と <span class="tex2jax_process">$z$</span> 方向にはゼロなので、<strong>円柱座標のパラメータの変化量</strong>を縦に並べたベクトルとして次のように書ける：
+</p>
+<div class="math-block tex2jax_process">$$
 \mathbf{v} = \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix}
-$$
-</p>
+$$</div>
 <strong>問2の解答</strong>  
-<p>点 $P$ における行列 $dx$ は、$\theta = \pi/6, r=2$ を代入して得られる $1\times 3$ 行ベクトルとして
-$$
+<p>点 <span class="tex2jax_process">$P$</span> における行列 <span class="tex2jax_process">$dx$</span> は、<span class="tex2jax_process">$\theta = \pi/6, r=2$</span> を代入して得られる <span class="tex2jax_process">$1\times 3$</span> 行ベクトルとして
+</p>
+<div class="math-block tex2jax_process">$$
 dx = \begin{pmatrix} \cos(\frac{\pi}{6}) & -2\sin(\frac{\pi}{6}) & 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} & -2 \times \frac{1}{2} & 0 \end{pmatrix} = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix}
-$$
-と書く（円柱座標では $dx$ の成分は $r,\theta$ に依存するので、ここでは点 $P$ の座標で評価したあとを指す。$\mathbf{v}$ への作用の記号 $dx(\mathbf{v})$ 自体は §1.1.3 以来と同じである）。
+$$</div>
+<p>と書く（円柱座標では <span class="tex2jax_process">$dx$</span> の成分は <span class="tex2jax_process">$r,\theta$</span> に依存するので、ここでは点 <span class="tex2jax_process">$P$</span> の座標で評価したあとを指す。<span class="tex2jax_process">$\mathbf{v}$</span> への作用の記号 <span class="tex2jax_process">$dx(\mathbf{v})$</span> 自体は §1.1.3 以来と同じである）。
 </p>
-<p>重要なのは、第2成分は一般に <strong>$-r\sin\theta$</strong> という係数であり、$r$ のおかげで<strong>長さの次元を持つ</strong>ことだ。$r=2,\;\theta=\pi/6$ と代入するとその係数の値として $-1$ が見えるが、<strong>数値の $-1$ そのものに次元が付いているのではない</strong>。行列の成分としての $-r\sin\theta$ が長さの次元を運んでいる、と読むのが正確である。これが次元解析の鍵となる。
-これを変位ベクトル $\mathbf{v}$ に作用させると：
-$$
+<p>重要なのは、第2成分は一般に <strong><span class="tex2jax_process">$-r\sin\theta$</span></strong> という係数であり、<span class="tex2jax_process">$r$</span> のおかげで<strong>長さの次元を持つ</strong>ことだ。<span class="tex2jax_process">$r=2,\;\theta=\pi/6$</span> と代入するとその係数の値として <span class="tex2jax_process">$-1$</span> が見えるが、<strong>数値の <span class="tex2jax_process">$-1$</span> そのものに次元が付いているのではない</strong>。行列の成分としての <span class="tex2jax_process">$-r\sin\theta$</span> が長さの次元を運んでいる、と読むのが正確である。これが次元解析の鍵となる。
+これを変位ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> に作用させると：
+</p>
+<div class="math-block tex2jax_process">$$
 dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \begin{pmatrix} 0.1 \\ 0 \\ 0 \end{pmatrix} = 0.1 \times \frac{\sqrt{3}}{2} \approx 0.0866
-$$
-</p>
+$$</div>
 <strong>問3の解答（物理的意味）</strong>  
-<p>この結果は、<strong>「円柱座標において外側（$r$方向）へ $0.1$ だけ進むという運動は、実空間の $x$ 軸方向から見ると約 $0.0866$ の前進に相当する」</strong>という物理的事実を表している。
+<p>この結果は、<strong>「円柱座標において外側（<span class="tex2jax_process">$r$</span>方向）へ <span class="tex2jax_process">$0.1$</span> だけ進むという運動は、実空間の <span class="tex2jax_process">$x$</span> 軸方向から見ると約 <span class="tex2jax_process">$0.0866$</span> の前進に相当する」</strong>という物理的事実を表している。
 </p>
-<blockquote><p>**注** （「約」と厳密一致）この変位では $\Delta\theta=\Delta z=0$ なので、$x=r\cos\theta$ より $\Delta x=(\Delta r)\cos\theta$ が**厳密に**成り立つ。したがって $dx(\mathbf{v})$ の値は、**この変位のもとでは**真の $\Delta x$ と誤差なく一致する。「約」は $\sqrt{3}/2$ を小数で表した丸めにすぎず、一次近似の誤差ではない。</p>
+<blockquote><p>**注** （「約」と厳密一致）この変位では <span class="tex2jax_process">$\Delta\theta=\Delta z=0$</span> なので、<span class="tex2jax_process">$x=r\cos\theta$</span> より <span class="tex2jax_process">$\Delta x=(\Delta r)\cos\theta$</span> が**厳密に**成り立つ。したがって <span class="tex2jax_process">$dx(\mathbf{v})$</span> の値は、**この変位のもとでは**真の <span class="tex2jax_process">$\Delta x$</span> と誤差なく一致する。「約」は <span class="tex2jax_process">$\sqrt{3}/2$</span> を小数で表した丸めにすぎず、一次近似の誤差ではない。</p>
 </p></blockquote>
 <h4 id="153-次元解析の深い考察">1.5.3 次元解析の深い考察</h4>
-<p>計算結果 $dx(\mathbf{v}) = 0.1 \times \frac{\sqrt{3}}{2}$ を見ると、$r$方向成分$0.1$（長さの次元）と、第1成分の係数$\frac{\sqrt{3}}{2}$（無次元）の積となっており、出力は確かに長さの次元を持つ。
-しかし、もし$\theta$方向の変位$\mathbf{v} = \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix}$（角度変位$0.1$ラジアン）を入力したとすると（係数はいまも点 $P$ で評価した同じ行ベクトル）：
-$$dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix} = -0.1$$
-この場合、<strong>入力ベクトルの第2成分</strong> $0.1$ は角度（無次元）だが、<strong>行列の第2列に対応する係数</strong> $-r\sin\theta$ が長さの次元を運ぶため、積としての出力 $-0.1$ は長さの次元を持つ。
+<p>計算結果 <span class="tex2jax_process">$dx(\mathbf{v}) = 0.1 \times \frac{\sqrt{3}}{2}$</span> を見ると、<span class="tex2jax_process">$r$</span>方向成分<span class="tex2jax_process">$0.1$</span>（長さの次元）と、第1成分の係数<span class="tex2jax_process">$\frac{\sqrt{3}}{2}$</span>（無次元）の積となっており、出力は確かに長さの次元を持つ。
+しかし、もし<span class="tex2jax_process">$\theta$</span>方向の変位<span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix}$</span>（角度変位<span class="tex2jax_process">$0.1$</span>ラジアン）を入力したとすると（係数はいまも点 <span class="tex2jax_process">$P$</span> で評価した同じ行ベクトル）：
 </p>
-<p>ここに<strong>一次形式</strong>の驚くべき性質がある： $dx$ の行列成分自体が $r$ を含む関数であり、入力が座標成分（次元がバラバラでも）であっても、出力は常に「$x$ 方向の長さ」という正しい物理的次元を持つように自動調整される。<strong>一次形式は、座標系の歪みを吸収し、物理的に意味のある測定値を出力する「賢い測定器」</strong>なのである。
+<div class="math-block tex2jax_process">$$dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \begin{pmatrix} 0 \\ 0.1 \\ 0 \end{pmatrix} = -0.1$$</div>
+<p>この場合、<strong>入力ベクトルの第2成分</strong> <span class="tex2jax_process">$0.1$</span> は角度（無次元）だが、<strong>行列の第2列に対応する係数</strong> <span class="tex2jax_process">$-r\sin\theta$</span> が長さの次元を運ぶため、積としての出力 <span class="tex2jax_process">$-0.1$</span> は長さの次元を持つ。
+</p>
+<p>ここに<strong>一次形式</strong>の驚くべき性質がある： <span class="tex2jax_process">$dx$</span> の行列成分自体が <span class="tex2jax_process">$r$</span> を含む関数であり、入力が座標成分（次元がバラバラでも）であっても、出力は常に「<span class="tex2jax_process">$x$</span> 方向の長さ」という正しい物理的次元を持つように自動調整される。<strong>一次形式は、座標系の歪みを吸収し、物理的に意味のある測定値を出力する「賢い測定器」</strong>なのである。
 </p>
 <h3 id="16-本章のまとめと次章への展望">§1.6 本章のまとめと次章への展望</h3>
 <blockquote><p>**【ここまでのチェックポイント — 第1章全体】**</p>
-- 第1章の主役は「$dx$ を行列・一次形式として読み、$\int f\,dx$ を作用の極限として読む」ことである。説明の主線は $x$ 方向に寄せたが、デカルトの物差し $dy$, $dz$ は §1.2.3 で $dx$ と同様に定義済みである。
-- $df$ も横ベクトルとして統一し、多次元への拡張は成分の増加として素直に繋がる。
+- 第1章の主役は「<span class="tex2jax_process">$dx$</span> を行列・一次形式として読み、<span class="tex2jax_process">$\int f\,dx$</span> を作用の極限として読む」ことである。説明の主線は <span class="tex2jax_process">$x$</span> 方向に寄せたが、デカルトの物差し <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> は §1.2.3 で <span class="tex2jax_process">$dx$</span> と同様に定義済みである。
+- <span class="tex2jax_process">$df$</span> も横ベクトルとして統一し、多次元への拡張は成分の増加として素直に繋がる。
 - 次章以降は、これらの物差しの**ウェッジ積**、外微分、ホッジスターへと拡張する。
 </p></blockquote>
-<p>本章では<strong>積分と $df$ の具体例</strong>の主線として $x$ 方向に寄せ、$y,z$ は多くの場面で「断面」として抑えてきた。とはいえ、実空間での一次形式は <strong>$dx$, $dy$, $dz$ の三つがそろっている</strong>（§1.2.3）。
-次章では、この三つを組み合わせて<strong>面積計・体積計（$2$-form, $3$-form）</strong>を作る<strong>ウェッジ積（外積 $\wedge$）</strong>を導入し、ベクトルに作用してスカラーを返す型にとどまらない<strong>高次の微分形式</strong>へと進む。曲線・曲面・領域に沿った集計（線積分・面積分・体積分）は、それらの測定器を揃えた後の章で扱う。
+<p>本章では<strong>積分と <span class="tex2jax_process">$df$</span> の具体例</strong>の主線として <span class="tex2jax_process">$x$</span> 方向に寄せ、<span class="tex2jax_process">$y,z$</span> は多くの場面で「断面」として抑えてきた。とはいえ、実空間での一次形式は <strong><span class="tex2jax_process">$dx$</span>, <span class="tex2jax_process">$dy$</span>, <span class="tex2jax_process">$dz$</span> の三つがそろっている</strong>（§1.2.3）。
+次章では、この三つを組み合わせて<strong>面積計・体積計（<span class="tex2jax_process">$2$</span>-form, <span class="tex2jax_process">$3$</span>-form）</strong>を作る<strong>ウェッジ積（外積 <span class="tex2jax_process">$\wedge$</span>）</strong>を導入し、ベクトルに作用してスカラーを返す型にとどまらない<strong>高次の微分形式</strong>へと進む。曲線・曲面・領域に沿った集計（線積分・面積分・体積分）は、それらの測定器を揃えた後の章で扱う。
 </p>
 <!-- role: roadmap -->
-<p>その後の部では、<strong>微分演算子 $\mathrm{d}$</strong>、<strong>ホッジスター演算子 $\ast$</strong>、ベクトル解析の $\mathrm{grad}$（$\nabla$）、$\mathrm{rot}$（$\nabla\times$、$\mathrm{curl}$）、$\mathrm{div}$（$\nabla\cdot$）、ストークスの定理、マクスウェル方程式や流体力学の基礎方程式へと進む。3次元での微分形式とベクトル場の対応は、ホッジスターで整理できる。
+<p>その後の部では、<strong>微分演算子 <span class="tex2jax_process">$\mathrm{d}$</span></strong>、<strong>ホッジスター演算子 <span class="tex2jax_process">$\ast$</span></strong>、ベクトル解析の <span class="tex2jax_process">$\mathrm{grad}$</span>（<span class="tex2jax_process">$\nabla$</span>）、<span class="tex2jax_process">$\mathrm{rot}$</span>（<span class="tex2jax_process">$\nabla\times$</span>、<span class="tex2jax_process">$\mathrm{curl}$</span>）、<span class="tex2jax_process">$\mathrm{div}$</span>（<span class="tex2jax_process">$\nabla\cdot$</span>）、ストークスの定理、マクスウェル方程式や流体力学の基礎方程式へと進む。3次元での微分形式とベクトル場の対応は、ホッジスターで整理できる。
 </p>
 <p>3次元ユークリッド空間の真の姿を解き明かす旅へ、いざ出発しよう。
 </p>
@@ -860,29 +896,27 @@ $$dx(\mathbf{v}) = \begin{pmatrix} \frac{\sqrt{3}}{2} & -1 & 0 \end{pmatrix} \be
 </p>
 <h1 id="第2章面積とは何か--平行多面体に潜む符号のルール">第2章：面積とは何か —— 平行多面体に潜む、符号のルール</h1>
 <h3 id="20-測定器と面積・体積そして長さ">§2.0 測定器と面積・体積、そして長さ</h3>
-<p>　第1章では、$dx, dy, dz$ を「ベクトルを1つ食べてスカラーを返す横ベクトル（$1$-form）」として定義し、$\int f\,dx$ を行列作用の極限として読み直した。本章ではこれを拡張し、<strong>2つのベクトルを食べる面積測定器（$2$-form）</strong>と<strong>3つのベクトルを食べる体積測定器（$3$-form）</strong>を、同じ部品 $dx, dy, dz$ から発見する。
+<p>　第1章では、<span class="tex2jax_process">$dx, dy, dz$</span> を「ベクトルを1つ食べてスカラーを返す横ベクトル（<span class="tex2jax_process">$1$</span>-form）」として定義し、<span class="tex2jax_process">$\int f\,dx$</span> を行列作用の極限として読み直した。本章ではこれを拡張し、<strong>2つのベクトルを食べる面積測定器（<span class="tex2jax_process">$2$</span>-form）</strong>と<strong>3つのベクトルを食べる体積測定器（<span class="tex2jax_process">$3$</span>-form）</strong>を、同じ部品 <span class="tex2jax_process">$dx, dy, dz$</span> から発見する。
 </p>
 <h3 id="21-小学校の面積の限界">§2.1 小学校の面積の限界</h3>
 <p>多くの読者は「積分とはつまり面積を求める計算だ」ということを知っているだろう。
 ところで、面積とはなんだろうか。改めて考えてみると、小学校以来、改めて定式化したことがないのではないだろうか。
 </p>
-<p>ではその小学校での定式化とは何だったか。それは<strong>「$1 \times 1$ の正方形（タイル）が、その図形の中にいくつ敷き詰められるか」</strong>という、極めて素朴な直感に基づいていただろう。
+<p>ではその小学校での定式化とは何だったか。それは<strong>「<span class="tex2jax_process">$1 \times 1$</span> の正方形（タイル）が、その図形の中にいくつ敷き詰められるか」</strong>という、極めて素朴な直感に基づいていただろう。
 </p>
-<p>2次元の紙の上（$xy$平面）に描かれた図形であれば、この「正方形の敷き詰め」はうまく機能する。例えば、2つの2次元ベクトル $\mathbf{v}_1 = (x_1, y_1)$ と $\mathbf{v}_2 = (x_2, y_2)$ が張る平行四辺形の面積 $S$ は次のように書ける：
+<p>2次元の紙の上（<span class="tex2jax_process">$xy$</span>平面）に描かれた図形であれば、この「正方形の敷き詰め」はうまく機能する。例えば、2つの2次元ベクトル <span class="tex2jax_process">$\mathbf{v}_1 = (x_1, y_1)$</span> と <span class="tex2jax_process">$\mathbf{v}_2 = (x_2, y_2)$</span> が張る平行四辺形の面積 <span class="tex2jax_process">$S$</span> は次のように書ける：
 </p>
-<p>$$S = \sqrt{(x_1 y_2 - x_2 y_1)^2}$$
-</p>
+<div class="math-block tex2jax_process">$$S = \sqrt{(x_1 y_2 - x_2 y_1)^2}$$</div>
 <p>ところが、我々が生きているのは3次元空間である。3次元空間の中で「斜めに傾いた平面」の面積を測ろうとしたとき、事態は少し大変になる。
 </p>
-<p>多くの読者は、高校数学で3次元空間のベクトル $\mathbf{v}_1 = (x_1, y_1, z_1)$ と $\mathbf{v}_2 = (x_2, y_2, z_2)$ が張る平行四辺形の面積を求めさせられた経験があるだろう。高校の記法を使って、次のように書ける：
-$$
-S = \sqrt{|\mathbf{v}_1|^2 |\mathbf{v}_2|^2 - (\mathbf{v}_1 \cdot \mathbf{v}_2)^2}
-$$
+<p>多くの読者は、高校数学で3次元空間のベクトル <span class="tex2jax_process">$\mathbf{v}_1 = (x_1, y_1, z_1)$</span> と <span class="tex2jax_process">$\mathbf{v}_2 = (x_2, y_2, z_2)$</span> が張る平行四辺形の面積を求めさせられた経験があるだろう。高校の記法を使って、次のように書ける：
 </p>
+<div class="math-block tex2jax_process">$$
+S = \sqrt{|\mathbf{v}_1|^2 |\mathbf{v}_2|^2 - (\mathbf{v}_1 \cdot \mathbf{v}_2)^2}
+$$</div>
 <p>成分表示を考えると、ノートの幅を埋め尽くすような計算の末に、ようやく次の式にたどり着く。
 </p>
-<p>$$S = \sqrt{(y_1z_2 - z_1y_2)^2 + (z_1x_2 - x_1z_2)^2 + (x_1y_2 - x_2y_1)^2}$$
-</p>
+<div class="math-block tex2jax_process">$$S = \sqrt{(y_1z_2 - z_1y_2)^2 + (z_1x_2 - x_1z_2)^2 + (x_1y_2 - x_2y_1)^2}$$</div>
 <p>その過程はなかなか長大であり、人生で何度もやりたくないほどには大変である。
 なぜそんなに大変になってしまうのか？ それは、我々が<strong>面積というものを、はじめに「2次元世界の中」で定義してきたから</strong>だ。<strong>3次元空間では</strong>、平面の「傾き」と、そこに載る2本のベクトルの関係とが絡み、<strong>角度の取り扱い</strong>まで含めて式が膨らんでしまう。
 </p>
@@ -892,55 +926,54 @@ $$
 </p>
 <hr />
 <h3 id="22-面積測定器が満たすべき3つのルール">§2.2 面積測定器が満たすべき「3つのルール」</h3>
-<p>設計の第一歩として、「$1\times 1$ の正方形だけ」を足掛かりにするのではなく、<strong>「2つのベクトルが張る平行四辺形」</strong>を基本に据えることにする。
+<p>設計の第一歩として、「<span class="tex2jax_process">$1\times 1$</span> の正方形だけ」を足掛かりにするのではなく、<strong>「2つのベクトルが張る平行四辺形」</strong>を基本に据えることにする。
 </p>
 <blockquote><p>**注** （平行四辺形から始める理由）いままで「面積＝正方形の敷き詰め」と数えていた読者には、**なぜいきなり平行四辺形なのか**という動機づけが見えにくいかもしれない。平行四辺形を基本に据えると、辺が直交する、という条件が緩和されることになり、これから組み立てるルールがすっきりする。正方形はその**特別な場合**として自然に含まれる。また**積分を高次元へと拡張する**ときにも、こちらのほうが扱いやすい。</p>
 </p></blockquote>
-<p>上記を言い換えると、我々が欲しいのは、2つのベクトル $\mathbf{v}_1$ と $\mathbf{v}_2$ を入力（インプット）として食べると、それらが張る平行四辺形の面積 $S$ を出力（アウトプット）として吐き出す、魔法のブラックボックス $S(\mathbf{v}_1, \mathbf{v}_2)$ である。
+<p>上記を言い換えると、我々が欲しいのは、2つのベクトル <span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> を入力（インプット）として食べると、それらが張る平行四辺形の面積 <span class="tex2jax_process">$S$</span> を出力（アウトプット）として吐き出す、魔法のブラックボックス <span class="tex2jax_process">$S(\mathbf{v}_1, \mathbf{v}_2)$</span> である。
 </p>
 <p>このブラックボックスが「面積測定器」としてまともに機能するためには、最低限、次の3つのルールを満たさなければならない。原点から伸びる2本の矢印を隣り合う辺とする平行四辺形を思い浮かべながら確認してほしい。
 </p>
 <h4 id="221-ルール1片方が伸びれば面積も伸びる比例関係">2.2.1 ルール1：片方が伸びれば、面積も伸びる（比例関係）</h4>
-<p>もしベクトル $\mathbf{v}_1$ の長さが2倍になれば、作られる平行四辺形の面積も当然2倍になるはずだ。
-$$S(2\mathbf{v}_1, \mathbf{v}_2) = 2 S(\mathbf{v}_1, \mathbf{v}_2)$$
-同様に、2つのベクトルを足し合わせたものを入力すれば、面積も足し算に分解できる：
-$$S(\mathbf{v}_1 + \mathbf{u}, \mathbf{v}_2) = S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{u}, \mathbf{v}_2)$$
-この2つの性質を合わせて<strong>線形性</strong>と呼ぶ。第2引数 $\mathbf{v}_2$ についても、同様に「スカラー倍」と「和に関する分配」が成り立つ——すなわち $S$ は<strong>両方の引数について線形</strong>（<strong>双線形</strong>）である。
+<p>もしベクトル <span class="tex2jax_process">$\mathbf{v}_1$</span> の長さが2倍になれば、作られる平行四辺形の面積も当然2倍になるはずだ。
+</p>
+<div class="math-block tex2jax_process">$$S(2\mathbf{v}_1, \mathbf{v}_2) = 2 S(\mathbf{v}_1, \mathbf{v}_2)$$</div>
+<p>同様に、2つのベクトルを足し合わせたものを入力すれば、面積も足し算に分解できる：
+</p>
+<div class="math-block tex2jax_process">$$S(\mathbf{v}_1 + \mathbf{u}, \mathbf{v}_2) = S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{u}, \mathbf{v}_2)$$</div>
+<p>この2つの性質を合わせて<strong>線形性</strong>と呼ぶ。第2引数 <span class="tex2jax_process">$\mathbf{v}_2$</span> についても、同様に「スカラー倍」と「和に関する分配」が成り立つ——すなわち <span class="tex2jax_process">$S$</span> は<strong>両方の引数について線形</strong>（<strong>双線形</strong>）である。
 </p>
 <h4 id="222-ルール2重なればペチャンコでゼロ交代性">2.2.2 ルール2：重なれば、ペチャンコでゼロ（交代性）</h4>
-<p>これが最も重要だ。もし $\mathbf{v}_1$ と $\mathbf{v}_2$ が全く同じベクトルだったらどうなるか。平行四辺形は潰れてただの「線」になってしまい、面積はゼロになる。
-$$S(\mathbf{v}_1, \mathbf{v}_1) = 0$$
+<p>これが最も重要だ。もし <span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> が全く同じベクトルだったらどうなるか。平行四辺形は潰れてただの「線」になってしまい、面積はゼロになる。
 </p>
-<p>実は、この「同じならゼロ」というルールから、非常に奇妙な性質が導かれる。ルール1（線形性）を使って、$\mathbf{v}_1 + \mathbf{v}_2$ を両方の引数に入れてみよう。「同じならゼロ」だから：
+<div class="math-block tex2jax_process">$$S(\mathbf{v}_1, \mathbf{v}_1) = 0$$</div>
+<p>実は、この「同じならゼロ」というルールから、非常に奇妙な性質が導かれる。ルール1（線形性）を使って、<span class="tex2jax_process">$\mathbf{v}_1 + \mathbf{v}_2$</span> を両方の引数に入れてみよう。「同じならゼロ」だから：
 </p>
-<p>$$S(\mathbf{v}_1 + \mathbf{v}_2,\; \mathbf{v}_1 + \mathbf{v}_2) = 0$$
-</p>
+<div class="math-block tex2jax_process">$$S(\mathbf{v}_1 + \mathbf{v}_2,\; \mathbf{v}_1 + \mathbf{v}_2) = 0$$</div>
 <p>左辺を線形性で展開すると：
 </p>
-<p>$$S(\mathbf{v}_1, \mathbf{v}_1) + S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{v}_2, \mathbf{v}_1) + S(\mathbf{v}_2, \mathbf{v}_2) = 0$$
+<div class="math-block tex2jax_process">$$S(\mathbf{v}_1, \mathbf{v}_1) + S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{v}_2, \mathbf{v}_1) + S(\mathbf{v}_2, \mathbf{v}_2) = 0$$</div>
+<p>第1項と第4項はルール2で消えるから、残るのは <span class="tex2jax_process">$S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{v}_2, \mathbf{v}_1) = 0$</span>。すなわち：
 </p>
-<p>第1項と第4項はルール2で消えるから、残るのは $S(\mathbf{v}_1, \mathbf{v}_2) + S(\mathbf{v}_2, \mathbf{v}_1) = 0$。すなわち：
-</p>
-<p>$$S(\mathbf{v}_1, \mathbf{v}_2) = - S(\mathbf{v}_2, \mathbf{v}_1)$$
-</p>
+<div class="math-block tex2jax_process">$$S(\mathbf{v}_1, \mathbf{v}_2) = - S(\mathbf{v}_2, \mathbf{v}_1)$$</div>
 <p>入力するベクトルの順番を入れ替えると、<strong>面積の符号がマイナスに反転してしまう</strong>のだ。
 </p>
 <blockquote><p>**注**（面積の符号1）「面積がマイナスになる？ それは困る」と驚くかもしれない。しかし、物理学者は自然界の「向き」を無視しない。電流の向き、磁場の向き——すべてベクトルの「向き」が本質だ。だから「面積にも向き（向き付き面積）がある」という発想は、我々物理学者にはむしろ自然なのだ。この概念は後で曲面の「裏表」を区別したり、空間を貫く磁束や流体の流れを計算する際に絶対に不可欠なものとなる。今のところはこだわりすぎずに進んでほしい。</p>
 </p></blockquote>
-<blockquote><p>**注** （面積の符号2）1変数でも、$f(x)<0$ の区間では $\displaystyle\int_a^b f(x)\,dx<0$ となり得る——符号付き「面積」はそこで既に現れている。向き付き面積は、その考え方を2次元に持ち上げたものだ。</p>
+<blockquote><p>**注** （面積の符号2）1変数でも、<span class="tex2jax_process">$f(x)<0$</span> の区間では <span class="tex2jax_process">$\displaystyle\int_a^b f(x)\,dx<0$</span> となり得る——符号付き「面積」はそこで既に現れている。向き付き面積は、その考え方を2次元に持ち上げたものだ。</p>
 <h4 id="223-ルール3基準の決定規格化">2.2.3 ルール3：基準の決定（規格化）</h4>
 </p></blockquote>
-<p>最後に、「どのくらいの大きさを1とするか」を決めなければならない。ここでは素直に、$x$方向の<strong>基底ベクトル</strong>（標準基底の一つ）$\hat{e}_x$ と $y$方向の基底ベクトル $\hat{e}_y$ が作る正方形の面積を $1$ としよう。本書の慣例どおり<strong>縦ベクトル</strong>で書けば
-$$\hat{e}_x = \begin{pmatrix} 1 \\ 0 \\ 0 \end{pmatrix}, \quad \hat{e}_y = \begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix}$$
-である。
+<p>最後に、「どのくらいの大きさを1とするか」を決めなければならない。ここでは素直に、<span class="tex2jax_process">$x$</span>方向の<strong>基底ベクトル</strong>（標準基底の一つ）<span class="tex2jax_process">$\hat{e}_x$</span> と <span class="tex2jax_process">$y$</span>方向の基底ベクトル <span class="tex2jax_process">$\hat{e}_y$</span> が作る正方形の面積を <span class="tex2jax_process">$1$</span> としよう。本書の慣例どおり<strong>縦ベクトル</strong>で書けば
 </p>
-<p>$$S(\hat{e}_x, \hat{e}_y) = 1$$
+<div class="math-block tex2jax_process">$$\hat{e}_x = \begin{pmatrix} 1 \\ 0 \\ 0 \end{pmatrix}, \quad \hat{e}_y = \begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix}$$</div>
+<p>である。
 </p>
-<blockquote><p>**注** （基底ベクトル（標準基底））デカルト座標の各軸方向に長さ $1$ の足を伸ばしたものを、基底ベクトル（標準基底）と呼ぶ、といって良いだろう。厳密な定義は線形代数に任せる。</p>
+<div class="math-block tex2jax_process">$$S(\hat{e}_x, \hat{e}_y) = 1$$</div>
+<blockquote><p>**注** （基底ベクトル（標準基底））デカルト座標の各軸方向に長さ <span class="tex2jax_process">$1$</span> の足を伸ばしたものを、基底ベクトル（標準基底）と呼ぶ、といって良いだろう。厳密な定義は線形代数に任せる。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
 - 面積測定器は「2つのベクトルを食べてスカラーを返す」装置。3つのルール——線形性・交代性・規格化——を満たさなければならない。
-- 交代性（同じベクトルを2つ入れるとゼロ）から $S(\mathbf{v}_1,\mathbf{v}_2) = -S(\mathbf{v}_2,\mathbf{v}_1)$ が導かれ、面積は**符号付き**になる。
+- 交代性（同じベクトルを2つ入れるとゼロ）から <span class="tex2jax_process">$S(\mathbf{v}_1,\mathbf{v}_2) = -S(\mathbf{v}_2,\mathbf{v}_1)$</span> が導かれ、面積は**符号付き**になる。
 - 次節では、この3ルールを満たす代数的な装置を具体的に探す。
 </p></blockquote>
 <hr />
@@ -948,17 +981,16 @@ $$\hat{e}_x = \begin{pmatrix} 1 \\ 0 \\ 0 \end{pmatrix}, \quad \hat{e}_y = \begi
 <p>さて、ここからが数学の魔法だ。
 我々は今、この「平行四辺形」という<strong>図形のイメージ</strong>を頭に描きながら3つのルールを設定した。しかし、一度ルールを決めてしまえば、もはや図形を思い浮かべる必要はない。<strong>「この3つのルールを満たす代数的な計算式」を探せば、それが面積の定義になるからだ。</strong>
 </p>
-<p>本質を抽出するため、まずは $z$成分が常にゼロのベクトル、つまり $xy$平面上にある2つのベクトルで考えよう。
+<p>本質を抽出するため、まずは <span class="tex2jax_process">$z$</span>成分が常にゼロのベクトル、つまり <span class="tex2jax_process">$xy$</span>平面上にある2つのベクトルで考えよう。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ 0 \end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
-$$
+$$</div>
+<p>結論から言おう。この <strong><span class="tex2jax_process">$xy$</span> 平面上のベクトルという制約のもとで</strong>、先ほどの3ルールを完璧に満たす量を出力する装置は、線形代数の世界にただ一つしか存在しない。
 </p>
-<p>結論から言おう。この <strong>$xy$ 平面上のベクトルという制約のもとで</strong>、先ほどの3ルールを完璧に満たす量を出力する装置は、線形代数の世界にただ一つしか存在しない。
+<p>それは、真ん中に特定の <strong><span class="tex2jax_process">$3 \times 3$</span> 行列</strong> を挟んだ、次のような「<strong>横ベクトル</strong> <span class="tex2jax_process">$\times$</span> 行列 <span class="tex2jax_process">$\times$</span> <strong>縦ベクトル</strong>」の計算である：
 </p>
-<p>それは、真ん中に特定の <strong>$3 \times 3$ 行列</strong> を挟んだ、次のような「<strong>横ベクトル</strong> $\times$ 行列 $\times$ <strong>縦ベクトル</strong>」の計算である：
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{pmatrix} x_1 & y_1 & 0 \end{pmatrix}
 \begin{pmatrix}
   0 & 1 & 0 \\
@@ -966,11 +998,10 @@ $$
   0 & 0 & 0
 \end{pmatrix}
 \begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
-$$
+$$</div>
+<p>実際に <span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> を代入して計算してみよう：
 </p>
-<p>実際に $\mathbf{v}_1$ と $\mathbf{v}_2$ を代入して計算してみよう：
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{pmatrix} x_1 & y_1 & 0 \end{pmatrix}
 \begin{pmatrix}
   0 & 1 & 0 \\
@@ -981,73 +1012,71 @@ $$
 = \begin{pmatrix} -y_1 & x_1 & 0 \end{pmatrix}
 \begin{pmatrix} x_2 \\ y_2 \\ 0 \end{pmatrix}
 = x_1 y_2 - x_2 y_1
-$$
+$$</div>
+<p>出てきた出力 <span class="tex2jax_process">$x_1 y_2 - x_2 y_1$</span> は、まさしく冒頭で触れた「2次元の面積公式」の中身そのものである！
 </p>
-<p>出てきた出力 $x_1 y_2 - x_2 y_1$ は、まさしく冒頭で触れた「2次元の面積公式」の中身そのものである！
-</p>
-<blockquote><p>**注** （数学者へのエクスキューズ）我々は今、平然と $\mathbf{v}_1^T M \mathbf{v}_2$ （横 $\times$ 行列 $\times$ 縦）という書き方をした。厳密な純粋数学の流儀では行儀が悪い——ベクトルを横に寝かせる操作には、計量の議論が絡むからだ。**しかし、我々は物理学者だ。** デカルト直交座標に固定しているかぎり、この計算に支障はない。割り切って進もう。</p>
+<blockquote><p>**注** （数学者へのエクスキューズ）我々は今、平然と <span class="tex2jax_process">$\mathbf{v}_1^T M \mathbf{v}_2$</span> （横 <span class="tex2jax_process">$\times$</span> 行列 <span class="tex2jax_process">$\times$</span> 縦）という書き方をした。厳密な純粋数学の流儀では行儀が悪い——ベクトルを横に寝かせる操作には、計量の議論が絡むからだ。**しかし、我々は物理学者だ。** デカルト直交座標に固定しているかぎり、この計算に支障はない。割り切って進もう。</p>
 </p></blockquote>
 <h4 id="231-なぜ反対称なのか">2.3.1 なぜ「反対称」なのか？</h4>
 <p>話を戻そう。真ん中に挟まった行列の構造をじっくり観察してほしい。
-対角成分（左上から右下）はすべて $0$ であり、それを挟んで $1$ と $-1$ が<strong>符号を反転させて向かい合っている</strong>。このような行列を「反対称行列（交代行列）」と呼ぶ。
+対角成分（左上から右下）はすべて <span class="tex2jax_process">$0$</span> であり、それを挟んで <span class="tex2jax_process">$1$</span> と <span class="tex2jax_process">$-1$</span> が<strong>符号を反転させて向かい合っている</strong>。このような行列を「反対称行列（交代行列）」と呼ぶ。
 </p>
 <p>この「反対称」こそが、面積の核心である。
-式 $x_1 y_2 - x_2 y_1$ を見ればわかるように、これは「$\mathbf{v}_1$の$x$と$\mathbf{v}_2$の$y$の組み合わせ」から、「$\mathbf{v}_2$の$x$と$\mathbf{v}_1$の$y$の組み合わせ」を<strong>引き算</strong>している。
-もし $\mathbf{v}_1$ と $\mathbf{v}_2$ が全く同じベクトルなら、$x_1 y_1 - x_1 y_1 = 0$ となり、見事に打ち消し合う。行列の「非対角成分の符号反転」という性質が、ルール2の「ペチャンコならゼロ（打ち消し合い）」を自動的に代数処理してくれているのだ。
+式 <span class="tex2jax_process">$x_1 y_2 - x_2 y_1$</span> を見ればわかるように、これは「<span class="tex2jax_process">$\mathbf{v}_1$</span>の<span class="tex2jax_process">$x$</span>と<span class="tex2jax_process">$\mathbf{v}_2$</span>の<span class="tex2jax_process">$y$</span>の組み合わせ」から、「<span class="tex2jax_process">$\mathbf{v}_2$</span>の<span class="tex2jax_process">$x$</span>と<span class="tex2jax_process">$\mathbf{v}_1$</span>の<span class="tex2jax_process">$y$</span>の組み合わせ」を<strong>引き算</strong>している。
+もし <span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> が全く同じベクトルなら、<span class="tex2jax_process">$x_1 y_1 - x_1 y_1 = 0$</span> となり、見事に打ち消し合う。行列の「非対角成分の符号反転」という性質が、ルール2の「ペチャンコならゼロ（打ち消し合い）」を自動的に代数処理してくれているのだ。
 </p>
-<p>なぜ唯一に決まるのか？ ルール1（線形性）により、どんなベクトルの面積も基底ベクトル（標準基底）同士の面積の足し合わせに分解できる。そしてルール3（規格化）で基準の正方形を「1」と決めた瞬間、行列の右上成分が1に固定される。さらにルール2（交代性）の「ペチャンコならゼロ」が、対角成分を0にし、左下成分を-1へと強制的に反転させるのだ。なお、行列の第3行・第3列がすべてゼロなのは、入力ベクトルの $z$ 成分が常にゼロだから——この位置にどんな値を入れても $\mathbf{v}_1^T M \mathbf{v}_2$ の計算結果は変わらないので、3ルールだけからは決まらない（不定）。いまの議論は $xy$ 平面を $\mathbb{R}^3$ に埋め込んだものと見なせるので、<strong>余剰の $z$ 方向は測定に入ってこない</strong>——その意味でもゼロを置くのが素直である。つまり、<strong>我々の定めた物理的ルールが、この行列の形を完全に「設計」した</strong>のである。
+<p>なぜ唯一に決まるのか？ ルール1（線形性）により、どんなベクトルの面積も基底ベクトル（標準基底）同士の面積の足し合わせに分解できる。そしてルール3（規格化）で基準の正方形を「1」と決めた瞬間、行列の右上成分が1に固定される。さらにルール2（交代性）の「ペチャンコならゼロ」が、対角成分を0にし、左下成分を-1へと強制的に反転させるのだ。なお、行列の第3行・第3列がすべてゼロなのは、入力ベクトルの <span class="tex2jax_process">$z$</span> 成分が常にゼロだから——この位置にどんな値を入れても <span class="tex2jax_process">$\mathbf{v}_1^T M \mathbf{v}_2$</span> の計算結果は変わらないので、3ルールだけからは決まらない（不定）。いまの議論は <span class="tex2jax_process">$xy$</span> 平面を <span class="tex2jax_process">$\mathbb{R}^3$</span> に埋め込んだものと見なせるので、<strong>余剰の <span class="tex2jax_process">$z$</span> 方向は測定に入ってこない</strong>——その意味でもゼロを置くのが素直である。つまり、<strong>我々の定めた物理的ルールが、この行列の形を完全に「設計」した</strong>のである。
 </p>
 <h4 id="232-測定器の進化と次なる壁">2.3.2 測定器の進化と、次なる壁</h4>
 <p>我々はここで、次の立場をはっきりさせる。
-小学校で数えていた<strong>タイルの枚数</strong>に相当する素朴な直感を先に置くのではなく、<strong>いま定めたこの $3 \times 3$ 反対称行列に2本のベクトルを食わせて得られる量</strong>を、<strong>この測定器（$xy$ 平面専用の面積測定器）が返す面積の成分</strong>——$dx \wedge dy$ に沿った読み取り値——だと定義するのである。三次元空間における向き付き面積の<strong>すべての情報</strong>を一つの数で尽くすわけではなく、あくまで<strong>一つの眼鏡が切り出したスカラー</strong>にすぎない。全体像は §2.4.5 で3種の測定器をそろえて述べる。
+小学校で数えていた<strong>タイルの枚数</strong>に相当する素朴な直感を先に置くのではなく、<strong>いま定めたこの <span class="tex2jax_process">$3 \times 3$</span> 反対称行列に2本のベクトルを食わせて得られる量</strong>を、<strong>この測定器（<span class="tex2jax_process">$xy$</span> 平面専用の面積測定器）が返す面積の成分</strong>——<span class="tex2jax_process">$dx \wedge dy$</span> に沿った読み取り値——だと定義するのである。三次元空間における向き付き面積の<strong>すべての情報</strong>を一つの数で尽くすわけではなく、あくまで<strong>一つの眼鏡が切り出したスカラー</strong>にすぎない。全体像は §2.4.5 で3種の測定器をそろえて述べる。
 </p>
-<p>前章の <strong>$1$-form（一次形式）</strong> は、1つのベクトルを捕まえる<strong>「$1 \times 3$行列」</strong>だった。
-今目の前にある行列は、<strong>2つのベクトルを同時に受け取り面積を計算</strong>する<strong>「$3 \times 3$反対称行列」</strong>へと進化したのである。
+<p>前章の <strong><span class="tex2jax_process">$1$</span>-form（一次形式）</strong> は、1つのベクトルを捕まえる<strong>「<span class="tex2jax_process">$1 \times 3$</span>行列」</strong>だった。
+今目の前にある行列は、<strong>2つのベクトルを同時に受け取り面積を計算</strong>する<strong>「<span class="tex2jax_process">$3 \times 3$</span>反対称行列」</strong>へと進化したのである。
 </p>
-<p>この行列（あるいは演算子）を、<strong>$2$-form</strong> と呼ぶことにする。
+<p>この行列（あるいは演算子）を、<strong><span class="tex2jax_process">$2$</span>-form</strong> と呼ぶことにする。
 </p>
-<blockquote><p>**注** （二次形式と $2$-form）線形代数の「二次形式（quadratic form）」は、多くの場合「二次の多項式」を指す。ここでの **$2$-form** は微分形式の用語であり、上の quadratic form とは別物である。</p>
+<blockquote><p>**注** （二次形式と <span class="tex2jax_process">$2$</span>-form）線形代数の「二次形式（quadratic form）」は、多くの場合「二次の多項式」を指す。ここでの **<span class="tex2jax_process">$2$</span>-form** は微分形式の用語であり、上の quadratic form とは別物である。</p>
 </p></blockquote>
 <p>さて、読者はこう思っているはずだ。
-「なるほど、行列で面積が出るのは分かった。でも、この行列は第3行・第3列がゼロだから、$z$成分を完全に無視しているじゃないか。これではあの『3次元の大変な計算』の解決になっていないぞ」と。
+「なるほど、行列で面積が出るのは分かった。でも、この行列は第3行・第3列がゼロだから、<span class="tex2jax_process">$z$</span>成分を完全に無視しているじゃないか。これではあの『3次元の大変な計算』の解決になっていないぞ」と。
 </p>
 <strong>まったくその通りである。</strong>
-<p>今我々が手にした $\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$ という行列は、3次元空間に3種類ある基本測定器の一つ——<strong>$xy$平面専用の面積測定器</strong>——に過ぎない。
-言い換えれば、これは<strong>$xy$平面「だけ」を見る「偏った眼鏡」</strong>のようなものだ。空間には、$yz$平面を見る眼鏡や、$zx$平面を見る眼鏡も存在する。
+<p>今我々が手にした <span class="tex2jax_process">$\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$</span> という行列は、3次元空間に3種類ある基本測定器の一つ——<strong><span class="tex2jax_process">$xy$</span>平面専用の面積測定器</strong>——に過ぎない。
+言い換えれば、これは<strong><span class="tex2jax_process">$xy$</span>平面「だけ」を見る「偏った眼鏡」</strong>のようなものだ。空間には、<span class="tex2jax_process">$yz$</span>平面を見る眼鏡や、<span class="tex2jax_process">$zx$</span>平面を見る眼鏡も存在する。
 </p>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 面積測定器（$2$-form）とは「2つのベクトルの絡み合い」を測る代数的な装置であり、測定対象である平行四辺形そのものではない。
+- 面積測定器（<span class="tex2jax_process">$2$</span>-form）とは「2つのベクトルの絡み合い」を測る代数的な装置であり、測定対象である平行四辺形そのものではない。
 - 面積測定器の正体は「反対称行列」であり、物理的ルールが行列の形を完全に決める。
-- 3次元空間には3種類の「偏った眼鏡」（基底$2$-form）が存在する。
+- 3次元空間には3種類の「偏った眼鏡」（基底<span class="tex2jax_process">$2$</span>-form）が存在する。
 - 続く §2.4 で、物差しから面積測定器をリバースエンジニアリングする（テンソル積とウェッジ積）。
 </p></blockquote>
 <hr />
 <h3 id="24-面積測定器の内部構造">§2.4 面積測定器の内部構造</h3>
 <h4 id="241-2つの入力をさばく装置の形を決める">2.4.1 「2つの入力をさばく装置」の形を決める</h4>
-<p>§2.3 で、面積測定器（$2$-form）の正体は真ん中に挟まった「$3 \times 3$ の反対称行列」であると述べた。しかし、あの行列は筆者から天下り的に与えられたものだった。
+<p>§2.3 で、面積測定器（<span class="tex2jax_process">$2$</span>-form）の正体は真ん中に挟まった「<span class="tex2jax_process">$3 \times 3$</span> の反対称行列」であると述べた。しかし、あの行列は筆者から天下り的に与えられたものだった。
 </p>
 <p>我々の次なる野望はこうだ：
 </p>
-<strong>「第1章で導入したシンプルな物差し $dx, dy, dz$ を部品として組み合わせて、あの複雑な行列をシステマティックに作り出せないだろうか？」</strong>
-<p>こうすれば、いまは $xy$ 平面専用の面積測定器しかないが、$yz$ 平面用・$zx$ 平面用の面積測定器も同じ部品から同じ手順で量産できるようになる。
+<strong>「第1章で導入したシンプルな物差し <span class="tex2jax_process">$dx, dy, dz$</span> を部品として組み合わせて、あの複雑な行列をシステマティックに作り出せないだろうか？」</strong>
+<p>こうすれば、いまは <span class="tex2jax_process">$xy$</span> 平面専用の面積測定器しかないが、<span class="tex2jax_process">$yz$</span> 平面用・<span class="tex2jax_process">$zx$</span> 平面用の面積測定器も同じ部品から同じ手順で量産できるようになる。
 </p>
 <p>これを実現するために、まずは「2つのベクトルを食べてスカラーを吐き出す装置」の外枠がどうなるべきかを考えよう。
 </p>
-<p>第1章で、ベクトルを1つ食べる装置（$1$-form）は「横ベクトル」で表現できることを見た（横 $\times$ 縦 $=$ スカラー）。
-では、$\mathbf{v}_1$ と $\mathbf{v}_2$ という2つのベクトルを同時に食べて、しかも §2.2 のルール1（比例関係・線形性）を両方に対して保つ装置はどう書けるだろうか？
+<p>第1章で、ベクトルを1つ食べる装置（<span class="tex2jax_process">$1$</span>-form）は「横ベクトル」で表現できることを見た（横 <span class="tex2jax_process">$\times$</span> 縦 <span class="tex2jax_process">$=$</span> スカラー）。
+では、<span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> という2つのベクトルを同時に食べて、しかも §2.2 のルール1（比例関係・線形性）を両方に対して保つ装置はどう書けるだろうか？
 </p>
-<p>それは、2つのベクトルの間に真四角の表（行列）を挟み込む形、すなわち <strong>「横 $\times$ 行列 $\times$ 縦（$\mathbf{v}_1^T M \mathbf{v}_2$）」</strong> の形になるしかない。これが線形代数の要請である。我々が探すべきは、この真ん中に挟まる行列 $M$ の中身だ。
+<p>それは、2つのベクトルの間に真四角の表（行列）を挟み込む形、すなわち <strong>「横 <span class="tex2jax_process">$\times$</span> 行列 <span class="tex2jax_process">$\times$</span> 縦（<span class="tex2jax_process">$\mathbf{v}_1^T M \mathbf{v}_2$</span>）」</strong> の形になるしかない。これが線形代数の要請である。我々が探すべきは、この真ん中に挟まる行列 <span class="tex2jax_process">$M$</span> の中身だ。
 </p>
 <h4 id="242-欲しい結果からマス目を埋める">2.4.2 欲しい結果からマス目を埋める</h4>
 <p>闇雲に探す必要はない。我々はすでに、出力されるべき<strong>「答え」</strong>を知っている。
-$xy$ 平面の面積公式だ。
 </p>
-<p>$$\text{欲しい出力} = x_1 y_2 - x_2 y_1$$
+<span class="tex2jax_process">$xy$</span> 平面の面積公式だ。
+<div class="math-block tex2jax_process">$$\text{欲しい出力} = x_1 y_2 - x_2 y_1$$</div>
+<p>この出力を吐き出すためには、行列 <span class="tex2jax_process">$M$</span> のマス目にどんな数字を配置すればよいか？ 読者も一緒に、<span class="tex2jax_process">$\mathbf{v}_1^T M \mathbf{v}_2$</span> の展開式を想像しながらマス目を埋めるパズルをしてほしい。
 </p>
-<p>この出力を吐き出すためには、行列 $M$ のマス目にどんな数字を配置すればよいか？ 読者も一緒に、$\mathbf{v}_1^T M \mathbf{v}_2$ の展開式を想像しながらマス目を埋めるパズルをしてほしい。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
 \begin{pmatrix}
   ? & ? & ? \\
@@ -1055,94 +1084,83 @@ $xy$ 平面の面積公式だ。
   ? & ? & ?
 \end{pmatrix}
 \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
-$$
-</p>
+$$</div>
 <ol>
-<li>**$x_1 y_2$ を作る：** $\mathbf{v}_1$ の $x$ 成分（$x_1$）と $\mathbf{v}_2$ の $y$ 成分（$y_2$）が掛け合わされる場所、すなわち「1行2列目」には $+1$ を置けばよい。</li>
+<li>**<span class="tex2jax_process">$x_1 y_2$</span> を作る：** <span class="tex2jax_process">$\mathbf{v}_1$</span> の <span class="tex2jax_process">$x$</span> 成分（<span class="tex2jax_process">$x_1$</span>）と <span class="tex2jax_process">$\mathbf{v}_2$</span> の <span class="tex2jax_process">$y$</span> 成分（<span class="tex2jax_process">$y_2$</span>）が掛け合わされる場所、すなわち「1行2列目」には <span class="tex2jax_process">$+1$</span> を置けばよい。</li>
 </ol>
-<p>2. <strong>$-x_2 y_1$ を作る：</strong> $\mathbf{v}_1$ の $y$ 成分（$y_1$）と $\mathbf{v}_2$ の $x$ 成分（$x_2$）が掛け合わされる場所、すなわち「2行1列目」には $-1$ を置けばよい。
+<p>2. <strong><span class="tex2jax_process">$-x_2 y_1$</span> を作る：</strong> <span class="tex2jax_process">$\mathbf{v}_1$</span> の <span class="tex2jax_process">$y$</span> 成分（<span class="tex2jax_process">$y_1$</span>）と <span class="tex2jax_process">$\mathbf{v}_2$</span> の <span class="tex2jax_process">$x$</span> 成分（<span class="tex2jax_process">$x_2$</span>）が掛け合わされる場所、すなわち「2行1列目」には <span class="tex2jax_process">$-1$</span> を置けばよい。
 <ol>
-<li>**それ以外：** 面積の式には $x_1 x_2$ や $z$ 成分などは一切登場しない。したがって、残りのマス目はすべて $0$ である。</li>
+<li>**それ以外：** 面積の式には <span class="tex2jax_process">$x_1 x_2$</span> や <span class="tex2jax_process">$z$</span> 成分などは一切登場しない。したがって、残りのマス目はすべて <span class="tex2jax_process">$0$</span> である。</li>
 </ol>
 <p>こうして出来上がったのが、§2.3 で天下り的に登場したあの反対称行列なのだ！
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 M = \begin{pmatrix}
   0 & 1 & 0 \\
   -1 & 0 & 0 \\
   0 & 0 & 0
 \end{pmatrix}
-$$
-</p>
+$$</div>
 <h4 id="243-テンソル積の導入">2.4.3 テンソル積の導入</h4>
-<p>さて、この面積測定器の行列 $M$ をよく見ると、2つの部品の「引き算」でできていることがわかる。
+<p>さて、この面積測定器の行列 <span class="tex2jax_process">$M$</span> をよく見ると、2つの部品の「引き算」でできていることがわかる。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 = \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} - 
  \begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-$$
+$$</div>
+<p>右辺の第1項は「1行2列目だけが <span class="tex2jax_process">$1$</span> の行列」であり、これは <span class="tex2jax_process">$\mathbf{v}_1$</span> から <span class="tex2jax_process">$x$</span> 成分を、<span class="tex2jax_process">$\mathbf{v}_2$</span> から <span class="tex2jax_process">$y$</span> 成分を抽出して掛ける（<span class="tex2jax_process">$x_1 y_2$</span>）という<strong>片道切符の演算</strong>を表している。
 </p>
-<p>右辺の第1項は「1行2列目だけが $1$ の行列」であり、これは $\mathbf{v}_1$ から $x$ 成分を、$\mathbf{v}_2$ から $y$ 成分を抽出して掛ける（$x_1 y_2$）という<strong>片道切符の演算</strong>を表している。
+<p>ここで第1章の物差しを思い出そう。<span class="tex2jax_process">$x$</span> 成分を抽出する物差しは <span class="tex2jax_process">$dx$</span>、<span class="tex2jax_process">$y$</span> 成分を抽出する物差しは <span class="tex2jax_process">$dy$</span> だった。
+この2つの物差しを組み合わせて「<span class="tex2jax_process">$\mathbf{v}_1$</span> は <span class="tex2jax_process">$dx$</span> で測り、<span class="tex2jax_process">$\mathbf{v}_2$</span> は <span class="tex2jax_process">$dy$</span> で測って掛ける」という新しい演算子を作り、これを <strong>テンソル積</strong> と呼び、<span class="tex2jax_process">$dx \otimes dy$</span> と書くことにしよう。
 </p>
-<p>ここで第1章の物差しを思い出そう。$x$ 成分を抽出する物差しは $dx$、$y$ 成分を抽出する物差しは $dy$ だった。
-この2つの物差しを組み合わせて「$\mathbf{v}_1$ は $dx$ で測り、$\mathbf{v}_2$ は $dy$ で測って掛ける」という新しい演算子を作り、これを <strong>テンソル積</strong> と呼び、$dx \otimes dy$ と書くことにしよう。
+<div class="math-block tex2jax_process">$$(dx \otimes dy)(\mathbf{v}_1, \mathbf{v}_2) := dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) = x_1 y_2$$</div>
+<p>テンソル積 <span class="tex2jax_process">$dx \otimes dy$</span> というといかにも難しそうな響きだが、恐れることはない。行列表現の世界では、これは単に<strong>「1行2列目のマス目だけを <span class="tex2jax_process">$1$</span> にする」</strong>スイッチのような操作に過ぎないのだ。
 </p>
-<p>$$(dx \otimes dy)(\mathbf{v}_1, \mathbf{v}_2) := dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) = x_1 y_2$$
-</p>
-<p>テンソル積 $dx \otimes dy$ というといかにも難しそうな響きだが、恐れることはない。行列表現の世界では、これは単に<strong>「1行2列目のマス目だけを $1$ にする」</strong>スイッチのような操作に過ぎないのだ。
-</p>
-<blockquote><p>**注** （テンソル積の行列表現）数式が好きな読者のために書いておくと、$dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$、$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}$ としたとき、「前のベクトルを転置して縦にし、後ろの横ベクトルと隣り合わせに置き（$dx^T dy$）、縦と横の成分を総当たりで掛け合わせて行列のマス目に配置する」という操作で$dx \otimes dy$の行列表現が機械的に得られる。</p>
+<blockquote><p>**注** （テンソル積の行列表現）数式が好きな読者のために書いておくと、<span class="tex2jax_process">$dx = \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$</span>、<span class="tex2jax_process">$dy = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}$</span> としたとき、「前のベクトルを転置して縦にし、後ろの横ベクトルと隣り合わせに置き（<span class="tex2jax_process">$dx^T dy$</span>）、縦と横の成分を総当たりで掛け合わせて行列のマス目に配置する」という操作で<span class="tex2jax_process">$dx \otimes dy$</span>の行列表現が機械的に得られる。</p>
 <h4 id="244-ウェッジ積の完成">2.4.4 ウェッジ積の完成</h4>
 </p></blockquote>
 <p>これで準備は整った。
-我々が導き出した $xy$ 平面の面積測定器行列は、「$x_1 y_2$ のスイッチ」から「$y_1 x_2$ のスイッチ」を引いたものだった。
+我々が導き出した <span class="tex2jax_process">$xy$</span> 平面の面積測定器行列は、「<span class="tex2jax_process">$x_1 y_2$</span> のスイッチ」から「<span class="tex2jax_process">$y_1 x_2$</span> のスイッチ」を引いたものだった。
 </p>
-<p>これを物差し（$1$-form）の言葉で翻訳すれば、新しい演算子 <strong>ウェッジ積（$dx \wedge dy$）</strong> の定義が自然に立ち上がる。
+<p>これを物差し（<span class="tex2jax_process">$1$</span>-form）の言葉で翻訳すれば、新しい演算子 <strong>ウェッジ積（<span class="tex2jax_process">$dx \wedge dy$</span>）</strong> の定義が自然に立ち上がる。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 dx \wedge dy := dx \otimes dy - dy \otimes dx
-$$
+$$</div>
+<p>記号 <span class="tex2jax_process">$\wedge$</span> は英語で "wedge"、くさびを意味する。この定義をベクトルに作用させるとこうなる：
 </p>
-<p>記号 $\wedge$ は英語で "wedge"、くさびを意味する。この定義をベクトルに作用させるとこうなる：
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 (dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) - dy(\mathbf{v}_1)\,dx(\mathbf{v}_2) = x_1 y_2 - x_2 y_1
-$$
-</p>
-<p>見事に、第1章の物差し（$1$-form）の組み合わせから、面積測定器（$2$-form）をシステマティックに構成することができた。
+$$</div>
+<p>見事に、第1章の物差し（<span class="tex2jax_process">$1$</span>-form）の組み合わせから、面積測定器（<span class="tex2jax_process">$2$</span>-form）をシステマティックに構成することができた。
 テンソル積の引き算で構成したことにより、<strong>引数を入れ替えると符号が反転する（交代性）</strong>という §2.2 のルール2が、自動的に「仕込まれている」ことにも注目してほしい。
 </p>
-<h4 id="245-3つの基底-form">2.4.5 3つの基底$2$-form</h4>
+<h4 id="245-3つの基底span-classtex2jaxprocessspan-form">2.4.5 3つの基底<span class="tex2jax_process">$2$</span>-form</h4>
 <p>同じ方法で、残る2つの「偏った眼鏡」も構成できる。
 </p>
-<strong>$yz$ 平面を見る眼鏡：$dy \wedge dz$</strong>
-<p>$$
+<strong><span class="tex2jax_process">$yz$</span> 平面を見る眼鏡：<span class="tex2jax_process">$dy \wedge dz$</span></strong>
+<div class="math-block tex2jax_process">$$
 dy \otimes dz - dz \otimes dy = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 0 & 0 \end{pmatrix} - \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 0 \\ 0 & 1 & 0 \end{pmatrix} = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}
-$$
-</p>
-<strong>$zx$ 平面を見る眼鏡：$dz \wedge dx$</strong>
-<p>$$
+$$</div>
+<strong><span class="tex2jax_process">$zx$</span> 平面を見る眼鏡：<span class="tex2jax_process">$dz \wedge dx$</span></strong>
+<div class="math-block tex2jax_process">$$
 dz \otimes dx - dx \otimes dz = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} - \begin{pmatrix} 0 & 0 & 1 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} = \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}
-$$
-</p>
+$$</div>
 <strong>これで全部だ！</strong>
 <p>では、3つの眼鏡を一つずつ一般のベクトルにかけて、それぞれ何を測るか見てみよう。
 </p>
-<p>一般の3次元ベクトル $\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$, $\mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$ に対し、§2.4.4 の定義どおりに（第1引数に $\mathbf{v}_1$、第2引数に $\mathbf{v}_2$ を入れる）計算すればよい：
+<p>一般の3次元ベクトル <span class="tex2jax_process">$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$</span>, <span class="tex2jax_process">$\mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$</span> に対し、§2.4.4 の定義どおりに（第1引数に <span class="tex2jax_process">$\mathbf{v}_1$</span>、第2引数に <span class="tex2jax_process">$\mathbf{v}_2$</span> を入れる）計算すればよい：
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 (dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2) = y_1 z_2 - z_1 y_2
-$$
-</p>
-<p>$$
+$$</div>
+<div class="math-block tex2jax_process">$$
 (dz \wedge dx)(\mathbf{v}_1, \mathbf{v}_2) = z_1 x_2 - x_1 z_2
-$$
-</p>
-<p>$$
+$$</div>
+<div class="math-block tex2jax_process">$$
 (dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = x_1 y_2 - x_2 y_1
-$$
-</p>
+$$</div>
 <p>各計算は引き算1回。ベクトルの向きがどうであれ、ウェッジ積の定義が自動的に正しい値を返す。
 </p>
 <h4 id="246-向き付き面積の正体と図形側の基底">2.4.6 向き付き面積の正体と「図形側の基底」</h4>
@@ -1150,72 +1168,70 @@ $$
 </p>
 <p>実は、そう単純ではない。
 </p>
-<p>§2.2 で面積測定器を設計したとき、$xy$平面に張り付いた話では確かに<strong>一つの数</strong>で足りた。しかし3次元空間の一般の平行四辺形では、向きは $+/-$ の2択では済まない。3つの基底 $2$-form（眼鏡）を通した測定値
-$$A_{yz} = (dy \wedge dz)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{zx} = (dz \wedge dx)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{xy} = (dx \wedge dy)(\mathbf{v}_1,\mathbf{v}_2)$$
-が、まるごと「向き付き面積」として必要な情報になる。
+<p>§2.2 で面積測定器を設計したとき、<span class="tex2jax_process">$xy$</span>平面に張り付いた話では確かに<strong>一つの数</strong>で足りた。しかし3次元空間の一般の平行四辺形では、向きは <span class="tex2jax_process">$+/-$</span> の2択では済まない。3つの基底 <span class="tex2jax_process">$2$</span>-form（眼鏡）を通した測定値
+</p>
+<div class="math-block tex2jax_process">$$A_{yz} = (dy \wedge dz)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{zx} = (dz \wedge dx)(\mathbf{v}_1,\mathbf{v}_2),\quad A_{xy} = (dx \wedge dy)(\mathbf{v}_1,\mathbf{v}_2)$$</div>
+<p>が、まるごと「向き付き面積」として必要な情報になる。
 </p>
 <p>ここで、鋭い読者は一つの疑問に行き着くはずだ。
 「この3つの数は、いったい<strong>何の基底</strong>に乗っている係数なのか？」と。
 </p>
-<p>思い出してほしい。第1章で、我々は「測る装置（横ベクトル）」である $1$-form の $dx$ と、「測られる図形（縦ベクトル）」である標準基底 $\hat{e}_x$ が対になっていることを学んだ。横と縦を組み合わせることで、$dx$ は $\hat{e}_x$ を食べて $1$ というスカラーを返す（$dx(\hat{e}_x) = 1$）。
+<p>思い出してほしい。第1章で、我々は「測る装置（横ベクトル）」である <span class="tex2jax_process">$1$</span>-form の <span class="tex2jax_process">$dx$</span> と、「測られる図形（縦ベクトル）」である標準基底 <span class="tex2jax_process">$\hat{e}_x$</span> が対になっていることを学んだ。横と縦を組み合わせることで、<span class="tex2jax_process">$dx$</span> は <span class="tex2jax_process">$\hat{e}_x$</span> を食べて <span class="tex2jax_process">$1$</span> というスカラーを返す（<span class="tex2jax_process">$dx(\hat{e}_x) = 1$</span>）。
 </p>
-<p>では、面積測定器（$2$-form）である $dy \wedge dz$ が食べて $1$ を返す<strong>「図形（縦）側の基底」</strong>とは何だろうか？
-横ベクトル同士をウェッジ積 $\wedge$ で結んで装置を作ったのなら、<strong>縦ベクトル同士も $\wedge$ で結べばよいのだ！</strong>
+<p>では、面積測定器（<span class="tex2jax_process">$2$</span>-form）である <span class="tex2jax_process">$dy \wedge dz$</span> が食べて <span class="tex2jax_process">$1$</span> を返す<strong>「図形（縦）側の基底」</strong>とは何だろうか？
+横ベクトル同士をウェッジ積 <span class="tex2jax_process">$\wedge$</span> で結んで装置を作ったのなら、<strong>縦ベクトル同士も <span class="tex2jax_process">$\wedge$</span> で結べばよいのだ！</strong>
 </p>
-<p>すなわち、図形側の基底は $\hat{e}_y \wedge \hat{e}_z$ という「二重ベクトル（2-vector）」もしくは「面素（area element）」と呼ばれるものである。
+<p>すなわち、図形側の基底は <span class="tex2jax_process">$\hat{e}_y \wedge \hat{e}_z$</span> という「二重ベクトル（2-vector）」もしくは「面素（area element）」と呼ばれるものである。
 これを用いれば、測られた結果である「向き付き面積の正体」は、次のような明確な実体（図形）として書き下される。
 </p>
-<p>$$\text{向き付き面積} = A_{yz}\,(\hat{e}_y \wedge \hat{e}_z) + A_{zx}\,(\hat{e}_z \wedge \hat{e}_x) + A_{xy}\,(\hat{e}_x \wedge \hat{e}_y)$$
-</p>
+<div class="math-block tex2jax_process">$$\text{向き付き面積} = A_{yz}\,(\hat{e}_y \wedge \hat{e}_z) + A_{zx}\,(\hat{e}_z \wedge \hat{e}_x) + A_{xy}\,(\hat{e}_x \wedge \hat{e}_y)$$</div>
 <p>これで完全にスッキリしたはずだ。
-係数に場を含む一般の $\alpha\,dy \wedge dz + \cdots$ は<strong>「面積測定器（はかり）」</strong>であり、測定結果の数値を入れた $A_{yz}(\hat{e}_y \wedge \hat{e}_z) + \cdots$ は<strong>「測られた図形（面積そのもの）」</strong>である。両者は横と縦の関係にあり、決して混同してはならない。
+係数に場を含む一般の <span class="tex2jax_process">$\alpha\,dy \wedge dz + \cdots$</span> は<strong>「面積測定器（はかり）」</strong>であり、測定結果の数値を入れた <span class="tex2jax_process">$A_{yz}(\hat{e}_y \wedge \hat{e}_z) + \cdots$</span> は<strong>「測られた図形（面積そのもの）」</strong>である。両者は横と縦の関係にあり、決して混同してはならない。
 </p>
-<blockquote><p>**注** （行列はどこへ行った？）前の節まで「面積測定器は反対称行列だ」と散々やってきたのに、図形側の行列表現はどうなるのかと気になるかもしれない。3次元空間では、図形側の二重ベクトルも $3 \times 3$ 反対称行列と同型になる（成分に $A_{yz}$ 等を並べた行列になる）。しかし、この行列表示をここに明示してしまうと「面積測定器の行列」と足したり掛けたりできそうな気がしてしまい読者の直感に悪影響であるので、本書では「図形は二重ベクトルの基底に乗る」という説明でとどめておく。</p>
+<blockquote><p>**注** （行列はどこへ行った？）前の節まで「面積測定器は反対称行列だ」と散々やってきたのに、図形側の行列表現はどうなるのかと気になるかもしれない。3次元空間では、図形側の二重ベクトルも <span class="tex2jax_process">$3 \times 3$</span> 反対称行列と同型になる（成分に <span class="tex2jax_process">$A_{yz}$</span> 等を並べた行列になる）。しかし、この行列表示をここに明示してしまうと「面積測定器の行列」と足したり掛けたりできそうな気がしてしまい読者の直感に悪影響であるので、本書では「図形は二重ベクトルの基底に乗る」という説明でとどめておく。</p>
 </p></blockquote>
 <h4 id="247-小学校のスカラー面積に戻すには">2.4.7 小学校のスカラー面積に戻すには</h4>
 <p>では、小学校で習った「正の値の面積」に戻していこう。
 </p>
-<p>読者は、1次元の図形データであるベクトル $\mathbf{v} = x\hat{e}_x + y\hat{e}_y + z\hat{e}_z$ から「長さ（スカラー）」を取り出すとき、各基底の係数の二乗和の平方根 $\sqrt{x^2+y^2+z^2}$ を計算すればよいことを知っているだろう。
+<p>読者は、1次元の図形データであるベクトル <span class="tex2jax_process">$\mathbf{v} = x\hat{e}_x + y\hat{e}_y + z\hat{e}_z$</span> から「長さ（スカラー）」を取り出すとき、各基底の係数の二乗和の平方根 <span class="tex2jax_process">$\sqrt{x^2+y^2+z^2}$</span> を計算すればよいことを知っているだろう。
 </p>
-<p>2次元の図形データである二重ベクトルの「大きさ（スカラー面積）」を取り出す操作も、これと同じ形である。向き付き面積を構成する3つの基底 $\hat{e}_y \wedge \hat{e}_z,\,\hat{e}_z \wedge \hat{e}_x,\,\hat{e}_x \wedge \hat{e}_y$ の係数 $A_{yz}, A_{zx}, A_{xy}$ について、縦ベクトルに並べ替えずに、直接その二乗和の平方根をとればよい。
+<p>2次元の図形データである二重ベクトルの「大きさ（スカラー面積）」を取り出す操作も、これと同じ形である。向き付き面積を構成する3つの基底 <span class="tex2jax_process">$\hat{e}_y \wedge \hat{e}_z,\,\hat{e}_z \wedge \hat{e}_x,\,\hat{e}_x \wedge \hat{e}_y$</span> の係数 <span class="tex2jax_process">$A_{yz}, A_{zx}, A_{xy}$</span> について、縦ベクトルに並べ替えずに、直接その二乗和の平方根をとればよい。
 </p>
-<p>$$S = \sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2} = \sqrt{(y_1 z_2 - z_1 y_2)^2 + (z_1 x_2 - x_1 z_2)^2 + (x_1 y_2 - x_2 y_1)^2}$$
-</p>
+<div class="math-block tex2jax_process">$$S = \sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2} = \sqrt{(y_1 z_2 - z_1 y_2)^2 + (z_1 x_2 - x_1 z_2)^2 + (x_1 y_2 - x_2 y_1)^2}$$</div>
 <p>これはまさしく §2.1 で「大変な計算」と呼んだ高校数学の面積の式と完全に一致する。我々はついに、代数的な測定器の設計から出発し、小学校の「タイルの枚数」にまで無事に帰還したのである。
 </p>
 <h4 id="248-1次元の面積長さと0次元の面積点">2.4.8 1次元の「面積」（長さ）と0次元の「面積」（点）</h4>
 <p>ここで少し視点を下げてみよう。「成分の二乗和の平方根」という操作に見覚えがあると言ったが、実は我々は<strong>1次元の図形（線分）</strong>に対しても、全く同じ「はかり」と「図形」の構造をすでに知っている。
 </p>
-<p>第1章で扱った $1$-form（$dx, dy, dz$）は、「ベクトルを1つだけ食べる」測定器だった。
-はかられる図形は、ベクトルそのもの（$\mathbf{v} = x\hat{e}_x + y\hat{e}_y + z\hat{e}_z$）であり、これは「1次元の向き付き面積（向き付きの長さ）」のデータに他ならない。ここから「スカラーの長さ」を取り出す操作が $\sqrt{x^2+y^2+z^2}$ だった。
+<p>第1章で扱った <span class="tex2jax_process">$1$</span>-form（<span class="tex2jax_process">$dx, dy, dz$</span>）は、「ベクトルを1つだけ食べる」測定器だった。
+はかられる図形は、ベクトルそのもの（<span class="tex2jax_process">$\mathbf{v} = x\hat{e}_x + y\hat{e}_y + z\hat{e}_z$</span>）であり、これは「1次元の向き付き面積（向き付きの長さ）」のデータに他ならない。ここから「スカラーの長さ」を取り出す操作が <span class="tex2jax_process">$\sqrt{x^2+y^2+z^2}$</span> だった。
 </p>
-<p>では、<strong>$0$-form</strong> とは何か？
-「ベクトルを $k$ 個食べる測定器が $k$-form」なのだから、$0$-form とは<strong>「ベクトルを1つも食べない測定器」</strong>である。入力する方向（矢印）すら必要なく、その場に置くだけで1つのスカラー（温度や密度など）を返すもの——すなわち、ただの<strong>「スカラー場」</strong>のことだ。
-$0$-form が測る「0次元の図形」とは単なる「点」であり、成分は1つしかなく、大きさはその絶対値をとるだけだ。
+<p>では、<strong><span class="tex2jax_process">$0$</span>-form</strong> とは何か？
+「ベクトルを <span class="tex2jax_process">$k$</span> 個食べる測定器が <span class="tex2jax_process">$k$</span>-form」なのだから、<span class="tex2jax_process">$0$</span>-form とは<strong>「ベクトルを1つも食べない測定器」</strong>である。入力する方向（矢印）すら必要なく、その場に置くだけで1つのスカラー（温度や密度など）を返すもの——すなわち、ただの<strong>「スカラー場」</strong>のことだ。
 </p>
-<p>点（0次元）、線分（1次元）、平行四辺形（2次元）。すべては「はかり（$k$-form）」と「図形（$k$-ベクトル）」の、横ベクトルと縦ベクトルの関係という、全く同じ構造の反復だったのである。
+<span class="tex2jax_process">$0$</span>-form が測る「0次元の図形」とは単なる「点」であり、成分は1つしかなく、大きさはその絶対値をとるだけだ。
+<p>点（0次元）、線分（1次元）、平行四辺形（2次元）。すべては「はかり（<span class="tex2jax_process">$k$</span>-form）」と「図形（<span class="tex2jax_process">$k$</span>-ベクトル）」の、横ベクトルと縦ベクトルの関係という、全く同じ構造の反復だったのである。
 </p>
 <p>§2.5 ではこれをさらに一段上げて、3次元の平行六面体（体積）に同じ構造を適用する。まとめると：
 <ul>
-<li>**$k=0$**：$0$-form は点を測る。成分1つ、大きさは絶対値</li>
+<li>**<span class="tex2jax_process">$k=0$</span>**：<span class="tex2jax_process">$0$</span>-form は点を測る。成分1つ、大きさは絶対値</li>
 </ol>
 <ul>
-<li>**$k=1$**：$1$-form はベクトル（**向き付きの長さ**）を測る。成分3つ、大きさは $\sqrt{x^2+y^2+z^2}$</li>
+<li>**<span class="tex2jax_process">$k=1$</span>**：<span class="tex2jax_process">$1$</span>-form はベクトル（**向き付きの長さ**）を測る。成分3つ、大きさは <span class="tex2jax_process">$\sqrt{x^2+y^2+z^2}$</span></li>
 </ol>
 <ul>
-<li>**$k=2$**：$2$-form は二重ベクトル（**向き付きの面積**）を測る。成分3つ、大きさは $\sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}$</li>
+<li>**<span class="tex2jax_process">$k=2$</span>**：<span class="tex2jax_process">$2$</span>-form は二重ベクトル（**向き付きの面積**）を測る。成分3つ、大きさは <span class="tex2jax_process">$\sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}$</span></li>
 </ol>
 <ul>
-<li>**$k=3$**：$3$-form は三重ベクトル（**向き付きの体積**）を測る。成分1つ、大きさは絶対値</li>
+<li>**<span class="tex2jax_process">$k=3$</span>**：<span class="tex2jax_process">$3$</span>-form は三重ベクトル（**向き付きの体積**）を測る。成分1つ、大きさは絶対値</li>
 </ol>
-<p>本書の舞台は3次元空間だから $k=0,1,2,3$ で打ち止めだが、「$k$-form が $k$-vector を食べてスカラーを返す」という原理は $k$ によらない。このパターンが第3章の積分、第5章の外微分へと受け継がれていく。
+<p>本書の舞台は3次元空間だから <span class="tex2jax_process">$k=0,1,2,3$</span> で打ち止めだが、「<span class="tex2jax_process">$k$</span>-form が <span class="tex2jax_process">$k$</span>-vector を食べてスカラーを返す」という原理は <span class="tex2jax_process">$k$</span> によらない。このパターンが第3章の積分、第5章の外微分へと受け継がれていく。
 </p>
 <h4 id="249-クロス積との符合">2.4.9 クロス積との符合</h4>
 <p>大学の線形代数で「ベクトルの外積（クロス積）」を学んだ読者なら、次の3成分に見覚えがあるだろう。
 </p>
-<p>$$\mathbf{v}_1 \times \mathbf{v}_2 = (y_1 z_2 - z_1 y_2)\,\hat{e}_x + (z_1 x_2 - x_1 z_2)\,\hat{e}_y + (x_1 y_2 - x_2 y_1)\,\hat{e}_z = \begin{pmatrix} y_1 z_2 - z_1 y_2 \\ z_1 x_2 - x_1 z_2 \\ x_1 y_2 - x_2 y_1 \end{pmatrix}$$
-</p>
-<p>これは、いまの $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ の<strong>値</strong>を、この順に並べたものにほかならない。
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 \times \mathbf{v}_2 = (y_1 z_2 - z_1 y_2)\,\hat{e}_x + (z_1 x_2 - x_1 z_2)\,\hat{e}_y + (x_1 y_2 - x_2 y_1)\,\hat{e}_z = \begin{pmatrix} y_1 z_2 - z_1 y_2 \\ z_1 x_2 - x_1 z_2 \\ x_1 y_2 - x_2 y_1 \end{pmatrix}$$</div>
+<p>これは、いまの <span class="tex2jax_process">$dy \wedge dz$</span>, <span class="tex2jax_process">$dz \wedge dx$</span>, <span class="tex2jax_process">$dx \wedge dy$</span> の<strong>値</strong>を、この順に並べたものにほかならない。
 </p>
 <blockquote><p>**注**（不安な読者へ）見覚えがなくとも、本書ではウェッジ積を先に発見した、というだけでこの先の理解に支障はない。</p>
 </p></blockquote>
@@ -1223,94 +1239,94 @@ $0$-form が測る「0次元の図形」とは単なる「点」であり、成�
 </p></blockquote>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- ウェッジ積 $dx \wedge dy := dx \otimes dy - dy \otimes dx$ は、テンソル積の引き算で反対称行列を自動生成する。$dy \wedge dz$, $dz \wedge dx$ も同様に構成され、3つの基底 $2$-form の線形結合で任意の面積測定器を組み立てられる。
-- 向き付き面積の正体は、測定値 $A_{yz}, A_{zx}, A_{xy}$ を図形側の基底 $\hat{e}_y \wedge \hat{e}_z$, $\hat{e}_z \wedge \hat{e}_x$, $\hat{e}_x \wedge \hat{e}_y$ に乗じた二重ベクトルである——はかり（基底 $2$-form）と図形（$k$-ベクトル）は横と縦の関係にあり、混同してはならない。
-- スカラー面積（タイルの枚数に相当する正の大きさ）は、係数の二乗和の平方根 $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ で §2.1 の式に戻る（ラグランジュの恒等式）。ベクトルの長さの公式と同じ形の操作だ。
+- ウェッジ積 <span class="tex2jax_process">$dx \wedge dy := dx \otimes dy - dy \otimes dx$</span> は、テンソル積の引き算で反対称行列を自動生成する。<span class="tex2jax_process">$dy \wedge dz$</span>, <span class="tex2jax_process">$dz \wedge dx$</span> も同様に構成され、3つの基底 <span class="tex2jax_process">$2$</span>-form の線形結合で任意の面積測定器を組み立てられる。
+- 向き付き面積の正体は、測定値 <span class="tex2jax_process">$A_{yz}, A_{zx}, A_{xy}$</span> を図形側の基底 <span class="tex2jax_process">$\hat{e}_y \wedge \hat{e}_z$</span>, <span class="tex2jax_process">$\hat{e}_z \wedge \hat{e}_x$</span>, <span class="tex2jax_process">$\hat{e}_x \wedge \hat{e}_y$</span> に乗じた二重ベクトルである——はかり（基底 <span class="tex2jax_process">$2$</span>-form）と図形（<span class="tex2jax_process">$k$</span>-ベクトル）は横と縦の関係にあり、混同してはならない。
+- スカラー面積（タイルの枚数に相当する正の大きさ）は、係数の二乗和の平方根 <span class="tex2jax_process">$\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$</span> で §2.1 の式に戻る（ラグランジュの恒等式）。ベクトルの長さの公式と同じ形の操作だ。
 </p></blockquote>
 <hr />
 <h3 id="25-体積測定器と行列式">§2.5 体積測定器と行列式</h3>
-<p>前節で我々は、2つの一次形式（物差し）$dx, dy$ をウェッジ積で掛け合わせ、面積測定器（$2$-form）$dx \wedge dy$ を組み立てた。面積測定器は「2つのベクトルを食べて、それらが張る平行四辺形の符号付き面積を返す装置」だった。
+<p>前節で我々は、2つの一次形式（物差し）<span class="tex2jax_process">$dx, dy$</span> をウェッジ積で掛け合わせ、面積測定器（<span class="tex2jax_process">$2$</span>-form）<span class="tex2jax_process">$dx \wedge dy$</span> を組み立てた。面積測定器は「2つのベクトルを食べて、それらが張る平行四辺形の符号付き面積を返す装置」だった。
 </p>
-<p>いよいよ<strong>体積</strong>だが、ここでも立場は同じである。まず<strong>標準基底 $\hat{e}_x,\hat{e}_y,\hat{e}_z$ を並べた単位立方体</strong>に体積 $1$ を対応させ（ルール3）、交代性・線形性で測定器を定める。小学校の「単位立方体がいくつ入るか」という<strong>正の体積</strong>に戻すには、やはり<strong>成分の二乗和の平方根</strong>（あるいは絶対値）が入る——面積のときと同じ構造だ。
+<p>いよいよ<strong>体積</strong>だが、ここでも立場は同じである。まず<strong>標準基底 <span class="tex2jax_process">$\hat{e}_x,\hat{e}_y,\hat{e}_z$</span> を並べた単位立方体</strong>に体積 <span class="tex2jax_process">$1$</span> を対応させ（ルール3）、交代性・線形性で測定器を定める。小学校の「単位立方体がいくつ入るか」という<strong>正の体積</strong>に戻すには、やはり<strong>成分の二乗和の平方根</strong>（あるいは絶対値）が入る——面積のときと同じ構造だ。
 </p>
 <p>自然な問いが湧く。
 </p>
-<strong>「3つのベクトルが張る平行六面体の体積を測る装置——体積測定器（$3$-form）——も、同じ方法で組み立てられるだろうか？」</strong>
+<strong>「3つのベクトルが張る平行六面体の体積を測る装置——体積測定器（<span class="tex2jax_process">$3$</span>-form）——も、同じ方法で組み立てられるだろうか？」</strong>
 <h4 id="251-体積測定器が満たすべきルール">2.5.1 体積測定器が満たすべきルール</h4>
-<p>§2.2 で面積測定器を設計したときとまったく同じ戦略をとろう。まず「体積測定器 $V$ が満たすべきルール」を決め、その後でルールから装置の形を一意に導く。
+<p>§2.2 で面積測定器を設計したときとまったく同じ戦略をとろう。まず「体積測定器 <span class="tex2jax_process">$V$</span> が満たすべきルール」を決め、その後でルールから装置の形を一意に導く。
 </p>
-<p>体積測定器 $V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$ は3つのベクトルを食べて1つのスカラーを返す関数である。これに課すルールは、面積測定器の3ルールを<strong>3引数へそのまま拡張</strong>したものだ：
+<p>体積測定器 <span class="tex2jax_process">$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$</span> は3つのベクトルを食べて1つのスカラーを返す関数である。これに課すルールは、面積測定器の3ルールを<strong>3引数へそのまま拡張</strong>したものだ：
 </p>
 <strong>ルール1（各引数について線形）</strong>
 <p>片方のベクトルが2倍になれば体積も2倍。ベクトルの足し算にも分配する。
-$$V(a\mathbf{v}_1 + b\mathbf{u},\; \mathbf{v}_2,\; \mathbf{v}_3) = a\,V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) + b\,V(\mathbf{u}, \mathbf{v}_2, \mathbf{v}_3)$$
-第2・第3引数についても同様。
+</p>
+<div class="math-block tex2jax_process">$$V(a\mathbf{v}_1 + b\mathbf{u},\; \mathbf{v}_2,\; \mathbf{v}_3) = a\,V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) + b\,V(\mathbf{u}, \mathbf{v}_2, \mathbf{v}_3)$$</div>
+<p>第2・第3引数についても同様。
 </p>
 <strong>ルール2（交代性 — どの2つを入れ替えても符号反転）</strong>
-<p>$$V(\mathbf{v}_2, \mathbf{v}_1, \mathbf{v}_3) = -V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$$
-他のペアについても同様。§2.2 と同じ論法で、<strong>同じベクトルを2つのスロットに入れると必ずゼロ</strong>になる——$\mathbf{v}_1 = \mathbf{v}_2$ なら $V(\mathbf{v}_1,\mathbf{v}_1,\mathbf{v}_3) = -V(\mathbf{v}_1,\mathbf{v}_1,\mathbf{v}_3)$ だから $V=0$ である。図形としては平行六面体が潰れるが、<strong>代数では交代性だけで「潰れてゼロ」が強制される</strong>。これが2次元の面積測定器のルール2と同じ構造だ。
+<div class="math-block tex2jax_process">$$V(\mathbf{v}_2, \mathbf{v}_1, \mathbf{v}_3) = -V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$$</div>
+<p>他のペアについても同様。§2.2 と同じ論法で、<strong>同じベクトルを2つのスロットに入れると必ずゼロ</strong>になる——<span class="tex2jax_process">$\mathbf{v}_1 = \mathbf{v}_2$</span> なら <span class="tex2jax_process">$V(\mathbf{v}_1,\mathbf{v}_1,\mathbf{v}_3) = -V(\mathbf{v}_1,\mathbf{v}_1,\mathbf{v}_3)$</span> だから <span class="tex2jax_process">$V=0$</span> である。図形としては平行六面体が潰れるが、<strong>代数では交代性だけで「潰れてゼロ」が強制される</strong>。これが2次元の面積測定器のルール2と同じ構造だ。
 </p>
 <strong>ルール3（規格化 — 単位立方体の体積を1とする）</strong>
-<p>$$V(\hat{e}_x, \hat{e}_y, \hat{e}_z) = 1$$
-</p>
+<div class="math-block tex2jax_process">$$V(\hat{e}_x, \hat{e}_y, \hat{e}_z) = 1$$</div>
 <h4 id="252-ルールから形を決める基底展開と消去">2.5.2 ルールから形を決める——基底展開と消去</h4>
 <p>§2.3 で面積測定器の行列を導いたときと同じ手順を踏もう。3つのベクトルを基底で展開する：
-$$\mathbf{v}_1 = x_1 \hat{e}_x + y_1 \hat{e}_y + z_1 \hat{e}_z, \quad \mathbf{v}_2 = x_2 \hat{e}_x + y_2 \hat{e}_y + z_2 \hat{e}_z, \quad \mathbf{v}_3 = x_3 \hat{e}_x + y_3 \hat{e}_y + z_3 \hat{e}_z$$
 </p>
-<p>ルール1（多重線形性）により、$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$ は $3 \times 3 \times 3 = 27$ 個の項に展開される：
-$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k v_{1i}\,v_{2j}\,v_{3k}\; V(\hat{e}_i, \hat{e}_j, \hat{e}_k)$$
-ここで $i, j, k$ はそれぞれ<strong>独立に</strong> $x, y, z$ のいずれかをとる添字だ（「走る」＝和をとるときに $x,y,z$ の三通りそれぞれをめぐる、と読めばよい）。
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 = x_1 \hat{e}_x + y_1 \hat{e}_y + z_1 \hat{e}_z, \quad \mathbf{v}_2 = x_2 \hat{e}_x + y_2 \hat{e}_y + z_2 \hat{e}_z, \quad \mathbf{v}_3 = x_3 \hat{e}_x + y_3 \hat{e}_y + z_3 \hat{e}_z$$</div>
+<p>ルール1（多重線形性）により、<span class="tex2jax_process">$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$</span> は <span class="tex2jax_process">$3 \times 3 \times 3 = 27$</span> 個の項に展開される：
+</p>
+<div class="math-block tex2jax_process">$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k v_{1i}\,v_{2j}\,v_{3k}\; V(\hat{e}_i, \hat{e}_j, \hat{e}_k)$$</div>
+<p>ここで <span class="tex2jax_process">$i, j, k$</span> はそれぞれ<strong>独立に</strong> <span class="tex2jax_process">$x, y, z$</span> のいずれかをとる添字だ（「走る」＝和をとるときに <span class="tex2jax_process">$x,y,z$</span> の三通りそれぞれをめぐる、と読めばよい）。
 </p>
 <p>27項は多いが、ルール2（交代性）が大量の項を消してくれる：
 <ul>
-<li>添字に**重複がある項はすべてゼロ**（例：$V(\hat{e}_x, \hat{e}_x, \hat{e}_z) = 0$）</li>
+<li>添字に**重複がある項はすべてゼロ**（例：<span class="tex2jax_process">$V(\hat{e}_x, \hat{e}_x, \hat{e}_z) = 0$</span>）</li>
 </ol>
 <ul>
-<li>重複のない組み合わせは $i, j, k$ がすべて異なる場合だけ、すなわち $(x,y,z)$ の**置換**</li>
+<li>重複のない組み合わせは <span class="tex2jax_process">$i, j, k$</span> がすべて異なる場合だけ、すなわち <span class="tex2jax_process">$(x,y,z)$</span> の**置換**</li>
 </ol>
-<p>$(x, y, z)$ の置換は全部で $3! = 6$ 通り。交代性により、偶置換は $V(\hat{e}_x, \hat{e}_y, \hat{e}_z)$ と同符号、奇置換は反対符号になる。ルール3で $V(\hat{e}_x, \hat{e}_y, \hat{e}_z) = 1$ と決めたから：
-</p>
+<span class="tex2jax_process">$(x, y, z)$</span> の置換は全部で <span class="tex2jax_process">$3! = 6$</span> 通り。交代性により、偶置換は <span class="tex2jax_process">$V(\hat{e}_x, \hat{e}_y, \hat{e}_z)$</span> と同符号、奇置換は反対符号になる。ルール3で <span class="tex2jax_process">$V(\hat{e}_x, \hat{e}_y, \hat{e}_z) = 1$</span> と決めたから：
 <p>| 置換 | 偶/奇 | 値 |
 |------|-------|----|
-| $(x,y,z)$ | 偶（0回交換） | $+1$ |
-| $(y,z,x)$ | 偶（2回交換） | $+1$ |
-| $(z,x,y)$ | 偶（2回交換） | $+1$ |
-| $(y,x,z)$ | 奇（1回交換） | $-1$ |
-| $(x,z,y)$ | 奇（1回交換） | $-1$ |
-| $(z,y,x)$ | 奇（1回交換） | $-1$ |
+| <span class="tex2jax_process">$(x,y,z)$</span> | 偶（0回交換） | <span class="tex2jax_process">$+1$</span> |
+| <span class="tex2jax_process">$(y,z,x)$</span> | 偶（2回交換） | <span class="tex2jax_process">$+1$</span> |
+| <span class="tex2jax_process">$(z,x,y)$</span> | 偶（2回交換） | <span class="tex2jax_process">$+1$</span> |
+| <span class="tex2jax_process">$(y,x,z)$</span> | 奇（1回交換） | <span class="tex2jax_process">$-1$</span> |
+| <span class="tex2jax_process">$(x,z,y)$</span> | 奇（1回交換） | <span class="tex2jax_process">$-1$</span> |
+| <span class="tex2jax_process">$(z,y,x)$</span> | 奇（1回交換） | <span class="tex2jax_process">$-1$</span> |
 </p>
 <p>したがって：
-$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_2 x_3$$
 </p>
+<div class="math-block tex2jax_process">$$V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_2 x_3$$</div>
 <p>線形代数を学んだ読者なら、3つのベクトルを列に並べた行列
-$$\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$
-の<strong>行列式（determinant）</strong>に見えるはずだ。知らない読者も、<strong>いまこの6項の和を「行列式」と呼ぶ</strong>と決めて先に進んでかまわない——上のルールからこの形に落ちた、という事実のほうが本質である。
 </p>
-<p>ここで押さえたいのは次の一点だけだ。行列式は、単なる「成分を掛けて引く手続き」にとどまらず、<strong>3本の列ベクトルをこの順に食わせたときの「符号付き体積」という1つの数</strong>を返す演算子としても読める。第1章の $1$-form は「ベクトル1つ → スカラー」、§2.3 の $2$-form は「ベクトル2つ → スカラー」——行列式は「ベクトル3つ → スカラー」で、この系列をつなぐ。
+<div class="math-block tex2jax_process">$$\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$</div>
+<p>の<strong>行列式（determinant）</strong>に見えるはずだ。知らない読者も、<strong>いまこの6項の和を「行列式」と呼ぶ</strong>と決めて先に進んでかまわない——上のルールからこの形に落ちた、という事実のほうが本質である。
+</p>
+<p>ここで押さえたいのは次の一点だけだ。行列式は、単なる「成分を掛けて引く手続き」にとどまらず、<strong>3本の列ベクトルをこの順に食わせたときの「符号付き体積」という1つの数</strong>を返す演算子としても読める。第1章の <span class="tex2jax_process">$1$</span>-form は「ベクトル1つ → スカラー」、§2.3 の <span class="tex2jax_process">$2$</span>-form は「ベクトル2つ → スカラー」——行列式は「ベクトル3つ → スカラー」で、この系列をつなぐ。
 </p>
 <p>面積測定器のときは反対称行列、体積測定器のときは行列式が立ち上がったが、<strong>いずれも、先に課したルールが代数的な形を決めた</strong>のだ。
 </p>
 <blockquote><p>**注** （行列式の6項の順序）教科書によっては、いきなり「行列式の定義はこの6項」と置く。本書の流れでは、**測定器のルール → 6項**の順である。</p>
 </p></blockquote>
-<h4 id="253-form-の行列式としての再解釈">2.5.3 $2$-form の行列式としての再解釈</h4>
-<p>実は、§2.4 で定義した $2$-form のウェッジ積にも、行列式が隠れていた。定義を振り返ろう：
-$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) - dy(\mathbf{v}_1)\,dx(\mathbf{v}_2)$$
+<h4 id="253-span-classtex2jaxprocessspan-form-の行列式としての再解釈">2.5.3 <span class="tex2jax_process">$2$</span>-form の行列式としての再解釈</h4>
+<p>実は、§2.4 で定義した <span class="tex2jax_process">$2$</span>-form のウェッジ積にも、行列式が隠れていた。定義を振り返ろう：
 </p>
-<p>右辺は、次の $2 \times 2$ 行列式に他ならない：
-$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) - dy(\mathbf{v}_1)\,dx(\mathbf{v}_2)$$</div>
+<p>右辺は、次の <span class="tex2jax_process">$2 \times 2$</span> 行列式に他ならない：
 </p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$</div>
 <p>つまり、横に「どの物差しか」、縦に「どのベクトルか」を並べた行列の行列式が、ウェッジ積の値だったのだ。
 </p>
-<h4 id="254-の定義行列式パターンの完成">2.5.4 $dx \wedge dy \wedge dz$ の定義——行列式パターンの完成</h4>
-<p>この「行列式パターン」を素直に $3 \times 3$ に拡張すれば、体積測定器が手に入る。
+<h4 id="254-span-classtex2jaxprocessspan-の定義行列式パターンの完成">2.5.4 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の定義——行列式パターンの完成</h4>
+<p>この「行列式パターン」を素直に <span class="tex2jax_process">$3 \times 3$</span> に拡張すれば、体積測定器が手に入る。
 </p>
-<strong>定義：</strong> 3つのベクトル $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ に対し、
-<p>$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) := \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) & dx(\mathbf{v}_3) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) & dy(\mathbf{v}_3) \\ dz(\mathbf{v}_1) & dz(\mathbf{v}_2) & dz(\mathbf{v}_3) \end{pmatrix}$$
+<strong>定義：</strong> 3つのベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$</span> に対し、
+<div class="math-block tex2jax_process">$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) := \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) & dx(\mathbf{v}_3) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) & dy(\mathbf{v}_3) \\ dz(\mathbf{v}_1) & dz(\mathbf{v}_2) & dz(\mathbf{v}_3) \end{pmatrix}$$</div>
+<p>右辺の各成分は「一次形式 <span class="tex2jax_process">$dx, dy, dz$</span> がベクトル <span class="tex2jax_process">$\mathbf{v}_i$</span> から抽出した座標成分」だから、これはまさに：
 </p>
-<p>右辺の各成分は「一次形式 $dx, dy, dz$ がベクトル $\mathbf{v}_i$ から抽出した座標成分」だから、これはまさに：
-$$= \det\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$
-</p>
-<p>§2.5.2 で導いた $V$ と完全に一致する。<strong>体積測定器は、3つの物差し $dx, dy, dz$ のウェッジ積として構成できた。</strong>
+<div class="math-block tex2jax_process">$$= \det\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pmatrix}$$</div>
+<p>§2.5.2 で導いた <span class="tex2jax_process">$V$</span> と完全に一致する。<strong>体積測定器は、3つの物差し <span class="tex2jax_process">$dx, dy, dz$</span> のウェッジ積として構成できた。</strong>
 </p>
 <p>線形代数で行列式を学んだ読者なら、この定義が §2.5.1 の3ルールを満たすことが容易に分かるだろう：
 <ul>
@@ -1320,67 +1336,65 @@ $$= \det\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \e
 <li>**交代性**：行列式の2つの列を入れ替えると符号が反転する。</li>
 </ol>
 <ul>
-<li>**規格化**：$\hat{e}_x, \hat{e}_y, \hat{e}_z$ を入れると行列は単位行列になり、$\det(I) = 1$。</li>
+<li>**規格化**：<span class="tex2jax_process">$\hat{e}_x, \hat{e}_y, \hat{e}_z$</span> を入れると行列は単位行列になり、<span class="tex2jax_process">$\det(I) = 1$</span>。</li>
 </ol>
-<h4 id="255-体積測定器のテンソル積表現-ブロックを横に並べた配列">2.5.5 体積測定器のテンソル積表現——$3 \times 3$ ブロックを横に並べた配列</h4>
-<p>§2.4.3–2.4.4 で我々は、面積測定器 $dx \wedge dy$ がテンソル積の引き算 $dx \otimes dy - dy \otimes dx$ で構成でき、その結果が $3 \times 3$ の反対称行列であることを見た。体積測定器 $dx \wedge dy \wedge dz$ にも同じ手が使えるだろうか？
+<h4 id="255-体積測定器のテンソル積表現span-classtex2jaxprocessspan-ブロックを横に並べた配列">2.5.5 体積測定器のテンソル積表現——<span class="tex2jax_process">$3 \times 3$</span> ブロックを横に並べた配列</h4>
+<p>§2.4.3–2.4.4 で我々は、面積測定器 <span class="tex2jax_process">$dx \wedge dy$</span> がテンソル積の引き算 <span class="tex2jax_process">$dx \otimes dy - dy \otimes dx$</span> で構成でき、その結果が <span class="tex2jax_process">$3 \times 3$</span> の反対称行列であることを見た。体積測定器 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> にも同じ手が使えるだろうか？
 </p>
-<p>なぜここで敢えてテンソル配列を持ち出すのか——それは、<strong>ベクトル3本を食べて行列式を返す操作が、実は面積測定器のときとまったく同じ「添字の縮約」という統一的視点で書ける</strong>ことを示すためである。これを理解すれば、$1$-form・$2$-form・$3$-form がすべて同じ原理で動いていることが見えてくる。
+<p>なぜここで敢えてテンソル配列を持ち出すのか——それは、<strong>ベクトル3本を食べて行列式を返す操作が、実は面積測定器のときとまったく同じ「添字の縮約」という統一的視点で書ける</strong>ことを示すためである。これを理解すれば、<span class="tex2jax_process">$1$</span>-form・<span class="tex2jax_process">$2$</span>-form・<span class="tex2jax_process">$3$</span>-form がすべて同じ原理で動いていることが見えてくる。
 </p>
-<p>答えはイエスだ。ただし、2つの物差しのテンソル積は $3 \times 3$ 行列に収まったが、3つの物差しでは添字が1つ増えて $3 \times 3 \times 3 = 27$ 成分の<strong>3次元配列</strong>になる。添字を3つ持つこのような多次元配列は数学でも物理学でも<strong>テンソル</strong>（tensor）と呼ばれる。行列（添字2つ）はテンソルの特殊例であり、今回登場するのは添字を3つ持つ<strong>3階のテンソル</strong>だ。
+<p>答えはイエスだ。ただし、2つの物差しのテンソル積は <span class="tex2jax_process">$3 \times 3$</span> 行列に収まったが、3つの物差しでは添字が1つ増えて <span class="tex2jax_process">$3 \times 3 \times 3 = 27$</span> 成分の<strong>3次元配列</strong>になる。添字を3つ持つこのような多次元配列は数学でも物理学でも<strong>テンソル</strong>（tensor）と呼ばれる。行列（添字2つ）はテンソルの特殊例であり、今回登場するのは添字を3つ持つ<strong>3階のテンソル</strong>だ。
 </p>
-<p>ところで、3階以上のテンソルは、全成分を書き並べると紙面が爆発するので、さすがの物理学者もめったに配列表示はしない。代わりに成分 $\epsilon_{ijk}$ のように<strong>添字つきの代表</strong>で書いて、あとの計算は添字の足し算ルールに任せるのが通常のやり方だ。本節でもその流儀に倣い、必要に応じて成分だけを取り出して話を進める。
+<p>ところで、3階以上のテンソルは、全成分を書き並べると紙面が爆発するので、さすがの物理学者もめったに配列表示はしない。代わりに成分 <span class="tex2jax_process">$\epsilon_{ijk}$</span> のように<strong>添字つきの代表</strong>で書いて、あとの計算は添字の足し算ルールに任せるのが通常のやり方だ。本節でもその流儀に倣い、必要に応じて成分だけを取り出して話を進める。
 </p>
-<blockquote><p>**注** （テンソルの記法）テンソル代数では、しばしば $\epsilon_{ijk}$ という**書き方そのもの**が「3階テンソル全体」を指す。本書では紛らわしいので、**3階テンソル全体**を $\widehat{\epsilon}$ と書き、**1成分**を $\epsilon_{ijk}$ と書き分ける。行列表示（§2.3 の $3\times3$）と「成分1つ」を同一視しないということだ。他書を読む際には気を付けてほしい。</p>
+<blockquote><p>**注** （テンソルの記法）テンソル代数では、しばしば <span class="tex2jax_process">$\epsilon_{ijk}$</span> という**書き方そのもの**が「3階テンソル全体」を指す。本書では紛らわしいので、**3階テンソル全体**を <span class="tex2jax_process">$\widehat{\epsilon}$</span> と書き、**1成分**を <span class="tex2jax_process">$\epsilon_{ijk}$</span> と書き分ける。行列表示（§2.3 の <span class="tex2jax_process">$3\times3$</span>）と「成分1つ」を同一視しないということだ。他書を読む際には気を付けてほしい。</p>
 </p></blockquote>
-<blockquote><p>**注** （上付き・下付き添字）本書をのぞき見している数学者のために言い訳しておく。厳密な微分幾何やテンソル解析では、ベクトルと余ベクトル、基底と双対基底を区別するために**上付き・下付きの位置**で添字を書き分ける流儀がよく用いられる。本書は**デカルト直交座標**に固定して議論しており、この座標系では余ベクトル成分とベクトル成分の区別が表面化しないため、$\epsilon_{ijk}$ のように**すべて下付き**で通す。</p>
+<blockquote><p>**注** （上付き・下付き添字）本書をのぞき見している数学者のために言い訳しておく。厳密な微分幾何やテンソル解析では、ベクトルと余ベクトル、基底と双対基底を区別するために**上付き・下付きの位置**で添字を書き分ける流儀がよく用いられる。本書は**デカルト直交座標**に固定して議論しており、この座標系では余ベクトル成分とベクトル成分の区別が表面化しないため、<span class="tex2jax_process">$\epsilon_{ijk}$</span> のように**すべて下付き**で通す。</p>
 </p></blockquote>
-<p>さて、この27成分の配列を反対称化（6つの置換を符号つきで足す）すると、27成分のうち6箇所だけが $\pm 1$、残りはゼロの配列が立ち上がる。§2.5.2 で導いた置換の表そのものだ——成分の取り方は次のとおりだ（$\widehat{\epsilon}$ の $(i,j,k)$ 成分）：
+<p>さて、この27成分の配列を反対称化（6つの置換を符号つきで足す）すると、27成分のうち6箇所だけが <span class="tex2jax_process">$\pm 1$</span>、残りはゼロの配列が立ち上がる。§2.5.2 で導いた置換の表そのものだ——成分の取り方は次のとおりだ（<span class="tex2jax_process">$\widehat{\epsilon}$</span> の <span class="tex2jax_process">$(i,j,k)$</span> 成分）：
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \epsilon_{ijk} = \begin{cases} +1 & (i,j,k) \text{ が } (x,y,z) \text{ の偶置換} \\ -1 & (i,j,k) \text{ が } (x,y,z) \text{ の奇置換} \\ 0 & \text{添字に重複あり} \end{cases}
-$$
+$$</div>
+<p>27個の数をどう並べて見せるか——良い方法がある。<strong><span class="tex2jax_process">$3 \times 3$</span> 行列を3枚、横一列に並べた</strong>と考えるとよい：
 </p>
-<p>27個の数をどう並べて見せるか——良い方法がある。<strong>$3 \times 3$ 行列を3枚、横一列に並べた</strong>と考えるとよい：
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \widehat{\epsilon} \;\longleftrightarrow\;
 \begin{pmatrix}
 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
-$$
-</p>
-<p>第1添字 $i$ が「左から何枚目の断面か」を指定し、各断面の中身は $j,k$ で添字づけされた $3 \times 3$ ブロックだ。
+$$</div>
+<p>第1添字 <span class="tex2jax_process">$i$</span> が「左から何枚目の断面か」を指定し、各断面の中身は <span class="tex2jax_process">$j,k$</span> で添字づけされた <span class="tex2jax_process">$3 \times 3$</span> ブロックだ。
 </p>
 <p>ここで、
-$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$$
-としたとき、$1$-form（横ベクトル）が縦ベクトルを食べてスカラーを返すアナロジーの延長として、左から $i$ 枚目のブロック $M_i$ と成分 $v_{1i}$ を添字 $i$ で対応付けて掛けて足す——すなわち
-$$
+</p>
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix}$$</div>
+<p>としたとき、<span class="tex2jax_process">$1$</span>-form（横ベクトル）が縦ベクトルを食べてスカラーを返すアナロジーの延長として、左から <span class="tex2jax_process">$i$</span> 枚目のブロック <span class="tex2jax_process">$M_i$</span> と成分 <span class="tex2jax_process">$v_{1i}$</span> を添字 <span class="tex2jax_process">$i$</span> で対応付けて掛けて足す——すなわち
+</p>
+<div class="math-block tex2jax_process">$$
 M := x_1 M_1 + y_1 M_2 + z_1 M_3 = \sum_{i=1}^3 v_{1i}\, M_i
-$$
-と定めれば、結果は一つの $3 \times 3$ 行列に落ちる。
+$$</div>
+<p>と定めれば、結果は一つの <span class="tex2jax_process">$3 \times 3$</span> 行列に落ちる。
 なお、実はこの3つのブロックは、§2.4.4–2.4.5 で構成した<strong>面積測定器の行列そのもの</strong>となり、対応は次のとおりだ：
 </p>
-<p>| 左から $i$ 枚目 | 正体 |
+<p>| 左から <span class="tex2jax_process">$i$</span> 枚目 | 正体 |
 |:---:|:---:|
-| $i=1$ | $dy \wedge dz$（$yz$ 平面の面積測定器） |
-| $i=2$ | $dz \wedge dx$（$zx$ 平面の面積測定器） |
-| $i=3$ | $dx \wedge dy$（$xy$ 平面の面積測定器） |
+| <span class="tex2jax_process">$i=1$</span> | <span class="tex2jax_process">$dy \wedge dz$</span>（<span class="tex2jax_process">$yz$</span> 平面の面積測定器） |
+| <span class="tex2jax_process">$i=2$</span> | <span class="tex2jax_process">$dz \wedge dx$</span>（<span class="tex2jax_process">$zx$</span> 平面の面積測定器） |
+| <span class="tex2jax_process">$i=3$</span> | <span class="tex2jax_process">$dx \wedge dy$</span>（<span class="tex2jax_process">$xy$</span> 平面の面積測定器） |
 </p>
 <strong>ベクトル3本を食べてスカラーに潰す</strong>
-<p>$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ を代入する手順は、<strong>配列の添字とベクトル成分を、合うところどうしで掛けて足す</strong>——と見るのが早い：
-</p>
-<p>$$
+<span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$</span> を代入する手順は、<strong>配列の添字とベクトル成分を、合うところどうしで掛けて足す</strong>——と見るのが早い：
+<div class="math-block tex2jax_process">$$
 V(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \sum_i\sum_j\sum_k \epsilon_{ijk}\, v_{1i}\, v_{2j}\, v_{3k}
-$$
-</p>
+$$</div>
 <ul>
-<li>**ステップ1（3次元配列 → 行列）：** 添字 $i$ について、$\mathbf{v}_1$ の各成分で3つの面積測定器行列を重みづけして足す——すなわち $\displaystyle M = \sum_{i=1}^3 v_{1i}\,\epsilon_{i,\cdot,\cdot}$（$\epsilon_{i,\cdot,\cdot}$ は $\widehat{\epsilon}$ の左から $i$ 枚目の $3 \times 3$ ブロック）。結果は1つの $3 \times 3$ 行列 $M$ に降りる。</li>
+<li>**ステップ1（3次元配列 → 行列）：** 添字 <span class="tex2jax_process">$i$</span> について、<span class="tex2jax_process">$\mathbf{v}_1$</span> の各成分で3つの面積測定器行列を重みづけして足す——すなわち <span class="tex2jax_process">$\displaystyle M = \sum_{i=1}^3 v_{1i}\,\epsilon_{i,\cdot,\cdot}$</span>（<span class="tex2jax_process">$\epsilon_{i,\cdot,\cdot}$</span> は <span class="tex2jax_process">$\widehat{\epsilon}$</span> の左から <span class="tex2jax_process">$i$</span> 枚目の <span class="tex2jax_process">$3 \times 3$</span> ブロック）。結果は1つの <span class="tex2jax_process">$3 \times 3$</span> 行列 <span class="tex2jax_process">$M$</span> に降りる。</li>
 </ol>
 <ul>
-<li>**ステップ2（行列 → スカラー）：** 残り2本で「横 $\times$ 行列 $\times$ 縦」—— $V = \mathbf{v}_2^T\, M\, \mathbf{v}_3$。§2.4 で慣れ親しんだ操作だ。</li>
+<li>**ステップ2（行列 → スカラー）：** 残り2本で「横 <span class="tex2jax_process">$\times$</span> 行列 <span class="tex2jax_process">$\times$</span> 縦」—— <span class="tex2jax_process">$V = \mathbf{v}_2^T\, M\, \mathbf{v}_3$</span>。§2.4 で慣れ親しんだ操作だ。</li>
 </ol>
 <blockquote><p>**注** （縮約）上の「共通添字で和をとって次元を落とす」操作を**縮約**と呼ぶ。実は内積や行列の挟み込みも縮約の一種とみなせる。</p>
 </p></blockquote>
@@ -1389,156 +1403,142 @@ $$
 <h4 id="256-具体例平行六面体の符号付き体積">2.5.6 具体例：平行六面体の符号付き体積</h4>
 <p>手を動かして確認しよう。§2.4.5 で面積を測った2つのベクトルに、3つ目を加えてみる：
 </p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix}1\\0\\1\end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix}0\\1\\1\end{pmatrix}, \quad \mathbf{v}_3 = \begin{pmatrix}1\\1\\0\end{pmatrix}$$
-</p>
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 = \begin{pmatrix}1\\0\\1\end{pmatrix}, \quad \mathbf{v}_2 = \begin{pmatrix}0\\1\\1\end{pmatrix}, \quad \mathbf{v}_3 = \begin{pmatrix}1\\1\\0\end{pmatrix}$$</div>
 <p>体積測定器に投入する：
-$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \det\begin{pmatrix}1 & 0 & 1 \\ 0 & 1 & 1 \\ 1 & 1 & 0\end{pmatrix}$$
 </p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3) = \det\begin{pmatrix}1 & 0 & 1 \\ 0 & 1 & 1 \\ 1 & 1 & 0\end{pmatrix}$$</div>
 <p>これを定義に従って計算すると：
-$$= 1\cdot1\cdot0 + 0\cdot1\cdot1 + 1\cdot0\cdot1 - 1\cdot1\cdot1 - 0\cdot0\cdot0 - 1\cdot1\cdot1 = 0 + 0 + 0 - 1 - 0 - 1 = -2$$
 </p>
+<div class="math-block tex2jax_process">$$= 1\cdot1\cdot0 + 0\cdot1\cdot1 + 1\cdot0\cdot1 - 1\cdot1\cdot1 - 0\cdot0\cdot0 - 1\cdot1\cdot1 = 0 + 0 + 0 - 1 - 0 - 1 = -2$$</div>
 <blockquote><p>**注** （体積が負？）§2.2 の向き付き面積と同じで、**順序**によってはマイナスがあり得る。</p>
 </p></blockquote>
-<p>試しに $\mathbf{v}_1$ と $\mathbf{v}_2$ を入れ替えてみよう：
-$$(dx \wedge dy \wedge dz)(\mathbf{v}_2, \mathbf{v}_1, \mathbf{v}_3) = -(-2) = +2$$
+<p>試しに <span class="tex2jax_process">$\mathbf{v}_1$</span> と <span class="tex2jax_process">$\mathbf{v}_2$</span> を入れ替えてみよう：
 </p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy \wedge dz)(\mathbf{v}_2, \mathbf{v}_1, \mathbf{v}_3) = -(-2) = +2$$</div>
 <h4 id="257-スカラー三重積との符合">2.5.7 スカラー三重積との符合</h4>
 <p>ベクトル解析で「スカラー三重積」を学んだ読者は、次の恒等式を知っているかもしれない：
-$$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3\end{pmatrix}$$
 </p>
-<p>右辺は、我々が定義した $(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$ そのものだ。
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3\end{pmatrix}$$</div>
+<p>右辺は、我々が定義した <span class="tex2jax_process">$(dx \wedge dy \wedge dz)(\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3)$</span> そのものだ。
 </p>
-<blockquote><p>**注** （内積記号の先取り）左辺の「$\cdot$」は**内積**の記号であり、ここでは小学校以来おなじみの「成分ごとの積の和」という意味で使っている。第6章で計量 $g$ を使った形式的な定義を与える。</p>
+<blockquote><p>**注** （内積記号の先取り）左辺の「<span class="tex2jax_process">$\cdot$</span>」は**内積**の記号であり、ここでは小学校以来おなじみの「成分ごとの積の和」という意味で使っている。第6章で計量 <span class="tex2jax_process">$g$</span> を使った形式的な定義を与える。</p>
 </p></blockquote>
 <h4 id="258-体積における図形側の基底">2.5.8 体積における「図形側の基底」</h4>
 <p>面積（2次元）のときと同じように、ここでも「はかり」と「図形」を明確に分けておこう。
 </p>
-<p>我々が組み立てた $dx \wedge dy \wedge dz$ は、あくまで3つのベクトルを待ち構える<strong>体積測定器（$3$-form）</strong>である。
-これに対して、3つのベクトル $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ によって作られる「平行六面体という図形そのもの（向き付き体積）」は、縦ベクトル同士のウェッジ積で作られる<strong>「三重ベクトル（体積要素）」</strong>の基底に乗る。
+<p>我々が組み立てた <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> は、あくまで3つのベクトルを待ち構える<strong>体積測定器（<span class="tex2jax_process">$3$</span>-form）</strong>である。
+これに対して、3つのベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$</span> によって作られる「平行六面体という図形そのもの（向き付き体積）」は、縦ベクトル同士のウェッジ積で作られる<strong>「三重ベクトル（体積要素）」</strong>の基底に乗る。
 </p>
-<p>3次元空間における体積要素の基底は、$\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z$ のただ1種類しかない（順番を変えても符号が変わるだけだ）。
+<p>3次元空間における体積要素の基底は、<span class="tex2jax_process">$\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z$</span> のただ1種類しかない（順番を変えても符号が変わるだけだ）。
 したがって、測られた「向き付き体積」のデータは、次のように書ける。
 </p>
-<p>$$\text{向き付き体積} = V\,(\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z)$$
+<div class="math-block tex2jax_process">$$\text{向き付き体積} = V\,(\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z)$$</div>
+<p>係数となる <span class="tex2jax_process">$V$</span> は、体積測定器にベクトルを入れて計算した行列式の値（§2.5.6 の例なら <span class="tex2jax_process">$-2$</span>）である。
+そして「小学校の正の体積（スカラー体積）」が欲しければ、成分の二乗和の平方根（<span class="tex2jax_process">$\sqrt{V^2} = |V|$</span>）をとればよい。独立成分が1つしかないので、ただの絶対値になるというわけだ。
 </p>
-<p>係数となる $V$ は、体積測定器にベクトルを入れて計算した行列式の値（§2.5.6 の例なら $-2$）である。
-そして「小学校の正の体積（スカラー体積）」が欲しければ、成分の二乗和の平方根（$\sqrt{V^2} = |V|$）をとればよい。独立成分が1つしかないので、ただの絶対値になるというわけだ。
+<h4 id="259-span-classtex2jaxprocessspan-form-のサイズなぜ独立成分は1つだけか">2.5.9 <span class="tex2jax_process">$3$</span>-form の「サイズ」——なぜ独立成分は1つだけか</h4>
+<p>面積測定器（<span class="tex2jax_process">$2$</span>-form）は <span class="tex2jax_process">$3 \times 3$</span> 反対称行列で表現でき、独立な成分は3つだった（<span class="tex2jax_process">$dy \wedge dz$</span>, <span class="tex2jax_process">$dz \wedge dx$</span>, <span class="tex2jax_process">$dx \wedge dy$</span> の係数）。
 </p>
-<h4 id="259-form-のサイズなぜ独立成分は1つだけか">2.5.9 $3$-form の「サイズ」——なぜ独立成分は1つだけか</h4>
-<p>面積測定器（$2$-form）は $3 \times 3$ 反対称行列で表現でき、独立な成分は3つだった（$dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ の係数）。
+<p>では体積測定器（<span class="tex2jax_process">$3$</span>-form）の独立成分はいくつか？ 基底 <span class="tex2jax_process">$3$</span>-form として作れる候補を考えてみよう。3つの物差し <span class="tex2jax_process">$dx, dy, dz$</span> から<strong>重複なく</strong>3つを選ぶ方法は……1通りしかない。<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> だけだ（順序を変えると符号が変わるだけで、新しい基底にはならない）。
 </p>
-<p>では体積測定器（$3$-form）の独立成分はいくつか？ 基底 $3$-form として作れる候補を考えてみよう。3つの物差し $dx, dy, dz$ から<strong>重複なく</strong>3つを選ぶ方法は……1通りしかない。$dx \wedge dy \wedge dz$ だけだ（順序を変えると符号が変わるだけで、新しい基底にはならない）。
-</p>
-<blockquote><p>**注** （ホッジ双対の伏線）読者はお気づきだろうか——体積の向きは、面積のときとは違って $+/-$ のスカラー1つに収まった。§2.4.6 で面積のときに行ったような「ごまかし」の告白を、体積の側でもう一度繰り返す羽目にならずに済んだのは、$3$-form の独立成分がちょうど1つだからだ。そしてこれは偶然ではない。$0$-form（スカラー場）の独立成分も1つ、$1$-form の独立成分は3つ、$2$-form の独立成分も3つ——つまり $1, 3, 3, 1$ と、両端から鏡写しになっている。この並びは、**ホッジ双対**という対称性の前触れだ。詳しくは後の章で。</p>
+<blockquote><p>**注** （ホッジ双対の伏線）読者はお気づきだろうか——体積の向きは、面積のときとは違って <span class="tex2jax_process">$+/-$</span> のスカラー1つに収まった。§2.4.6 で面積のときに行ったような「ごまかし」の告白を、体積の側でもう一度繰り返す羽目にならずに済んだのは、<span class="tex2jax_process">$3$</span>-form の独立成分がちょうど1つだからだ。そしてこれは偶然ではない。<span class="tex2jax_process">$0$</span>-form（スカラー場）の独立成分も1つ、<span class="tex2jax_process">$1$</span>-form の独立成分は3つ、<span class="tex2jax_process">$2$</span>-form の独立成分も3つ——つまり <span class="tex2jax_process">$1, 3, 3, 1$</span> と、両端から鏡写しになっている。この並びは、**ホッジ双対**という対称性の前触れだ。詳しくは後の章で。</p>
 </p></blockquote>
 <h4 id="2510-測定器の階層第2章で手に入れた武器の整理">2.5.10 測定器の階層——第2章で手に入れた武器の整理</h4>
 <p>ここで、我々が第1章から積み上げてきた「測定器」の全体像を俯瞰しよう。
 </p>
-<p>§2.4.8 以降、とくに §2.5.8（図形側の三重ベクトル）と §2.5.9（独立成分の個数）までを通じて、<strong>次元 $k$ ごとに「はかり（$k$-form）」と「図形（$k$-ベクトル）」の横と縦の関係</strong>が同じ型で繰り返されることが見えてきた。データの成分の個数と、「スカラー（正の大きさ）」の取り出し方を一枚の表にまとめると、次のとおりだ。
+<p>§2.4.8 以降、とくに §2.5.8（図形側の三重ベクトル）と §2.5.9（独立成分の個数）までを通じて、<strong>次元 <span class="tex2jax_process">$k$</span> ごとに「はかり（<span class="tex2jax_process">$k$</span>-form）」と「図形（<span class="tex2jax_process">$k$</span>-ベクトル）」の横と縦の関係</strong>が同じ型で繰り返されることが見えてきた。データの成分の個数と、「スカラー（正の大きさ）」の取り出し方を一枚の表にまとめると、次のとおりだ。
 </p>
-<p>| 次元 ($k$) | はかり（$k$-form） | 図形（$k$-ベクトル） | 値（データ）の出方 | スカラーの取り出し方 |
+<p>| 次元 (<span class="tex2jax_process">$k$</span>) | はかり（<span class="tex2jax_process">$k$</span>-form） | 図形（<span class="tex2jax_process">$k$</span>-ベクトル） | 値（データ）の出方 | スカラーの取り出し方 |
 | :--- | :--- | :--- | :--- | :--- |
-| <strong>0次元</strong> | $0$-form（スカラー場 $f$） | 点 | 1成分（$f$） | $\sqrt{f^2}$  |
-| <strong>1次元</strong> | $1$-form（$dx, dy, dz$） | ベクトル（$\hat{e}_x$ 等） | 3成分（$x, y, z$） | $\sqrt{x^2 + y^2 + z^2}$ |
-| <strong>2次元</strong> | $2$-form（$dy \wedge dz$ 等） | 二重ベクトル（$\hat{e}_y \wedge \hat{e}_z$ 等） | 係数3つ（$A_{yz}, A_{zx}, A_{xy}$） | $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ |
-| <strong>3次元</strong> | $3$-form（$dx \wedge dy \wedge dz$） | 三重ベクトル（$\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z$） | 1成分（$V$） | $\sqrt{V^2}$ |
+| <strong>0次元</strong> | <span class="tex2jax_process">$0$</span>-form（スカラー場 <span class="tex2jax_process">$f$</span>） | 点 | 1成分（<span class="tex2jax_process">$f$</span>） | <span class="tex2jax_process">$\sqrt{f^2}$</span>  |
+| <strong>1次元</strong> | <span class="tex2jax_process">$1$</span>-form（<span class="tex2jax_process">$dx, dy, dz$</span>） | ベクトル（<span class="tex2jax_process">$\hat{e}_x$</span> 等） | 3成分（<span class="tex2jax_process">$x, y, z$</span>） | <span class="tex2jax_process">$\sqrt{x^2 + y^2 + z^2}$</span> |
+| <strong>2次元</strong> | <span class="tex2jax_process">$2$</span>-form（<span class="tex2jax_process">$dy \wedge dz$</span> 等） | 二重ベクトル（<span class="tex2jax_process">$\hat{e}_y \wedge \hat{e}_z$</span> 等） | 係数3つ（<span class="tex2jax_process">$A_{yz}, A_{zx}, A_{xy}$</span>） | <span class="tex2jax_process">$\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$</span> |
+| <strong>3次元</strong> | <span class="tex2jax_process">$3$</span>-form（<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span>） | 三重ベクトル（<span class="tex2jax_process">$\hat{e}_x \wedge \hat{e}_y \wedge \hat{e}_z$</span>） | 1成分（<span class="tex2jax_process">$V$</span>） | <span class="tex2jax_process">$\sqrt{V^2}$</span> |
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 体積測定器 $dx \wedge dy \wedge dz$（$3$-form）は、3つの物差しのウェッジ積であり、その値は $3 \times 3$ 行列式に等しい。
-- $0$-form（1成分）→ $1$-form（3成分）→ $2$-form（3成分）→ $3$-form（1成分）と、$1, 3, 3, 1$ の対称性がある。
-- はかり（$k$-form）と図形（$k$-ベクトル）の横と縦の関係は、次元が変わっても同じ型で繰り返される。スカラーの大きさは成分の二乗和の平方根で取り出す。
+- 体積測定器 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span>（<span class="tex2jax_process">$3$</span>-form）は、3つの物差しのウェッジ積であり、その値は <span class="tex2jax_process">$3 \times 3$</span> 行列式に等しい。
+- <span class="tex2jax_process">$0$</span>-form（1成分）→ <span class="tex2jax_process">$1$</span>-form（3成分）→ <span class="tex2jax_process">$2$</span>-form（3成分）→ <span class="tex2jax_process">$3$</span>-form（1成分）と、<span class="tex2jax_process">$1, 3, 3, 1$</span> の対称性がある。
+- はかり（<span class="tex2jax_process">$k$</span>-form）と図形（<span class="tex2jax_process">$k$</span>-ベクトル）の横と縦の関係は、次元が変わっても同じ型で繰り返される。スカラーの大きさは成分の二乗和の平方根で取り出す。
 </p></blockquote>
 <h3 id="26-本章のまとめと第3章への展望">§2.6 本章のまとめと第3章への展望</h3>
 <blockquote><p>**【ここまでのチェックポイント — 第2章全体】**</p>
-- 面積とは「2つのベクトルの絡み合い」を測る反対称行列（$2$-form）であり、物理的ルールが行列の形を完全に決める。
-- ウェッジ積 $\wedge$ は「テンソル積の引き算」で反対称行列を構成する演算。3つの基底 $2$-form から場の係数を載せて一般の $2$-form を組み立てる（係数の意味は後章）。
-- 体積測定器 $dx \wedge dy \wedge dz$（$3$-form）は、3つの物差しのウェッジ積であり、その値は $3 \times 3$ 行列式に等しい。反対称化した $\widehat{\epsilon}$（成分 $\epsilon_{ijk}$、レヴィ=チヴィタ記号）と縮約でも表せる（付録Aで全成分を確認）。
+- 面積とは「2つのベクトルの絡み合い」を測る反対称行列（<span class="tex2jax_process">$2$</span>-form）であり、物理的ルールが行列の形を完全に決める。
+- ウェッジ積 <span class="tex2jax_process">$\wedge$</span> は「テンソル積の引き算」で反対称行列を構成する演算。3つの基底 <span class="tex2jax_process">$2$</span>-form から場の係数を載せて一般の <span class="tex2jax_process">$2$</span>-form を組み立てる（係数の意味は後章）。
+- 体積測定器 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span>（<span class="tex2jax_process">$3$</span>-form）は、3つの物差しのウェッジ積であり、その値は <span class="tex2jax_process">$3 \times 3$</span> 行列式に等しい。反対称化した <span class="tex2jax_process">$\widehat{\epsilon}$</span>（成分 <span class="tex2jax_process">$\epsilon_{ijk}$</span>、レヴィ=チヴィタ記号）と縮約でも表せる（付録Aで全成分を確認）。
 </p></blockquote>
-<p>本章では、第1章で揃えた物差し $dx, dy, dz$ から出発し、<strong>面積（$2$-form）と体積（$3$-form）を代数的に組み立てる</strong>ところまで来た。ウェッジ積は「幾何を直接描く」のではなく、<strong>測定器のルールを満たす式を機械的に生成する</strong>ための道具である。
+<p>本章では、第1章で揃えた物差し <span class="tex2jax_process">$dx, dy, dz$</span> から出発し、<strong>面積（<span class="tex2jax_process">$2$</span>-form）と体積（<span class="tex2jax_process">$3$</span>-form）を代数的に組み立てる</strong>ところまで来た。ウェッジ積は「幾何を直接描く」のではなく、<strong>測定器のルールを満たす式を機械的に生成する</strong>ための道具である。
 </p>
-<p>次章（第3章）では、これらの形式を<strong>曲線・曲面・領域に沿って集計する</strong>——すなわち線積分・面積分・体積分を、$1$-form / $2$-form / $3$-form の言葉で統一的に書き直す。さらに変数変換と<strong>引き戻し（pullback）</strong>が登場し、ヤコビアンが「影の計算」として自然に現れる。
+<p>次章（第3章）では、これらの形式を<strong>曲線・曲面・領域に沿って集計する</strong>——すなわち線積分・面積分・体積分を、<span class="tex2jax_process">$1$</span>-form / <span class="tex2jax_process">$2$</span>-form / <span class="tex2jax_process">$3$</span>-form の言葉で統一的に書き直す。さらに変数変換と<strong>引き戻し（pullback）</strong>が登場し、ヤコビアンが「影の計算」として自然に現れる。
 </p>
 <hr />
 <h2 id="第2章-付録A体積測定器のテンソル積表現--全成分の計算">第2章 付録A：体積測定器のテンソル積表現 — 全成分の計算</h2>
-<p>§2.5.5 で、$\widehat{\epsilon}$（成分 $\epsilon_{ijk}$）とベクトル3本との縮約で行列式に一致すると述べた。ここではその全過程を手計算で追い、一つ残らず確認する。
+<p>§2.5.5 で、<span class="tex2jax_process">$\widehat{\epsilon}$</span>（成分 <span class="tex2jax_process">$\epsilon_{ijk}$</span>）とベクトル3本との縮約で行列式に一致すると述べた。ここではその全過程を手計算で追い、一つ残らず確認する。
 </p>
 <h4 id="A1-テンソル積の3引数への拡張">A.1 テンソル積の3引数への拡張</h4>
-<p>復習しよう。$dx \otimes dy$ の $(i,j)$ 成分は、$dx$ の第 $i$ 成分と $dy$ の第 $j$ 成分の積だった：
-$$(dx \otimes dy)_{ij} = (dx)_i\,(dy)_j$$
+<p>復習しよう。<span class="tex2jax_process">$dx \otimes dy$</span> の <span class="tex2jax_process">$(i,j)$</span> 成分は、<span class="tex2jax_process">$dx$</span> の第 <span class="tex2jax_process">$i$</span> 成分と <span class="tex2jax_process">$dy$</span> の第 <span class="tex2jax_process">$j$</span> 成分の積だった：
 </p>
+<div class="math-block tex2jax_process">$$(dx \otimes dy)_{ij} = (dx)_i\,(dy)_j$$</div>
 <p>3つの物差しへの拡張は自然だ——添字を1つ増やすだけ：
-$$(dx \otimes dy \otimes dz)_{ijk} = (dx)_i\,(dy)_j\,(dz)_k$$
 </p>
-<p>$dx = (1\ 0\ 0)$, $dy = (0\ 1\ 0)$, $dz = (0\ 0\ 1)$ を代入すると、$3^3 = 27$ マスのうち $(i,j,k) = (1,2,3)$ の1箇所だけが $1$、残り26マスはすべて $0$ になる。他の5つの並べ替え（$dx \otimes dz \otimes dy$ など）もそれぞれ1箇所だけ非ゼロになる——$dy \otimes dx \otimes dz$ なら位置 $(2,1,3)$ に、$dz \otimes dy \otimes dx$ なら $(3,2,1)$ に $1$ が立つ。
-</p>
+<div class="math-block tex2jax_process">$$(dx \otimes dy \otimes dz)_{ijk} = (dx)_i\,(dy)_j\,(dz)_k$$</div>
+<span class="tex2jax_process">$dx = (1\ 0\ 0)$</span>, <span class="tex2jax_process">$dy = (0\ 1\ 0)$</span>, <span class="tex2jax_process">$dz = (0\ 0\ 1)$</span> を代入すると、<span class="tex2jax_process">$3^3 = 27$</span> マスのうち <span class="tex2jax_process">$(i,j,k) = (1,2,3)$</span> の1箇所だけが <span class="tex2jax_process">$1$</span>、残り26マスはすべて <span class="tex2jax_process">$0$</span> になる。他の5つの並べ替え（<span class="tex2jax_process">$dx \otimes dz \otimes dy$</span> など）もそれぞれ1箇所だけ非ゼロになる——<span class="tex2jax_process">$dy \otimes dx \otimes dz$</span> なら位置 <span class="tex2jax_process">$(2,1,3)$</span> に、<span class="tex2jax_process">$dz \otimes dy \otimes dx$</span> なら <span class="tex2jax_process">$(3,2,1)$</span> に <span class="tex2jax_process">$1$</span> が立つ。
 <h4 id="A2-反対称化6つの配列を符号つきで重ねる">A.2 反対称化——6つの配列を符号つきで重ねる</h4>
-<p>§2.4.4 で面積のとき $dx \wedge dy = dx \otimes dy - dy \otimes dx$（2項の符号つき和）だった。3つの物差しは デカルト座標における $dx, dy, dz$ である。その並べ替えは $3! = 6$ 通りだから、置換 $\sigma$ ごとに $(dx,dy,dz)$ を並べ替えた順にテンソル積 $\otimes$ でつなぎ、符号 $\mathrm{sgn}(\sigma)$ を付けて $S_3$ 上で和をとる、という意味である——すなわち次の6行の和を、置換の言葉で一行にまとめたものだ。
+<p>§2.4.4 で面積のとき <span class="tex2jax_process">$dx \wedge dy = dx \otimes dy - dy \otimes dx$</span>（2項の符号つき和）だった。3つの物差しは デカルト座標における <span class="tex2jax_process">$dx, dy, dz$</span> である。その並べ替えは <span class="tex2jax_process">$3! = 6$</span> 通りだから、置換 <span class="tex2jax_process">$\sigma$</span> ごとに <span class="tex2jax_process">$(dx,dy,dz)$</span> を並べ替えた順にテンソル積 <span class="tex2jax_process">$\otimes$</span> でつなぎ、符号 <span class="tex2jax_process">$\mathrm{sgn}(\sigma)$</span> を付けて <span class="tex2jax_process">$S_3$</span> 上で和をとる、という意味である——すなわち次の6行の和を、置換の言葉で一行にまとめたものだ。
 </p>
-<blockquote><p>**注** （対称群と置換の符号）$S_3$ は3次対称群（置換の集合）。$\mathrm{sgn}(\sigma)$ は**偶置換なら $+1$、奇置換なら $-1$** と定める符号。</p>
+<blockquote><p>**注** （対称群と置換の符号）<span class="tex2jax_process">$S_3$</span> は3次対称群（置換の集合）。<span class="tex2jax_process">$\mathrm{sgn}(\sigma)$</span> は**偶置換なら <span class="tex2jax_process">$+1$</span>、奇置換なら <span class="tex2jax_process">$-1$</span>** と定める符号。</p>
 </p></blockquote>
 <p>書き下すと：
 </p>
-<p>$$\underbrace{dx \otimes dy \otimes dz}_{(1,2,3)\text{ に }+1} - \underbrace{dx \otimes dz \otimes dy}_{(1,3,2)\text{ に }-1} + \underbrace{dy \otimes dz \otimes dx}_{(2,3,1)\text{ に }+1}$$
-$$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{dz \otimes dx \otimes dy}_{(3,1,2)\text{ に }+1} - \underbrace{dz \otimes dy \otimes dx}_{(3,2,1)\text{ に }-1}$$
-</p>
-<p>6つの「1箇所だけ非ゼロの配列」を符号つきで重ねると、27成分のうち6箇所だけが $\pm 1$ で、残り21箇所はゼロになる。§2.5.2 の置換の表と見比べてほしい——これが $\widehat{\epsilon}$ の各成分 $\epsilon_{ijk}$ を与える構成原理だ。
+<div class="math-block tex2jax_process">$$\underbrace{dx \otimes dy \otimes dz}_{(1,2,3)\text{ に }+1} - \underbrace{dx \otimes dz \otimes dy}_{(1,3,2)\text{ に }-1} + \underbrace{dy \otimes dz \otimes dx}_{(2,3,1)\text{ に }+1}$$</div>
+<div class="math-block tex2jax_process">$$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{dz \otimes dx \otimes dy}_{(3,1,2)\text{ に }+1} - \underbrace{dz \otimes dy \otimes dx}_{(3,2,1)\text{ に }-1}$$</div>
+<p>6つの「1箇所だけ非ゼロの配列」を符号つきで重ねると、27成分のうち6箇所だけが <span class="tex2jax_process">$\pm 1$</span> で、残り21箇所はゼロになる。§2.5.2 の置換の表と見比べてほしい——これが <span class="tex2jax_process">$\widehat{\epsilon}$</span> の各成分 <span class="tex2jax_process">$\epsilon_{ijk}$</span> を与える構成原理だ。
 </p>
 <h4 id="A3-各成分の行列を書き下す">A.3 各成分の行列を書き下す</h4>
 <p>§2.5.5 で示した3つの成分行列を、ここでは1マスずつ確認しよう。
 </p>
-<strong>第1成分（$i = 1$, $x$）：</strong> 6項のうち $i = 1$ を持つのは $(1,2,3)$ に $+1$ と $(1,3,2)$ に $-1$。
-<p>$$\epsilon_{1,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}$$
-</p>
-<strong>第2成分（$i = 2$, $y$）：</strong> $(2,3,1)$ に $+1$ と $(2,1,3)$ に $-1$。
-<p>$$\epsilon_{2,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}$$
-</p>
-<strong>第3成分（$i = 3$, $z$）：</strong> $(3,1,2)$ に $+1$ と $(3,2,1)$ に $-1$。
-<p>$$\epsilon_{3,\cdot,\cdot} = \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$
-</p>
-<p>繰り返しになるが、これらはそれぞれ $dy \wedge dz$、$dz \wedge dx$、$dx \wedge dy$ の行列そのものである。
+<strong>第1成分（<span class="tex2jax_process">$i = 1$</span>, <span class="tex2jax_process">$x$</span>）：</strong> 6項のうち <span class="tex2jax_process">$i = 1$</span> を持つのは <span class="tex2jax_process">$(1,2,3)$</span> に <span class="tex2jax_process">$+1$</span> と <span class="tex2jax_process">$(1,3,2)$</span> に <span class="tex2jax_process">$-1$</span>。
+<div class="math-block tex2jax_process">$$\epsilon_{1,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}$$</div>
+<strong>第2成分（<span class="tex2jax_process">$i = 2$</span>, <span class="tex2jax_process">$y$</span>）：</strong> <span class="tex2jax_process">$(2,3,1)$</span> に <span class="tex2jax_process">$+1$</span> と <span class="tex2jax_process">$(2,1,3)$</span> に <span class="tex2jax_process">$-1$</span>。
+<div class="math-block tex2jax_process">$$\epsilon_{2,\cdot,\cdot} = \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}$$</div>
+<strong>第3成分（<span class="tex2jax_process">$i = 3$</span>, <span class="tex2jax_process">$z$</span>）：</strong> <span class="tex2jax_process">$(3,1,2)$</span> に <span class="tex2jax_process">$+1$</span> と <span class="tex2jax_process">$(3,2,1)$</span> に <span class="tex2jax_process">$-1$</span>。
+<div class="math-block tex2jax_process">$$\epsilon_{3,\cdot,\cdot} = \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$</div>
+<p>繰り返しになるが、これらはそれぞれ <span class="tex2jax_process">$dy \wedge dz$</span>、<span class="tex2jax_process">$dz \wedge dx$</span>、<span class="tex2jax_process">$dx \wedge dy$</span> の行列そのものである。
 </p>
 <h4 id="A4-ベクトル3本を食わせる縮約の全過程">A.4 ベクトル3本を食わせる——縮約の全過程</h4>
-<strong>ステップ1：添字 $i$ について $\mathbf{v}_1$ の成分で加重和（添字 $i$ を潰す）</strong>
-<p>$\mathbf{v}_1$ の各成分を重みにして3つの面積測定器行列を足し合わせる。3次元配列がベクトル1本を食べて $3 \times 3$ 行列に降りる：
-</p>
-<p>$$M := \sum_i v_{1i}\, \epsilon_{i,\cdot,\cdot} = x_1 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} + y_1 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} + z_1 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$
-</p>
+<strong>ステップ1：添字 <span class="tex2jax_process">$i$</span> について <span class="tex2jax_process">$\mathbf{v}_1$</span> の成分で加重和（添字 <span class="tex2jax_process">$i$</span> を潰す）</strong>
+<span class="tex2jax_process">$\mathbf{v}_1$</span> の各成分を重みにして3つの面積測定器行列を足し合わせる。3次元配列がベクトル1本を食べて <span class="tex2jax_process">$3 \times 3$</span> 行列に降りる：
+<div class="math-block tex2jax_process">$$M := \sum_i v_{1i}\, \epsilon_{i,\cdot,\cdot} = x_1 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} + y_1 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} + z_1 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}$$</div>
 <p>各成分を足し合わせると：
 </p>
-<p>$$M = \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$M = \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix}$$</div>
+<p>面積測定器3つを <span class="tex2jax_process">$\mathbf{v}_1$</span> の成分で配合した、「<span class="tex2jax_process">$\mathbf{v}_1$</span> 専用の面積測定器」が出現した。反対称行列であることに注目——<span class="tex2jax_process">$\widehat{\epsilon}$</span> の添字に対する反対称性が受け継がれている。
 </p>
-<p>面積測定器3つを $\mathbf{v}_1$ の成分で配合した、「$\mathbf{v}_1$ 専用の面積測定器」が出現した。反対称行列であることに注目——$\widehat{\epsilon}$ の添字に対する反対称性が受け継がれている。
+<strong>ステップ2：残り2本で行列を挟む（添字 <span class="tex2jax_process">$j, k$</span> を潰す）</strong>
+<p>あとは §2.4 で馴染んだ「横 <span class="tex2jax_process">$\times$</span> 行列 <span class="tex2jax_process">$\times$</span> 縦」だ：
 </p>
-<strong>ステップ2：残り2本で行列を挟む（添字 $j, k$ を潰す）</strong>
-<p>あとは §2.4 で馴染んだ「横 $\times$ 行列 $\times$ 縦」だ：
+<div class="math-block tex2jax_process">$$V = \mathbf{v}_2^T\, M\, \mathbf{v}_3 = \begin{pmatrix} x_2 & y_2 & z_2 \end{pmatrix} \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix} \begin{pmatrix} x_3 \\ y_3 \\ z_3 \end{pmatrix}$$</div>
+<p>まず <span class="tex2jax_process">$\mathbf{v}_2^T \times M$</span>（横 <span class="tex2jax_process">$\times$</span> 行列 → 横）を計算する：
 </p>
-<p>$$V = \mathbf{v}_2^T\, M\, \mathbf{v}_3 = \begin{pmatrix} x_2 & y_2 & z_2 \end{pmatrix} \begin{pmatrix} 0 & z_1 & -y_1 \\ -z_1 & 0 & x_1 \\ y_1 & -x_1 & 0 \end{pmatrix} \begin{pmatrix} x_3 \\ y_3 \\ z_3 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$= \begin{pmatrix} y_1 z_2 - z_1 y_2, & z_1 x_2 - x_1 z_2, & x_1 y_2 - x_2 y_1 \end{pmatrix}$$</div>
+<p>最後に、得た横ベクトルと <span class="tex2jax_process">$\mathbf{v}_3$</span> の対応成分の積の和（横 <span class="tex2jax_process">$\times$</span> 縦 → スカラー）：
 </p>
-<p>まず $\mathbf{v}_2^T \times M$（横 $\times$ 行列 → 横）を計算する：
-</p>
-<p>$$= \begin{pmatrix} y_1 z_2 - z_1 y_2, & z_1 x_2 - x_1 z_2, & x_1 y_2 - x_2 y_1 \end{pmatrix}$$
-</p>
-<p>最後に、得た横ベクトルと $\mathbf{v}_3$ の対応成分の積の和（横 $\times$ 縦 → スカラー）：
-</p>
-<p>$$V = (y_1 z_2 - z_1 y_2)\,x_3 + (z_1 x_2 - x_1 z_2)\,y_3 + (x_1 y_2 - x_2 y_1)\,z_3$$
-</p>
+<div class="math-block tex2jax_process">$$V = (y_1 z_2 - z_1 y_2)\,x_3 + (z_1 x_2 - x_1 z_2)\,y_3 + (x_1 y_2 - x_2 y_1)\,z_3$$</div>
 <p>展開して整理すると：
 </p>
-<p>$$= x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_2 x_3$$
-</p>
+<div class="math-block tex2jax_process">$$= x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_2 x_3$$</div>
 <p>となり、<strong>§2.5.2 の行列式と、6つの項が1つ残らず一致する。</strong>
 </p>
 <p>\newpage
 </p>
 <h1 id="第3章積分するとは何か--有限のマスを数え最後に極限を取る">第3章：積分するとは何か —— 有限のマスを数え、最後に極限を取る</h1>
 <h3 id="30-曲がったものを測る小学校以来の借りを返す">§3.0 曲がったものを測る——小学校以来の借りを返す</h3>
-<p>　第2章では、平行四辺形の面積や平行六面体の体積といった<strong>平らな図形</strong>の測り方を定義した。$dx \wedge dy$ という面積測定器に二本のベクトルを食わせれば符号付き面積が返り、$dx \wedge dy \wedge dz$ という体積測定器に三本のベクトルを食わせれば符号付き体積が返る。小学校の「$1 \times 1$ の正方形がいくつ入るか」という直感を、代数的な測定器として再設計したのである。
+<p>　第2章では、平行四辺形の面積や平行六面体の体積といった<strong>平らな図形</strong>の測り方を定義した。<span class="tex2jax_process">$dx \wedge dy$</span> という面積測定器に二本のベクトルを食わせれば符号付き面積が返り、<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> という体積測定器に三本のベクトルを食わせれば符号付き体積が返る。小学校の「<span class="tex2jax_process">$1 \times 1$</span> の正方形がいくつ入るか」という直感を、代数的な測定器として再設計したのである。
 </p>
 <p>しかし、物理学者が本当に知りたいのは平らな図形ではない。曲線の長さ、曲面の面積、曲がった領域の体積——すなわち<strong>曲がったもの</strong>の測り方だ。
 </p>
-<p>円周 $2\pi r$、球の表面積 $4\pi r^2$、球の体積 $4\pi r^3/3$。これらの公式は小学校以来「そういうもの」として使ってきた。だが、部分に刻んで足し上げる操作として——積分として——一度でも定義したことがあるだろうか。ないはずだ。
+<p>円周 <span class="tex2jax_process">$2\pi r$</span>、球の表面積 <span class="tex2jax_process">$4\pi r^2$</span>、球の体積 <span class="tex2jax_process">$4\pi r^3/3$</span>。これらの公式は小学校以来「そういうもの」として使ってきた。だが、部分に刻んで足し上げる操作として——積分として——一度でも定義したことがあるだろうか。ないはずだ。
 </p>
-<p>考えてみれば当然である。曲線を細かく刻んで足し上げるには「各小区間で何を測り、どう足すか」を決めなければならないが、それは<strong>微分形式</strong>という測定器なしには定義できない操作だからだ。いま我々の手元には、第1章と第2章で作り上げた測定器——$0$-form、$1$-form、$2$-form、$3$-form——がそろっている。本章の仕事は、これらを<strong>曲線・曲面・領域に沿って適用し、集計する</strong>ことである。
+<p>考えてみれば当然である。曲線を細かく刻んで足し上げるには「各小区間で何を測り、どう足すか」を決めなければならないが、それは<strong>微分形式</strong>という測定器なしには定義できない操作だからだ。いま我々の手元には、第1章と第2章で作り上げた測定器——<span class="tex2jax_process">$0$</span>-form、<span class="tex2jax_process">$1$</span>-form、<span class="tex2jax_process">$2$</span>-form、<span class="tex2jax_process">$3$</span>-form——がそろっている。本章の仕事は、これらを<strong>曲線・曲面・領域に沿って適用し、集計する</strong>ことである。
 </p>
 <p>原理はどの次数でも同じだ。まずは係数1の体積測定器がそのまま領域の体積を返してくれるケースから始め、次元を降りながら「どこで係数1の限界が姿を現すか」を確かめていこう。
 </p>
@@ -1547,288 +1547,250 @@ $$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{
 <hr />
 <h3 id="31-体積3次元係数1">§3.1 体積——3次元、係数1</h3>
 <h4 id="311-直方体から曲がった領域へリーマン和で定義する">3.1.1 直方体から曲がった領域へ——リーマン和で定義する</h4>
-<p>第2章 §2.5 で、我々は $dx \wedge dy \wedge dz$ という体積測定器を組み立てた。これに三本のベクトル $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ を食わせると、それらが張る平行六面体の符号付き体積が返ってくる。
+<p>第2章 §2.5 で、我々は <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> という体積測定器を組み立てた。これに三本のベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$</span> を食わせると、それらが張る平行六面体の符号付き体積が返ってくる。
 </p>
-<p>いま、空間内の領域 $V$ の体積を測りたい。$V$ の形がどんなに曲がっていても、十分細かく刻めば各小片はほぼ直方体と見なせる。そこで $V$ を $x$ 方向・$y$ 方向・$z$ 方向に刻み、$V$ の内部にある小直方体に番号 $i$ を振る。第 $i$ 小直方体の三辺を
+<p>いま、空間内の領域 <span class="tex2jax_process">$V$</span> の体積を測りたい。<span class="tex2jax_process">$V$</span> の形がどんなに曲がっていても、十分細かく刻めば各小片はほぼ直方体と見なせる。そこで <span class="tex2jax_process">$V$</span> を <span class="tex2jax_process">$x$</span> 方向・<span class="tex2jax_process">$y$</span> 方向・<span class="tex2jax_process">$z$</span> 方向に刻み、<span class="tex2jax_process">$V$</span> の内部にある小直方体に番号 <span class="tex2jax_process">$i$</span> を振る。第 <span class="tex2jax_process">$i$</span> 小直方体の三辺を
 </p>
-<p>$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z$$
+<div class="math-block tex2jax_process">$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z$$</div>
+<p>とする。これら三本のベクトルを体積測定器 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> に食わせると：
 </p>
-<p>とする。これら三本のベクトルを体積測定器 $dx \wedge dy \wedge dz$ に食わせると：
-</p>
-<p>$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i$$
-</p>
-<blockquote><p>**注** （はかりと図形の縮約）ここで起きていることは、第2章 §2.5.10 で見たパターンそのものだ。**$3$-form（体積測定器＝はかり）**が**$3$-vector（体積素＝図形）**を食べてスカラーを吐き出す。この縮約が各小直方体で行われる。</p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i$$</div>
+<blockquote><p>**注** （はかりと図形の縮約）ここで起きていることは、第2章 §2.5.10 で見たパターンそのものだ。**<span class="tex2jax_process">$3$</span>-form（体積測定器＝はかり）**が**<span class="tex2jax_process">$3$</span>-vector（体積素＝図形）**を食べてスカラーを吐き出す。この縮約が各小直方体で行われる。</p>
 </p></blockquote>
-<p>各小直方体から得られたスカラー $\Delta x_i\,\Delta y_i\,\Delta z_i$ を、$V$ の内部にあるすべての小直方体について足し上げる：
+<p>各小直方体から得られたスカラー <span class="tex2jax_process">$\Delta x_i\,\Delta y_i\,\Delta z_i$</span> を、<span class="tex2jax_process">$V$</span> の内部にあるすべての小直方体について足し上げる：
 </p>
-<p>$$\sum_{\text{小直方体 }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i$$
-</p>
+<div class="math-block tex2jax_process">$$\sum_{\text{小直方体 }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i$$</div>
 <p>そして刻みを無限に細かくする極限をとる。この極限を
 </p>
-<p>$$\iiint_V dx \wedge dy \wedge dz$$
+<div class="math-block tex2jax_process">$$\iiint_V dx \wedge dy \wedge dz$$</div>
+<p>と<strong>書くことにする</strong>。これが <span class="tex2jax_process">$3$</span>-form の積分——体積分——の定義である。
 </p>
-<p>と<strong>書くことにする</strong>。これが $3$-form の積分——体積分——の定義である。
-</p>
-<blockquote><p>**注** （$\iiint$ という記号について）本書では $\iiint_V$ を「3次元領域 $V$ における $3$-form の積分」を表す記号として**ここで初めて定義する**。高校数学の延長にある何かではなく、上記のリーマン和の極限に与えた名前である。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$\iiint$</span> という記号について）本書では <span class="tex2jax_process">$\iiint_V$</span> を「3次元領域 <span class="tex2jax_process">$V$</span> における <span class="tex2jax_process">$3$</span>-form の積分」を表す記号として**ここで初めて定義する**。高校数学の延長にある何かではなく、上記のリーマン和の極限に与えた名前である。</p>
 </p></blockquote>
-<p>さて、定義はした。ではこの和を実際にどう計算するか。$V$ が $x^2+y^2+z^2 \le R^2$ のような曲がった領域のとき、どの小直方体が $V$ の内部にあるかを判定しながら和をとるのは面倒だ。しかし和のとり方を工夫すれば、見通しがよくなる。次節で実際にやってみよう。
+<p>さて、定義はした。ではこの和を実際にどう計算するか。<span class="tex2jax_process">$V$</span> が <span class="tex2jax_process">$x^2+y^2+z^2 \le R^2$</span> のような曲がった領域のとき、どの小直方体が <span class="tex2jax_process">$V$</span> の内部にあるかを判定しながら和をとるのは面倒だ。しかし和のとり方を工夫すれば、見通しがよくなる。次節で実際にやってみよう。
 </p>
 <h4 id="312-球の体積泥臭く愚直に足す">3.1.2 球の体積——泥臭く、愚直に足す</h4>
-<p>半径 $R$ の球 $x^2 + y^2 + z^2 \le R^2$ の体積を、本当に泥臭く計算してみよう。これから示したいことはただ一つ——特別な座標系に逃げずとも、$x, y, z$ のまま愚直にリーマン和を整理するだけで、見慣れた $4\pi R^3/3$ に到達できることである。特別な座標系は使わない。$x, y, z$ のまま、小直方体 $\Delta x\,\Delta y\,\Delta z$ を愚直に積み重ねるだけだ。
+<p>半径 <span class="tex2jax_process">$R$</span> の球 <span class="tex2jax_process">$x^2 + y^2 + z^2 \le R^2$</span> の体積を、本当に泥臭く計算してみよう。これから示したいことはただ一つ——特別な座標系に逃げずとも、<span class="tex2jax_process">$x, y, z$</span> のまま愚直にリーマン和を整理するだけで、見慣れた <span class="tex2jax_process">$4\pi R^3/3$</span> に到達できることである。特別な座標系は使わない。<span class="tex2jax_process">$x, y, z$</span> のまま、小直方体 <span class="tex2jax_process">$\Delta x\,\Delta y\,\Delta z$</span> を愚直に積み重ねるだけだ。
 </p>
-<p>§3.1.1 のリーマン和をどう整理すれば計算できるか。球の内部で $z$ をある値に固定すると、$x, y$ の満たすべき条件は $x^2 + y^2 \le R^2 - z^2$ である。さらに $y$ も固定すれば $x^2 \le R^2 - z^2 - y^2$。したがって $x$ の動く範囲は $-\sqrt{R^2 - z^2 - y^2}$ から $+\sqrt{R^2 - z^2 - y^2}$ まで、$y$ の範囲は $-\sqrt{R^2 - z^2}$ から $+\sqrt{R^2 - z^2}$ まで、$z$ の範囲は $-R$ から $+R$ まで。この順に和をとる——第1章 §1.1 でやった1次元のリーマン和を三回重ねる——と考えれば、極限では：
+<p>§3.1.1 のリーマン和をどう整理すれば計算できるか。球の内部で <span class="tex2jax_process">$z$</span> をある値に固定すると、<span class="tex2jax_process">$x, y$</span> の満たすべき条件は <span class="tex2jax_process">$x^2 + y^2 \le R^2 - z^2$</span> である。さらに <span class="tex2jax_process">$y$</span> も固定すれば <span class="tex2jax_process">$x^2 \le R^2 - z^2 - y^2$</span>。したがって <span class="tex2jax_process">$x$</span> の動く範囲は <span class="tex2jax_process">$-\sqrt{R^2 - z^2 - y^2}$</span> から <span class="tex2jax_process">$+\sqrt{R^2 - z^2 - y^2}$</span> まで、<span class="tex2jax_process">$y$</span> の範囲は <span class="tex2jax_process">$-\sqrt{R^2 - z^2}$</span> から <span class="tex2jax_process">$+\sqrt{R^2 - z^2}$</span> まで、<span class="tex2jax_process">$z$</span> の範囲は <span class="tex2jax_process">$-R$</span> から <span class="tex2jax_process">$+R$</span> まで。この順に和をとる——第1章 §1.1 でやった1次元のリーマン和を三回重ねる——と考えれば、極限では：
 </p>
-<p>$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz$$
+<div class="math-block tex2jax_process">$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz$$</div>
+<p>右辺の <span class="tex2jax_process">$dx, dy, dz$</span> は、左辺の <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> を順に和の整理に使った結果として並んでいる。<span class="tex2jax_process">$\wedge$</span> を省略しているのではない。カッコの内側から順に、<span class="tex2jax_process">$x$</span> についての和（<span class="tex2jax_process">$\int dx$</span>）→ <span class="tex2jax_process">$y$</span> についての和（<span class="tex2jax_process">$\int dy$</span>）→ <span class="tex2jax_process">$z$</span> についての和（<span class="tex2jax_process">$\int dz$</span>）を実行する、という意味である。
 </p>
-<p>右辺の $dx, dy, dz$ は、左辺の $dx \wedge dy \wedge dz$ を順に和の整理に使った結果として並んでいる。$\wedge$ を省略しているのではない。カッコの内側から順に、$x$ についての和（$\int dx$）→ $y$ についての和（$\int dy$）→ $z$ についての和（$\int dz$）を実行する、という意味である。
+<p>一番内側の <span class="tex2jax_process">$x$</span> についての和（極限で <span class="tex2jax_process">$x$</span> 積分）はすぐに実行できる：
 </p>
-<p>一番内側の $x$ についての和（極限で $x$ 積分）はすぐに実行できる：
+<div class="math-block tex2jax_process">$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}$$</div>
+<p>次に <span class="tex2jax_process">$y$</span> 積分。<span class="tex2jax_process">$a = \sqrt{R^2 - z^2}$</span> とおけば：
 </p>
-<p>$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}$$
+<div class="math-block tex2jax_process">$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy$$</div>
+<p>ここで置換積分（高校数学）を使う。<span class="tex2jax_process">$y = a\sin t$</span> とおくと、<span class="tex2jax_process">$dy = a\cos t\,dt$</span>。<span class="tex2jax_process">$y$</span> が <span class="tex2jax_process">$-a \to a$</span> のとき <span class="tex2jax_process">$t$</span> は <span class="tex2jax_process">$-\pi/2 \to \pi/2$</span>。また <span class="tex2jax_process">$\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$</span>（<span class="tex2jax_process">$t \in [-\pi/2,\pi/2]$</span> では <span class="tex2jax_process">$\cos t \ge 0$</span> だから絶対値が外れる）。したがって：
 </p>
-<p>次に $y$ 積分。$a = \sqrt{R^2 - z^2}$ とおけば：
-</p>
-<p>$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy$$
-</p>
-<p>ここで置換積分（高校数学）を使う。$y = a\sin t$ とおくと、$dy = a\cos t\,dt$。$y$ が $-a \to a$ のとき $t$ は $-\pi/2 \to \pi/2$。また $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$（$t \in [-\pi/2,\pi/2]$ では $\cos t \ge 0$ だから絶対値が外れる）。したがって：
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy
 &= \int_{-\pi/2}^{\pi/2} 2\cdot a\cos t \cdot a\cos t\,dt \\
 &= 2a^2\!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
-\end{aligned}$$
-</p>
-<p>$\cos^2 t = (1 + \cos 2t)/2$ だから：
-</p>
-<p>$$\begin{aligned}
+\end{aligned}$$</div>
+<span class="tex2jax_process">$\cos^2 t = (1 + \cos 2t)/2$</span> だから：
+<div class="math-block tex2jax_process">$$\begin{aligned}
 2a^2\!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
 &= a^2\int_{-\pi/2}^{\pi/2} (1 + \cos 2t)\,dt \\[4pt]
 &= a^2\Bigl[t + \frac{\sin 2t}{2}\Bigr]_{-\pi/2}^{\pi/2} \\[4pt]
 &= a^2\Bigl[\Bigl(\frac{\pi}{2} + 0\Bigr) - \Bigl(-\frac{\pi}{2} + 0\Bigr)\Bigr] \\[4pt]
 &= \pi a^2 = \pi(R^2 - z^2)
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>最後に <span class="tex2jax_process">$z$</span> 積分：
 </p>
-<p>最後に $z$ 積分：
-</p>
-<p>$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3$$
-</p>
-<blockquote><p>**注** （この計算の意味）ここで我々がやったことは、§3.1.1 のリーマン和の整理にすぎない。$x,y,z$ のまま、どの小直方体が球の内部にあるかを判定しながら和をとるかわりに、和の順序を $x \to y \to z$ と整理した。各段階は第1章でやった1変数のリーマン和であり、極限で見慣れた1変数積分の計算になる。それだけである。測定器と図形の縮約を愚直に集計すれば $4\pi R^3/3$ に到達する。</p>
+<div class="math-block tex2jax_process">$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3$$</div>
+<blockquote><p>**注** （この計算の意味）ここで我々がやったことは、§3.1.1 のリーマン和の整理にすぎない。<span class="tex2jax_process">$x,y,z$</span> のまま、どの小直方体が球の内部にあるかを判定しながら和をとるかわりに、和の順序を <span class="tex2jax_process">$x \to y \to z$</span> と整理した。各段階は第1章でやった1変数のリーマン和であり、極限で見慣れた1変数積分の計算になる。それだけである。測定器と図形の縮約を愚直に集計すれば <span class="tex2jax_process">$4\pi R^3/3$</span> に到達する。</p>
 </p></blockquote>
-<p>こうして、$dx \wedge dy \wedge dz$ という<strong>一つの測定器</strong>の積分が、曲がった領域の体積 $4\pi R^3/3$ を正しく与えることが確認できた。3次元では、係数1の体積測定器がそのまま体積を直接測れるのである。
+<p>こうして、<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> という<strong>一つの測定器</strong>の積分が、曲がった領域の体積 <span class="tex2jax_process">$4\pi R^3/3$</span> を正しく与えることが確認できた。3次元では、係数1の体積測定器がそのまま体積を直接測れるのである。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $dx \wedge dy \wedge dz$ の積分は、領域を小直方体に刻み、各小片の体積素を体積測定器に食わせた値を足し上げるリーマン和の極限である。$\iiint_V$ は本書がこの極限に与えた記号である。
-- 係数1でそのまま体積が測れる。球の体積 $4\pi R^3/3$ が、リーマン和を $x \to y \to z$ の順に整理することで得られる。特別な座標系は不要。
+- <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の積分は、領域を小直方体に刻み、各小片の体積素を体積測定器に食わせた値を足し上げるリーマン和の極限である。<span class="tex2jax_process">$\iiint_V$</span> は本書がこの極限に与えた記号である。
+- 係数1でそのまま体積が測れる。球の体積 <span class="tex2jax_process">$4\pi R^3/3$</span> が、リーマン和を <span class="tex2jax_process">$x \to y \to z$</span> の順に整理することで得られる。特別な座標系は不要。
 - 次節では次元を一つ下げ、曲面の面積を測る。
 </p></blockquote>
 <hr />
 <h3 id="32-表面積2次元係数1">§3.2 表面積——2次元、係数1</h3>
 <h4 id="321-平行四辺形から曲面へ">3.2.1 平行四辺形から曲面へ</h4>
-<p>第2章 §2.4 で、我々は $dx \wedge dy$ という面積測定器を組み立てた。これに二本のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を食わせると、それらが $xy$ 平面に落とす影の符号付き面積が返ってくる。同様に $dy \wedge dz$ は $yz$ 平面への影、$dz \wedge dx$ は $zx$ 平面への影を測る。
+<p>第2章 §2.4 で、我々は <span class="tex2jax_process">$dx \wedge dy$</span> という面積測定器を組み立てた。これに二本のベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> を食わせると、それらが <span class="tex2jax_process">$xy$</span> 平面に落とす影の符号付き面積が返ってくる。同様に <span class="tex2jax_process">$dy \wedge dz$</span> は <span class="tex2jax_process">$yz$</span> 平面への影、<span class="tex2jax_process">$dz \wedge dx$</span> は <span class="tex2jax_process">$zx$</span> 平面への影を測る。
 </p>
-<p>では曲面の面積を測るにはどうすればよいか。まず平らな場合で確認しておこう。$xy$ 平面に乗った単位正方形 $\mathbf{r}(u,v) = (u,\,v,\,0),\; 0 \le u,v \le 1$ を考える。$\mathbf{r}_u = (1,0,0),\; \mathbf{r}_v = (0,1,0)$ だから、$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix}1&0\\0&1\end{pmatrix} = 1$。全区間で集計すれば $\iint_{[0,1]^2} 1 = 1$——正方形の面積だ。これは第2章の平らな平行四辺形の拡張にすぎず、面素という新しい道具が平らな面では正しく面積を返すことの確認である。
+<p>では曲面の面積を測るにはどうすればよいか。まず平らな場合で確認しておこう。<span class="tex2jax_process">$xy$</span> 平面に乗った単位正方形 <span class="tex2jax_process">$\mathbf{r}(u,v) = (u,\,v,\,0),\; 0 \le u,v \le 1$</span> を考える。<span class="tex2jax_process">$\mathbf{r}_u = (1,0,0),\; \mathbf{r}_v = (0,1,0)$</span> だから、<span class="tex2jax_process">$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix}1&0\\0&1\end{pmatrix} = 1$</span>。全区間で集計すれば <span class="tex2jax_process">$\iint_{[0,1]^2} 1 = 1$</span>——正方形の面積だ。これは第2章の平らな平行四辺形の拡張にすぎず、面素という新しい道具が平らな面では正しく面積を返すことの確認である。
 </p>
-<p>では曲面が曲がっていたらどうなるか。一般に、曲面 $S$ が二つのパラメータ $u, v$ で
+<p>では曲面が曲がっていたらどうなるか。一般に、曲面 <span class="tex2jax_process">$S$</span> が二つのパラメータ <span class="tex2jax_process">$u, v$</span> で
 </p>
-<p>$$\mathbf{r}(u,v) = \bigl(x(u,v),\, y(u,v),\, z(u,v)\bigr)$$
+<div class="math-block tex2jax_process">$$\mathbf{r}(u,v) = \bigl(x(u,v),\, y(u,v),\, z(u,v)\bigr)$$</div>
+<p>と表されているとする。<span class="tex2jax_process">$u, v$</span> が平面内の領域 <span class="tex2jax_process">$D$</span> を動くとき、<span class="tex2jax_process">$\mathbf{r}(u,v)$</span> が曲面 <span class="tex2jax_process">$S$</span> を描く。
 </p>
-<p>と表されているとする。$u, v$ が平面内の領域 $D$ を動くとき、$\mathbf{r}(u,v)$ が曲面 $S$ を描く。
+<p>曲面を小区画に刻む。<span class="tex2jax_process">$u$</span> 方向に <span class="tex2jax_process">$\Delta u$</span>、<span class="tex2jax_process">$v$</span> 方向に <span class="tex2jax_process">$\Delta v$</span> だけ進んだときの変位ベクトルは、偏微分を使って
 </p>
-<p>曲面を小区画に刻む。$u$ 方向に $\Delta u$、$v$ 方向に $\Delta v$ だけ進んだときの変位ベクトルは、偏微分を使って
+<div class="math-block tex2jax_process">$$\mathbf{r}_u = \frac{\partial \mathbf{r}}{\partial u},\qquad \mathbf{r}_v = \frac{\partial \mathbf{r}}{\partial v}$$</div>
+<p>と近似できる（<span class="tex2jax_process">$\Delta u, \Delta v$</span> が十分小さいとき）。この二本が張る平行四辺形が、曲面の小片の近似だ。<span class="tex2jax_process">$\mathbf{r}_u, \mathbf{r}_v$</span> が平行でなく、ちゃんと面を張っているとする。
 </p>
-<p>$$\mathbf{r}_u = \frac{\partial \mathbf{r}}{\partial u},\qquad \mathbf{r}_v = \frac{\partial \mathbf{r}}{\partial v}$$
-</p>
-<p>と近似できる（$\Delta u, \Delta v$ が十分小さいとき）。この二本が張る平行四辺形が、曲面の小片の近似だ。$\mathbf{r}_u, \mathbf{r}_v$ が平行でなく、ちゃんと面を張っているとする。
-</p>
-<blockquote><p>**注** （偏微分に不慣れな読者へ）$\mathbf{r}_u$ は「$v$ を止めて $u$ だけを少し動かしたときの変位ベクトル」と思えばよい。第1章の $\Delta x$ を2次元に拡張したものである。</p>
+<blockquote><p>**注** （偏微分に不慣れな読者へ）<span class="tex2jax_process">$\mathbf{r}_u$</span> は「<span class="tex2jax_process">$v$</span> を止めて <span class="tex2jax_process">$u$</span> だけを少し動かしたときの変位ベクトル」と思えばよい。第1章の <span class="tex2jax_process">$\Delta x$</span> を2次元に拡張したものである。</p>
 </p></blockquote>
-<p>この面素 $\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v$ を面積測定器 $dx \wedge dy$ に食わせる。$u,v$ 方向の刻みに番号 $i,j$ を振れば、第 $(i,j)$ 小区画からの寄与は：
+<p>この面素 <span class="tex2jax_process">$\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v$</span> を面積測定器 <span class="tex2jax_process">$dx \wedge dy$</span> に食わせる。<span class="tex2jax_process">$u,v$</span> 方向の刻みに番号 <span class="tex2jax_process">$i,j$</span> を振れば、第 <span class="tex2jax_process">$(i,j)$</span> 小区画からの寄与は：
 </p>
-<p>$$(dx \wedge dy)(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = (dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$
-</p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = (dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$</div>
 <p>第2章 §2.4.4 の定義より：
 </p>
-<p>$$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix} \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\ \frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} \end{pmatrix} = \frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$$
-</p>
-<blockquote><p>**注** （$2$-form と $2$-vector の縮約）ここでも同じ構図だ。**$2$-form（面積測定器＝はかり）**が**$2$-vector（面素＝図形）**を食べてスカラー（影の面積）を返す。各小区画でこの縮約が行われる。</p>
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix} \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\ \frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} \end{pmatrix} = \frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$$</div>
+<blockquote><p>**注** （<span class="tex2jax_process">$2$</span>-form と <span class="tex2jax_process">$2$</span>-vector の縮約）ここでも同じ構図だ。**<span class="tex2jax_process">$2$</span>-form（面積測定器＝はかり）**が**<span class="tex2jax_process">$2$</span>-vector（面素＝図形）**を食べてスカラー（影の面積）を返す。各小区画でこの縮約が行われる。</p>
 </p></blockquote>
-<p>これを $D$ 内のすべての小区画について足し上げる：
+<p>これを <span class="tex2jax_process">$D$</span> 内のすべての小区画について足し上げる：
 </p>
-<p>$$\sum_i\sum_j (\frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u})\,\Delta u\,\Delta v$$
-</p>
+<div class="math-block tex2jax_process">$$\sum_i\sum_j (\frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u})\,\Delta u\,\Delta v$$</div>
 <p>刻みを無限に細かくする極限を
 </p>
-<p>$$\iint_S dx \wedge dy$$
+<div class="math-block tex2jax_process">$$\iint_S dx \wedge dy$$</div>
+<p>と<strong>書くことにする</strong>。これが <span class="tex2jax_process">$2$</span>-form の積分——面積分——の定義である。構成は §3.1 の体積分と同じ型で、食わせるベクトルが2本になっただけだ。
 </p>
-<p>と<strong>書くことにする</strong>。これが $2$-form の積分——面積分——の定義である。構成は §3.1 の体積分と同じ型で、食わせるベクトルが2本になっただけだ。
+<h4 id="322-span-classtex2jaxprocessspan-が測るもの球面で試す">3.2.2 <span class="tex2jax_process">$dx \wedge dy$</span> が測るもの——球面で試す</h4>
+<p>実際に球面で計算してみよう。半径 <span class="tex2jax_process">$R$</span> の球面の上半分（<span class="tex2jax_process">$z \ge 0$</span>）を考える。この曲面は、<span class="tex2jax_process">$x, y$</span> をそのままパラメータとして
 </p>
-<h4 id="322-が測るもの球面で試す">3.2.2 $dx \wedge dy$ が測るもの——球面で試す</h4>
-<p>実際に球面で計算してみよう。半径 $R$ の球面の上半分（$z \ge 0$）を考える。この曲面は、$x, y$ をそのままパラメータとして
+<div class="math-block tex2jax_process">$$z = f(x,y) = \sqrt{R^2 - x^2 - y^2},\qquad x^2 + y^2 \le R^2$$</div>
+<p>と書ける（グラフ表示）。<span class="tex2jax_process">$\mathbf{r}(x,y) = (x,\; y,\; f(x,y))$</span> とパラメータ表示すれば、偏微分は：
 </p>
-<p>$$z = f(x,y) = \sqrt{R^2 - x^2 - y^2},\qquad x^2 + y^2 \le R^2$$
+<div class="math-block tex2jax_process">$$\mathbf{r}_x = \frac{\partial \mathbf{r}}{\partial x} = \begin{pmatrix} 1 \\[2pt] 0 \\[2pt] \frac{\partial f}{\partial x} \end{pmatrix},\qquad \mathbf{r}_y = \frac{\partial \mathbf{r}}{\partial y} = \begin{pmatrix} 0 \\[2pt] 1 \\[2pt] \frac{\partial f}{\partial y} \end{pmatrix}$$</div>
+<p>ここで <span class="tex2jax_process">$\frac{\partial f}{\partial x} = \dfrac{\partial f}{\partial x} = -\dfrac{x}{\sqrt{R^2 - x^2 - y^2}},\; \frac{\partial f}{\partial y} = \dfrac{\partial f}{\partial y} = -\dfrac{y}{\sqrt{R^2 - x^2 - y^2}}$</span>。
 </p>
-<p>と書ける（グラフ表示）。$\mathbf{r}(x,y) = (x,\; y,\; f(x,y))$ とパラメータ表示すれば、偏微分は：
+<p>まず <span class="tex2jax_process">$dx \wedge dy$</span> だけを曲面に食わせてみる：
 </p>
-<p>$$\mathbf{r}_x = \frac{\partial \mathbf{r}}{\partial x} = \begin{pmatrix} 1 \\[2pt] 0 \\[2pt] \frac{\partial f}{\partial x} \end{pmatrix},\qquad \mathbf{r}_y = \frac{\partial \mathbf{r}}{\partial y} = \begin{pmatrix} 0 \\[2pt] 1 \\[2pt] \frac{\partial f}{\partial y} \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = \det\begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix} = 1$$</div>
+<p>したがって上半球面での <span class="tex2jax_process">$dx \wedge dy$</span> の積分は：
 </p>
-<p>ここで $\frac{\partial f}{\partial x} = \dfrac{\partial f}{\partial x} = -\dfrac{x}{\sqrt{R^2 - x^2 - y^2}},\; \frac{\partial f}{\partial y} = \dfrac{\partial f}{\partial y} = -\dfrac{y}{\sqrt{R^2 - x^2 - y^2}}$。
+<div class="math-block tex2jax_process">$$\iint_{S_{\text{upper}}} dx \wedge dy$$</div>
+<p>の計算は §3.1.2 の <span class="tex2jax_process">$y$</span> 積分と同じ方法でできて（<span class="tex2jax_process">$a$</span> を <span class="tex2jax_process">$R$</span> と思えばまったく同じ）、結果は <span class="tex2jax_process">$\pi R^2$</span> である。これは上半球を <span class="tex2jax_process">$xy$</span> 平面に落とした影——半径 <span class="tex2jax_process">$R$</span> の円板——の面積にほかならない。
 </p>
-<p>まず $dx \wedge dy$ だけを曲面に食わせてみる：
+<p>下半球（<span class="tex2jax_process">$z = -\sqrt{R^2 - x^2 - y^2}$</span>）でも同様に計算すると、<span class="tex2jax_process">$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = 1$</span> は変わらない（確かめてほしい）が、面の向きが裏返るために符号が反転し、積分は <span class="tex2jax_process">$-\pi R^2$</span> になる。
 </p>
-<p>$$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = \det\begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix} = 1$$
-</p>
-<p>したがって上半球面での $dx \wedge dy$ の積分は：
-</p>
-<p>$$\iint_{S_{\text{upper}}} dx \wedge dy$$
-</p>
-<p>の計算は §3.1.2 の $y$ 積分と同じ方法でできて（$a$ を $R$ と思えばまったく同じ）、結果は $\pi R^2$ である。これは上半球を $xy$ 平面に落とした影——半径 $R$ の円板——の面積にほかならない。
-</p>
-<p>下半球（$z = -\sqrt{R^2 - x^2 - y^2}$）でも同様に計算すると、$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = 1$ は変わらない（確かめてほしい）が、面の向きが裏返るために符号が反転し、積分は $-\pi R^2$ になる。
-</p>
-<p>したがって球面全体での $dx \wedge dy$ の積分は $\pi R^2 + (-\pi R^2) = 0$。上半球の影と下半球の影が打ち消し合ったのだ。これではっきりした：<strong>$dx \wedge dy$ が測るのは「$xy$ 平面への影の符号付き面積」であり、曲面の面積そのものではない。</strong>同様に、$dy \wedge dz$ は $yz$ 平面への影、$dz \wedge dx$ は $zx$ 平面への影を測る。
+<p>したがって球面全体での <span class="tex2jax_process">$dx \wedge dy$</span> の積分は <span class="tex2jax_process">$\pi R^2 + (-\pi R^2) = 0$</span>。上半球の影と下半球の影が打ち消し合ったのだ。これではっきりした：<strong><span class="tex2jax_process">$dx \wedge dy$</span> が測るのは「<span class="tex2jax_process">$xy$</span> 平面への影の符号付き面積」であり、曲面の面積そのものではない。</strong>同様に、<span class="tex2jax_process">$dy \wedge dz$</span> は <span class="tex2jax_process">$yz$</span> 平面への影、<span class="tex2jax_process">$dz \wedge dx$</span> は <span class="tex2jax_process">$zx$</span> 平面への影を測る。
 </p>
 <h4 id="323-三つの影から本当の面積へ">3.2.3 三つの影から本当の面積へ</h4>
 <p>では曲面の本当の面積はどう測ればよいのか。各点で三つの面積測定器すべてに面素を食わせ、その結果を合成する。
 </p>
-<p>上半球面で残り二つも計算しよう（§3.2.1 の $u=x,\;v=y$ の例）：
+<p>上半球面で残り二つも計算しよう（§3.2.1 の <span class="tex2jax_process">$u=x,\;v=y$</span> の例）：
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 (dy \wedge dz)(\mathbf{r}_x, \mathbf{r}_y) &= y_x z_y - y_y z_x = 0\cdot \frac{\partial f}{\partial y} - 1\cdot \frac{\partial f}{\partial x} = -\frac{\partial f}{\partial x} = \frac{x}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
 (dz \wedge dx)(\mathbf{r}_x, \mathbf{r}_y) &= z_x x_y - z_y x_x = \frac{\partial f}{\partial x}\cdot 0 - \frac{\partial f}{\partial y}\cdot 1 = -\frac{\partial f}{\partial y} = \frac{y}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
 (dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) &= 1
-\end{aligned}$$
-</p>
-<p>これら三つの値——$A_{yz},\,A_{zx},\,A_{xy}$——が、各点での面素の<strong>向きと大きさ</strong>の情報を完全にエンコードしている。第2章 §2.4.6 で見た「向き付き面積＝三つの基底 $\hat{e}_y \wedge \hat{e}_z$ 等の線形結合」の曲面版である。
+\end{aligned}$$</div>
+<p>これら三つの値——<span class="tex2jax_process">$A_{yz},\,A_{zx},\,A_{xy}$</span>——が、各点での面素の<strong>向きと大きさ</strong>の情報を完全にエンコードしている。第2章 §2.4.6 で見た「向き付き面積＝三つの基底 <span class="tex2jax_process">$\hat{e}_y \wedge \hat{e}_z$</span> 等の線形結合」の曲面版である。
 </p>
 <p>では、これら三つの「影」から曲面のスカラー面積を取り出す。やることは第2章 §2.4.7 の平行四辺形のときと<strong>一字一句同じ</strong>——三つの値の二乗和の平方根をとればよい：
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}
 &= \sqrt{\Bigl(\frac{x}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + \Bigl(\frac{y}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + 1^2} \\
 &= \sqrt{\frac{x^2 + y^2}{R^2 - x^2 - y^2} + 1} \\
 &= \sqrt{\frac{R^2}{R^2 - x^2 - y^2}}
 = \frac{R}{\sqrt{R^2 - x^2 - y^2}}
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>これをパラメータ領域 <span class="tex2jax_process">$x^2 + y^2 \le R^2$</span> 全体で積分すれば、上半球面の面積が得られる：
 </p>
-<p>これをパラメータ領域 $x^2 + y^2 \le R^2$ 全体で積分すれば、上半球面の面積が得られる：
+<div class="math-block tex2jax_process">$$\iint_{x^2+y^2 \le R^2} \frac{R}{\sqrt{R^2 - x^2 - y^2}}\;dx \wedge dy = R\int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}} \frac{dy}{\sqrt{R^2 - x^2 - y^2}}\;dx$$</div>
+<p>内側の <span class="tex2jax_process">$y$</span> 積分。<span class="tex2jax_process">$a = \sqrt{R^2 - x^2}$</span> とおく：
 </p>
-<p>$$\iint_{x^2+y^2 \le R^2} \frac{R}{\sqrt{R^2 - x^2 - y^2}}\;dx \wedge dy = R\int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}} \frac{dy}{\sqrt{R^2 - x^2 - y^2}}\;dx$$
+<div class="math-block tex2jax_process">$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}}$$</div>
+<p>置換積分 <span class="tex2jax_process">$y = a\sin t$</span> を使う（§3.1.2 と同じ手順）。<span class="tex2jax_process">$dy = a\cos t\,dt$</span>、<span class="tex2jax_process">$\sqrt{a^2 - y^2} = a\cos t$</span>、<span class="tex2jax_process">$y$</span> が <span class="tex2jax_process">$-a \to a$</span> のとき <span class="tex2jax_process">$t$</span> は <span class="tex2jax_process">$-\pi/2 \to \pi/2$</span>：
 </p>
-<p>内側の $y$ 積分。$a = \sqrt{R^2 - x^2}$ とおく：
+<div class="math-block tex2jax_process">$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}} = \int_{-\pi/2}^{\pi/2} \frac{a\cos t}{a\cos t}\,dt = \int_{-\pi/2}^{\pi/2} dt = \pi$$</div>
+<p>積分結果は <span class="tex2jax_process">$a$</span> に依らず <span class="tex2jax_process">$\pi$</span> ！ したがって：
 </p>
-<p>$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}}$$
+<div class="math-block tex2jax_process">$$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2$$</div>
+<p>これが上半球面の面積。下半球面でも符号は一部反転するが二乗和は同じなので、同じく <span class="tex2jax_process">$2\pi R^2$</span>。よって球面全体の面積は：
 </p>
-<p>置換積分 $y = a\sin t$ を使う（§3.1.2 と同じ手順）。$dy = a\cos t\,dt$、$\sqrt{a^2 - y^2} = a\cos t$、$y$ が $-a \to a$ のとき $t$ は $-\pi/2 \to \pi/2$：
-</p>
-<p>$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}} = \int_{-\pi/2}^{\pi/2} \frac{a\cos t}{a\cos t}\,dt = \int_{-\pi/2}^{\pi/2} dt = \pi$$
-</p>
-<p>積分結果は $a$ に依らず $\pi$ ！ したがって：
-</p>
-<p>$$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2$$
-</p>
-<p>これが上半球面の面積。下半球面でも符号は一部反転するが二乗和は同じなので、同じく $2\pi R^2$。よって球面全体の面積は：
-</p>
-<p>$$2\pi R^2 + 2\pi R^2 = 4\pi R^2$$
-</p>
-<p>見事に $4\pi R^2$ が出た。第2章 §2.4.7 で平行四辺形の面積を三つの影から復元したのと、<strong>まったく同じパターン</strong>である。
+<div class="math-block tex2jax_process">$$2\pi R^2 + 2\pi R^2 = 4\pi R^2$$</div>
+<p>見事に <span class="tex2jax_process">$4\pi R^2$</span> が出た。第2章 §2.4.7 で平行四辺形の面積を三つの影から復元したのと、<strong>まったく同じパターン</strong>である。
 </p>
 <h4 id="324-ここまででわかったこと">3.2.4 ここまででわかったこと</h4>
-<p>係数1の $2$-form は、それ単独では曲面の面積を直接返さない。$dx \wedge dy$ だけでは「$xy$ 平面への影の面積」しか測れず、曲面の本当の面積を知るには三つの基底 $2$-form の測定値を合成しなければならない。これは第2章の平行四辺形の面積のときとまったく同じ状況だ。
+<p>係数1の <span class="tex2jax_process">$2$</span>-form は、それ単独では曲面の面積を直接返さない。<span class="tex2jax_process">$dx \wedge dy$</span> だけでは「<span class="tex2jax_process">$xy$</span> 平面への影の面積」しか測れず、曲面の本当の面積を知るには三つの基底 <span class="tex2jax_process">$2$</span>-form の測定値を合成しなければならない。これは第2章の平行四辺形の面積のときとまったく同じ状況だ。
 </p>
-<p>しかし、物理ではしばしば「各点でどの方向の影をどれだけ重視するか」を制御したくなる。たとえば、曲面を貫く流体の流れを測るとき、流れが $x$ 方向に強ければ $dy \wedge dz$（$yz$ 平面への影）に大きな重みをかけたい。そのような<strong>場所ごとに変わる重み</strong>——係数——の必要性が、ここで自然に姿を現す。これが §3.4 への伏線である。
+<p>しかし、物理ではしばしば「各点でどの方向の影をどれだけ重視するか」を制御したくなる。たとえば、曲面を貫く流体の流れを測るとき、流れが <span class="tex2jax_process">$x$</span> 方向に強ければ <span class="tex2jax_process">$dy \wedge dz$</span>（<span class="tex2jax_process">$yz$</span> 平面への影）に大きな重みをかけたい。そのような<strong>場所ごとに変わる重み</strong>——係数——の必要性が、ここで自然に姿を現す。これが §3.4 への伏線である。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 曲面積分は $\iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$。各小区画で面素を面積測定器に食わせてスカラーにし、集計する。
-- $dx \wedge dy$ は単独では $xy$ 平面への影の面積を測る。球面全体では正味ゼロ（上半球と下半球の影が打ち消し合う）。
-- 三つの基底 $2$-form の測定値の二乗和の平方根をとれば曲面のスカラー面積が得られる。球面では $4\pi R^2$。
+- 曲面積分は <span class="tex2jax_process">$\iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$</span>。各小区画で面素を面積測定器に食わせてスカラーにし、集計する。
+- <span class="tex2jax_process">$dx \wedge dy$</span> は単独では <span class="tex2jax_process">$xy$</span> 平面への影の面積を測る。球面全体では正味ゼロ（上半球と下半球の影が打ち消し合う）。
+- 三つの基底 <span class="tex2jax_process">$2$</span>-form の測定値の二乗和の平方根をとれば曲面のスカラー面積が得られる。球面では <span class="tex2jax_process">$4\pi R^2$</span>。
 - 次節ではさらに次元を下げ、曲線の長さを測る。そこで係数1の限界が最もはっきりと姿を現す。
 </p></blockquote>
 <hr />
 <h3 id="33-曲線1次元係数1限界があらわになる">§3.3 曲線——1次元、係数1（限界があらわになる）</h3>
 <h4 id="331-直線から曲線へリーマン和で定義する">3.3.1 直線から曲線へ——リーマン和で定義する</h4>
-<p>第1章で、我々は $dx, dy, dz$ を「ベクトルを食べて各成分を返す $1$-form（横ベクトル）」として定義した。$dx = \begin{pmatrix}1&0&0\end{pmatrix}$、$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ のとき $dx(\mathbf{v}) = \Delta x$ である。$dy, dz$ も同様。
+<p>第1章で、我々は <span class="tex2jax_process">$dx, dy, dz$</span> を「ベクトルを食べて各成分を返す <span class="tex2jax_process">$1$</span>-form（横ベクトル）」として定義した。<span class="tex2jax_process">$dx = \begin{pmatrix}1&0&0\end{pmatrix}$</span>、<span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> のとき <span class="tex2jax_process">$dx(\mathbf{v}) = \Delta x$</span> である。<span class="tex2jax_process">$dy, dz$</span> も同様。
 </p>
-<p>では曲線に沿ってこれらを適用し、集計すると何が出るか。曲線を時刻 $t$ の関数として
+<p>では曲線に沿ってこれらを適用し、集計すると何が出るか。曲線を時刻 <span class="tex2jax_process">$t$</span> の関数として
 </p>
-<p>$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$
+<div class="math-block tex2jax_process">$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$</div>
+<p>と表す。曲線を小区間に刻み、<span class="tex2jax_process">$i$</span> 番目の小区間での変位ベクトルを <span class="tex2jax_process">$\Delta\mathbf{r}_i = \gamma(t_i + \Delta t) - \gamma(t_i)$</span> とする。<span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> は有限の変位であり、近似ではない。成分を明示すれば <span class="tex2jax_process">$\Delta\mathbf{r}_i = (\Delta x_i,\; \Delta y_i,\; \Delta z_i)$</span> である。
 </p>
-<p>と表す。曲線を小区間に刻み、$i$ 番目の小区間での変位ベクトルを $\Delta\mathbf{r}_i = \gamma(t_i + \Delta t) - \gamma(t_i)$ とする。$\Delta\mathbf{r}_i$ は有限の変位であり、近似ではない。成分を明示すれば $\Delta\mathbf{r}_i = (\Delta x_i,\; \Delta y_i,\; \Delta z_i)$ である。
+<p>各小区間で<strong>行列 <span class="tex2jax_process">$dx$</span> を変位ベクトル <span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> に作用させる</strong>：
 </p>
-<p>各小区間で<strong>行列 $dx$ を変位ベクトル $\Delta\mathbf{r}_i$ に作用させる</strong>：
+<div class="math-block tex2jax_process">$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$</div>
+<p>この <span class="tex2jax_process">$\Delta x_i/\Delta t$</span> は有限のままの比であり、近似ではない。全区間で足し上げれば、各項が <span class="tex2jax_process">$\Delta t$</span> ごとの換算率 <span class="tex2jax_process">$\Delta x_i/\Delta t$</span> を持つ正確な和になる：
 </p>
-<p>$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$
-</p>
-<p>この $\Delta x_i/\Delta t$ は有限のままの比であり、近似ではない。全区間で足し上げれば、各項が $\Delta t$ ごとの換算率 $\Delta x_i/\Delta t$ を持つ正確な和になる：
-</p>
-<p>$$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$
-</p>
-<p>刻みを無限に細かくする極限で、換算率は導関数に収束する：$\Delta x_i/\Delta t \to dx/dt$。この極限を
+<div class="math-block tex2jax_process">$$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$</div>
+<p>刻みを無限に細かくする極限で、換算率は導関数に収束する：<span class="tex2jax_process">$\Delta x_i/\Delta t \to dx/dt$</span>。この極限を
 </p>
 <p>刻みを無限に細かくする極限を
 </p>
-<p>$$\int_\gamma dx$$
+<div class="math-block tex2jax_process">$$\int_\gamma dx$$</div>
+<p>と<strong>書くことにする</strong>。これが <span class="tex2jax_process">$1$</span>-form の積分——線積分——の定義である。
 </p>
-<p>と<strong>書くことにする</strong>。これが $1$-form の積分——線積分——の定義である。
-</p>
-<blockquote><p>**注** （$1$-form と $1$-vector の縮約）§3.1・§3.2 と同じく、**$1$-form（横ベクトル＝はかり）**が**$1$-vector（縦ベクトル＝図形）**を食べてスカラーを返す。各小区間でこの縮約を行い、集計する。次数が違うだけで原理は同じだ。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$1$</span>-vector の縮約）§3.1・§3.2 と同じく、**<span class="tex2jax_process">$1$</span>-form（横ベクトル＝はかり）**が**<span class="tex2jax_process">$1$</span>-vector（縦ベクトル＝図形）**を食べてスカラーを返す。各小区間でこの縮約を行い、集計する。次数が違うだけで原理は同じだ。</p>
 </p></blockquote>
 <p>この極限は第1章 §1.2.5 の置換積分とまったく同じ形であり：
 </p>
-<p>$$\int_\gamma dx = \int_{t_0}^{t_1} \frac{dx}{dt}\,dt = x(t_1) - x(t_0)$$
-</p>
-<p>同様に $\int_\gamma dy = y(t_1) - y(t_0)$、$\int_\gamma dz = z(t_1) - z(t_0)$。すなわち<strong>$dx, dy, dz$ という $1$-form の線積分は、曲線の正味の変位——始点と終点の座標の差——を返す。</strong>
+<div class="math-block tex2jax_process">$$\int_\gamma dx = \int_{t_0}^{t_1} \frac{dx}{dt}\,dt = x(t_1) - x(t_0)$$</div>
+<p>同様に <span class="tex2jax_process">$\int_\gamma dy = y(t_1) - y(t_0)$</span>、<span class="tex2jax_process">$\int_\gamma dz = z(t_1) - z(t_0)$</span>。すなわち<strong><span class="tex2jax_process">$dx, dy, dz$</span> という <span class="tex2jax_process">$1$</span>-form の線積分は、曲線の正味の変位——始点と終点の座標の差——を返す。</strong>
 </p>
 <h4 id="332-円周で試す弧長は出ない">3.3.2 円周で試す——弧長は出ない</h4>
-<p>確認しよう。半径 $R$ の円を
+<p>確認しよう。半径 <span class="tex2jax_process">$R$</span> の円を
 </p>
-<p>$$\gamma(t) = (R\cos t,\; R\sin t,\; 0),\qquad t \in [0, 2\pi]$$
+<div class="math-block tex2jax_process">$$\gamma(t) = (R\cos t,\; R\sin t,\; 0),\qquad t \in [0, 2\pi]$$</div>
+<p>とパラメータ表示する。<span class="tex2jax_process">$\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$</span> だから：
 </p>
-<p>とパラメータ表示する。$\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$ だから：
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \int_\gamma dx &= \int_0^{2\pi} dx(\gamma'(t))\,dt = \int_0^{2\pi} (-R\sin t)\,dt = R\bigl[\cos t\bigr]_0^{2\pi} = 0 \\[4pt]
 \int_\gamma dy &= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
-\end{aligned}$$
-</p>
+\end{aligned}$$</div>
 <p>いずれもゼロである。閉曲線だから始点と終点が同じで、行きと帰りで打ち消し合う——当然の結果だ。
 </p>
-<p>しかし、この円の弧長が $2\pi R$ であることも我々は知っている。係数1の $dx, dy$ だけではゼロになってしまうが、では<strong>どうすれば弧長が出るのか</strong>。
+<p>しかし、この円の弧長が <span class="tex2jax_process">$2\pi R$</span> であることも我々は知っている。係数1の <span class="tex2jax_process">$dx, dy$</span> だけではゼロになってしまうが、では<strong>どうすれば弧長が出るのか</strong>。
 </p>
-<p>各瞬間に $dx, dy$ が測った値はすでに手元にある。$dx(\gamma'(t)) = -R\sin t$、$dy(\gamma'(t)) = R\cos t$。これらはスカラーだから、二乗して足すことができる：
+<p>各瞬間に <span class="tex2jax_process">$dx, dy$</span> が測った値はすでに手元にある。<span class="tex2jax_process">$dx(\gamma'(t)) = -R\sin t$</span>、<span class="tex2jax_process">$dy(\gamma'(t)) = R\cos t$</span>。これらはスカラーだから、二乗して足すことができる：
 </p>
-<p>$$dx(\gamma'(t))^2 + dy(\gamma'(t))^2 = R^2\sin^2 t + R^2\cos^2 t = R^2$$
+<div class="math-block tex2jax_process">$$dx(\gamma'(t))^2 + dy(\gamma'(t))^2 = R^2\sin^2 t + R^2\cos^2 t = R^2$$</div>
+<p>その平方根をとれば、その瞬間の速さ <span class="tex2jax_process">$|\gamma'(t)| = R$</span> が得られる。全区間で積分すれば：
 </p>
-<p>その平方根をとれば、その瞬間の速さ $|\gamma'(t)| = R$ が得られる。全区間で積分すれば：
+<div class="math-block tex2jax_process">$$\int_0^{2\pi} \!\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} \!R\,dt = 2\pi R$$</div>
+<p>弧長 <span class="tex2jax_process">$2\pi R$</span> が出た。ここで起きていることは重要だ——<span class="tex2jax_process">$dx$</span> も <span class="tex2jax_process">$dy$</span> も単独では閉曲線でゼロになったのに、それらの二乗和の平方根をとって積分すると、正しい弧長が姿を現した。係数1の <span class="tex2jax_process">$1$</span>-form にはなかった「長さを測る力」が、二乗和という代数的な組み換えによって回復されたのである。
 </p>
-<p>$$\int_0^{2\pi} \!\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} \!R\,dt = 2\pi R$$
+<p>弧長 <span class="tex2jax_process">$2\pi R$</span> が出た。
 </p>
-<p>弧長 $2\pi R$ が出た。ここで起きていることは重要だ——$dx$ も $dy$ も単独では閉曲線でゼロになったのに、それらの二乗和の平方根をとって積分すると、正しい弧長が姿を現した。係数1の $1$-form にはなかった「長さを測る力」が、二乗和という代数的な組み換えによって回復されたのである。
+<p>ここで起きていることを整理しよう。各時刻 <span class="tex2jax_process">$t$</span> で <span class="tex2jax_process">$dx(\gamma'(t))$</span> と <span class="tex2jax_process">$dy(\gamma'(t))$</span> という二つのスカラーを得て、それらの二乗和の平方根 <span class="tex2jax_process">$\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$</span> をとり、<span class="tex2jax_process">$t$</span> で積分した。これはすなわち、「変位 <span class="tex2jax_process">$\mathbf{v}$</span> に対して <span class="tex2jax_process">$\sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$</span> を返す」という新しい <span class="tex2jax_process">$1$</span>-form を曲線上で積分したことにほかならない。この <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$ds$</span> と書く：
 </p>
-<p>弧長 $2\pi R$ が出た。
-</p>
-<p>ここで起きていることを整理しよう。各時刻 $t$ で $dx(\gamma'(t))$ と $dy(\gamma'(t))$ という二つのスカラーを得て、それらの二乗和の平方根 $\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$ をとり、$t$ で積分した。これはすなわち、「変位 $\mathbf{v}$ に対して $\sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$ を返す」という新しい $1$-form を曲線上で積分したことにほかならない。この $1$-form を $ds$ と書く：
-</p>
-<p>$$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$$
-</p>
-<blockquote><p>**注** （記法について）第1章 §1.1.6 の契約により、単独の $dx$ は横ベクトル（演算子）であり、それ自体を二乗することはできない。$dx(\mathbf{v})^2$ は、$1$-form $dx$ をベクトル $\mathbf{v}$ に**作用させて得たスカラー**を二乗したものである。この区別を崩さないことが、本書の記法の一貫性を保つ。</p>
+<div class="math-block tex2jax_process">$$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$$</div>
+<blockquote><p>**注** （記法について）第1章 §1.1.6 の契約により、単独の <span class="tex2jax_process">$dx$</span> は横ベクトル（演算子）であり、それ自体を二乗することはできない。<span class="tex2jax_process">$dx(\mathbf{v})^2$</span> は、<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$dx$</span> をベクトル <span class="tex2jax_process">$\mathbf{v}$</span> に**作用させて得たスカラー**を二乗したものである。この区別を崩さないことが、本書の記法の一貫性を保つ。</p>
 </p></blockquote>
-<p>この $ds$ も立派な $1$-form であり、$\int_\gamma ds$ は $1$-form の積分である。しかしながら、この $ds$ を $dx$ と $dy$ の線形結合——$\frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy$ の形——で書くことはできない。$ds$ の定義には二乗和の平方根が含まれており、$dx, dy$ について線形ではないからだ。
+<p>この <span class="tex2jax_process">$ds$</span> も立派な <span class="tex2jax_process">$1$</span>-form であり、<span class="tex2jax_process">$\int_\gamma ds$</span> は <span class="tex2jax_process">$1$</span>-form の積分である。しかしながら、この <span class="tex2jax_process">$ds$</span> を <span class="tex2jax_process">$dx$</span> と <span class="tex2jax_process">$dy$</span> の線形結合——<span class="tex2jax_process">$\frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy$</span> の形——で書くことはできない。<span class="tex2jax_process">$ds$</span> の定義には二乗和の平方根が含まれており、<span class="tex2jax_process">$dx, dy$</span> について線形ではないからだ。
 </p>
-<blockquote><p>**注** （計量への伏線）$dx(\mathbf{v})^2 + dy(\mathbf{v})^2$ という「成分の二乗和」の形は、第2章 §2.4.7 で平行四辺形のスカラー面積を $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ と出したのと完全に並行である。この「ピタゴラスの組み合わせ方」は、直交デカルト座標における自然な長さの定義に他ならない。任意の座標系への一般化は第6章で計量 $g$ を使って行う。ここでは「$dx, dy, dz$ の作用結果の二乗和の平方根をとれば、向きを捨てた正の大きさ（長さ・面積・体積）が得られる」という事実だけを押さえておけばよい。</p>
+<blockquote><p>**注** （計量への伏線）<span class="tex2jax_process">$dx(\mathbf{v})^2 + dy(\mathbf{v})^2$</span> という「成分の二乗和」の形は、第2章 §2.4.7 で平行四辺形のスカラー面積を <span class="tex2jax_process">$\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$</span> と出したのと完全に並行である。この「ピタゴラスの組み合わせ方」は、直交デカルト座標における自然な長さの定義に他ならない。任意の座標系への一般化は第6章で計量 <span class="tex2jax_process">$g$</span> を使って行う。ここでは「<span class="tex2jax_process">$dx, dy, dz$</span> の作用結果の二乗和の平方根をとれば、向きを捨てた正の大きさ（長さ・面積・体積）が得られる」という事実だけを押さえておけばよい。</p>
 </p></blockquote>
-<h4 id="333-では-form-で何が測れるのか">3.3.3 では $1$-form で何が測れるのか</h4>
-<p>弧長は $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$ という $1$-form の積分として測れた。この $ds$ は $dx$ と $dy$ の線形結合では書けず、二乗和の平方根を必要とする。この組み合わせ方を任意の座標系へ一般化するのが第6章の計量 $g$ の役割だが、ここではまず、計量を必要としない $1$-form——すなわち $dx, dy, dz$ の線形結合で書ける $1$-form——が、いったい何を測るのかを見ていこう。
+<h4 id="333-では-span-classtex2jaxprocessspan-form-で何が測れるのか">3.3.3 では <span class="tex2jax_process">$1$</span>-form で何が測れるのか</h4>
+<p>弧長は <span class="tex2jax_process">$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$</span> という <span class="tex2jax_process">$1$</span>-form の積分として測れた。この <span class="tex2jax_process">$ds$</span> は <span class="tex2jax_process">$dx$</span> と <span class="tex2jax_process">$dy$</span> の線形結合では書けず、二乗和の平方根を必要とする。この組み合わせ方を任意の座標系へ一般化するのが第6章の計量 <span class="tex2jax_process">$g$</span> の役割だが、ここではまず、計量を必要としない <span class="tex2jax_process">$1$</span>-form——すなわち <span class="tex2jax_process">$dx, dy, dz$</span> の線形結合で書ける <span class="tex2jax_process">$1$</span>-form——が、いったい何を測るのかを見ていこう。
 </p>
-<p>空間の各点に力の場 $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ が働いている。曲線に沿って質点を動かすとき、各小区間で力がする微小仕事は、力の変位方向成分と変位の大きさの積——すなわち $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$——である。これを全区間で足し上げたものが仕事 $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$ だ。
+<p>空間の各点に力の場 <span class="tex2jax_process">$\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$</span> が働いている。曲線に沿って質点を動かすとき、各小区間で力がする微小仕事は、力の変位方向成分と変位の大きさの積——すなわち <span class="tex2jax_process">$F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$</span>——である。これを全区間で足し上げたものが仕事 <span class="tex2jax_process">$W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$</span> だ。
 </p>
-<p>ここで重要なのは、力の成分 $F_x, F_y, F_z$ は<strong>場所ごとに変わる</strong>ことである。体積（§3.1）や表面積（§3.2）では係数1で十分な部分が多かったが、仕事を測るには場所ごとに変わる係数が不可欠だ。これが係数の必然性をもっとも鮮明に示す。
+<p>ここで重要なのは、力の成分 <span class="tex2jax_process">$F_x, F_y, F_z$</span> は<strong>場所ごとに変わる</strong>ことである。体積（§3.1）や表面積（§3.2）では係数1で十分な部分が多かったが、仕事を測るには場所ごとに変わる係数が不可欠だ。これが係数の必然性をもっとも鮮明に示す。
 </p>
 <p>これが、次節で係数を導入する動機である。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $dx, dy, dz$ の線積分は「正味の変位」を返す。閉曲線ではゼロ。
-- 弧長は $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$ という $1$-form の積分で計算できる。$ds$ は $dx, dy$ の線形結合で書くことはできない（二乗和の平方根を必要とする。任意の座標系への一般化は第6章）。
-- 計量なしの $1$-form（$dx, dy, dz$ の線形結合）が測るのは「仕事」のような量である。→ §3.4 へ。
+- <span class="tex2jax_process">$dx, dy, dz$</span> の線積分は「正味の変位」を返す。閉曲線ではゼロ。
+- 弧長は <span class="tex2jax_process">$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$</span> という <span class="tex2jax_process">$1$</span>-form の積分で計算できる。<span class="tex2jax_process">$ds$</span> は <span class="tex2jax_process">$dx, dy$</span> の線形結合で書くことはできない（二乗和の平方根を必要とする。任意の座標系への一般化は第6章）。
+- 計量なしの <span class="tex2jax_process">$1$</span>-form（<span class="tex2jax_process">$dx, dy, dz$</span> の線形結合）が測るのは「仕事」のような量である。→ §3.4 へ。
 </p></blockquote>
 <hr />
 <h3 id="34-係数をつける密度と幾何の積">§3.4 係数をつける——密度と幾何の積</h3>
@@ -1836,150 +1798,132 @@ $$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{
 <p>§3.1〜§3.3 では、係数1の形式で曲がった図形を測ってきた。しかし現実の物理では、測定器に<strong>場所ごとに変わる重み</strong>を掛けたくなる場面が無数にある：
 </p>
 <ul>
-<li>**力の場**（場所ごとに変わる）$\times$ **変位** $=$ **仕事**</li>
+<li>**力の場**（場所ごとに変わる）<span class="tex2jax_process">$\times$</span> **変位** <span class="tex2jax_process">$=$</span> **仕事**</li>
 </ol>
 <ul>
-<li>**流速の場**（場所ごとに変わる）$\times$ **断面** $=$ **流量**</li>
+<li>**流速の場**（場所ごとに変わる）<span class="tex2jax_process">$\times$</span> **断面** <span class="tex2jax_process">$=$</span> **流量**</li>
 </ol>
 <ul>
-<li>**密度の場**（場所ごとに変わる）$\times$ **体積** $=$ **質量**</li>
+<li>**密度の場**（場所ごとに変わる）<span class="tex2jax_process">$\times$</span> **体積** <span class="tex2jax_process">$=$</span> **質量**</li>
 </ol>
-<p>ここに共通する構造は明白だ。<strong>「場所ごとに変わる重み（$0$-form ＝ スカラー場）」</strong>と<strong>「幾何的な測り方（$k$-form）」</strong>の積が、一般の $k$-form を構成する。第2章 §2.4.8 で「$0$-form はベクトルを0本食べる測定器、すなわちスカラー場」と述べたのは、まさにこの布石である。
+<p>ここに共通する構造は明白だ。<strong>「場所ごとに変わる重み（<span class="tex2jax_process">$0$</span>-form ＝ スカラー場）」</strong>と<strong>「幾何的な測り方（<span class="tex2jax_process">$k$</span>-form）」</strong>の積が、一般の <span class="tex2jax_process">$k$</span>-form を構成する。第2章 §2.4.8 で「<span class="tex2jax_process">$0$</span>-form はベクトルを0本食べる測定器、すなわちスカラー場」と述べたのは、まさにこの布石である。
 </p>
 <p>以下、1次元・2次元・3次元の順に、係数付き形式の積分を定義していく。
 </p>
-<h4 id="341-一般の-form-の線積分仕事">3.4.1 一般の $1$-form の線積分（仕事）</h4>
-<p>実空間で、係数が点 $(x,y,z)$ に依存するスカラー場 $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ をとり、
+<h4 id="341-一般の-span-classtex2jaxprocessspan-form-の線積分仕事">3.4.1 一般の <span class="tex2jax_process">$1$</span>-form の線積分（仕事）</h4>
+<p>実空間で、係数が点 <span class="tex2jax_process">$(x,y,z)$</span> に依存するスカラー場 <span class="tex2jax_process">$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$</span> をとり、
 </p>
-<p>$$\omega = \frac{\partial f}{\partial x}(x,y,z)\,dx + \frac{\partial f}{\partial y}(x,y,z)\,dy + \frac{\partial f}{\partial z}(x,y,z)\,dz$$
+<div class="math-block tex2jax_process">$$\omega = \frac{\partial f}{\partial x}(x,y,z)\,dx + \frac{\partial f}{\partial y}(x,y,z)\,dy + \frac{\partial f}{\partial z}(x,y,z)\,dz$$</div>
+<p>を<strong><span class="tex2jax_process">$1$</span>-form の一般形</strong>と呼ぶ。各 <span class="tex2jax_process">$dx, dy, dz$</span> は第1章どおり、縦ベクトルから成分を読み取る横ベクトルである。係数 <span class="tex2jax_process">$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$</span> は場所ごとに変わる重み——<span class="tex2jax_process">$0$</span>-form——である。
 </p>
-<p>を<strong>$1$-form の一般形</strong>と呼ぶ。各 $dx, dy, dz$ は第1章どおり、縦ベクトルから成分を読み取る横ベクトルである。係数 $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ は場所ごとに変わる重み——$0$-form——である。
+<p>曲線 <span class="tex2jax_process">$\gamma(t)$</span> に沿った積分は、§3.3.1 のリーマン和に係数を乗せるだけだ。各小区間の変位 <span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> に <span class="tex2jax_process">$\omega$</span> を食わせる。<span class="tex2jax_process">$\omega$</span> は横ベクトル、<span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> は縦ベクトルであり、その縮約は定義そのものとして厳密な等式で書ける：
 </p>
-<p>曲線 $\gamma(t)$ に沿った積分は、§3.3.1 のリーマン和に係数を乗せるだけだ。各小区間の変位 $\Delta\mathbf{r}_i$ に $\omega$ を食わせる。$\omega$ は横ベクトル、$\Delta\mathbf{r}_i$ は縦ベクトルであり、その縮約は定義そのものとして厳密な等式で書ける：
+<div class="math-block tex2jax_process">$$\omega(\Delta\mathbf{r}_i) = \frac{\partial f}{\partial x}\,\Delta x_i + \frac{\partial f}{\partial y}\,\Delta y_i + \frac{\partial f}{\partial z}\,\Delta z_i$$</div>
+<p>ここで <span class="tex2jax_process">$=$</span> であって <span class="tex2jax_process">$\approx$</span> ではない——これは <span class="tex2jax_process">$\omega$</span> という横ベクトルと有限変位 <span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> の縮約であり、近似の余地はない。
 </p>
-<p>$$\omega(\Delta\mathbf{r}_i) = \frac{\partial f}{\partial x}\,\Delta x_i + \frac{\partial f}{\partial y}\,\Delta y_i + \frac{\partial f}{\partial z}\,\Delta z_i$$
+<p>各成分の変化を「有限の比 <span class="tex2jax_process">$\times \Delta t$</span>」の形に整理する：
 </p>
-<p>ここで $=$ であって $\approx$ ではない——これは $\omega$ という横ベクトルと有限変位 $\Delta\mathbf{r}_i$ の縮約であり、近似の余地はない。
-</p>
-<p>各成分の変化を「有限の比 $\times \Delta t$」の形に整理する：
-</p>
-<p>$$\omega(\Delta\mathbf{r}_i) = \bigl(\frac{\partial f}{\partial x}\frac{\Delta x_i}{\Delta t} + \frac{\partial f}{\partial y}\frac{\Delta y_i}{\Delta t} + \frac{\partial f}{\partial z}\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$
-</p>
-<p>$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ は点 $\gamma(t_i)$ での値。全区間で足し上げて極限をとる。$\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$ だから：
-</p>
-<p>$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,dt$$
-</p>
+<div class="math-block tex2jax_process">$$\omega(\Delta\mathbf{r}_i) = \bigl(\frac{\partial f}{\partial x}\frac{\Delta x_i}{\Delta t} + \frac{\partial f}{\partial y}\frac{\Delta y_i}{\Delta t} + \frac{\partial f}{\partial z}\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$</div>
+<span class="tex2jax_process">$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$</span> は点 <span class="tex2jax_process">$\gamma(t_i)$</span> での値。全区間で足し上げて極限をとる。<span class="tex2jax_process">$\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$</span> だから：
+<div class="math-block tex2jax_process">$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,dt$$</div>
 <p>この極限を
 </p>
-<p>$$\int_\gamma \omega$$
+<div class="math-block tex2jax_process">$$\int_\gamma \omega$$</div>
+<p>と書く。§3.3.1 の係数1の場合とまったく同じ型で、各瞬間に<strong>横ベクトル（係数付き <span class="tex2jax_process">$1$</span>-form）</strong>が<strong>縦ベクトル（<span class="tex2jax_process">$\gamma'(t)$</span>）</strong>を食べてスカラーを返し、それを集計している。これは第1章 §1.2.5 の <span class="tex2jax_process">$F(x)\,dx$</span> を3次元に自然拡張しただけである。
 </p>
-<p>と書く。§3.3.1 の係数1の場合とまったく同じ型で、各瞬間に<strong>横ベクトル（係数付き $1$-form）</strong>が<strong>縦ベクトル（$\gamma'(t)$）</strong>を食べてスカラーを返し、それを集計している。これは第1章 §1.2.5 の $F(x)\,dx$ を3次元に自然拡張しただけである。
-</p>
-<blockquote><p>**注** （ベクトル解析との対応）ベクトル解析では、この量を $\int_\gamma \mathbf{F}\cdot d\mathbf{r}$ と書く。本書の $\int_\gamma \omega$ はそれと同じでありながら、**場 $\omega$** と**経路 $\gamma$** が記号上も明確に分離されている。</p>
+<blockquote><p>**注** （ベクトル解析との対応）ベクトル解析では、この量を <span class="tex2jax_process">$\int_\gamma \mathbf{F}\cdot d\mathbf{r}$</span> と書く。本書の <span class="tex2jax_process">$\int_\gamma \omega$</span> はそれと同じでありながら、**場 <span class="tex2jax_process">$\omega$</span>** と**経路 <span class="tex2jax_process">$\gamma$</span>** が記号上も明確に分離されている。</p>
 </p></blockquote>
-<p>具体例を見よう。力場 $\mathbf{F} = (y,\; x,\; 0)$ が、単位円 $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$ に沿ってする仕事を計算する。
+<p>具体例を見よう。力場 <span class="tex2jax_process">$\mathbf{F} = (y,\; x,\; 0)$</span> が、単位円 <span class="tex2jax_process">$\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$</span> に沿ってする仕事を計算する。
 </p>
-<p>$\omega = y\,dx + x\,dy$ だから、係数は $\frac{\partial f}{\partial x} = y,\; \frac{\partial f}{\partial y} = x$。曲線上では $\frac{\partial f}{\partial x} = \sin t,\; \frac{\partial f}{\partial y} = \cos t$。また $dx/dt = -\sin t,\; dy/dt = \cos t$ より：
-</p>
-<p>$$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$
-</p>
+<span class="tex2jax_process">$\omega = y\,dx + x\,dy$</span> だから、係数は <span class="tex2jax_process">$\frac{\partial f}{\partial x} = y,\; \frac{\partial f}{\partial y} = x$</span>。曲線上では <span class="tex2jax_process">$\frac{\partial f}{\partial x} = \sin t,\; \frac{\partial f}{\partial y} = \cos t$</span>。また <span class="tex2jax_process">$dx/dt = -\sin t,\; dy/dt = \cos t$</span> より：
+<div class="math-block tex2jax_process">$$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$</div>
 <p>したがって：
 </p>
-<p>$$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$
-</p>
+<div class="math-block tex2jax_process">$$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$</div>
 <p>仕事がゼロになった。この力場は単位円に沿って正味の仕事をしないのである。
 </p>
-<h4 id="342-一般の-form-の面積分流量">3.4.2 一般の $2$-form の面積分（流量）</h4>
-<p>同様に、三つのスカラー場 $P, Q, R$ を係数とする一般の $2$-form：
+<h4 id="342-一般の-span-classtex2jaxprocessspan-form-の面積分流量">3.4.2 一般の <span class="tex2jax_process">$2$</span>-form の面積分（流量）</h4>
+<p>同様に、三つのスカラー場 <span class="tex2jax_process">$P, Q, R$</span> を係数とする一般の <span class="tex2jax_process">$2$</span>-form：
 </p>
-<p>$$\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy$$
+<div class="math-block tex2jax_process">$$\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy$$</div>
+<p>曲面 <span class="tex2jax_process">$\mathbf{r}(u,v)$</span> に沿った積分も、§3.2.1 のリーマン和に係数を乗せるだけだ。各小区画の面素 <span class="tex2jax_process">$(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v)$</span> に <span class="tex2jax_process">$\eta$</span> を食わせる：
 </p>
-<p>曲面 $\mathbf{r}(u,v)$ に沿った積分も、§3.2.1 のリーマン和に係数を乗せるだけだ。各小区画の面素 $(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v)$ に $\eta$ を食わせる：
-</p>
-<p>$$\eta(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = \bigl(P\,(dy \wedge dz) + Q\,(dz \wedge dx) + R\,(dx \wedge dy)\bigr)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$
-</p>
+<div class="math-block tex2jax_process">$$\eta(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = \bigl(P\,(dy \wedge dz) + Q\,(dz \wedge dx) + R\,(dx \wedge dy)\bigr)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$</div>
 <p>全区画で足し上げて極限をとる。この極限を
 </p>
-<p>$$\iint_S \eta$$
+<div class="math-block tex2jax_process">$$\iint_S \eta$$</div>
+<p>と記す。各点で面素を面積測定器 <span class="tex2jax_process">$\eta$</span> が食べてスカラーを返し、それを <span class="tex2jax_process">$D$</span> 全体で集計する点は §3.2 と同じである。
 </p>
-<p>と記す。各点で面素を面積測定器 $\eta$ が食べてスカラーを返し、それを $D$ 全体で集計する点は §3.2 と同じである。
-</p>
-<p>$dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ がそれぞれ各平面への「影の面積」を測ることは §3.2 で見た。係数 $P, Q, R$ は、それらの影に<strong>場所ごとに変わる重み</strong>をつける役割を果たす。物理的には、$(P, Q, R)$ が流速場の成分であり、$\iint_S \eta$ が曲面を貫く流量（フラックス）に対応するが、これをベクトル解析の言葉に翻訳して厳密に整理するには計量（内積）が必要である。詳しくは第6章で行う。
-</p>
-<blockquote><p>**注** （ここではベクトル解析との対応は補助線）流量との対応は、既にベクトル解析を知っている読者のための橋渡しにすぎない。本書の本線はあくまで「$2$-form を食わせて集計する」という操作であり、ベクトル解析の知識がなくともこの先の議論に支障はない。</p>
+<span class="tex2jax_process">$dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$</span> がそれぞれ各平面への「影の面積」を測ることは §3.2 で見た。係数 <span class="tex2jax_process">$P, Q, R$</span> は、それらの影に<strong>場所ごとに変わる重み</strong>をつける役割を果たす。物理的には、<span class="tex2jax_process">$(P, Q, R)$</span> が流速場の成分であり、<span class="tex2jax_process">$\iint_S \eta$</span> が曲面を貫く流量（フラックス）に対応するが、これをベクトル解析の言葉に翻訳して厳密に整理するには計量（内積）が必要である。詳しくは第6章で行う。
+<blockquote><p>**注** （ここではベクトル解析との対応は補助線）流量との対応は、既にベクトル解析を知っている読者のための橋渡しにすぎない。本書の本線はあくまで「<span class="tex2jax_process">$2$</span>-form を食わせて集計する」という操作であり、ベクトル解析の知識がなくともこの先の議論に支障はない。</p>
 </p></blockquote>
-<h4 id="343-一般の-form-の体積分総質量">3.4.3 一般の $3$-form の体積分（総質量）</h4>
-<p>$3$-form の一般形は、スカラー場 $\rho(x,y,z)$ を係数として：
+<h4 id="343-一般の-span-classtex2jaxprocessspan-form-の体積分総質量">3.4.3 一般の <span class="tex2jax_process">$3$</span>-form の体積分（総質量）</h4>
+<span class="tex2jax_process">$3$</span>-form の一般形は、スカラー場 <span class="tex2jax_process">$\rho(x,y,z)$</span> を係数として：
+<div class="math-block tex2jax_process">$$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$</div>
+<p>§3.1.1 のリーマン和に密度 <span class="tex2jax_process">$\rho$</span> を乗せればよい。各小直方体の体積素に <span class="tex2jax_process">$\Omega$</span> を食わせる：
 </p>
-<p>$$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$
-</p>
-<p>§3.1.1 のリーマン和に密度 $\rho$ を乗せればよい。各小直方体の体積素に $\Omega$ を食わせる：
-</p>
-<p>$$\Omega(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \rho(x_i,y_i,z_i)\,\Delta x_i\,\Delta y_i\,\Delta z_i$$
-</p>
+<div class="math-block tex2jax_process">$$\Omega(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \rho(x_i,y_i,z_i)\,\Delta x_i\,\Delta y_i\,\Delta z_i$$</div>
 <p>全区間で足し上げて極限をとる。この極限を
 </p>
-<p>$$\iiint_V \Omega$$
-</p>
-<p>と書く。$\rho=1$ なら §3.1 の係数1の場合に戻る。$\rho$ が質量密度なら総質量、電荷密度なら総電荷を与える。$3$-form の独立成分は $dx \wedge dy \wedge dz$ の1つだけなので、<strong>「密度（$\rho$）」と「体積の測り方（$dx \wedge dy \wedge dz$）」がきれいに分離</strong>して見通しがよい。
+<div class="math-block tex2jax_process">$$\iiint_V \Omega$$</div>
+<p>と書く。<span class="tex2jax_process">$\rho=1$</span> なら §3.1 の係数1の場合に戻る。<span class="tex2jax_process">$\rho$</span> が質量密度なら総質量、電荷密度なら総電荷を与える。<span class="tex2jax_process">$3$</span>-form の独立成分は <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の1つだけなので、<strong>「密度（<span class="tex2jax_process">$\rho$</span>）」と「体積の測り方（<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span>）」がきれいに分離</strong>して見通しがよい。
 </p>
 <h4 id="344-線・面・体の統一像">3.4.4 線・面・体の統一像</h4>
 <p>ここまでを俯瞰しよう。
 </p>
 <p>| 対象 | 形式 | 積分の骨格 | 物理的意味の例 |
 |:---:|:---|:---|:---|
-| 曲線 $\gamma$ | $1$-form $\omega$ | $\displaystyle\int \omega(\gamma')\,dt$ | 仕事 |
-| 曲面 $S$ | $2$-form $\eta$ | $\displaystyle\iint \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$ | 流量 |
-| 領域 $V$ | $3$-form $\Omega$ | $\displaystyle\iiint \Omega(\hat{e}_x,\hat{e}_y,\hat{e}_z)$ | 総質量 |
+| 曲線 <span class="tex2jax_process">$\gamma$</span> | <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> | <span class="tex2jax_process">$\displaystyle\int \omega(\gamma')\,dt$</span> | 仕事 |
+| 曲面 <span class="tex2jax_process">$S$</span> | <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\eta$</span> | <span class="tex2jax_process">$\displaystyle\iint \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$</span> | 流量 |
+| 領域 <span class="tex2jax_process">$V$</span> | <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\Omega$</span> | <span class="tex2jax_process">$\displaystyle\iiint \Omega(\hat{e}_x,\hat{e}_y,\hat{e}_z)$</span> | 総質量 |
 </p>
-<p>いずれも<strong>「$k$-form（はかり）が $k$-vector（図形）を食べてスカラーを返し、それを領域全体で集計する」</strong>という同一の型である。次数が上がるごとに食わせるベクトルの本数が増え、交代性が面積・体積の向きを司る。次数が違うだけで、原理はどこまでも同じだ。
+<p>いずれも<strong>「<span class="tex2jax_process">$k$</span>-form（はかり）が <span class="tex2jax_process">$k$</span>-vector（図形）を食べてスカラーを返し、それを領域全体で集計する」</strong>という同一の型である。次数が上がるごとに食わせるベクトルの本数が増え、交代性が面積・体積の向きを司る。次数が違うだけで、原理はどこまでも同じだ。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 一般の $k$-form は「場所ごとに変わる重み（$0$-form）」と「幾何的な測り方（基底 $k$-form）」の積。
-- 線積分 $\int_\gamma \omega$ は仕事、面積分 $\iint_S \eta$ は流量、体積分 $\iiint_V \Omega$ は総質量に対応する。
+- 一般の <span class="tex2jax_process">$k$</span>-form は「場所ごとに変わる重み（<span class="tex2jax_process">$0$</span>-form）」と「幾何的な測り方（基底 <span class="tex2jax_process">$k$</span>-form）」の積。
+- 線積分 <span class="tex2jax_process">$\int_\gamma \omega$</span> は仕事、面積分 <span class="tex2jax_process">$\iint_S \eta$</span> は流量、体積分 <span class="tex2jax_process">$\iiint_V \Omega$</span> は総質量に対応する。
 - いずれも「はかりと図形の縮約 → 集計」という同一原理。次節では、これらの積分を別の座標で計算し直す方法——引き戻し——を導入する。
 </p></blockquote>
 <h4 id="345-積分の一般形">3.4.5 積分の一般形</h4>
-<p>§3.1〜§3.3 で別々に定義した線積分、面積分、体積分は、実は一つのパターンにまとまる。$k$-form $\omega$ を $k$ 次元領域 $M$ 上で積分するという操作を、次元によらず
+<p>§3.1〜§3.3 で別々に定義した線積分、面積分、体積分は、実は一つのパターンにまとまる。<span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> を <span class="tex2jax_process">$k$</span> 次元領域 <span class="tex2jax_process">$M$</span> 上で積分するという操作を、次元によらず
 </p>
-<p>$$\int_M \omega$$
+<div class="math-block tex2jax_process">$$\int_M \omega$$</div>
+<p>と書く。<span class="tex2jax_process">$M$</span> が曲線（<span class="tex2jax_process">$k=1$</span>）なら <span class="tex2jax_process">$\int_\gamma$</span>、曲面（<span class="tex2jax_process">$k=2$</span>）なら <span class="tex2jax_process">$\iint_S$</span>、立体（<span class="tex2jax_process">$k=3$</span>）なら <span class="tex2jax_process">$\iiint_V$</span> ——積分記号の重なりは <span class="tex2jax_process">$M$</span> の次元で決まるにすぎない。中身は常に「小区分に刻む → <span class="tex2jax_process">$k$</span>-form を <span class="tex2jax_process">$k$</span>-vector に食わせる → 和 <span class="tex2jax_process">$\sum$</span> → 極限」である。
 </p>
-<p>と書く。$M$ が曲線（$k=1$）なら $\int_\gamma$、曲面（$k=2$）なら $\iint_S$、立体（$k=3$）なら $\iiint_V$ ——積分記号の重なりは $M$ の次元で決まるにすぎない。中身は常に「小区分に刻む → $k$-form を $k$-vector に食わせる → 和 $\sum$ → 極限」である。
-</p>
-<p>本書の舞台は 3 次元空間だから $k=1,2,3$ で十分だが、この式が $k$ によらず成立するという事実は頭の片隅に置いておいて損はない。次章で外微分 $d$ を導入したとき、この統一的な見方がストークスの定理の一般形 $\int_{\partial M} \omega = \int_M d\omega$ へと結実する。
+<p>本書の舞台は 3 次元空間だから <span class="tex2jax_process">$k=1,2,3$</span> で十分だが、この式が <span class="tex2jax_process">$k$</span> によらず成立するという事実は頭の片隅に置いておいて損はない。次章で外微分 <span class="tex2jax_process">$d$</span> を導入したとき、この統一的な見方がストークスの定理の一般形 <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> へと結実する。
 </p>
 <hr />
 <h3 id="35-本章のまとめと次章への展望">§3.5 本章のまとめと次章への展望</h3>
 <p>第I部「積分記号の尻尾の正体」の三段が、これで完結した：
 </p>
 <ol>
-<li>**第1章**：$dx$ を行列（$1$-form）と見なし、積分を行列作用の極限と読む</li>
+<li>**第1章**：<span class="tex2jax_process">$dx$</span> を行列（<span class="tex2jax_process">$1$</span>-form）と見なし、積分を行列作用の極限と読む</li>
 </ol>
-<p>2. <strong>第2章</strong>：ウェッジ積 $\wedge$ で $2$-form・$3$-form を構成し、面積・体積を代数で測る
+<p>2. <strong>第2章</strong>：ウェッジ積 <span class="tex2jax_process">$\wedge$</span> で <span class="tex2jax_process">$2$</span>-form・<span class="tex2jax_process">$3$</span>-form を構成し、面積・体積を代数で測る
 <ol>
 <li>**第3章（本章）**：曲線・曲面・領域に形式を適用し集計する（積分）という操作を確立した</li>
 </ol>
 <p>本章で確立したのは、次の統一原理である：
 </p>
-<strong>$k$-form（はかり）が $k$-vector（図形）を食べてスカラーを返し、それを領域全体で集計する。</strong>次数が $0,1,2,3$ と変わっても、この構図は不変だった。曲線上の仕事も、曲面上の流量も、領域内の総質量も——すべて同じ言語で書ける。
+<strong><span class="tex2jax_process">$k$</span>-form（はかり）が <span class="tex2jax_process">$k$</span>-vector（図形）を食べてスカラーを返し、それを領域全体で集計する。</strong>次数が <span class="tex2jax_process">$0,1,2,3$</span> と変わっても、この構図は不変だった。曲線上の仕事も、曲面上の流量も、領域内の総質量も——すべて同じ言語で書ける。
 <blockquote><p>**【ここまでのチェックポイント——第3章・第I部全体】**</p>
-- $k$-form $\omega$ の積分 $\int_M \omega$ は「小区分に刻む → $k$-form を $k$-vector に食わせる → 和 → 極限」で定義される。
-- $1$-form の線積分 $\int_\gamma \omega$ は、$\gamma'(t)$ に $\omega$ を食わせて集計する操作。仕事は $\int_\gamma \omega$ で、$\mathbf{F}\cdot d\mathbf{r}$ と同じ量。
-- $2$-form $\eta$ の面積分 $\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$。係数1では各平面への「影」を測り、三つの影を合成すればスカラー面積が得られる。
-- $3$-form $\Omega$ の体積分 $\iiint_V \Omega$。係数1でそのまま体積、係数 $\rho$ で総質量・総電荷。
-- 一般の $k$-form の積分は、係数（$0$-form）と $k$-form の積として書ける。
+- <span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> の積分 <span class="tex2jax_process">$\int_M \omega$</span> は「小区分に刻む → <span class="tex2jax_process">$k$</span>-form を <span class="tex2jax_process">$k$</span>-vector に食わせる → 和 → 極限」で定義される。
+- <span class="tex2jax_process">$1$</span>-form の線積分 <span class="tex2jax_process">$\int_\gamma \omega$</span> は、<span class="tex2jax_process">$\gamma'(t)$</span> に <span class="tex2jax_process">$\omega$</span> を食わせて集計する操作。仕事は <span class="tex2jax_process">$\int_\gamma \omega$</span> で、<span class="tex2jax_process">$\mathbf{F}\cdot d\mathbf{r}$</span> と同じ量。
+- <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\eta$</span> の面積分 <span class="tex2jax_process">$\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$</span>。係数1では各平面への「影」を測り、三つの影を合成すればスカラー面積が得られる。
+- <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\Omega$</span> の体積分 <span class="tex2jax_process">$\iiint_V \Omega$</span>。係数1でそのまま体積、係数 <span class="tex2jax_process">$\rho$</span> で総質量・総電荷。
+- 一般の <span class="tex2jax_process">$k$</span>-form の積分は、係数（<span class="tex2jax_process">$0$</span>-form）と <span class="tex2jax_process">$k$</span>-form の積として書ける。
 </p></blockquote>
 <p>次章（第4章）では、これらの積分を「別の変数で計算する」とは何かを掘り下げる。すなわち<strong>引き戻し</strong>——積分値を保つために測定器を作り替える操作——を、三つの保存則を通じて発見する。
 </p>
-<p>引き戻しを終えた先、ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 $d$</strong> を導入する。$d$ は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。
+<p>引き戻しを終えた先、ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 <span class="tex2jax_process">$d$</span></strong> を導入する。<span class="tex2jax_process">$d$</span> は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。
 </p>
 <p>\newpage
 </p>
-<h1 id="第4章変数変換とは何か--引き戻し-測定器のつじつま合わせ">第4章：変数変換とは何か —— 引き戻し $\Phi^*$：測定器のつじつま合わせ</h1>
+<h1 id="第4章変数変換とは何か--引き戻し-span-classtex2jaxprocessspan測定器のつじつま合わせ">第4章：変数変換とは何か —— 引き戻し <span class="tex2jax_process">$\Phi^*$</span>：測定器のつじつま合わせ</h1>
 <h3 id="40-物理は曲がる計算は四角">§4.0 物理は曲がる、計算は四角</h3>
 <p>物理で本当に測りたい量は、座標の名前に依らない。
 </p>
-<p>質点にした仕事は、軌道を $x$ で書いても、時刻 $t$ で書いても同じでなければならない。惑星が掃く面積は、直交座標で測っても、極座標で測っても同じでなければならない。物体の質量は、直交座標で積分しても、円柱座標で積分しても同じでなければならない。
+<p>質点にした仕事は、軌道を <span class="tex2jax_process">$x$</span> で書いても、時刻 <span class="tex2jax_process">$t$</span> で書いても同じでなければならない。惑星が掃く面積は、直交座標で測っても、極座標で測っても同じでなければならない。物体の質量は、直交座標で積分しても、円柱座標で積分しても同じでなければならない。
 </p>
 <p>ところで、物理はたいてい曲がっている。
 軌道は曲がり、面は曲がり、領域の境界も曲がる。
@@ -1990,300 +1934,257 @@ $$- \underbrace{dy \otimes dx \otimes dz}_{(2,1,3)\text{ に }-1} + \underbrace{
 <p>ここで問題が起こる。
 計算に使う変数を変えると、測定器をそのままでは使えなくなる。
 </p>
-<p>$dx$ は $x$ 方向の変位を測る測定器であり、$dt$ に差し替えただけでは仕事は正しく測れない。
-$dx \wedge dy$ は $xy$ 平面の面積測定器であり、$dr \wedge d\theta$ に差し替えただけでは面積は正しく測れない。
-$dx \wedge dy \wedge dz$ もまた、$dr \wedge d\theta \wedge dz$ に差し替えただけでは体積は正しく測れない。
-</p>
+<span class="tex2jax_process">$dx$</span> は <span class="tex2jax_process">$x$</span> 方向の変位を測る測定器であり、<span class="tex2jax_process">$dt$</span> に差し替えただけでは仕事は正しく測れない。
+<span class="tex2jax_process">$dx \wedge dy$</span> は <span class="tex2jax_process">$xy$</span> 平面の面積測定器であり、<span class="tex2jax_process">$dr \wedge d\theta$</span> に差し替えただけでは面積は正しく測れない。
+<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> もまた、<span class="tex2jax_process">$dr \wedge d\theta \wedge dz$</span> に差し替えただけでは体積は正しく測れない。
 <p>物理量は変わってはいけない。
 しかし、計算に使う四角は変わる。
 </p>
 <p>そのとき、測定器をどう作り替えればよいか。
 </p>
 <p>この問いに答える操作が、引き戻しである。
-引き戻し $\Phi^*$ に物理の測定器を渡せば、計算の変数で読める測定器を得る——座標を変えても物理量が変わらないように、測定器を作り替える操作である。
+引き戻し <span class="tex2jax_process">$\Phi^*$</span> に物理の測定器を渡せば、計算の変数で読める測定器を得る——座標を変えても物理量が変わらないように、測定器を作り替える操作である。
 </p>
 <p>本章では、公式を覚えるのではなく、つじつまを合わせる。
-仕事、面積、体積という三つの物理量を通じて、$dx$、$dx \wedge dy$、$dx \wedge dy \wedge dz$ が、それぞれどのように作り替えられるかを見る。
+仕事、面積、体積という三つの物理量を通じて、<span class="tex2jax_process">$dx$</span>、<span class="tex2jax_process">$dx \wedge dy$</span>、<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> が、それぞれどのように作り替えられるかを見る。
 </p>
 <h3 id="41-1-form-の引き戻し仕事と運動エネルギー定理">§4.1 1-form の引き戻し——仕事と運動エネルギー定理</h3>
-<blockquote><p>**注（物理学未習の読者へ）** 以下の例では、物理学を学ぶ者がよく知っている結論（運動エネルギー保存則）を先に使っている。しかし、単に「質点の位置 $x$ を時刻 $t$ の関数 $\gamma(t)$ で書き表せる」という状況だと思って読み進めてほしい。物理を知らなくても、$F(x)$ は $x$ の関数、$v(t)$ は $t$ の関数と読めれば十分である。</p>
+<blockquote><p>**注（物理学未習の読者へ）** 以下の例では、物理学を学ぶ者がよく知っている結論（運動エネルギー保存則）を先に使っている。しかし、単に「質点の位置 <span class="tex2jax_process">$x$</span> を時刻 <span class="tex2jax_process">$t$</span> の関数 <span class="tex2jax_process">$\gamma(t)$</span> で書き表せる」という状況だと思って読み進めてほしい。物理を知らなくても、<span class="tex2jax_process">$F(x)$</span> は <span class="tex2jax_process">$x$</span> の関数、<span class="tex2jax_process">$v(t)$</span> は <span class="tex2jax_process">$t$</span> の関数と読めれば十分である。</p>
 </p></blockquote>
 <strong>① 物理量から始める。</strong> いきなり一般論には行かない。まずは、よく知られた力学の事実から始めよう。
-<p>質点に力 $F$ が働き、質点が $x$ 軸上を運動しているとする。仕事は
+<p>質点に力 <span class="tex2jax_process">$F$</span> が働き、質点が <span class="tex2jax_process">$x$</span> 軸上を運動しているとする。仕事は
 </p>
-<p>$$W = \int F\,dx$$
-</p>
+<div class="math-block tex2jax_process">$$W = \int F\,dx$$</div>
 <p>で与えられる。一方、運動方程式は
 </p>
-<p>$$F = m\frac{dv}{dt}$$
-</p>
+<div class="math-block tex2jax_process">$$F = m\frac{dv}{dt}$$</div>
 <p>である。この二つから、おなじみの運動エネルギー保存則
 </p>
-<p>$$W = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
-</p>
+<div class="math-block tex2jax_process">$$W = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$</div>
 <p>が出る。本節ではこの導出を、「引き戻し」の目で読み直す。読者は最初から「何が出てくるか」を知っている。そのうえで、計算の裏で測定器がどう作り替えられているかだけを追えばよい。
 </p>
-<strong>② 素朴な置き換え——必ず間違える。</strong> 質点の位置を $x = \gamma(t)$ と書く。速度は $v(t) = \gamma'(t)$ である。仕事の測定器は $F\,dx$ ——これは実空間の変位を食べて仕事の小片を返す $1$-form だ。
-<p>しかし運動は時刻 $t$ によって与えられている。そこで、仕事を時間で計算したい。
+<strong>② 素朴な置き換え——必ず間違える。</strong> 質点の位置を <span class="tex2jax_process">$x = \gamma(t)$</span> と書く。速度は <span class="tex2jax_process">$v(t) = \gamma'(t)$</span> である。仕事の測定器は <span class="tex2jax_process">$F\,dx$</span> ——これは実空間の変位を食べて仕事の小片を返す <span class="tex2jax_process">$1$</span>-form だ。
+<p>しかし運動は時刻 <span class="tex2jax_process">$t$</span> によって与えられている。そこで、仕事を時間で計算したい。
 </p>
-<p>まず実空間側で、等加速度運動 $x(t) = \frac{1}{2}at^2$、一定力 $F = ma$ の場合を計算する。終点 $X = \frac{1}{2}aT^2$ だから
+<p>まず実空間側で、等加速度運動 <span class="tex2jax_process">$x(t) = \frac{1}{2}at^2$</span>、一定力 <span class="tex2jax_process">$F = ma$</span> の場合を計算する。終点 <span class="tex2jax_process">$X = \frac{1}{2}aT^2$</span> だから
 </p>
-<p>$$W_{\text{実}} = \int_0^X ma\,dx = ma\,X = \frac{1}{2}ma^2T^2$$
+<div class="math-block tex2jax_process">$$W_{\text{実}} = \int_0^X ma\,dx = ma\,X = \frac{1}{2}ma^2T^2$$</div>
+<p>である。一方、時間側で素朴に——つまり <span class="tex2jax_process">$dx$</span> をそのまま <span class="tex2jax_process">$dt$</span> に置き換えて——積分してみると
 </p>
-<p>である。一方、時間側で素朴に——つまり $dx$ をそのまま $dt$ に置き換えて——積分してみると
+<div class="math-block tex2jax_process">$$W_{\text{素朴}} = \int_0^T ma\,dt = ma\,T$$</div>
+<p>となる。<span class="tex2jax_process">$\frac{1}{2}ma^2T^2 \neq ma\,T$</span> だから、明らかに一致しない。<span class="tex2jax_process">$dt$</span> のままでは仕事の値が変わってしまうのだ。
 </p>
-<p>$$W_{\text{素朴}} = \int_0^T ma\,dt = ma\,T$$
+<strong>③ 有限マス目で原因を見る。</strong> 時刻の小区間 <span class="tex2jax_process">$[t_i, t_{i+1}]$</span> を考える。その幅を <span class="tex2jax_process">$\Delta t_i = t_{i+1} - t_i$</span>、対応する位置の変化を <span class="tex2jax_process">$\Delta x_i = \gamma(t_{i+1}) - \gamma(t_i)$</span> とする。実空間側の仕事の一項は <span class="tex2jax_process">$F_i\,\Delta x_i$</span>。時間側で素朴に作った一項は <span class="tex2jax_process">$F_i\,\Delta t_i$</span>。この二つが一致しないのは、<span class="tex2jax_process">$\Delta t_i$</span> と <span class="tex2jax_process">$\Delta x_i$</span> のつじつま係数を無視したからだ。
+<p>そこで、時間側の一項に係数 <span class="tex2jax_process">$c_i$</span> を掛けて <span class="tex2jax_process">$F_i\,c_i\,\Delta t_i$</span> としてみる。これが <span class="tex2jax_process">$F_i\,\Delta x_i$</span> と一致するには、<span class="tex2jax_process">$c_i\,\Delta t_i = \Delta x_i$</span> でなければならない。したがって
 </p>
-<p>となる。$\frac{1}{2}ma^2T^2 \neq ma\,T$ だから、明らかに一致しない。$dt$ のままでは仕事の値が変わってしまうのだ。
-</p>
-<strong>③ 有限マス目で原因を見る。</strong> 時刻の小区間 $[t_i, t_{i+1}]$ を考える。その幅を $\Delta t_i = t_{i+1} - t_i$、対応する位置の変化を $\Delta x_i = \gamma(t_{i+1}) - \gamma(t_i)$ とする。実空間側の仕事の一項は $F_i\,\Delta x_i$。時間側で素朴に作った一項は $F_i\,\Delta t_i$。この二つが一致しないのは、$\Delta t_i$ と $\Delta x_i$ のつじつま係数を無視したからだ。
-<p>そこで、時間側の一項に係数 $c_i$ を掛けて $F_i\,c_i\,\Delta t_i$ としてみる。これが $F_i\,\Delta x_i$ と一致するには、$c_i\,\Delta t_i = \Delta x_i$ でなければならない。したがって
-</p>
-<p>$$c_i = \frac{\Delta x_i}{\Delta t_i}$$
-</p>
-<p>である。分割を細かくすると、この比は速度 $v(t) = dx/dt$ へ近づく。
+<div class="math-block tex2jax_process">$$c_i = \frac{\Delta x_i}{\Delta t_i}$$</div>
+<p>である。分割を細かくすると、この比は速度 <span class="tex2jax_process">$v(t) = dx/dt$</span> へ近づく。
 </p>
 <strong>④ 具体例の引き戻しを書く。</strong> したがって、時間軸上での測定器は
-<p>$$F\,dx = F\,v(t)\,dt$$
-</p>
+<div class="math-block tex2jax_process">$$F\,dx = F\,v(t)\,dt$$</div>
 <p>へ作り替えられる。これを
 </p>
-<p>$$\gamma^*(F\,dx) = F(\gamma(t))\,v(t)\,dt$$
-</p>
+<div class="math-block tex2jax_process">$$\gamma^*(F\,dx) = F(\gamma(t))\,v(t)\,dt$$</div>
 <p>と書く。
 </p>
-<strong>⑤ 係数付き $1$-form の引き戻し。</strong> 任意の係数 $F(x)$ に対して、同じ構造が成り立つ。位置が $x = \gamma(t)$ で与えられるとき
-<p>$$\gamma^*(F(x)\,dx) = F(\gamma(t))\,\gamma'(t)\,dt$$
-</p>
+<strong>⑤ 係数付き <span class="tex2jax_process">$1$</span>-form の引き戻し。</strong> 任意の係数 <span class="tex2jax_process">$F(x)$</span> に対して、同じ構造が成り立つ。位置が <span class="tex2jax_process">$x = \gamma(t)$</span> で与えられるとき
+<div class="math-block tex2jax_process">$$\gamma^*(F(x)\,dx) = F(\gamma(t))\,\gamma'(t)\,dt$$</div>
 <p>である。
 </p>
-<strong>⑥ 一般の変換で定義する。</strong> より一般に、$1$-form $\omega = F(x)\,dx$ と、実数上の曲線 $\gamma: t \mapsto x$ に対して、引き戻し $\gamma^*$ は
-<p>$$\gamma^*(F(x)\,dx) = F(\gamma(t))\,\gamma'(t)\,dt$$
+<strong>⑥ 一般の変換で定義する。</strong> より一般に、<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega = F(x)\,dx$</span> と、実数上の曲線 <span class="tex2jax_process">$\gamma: t \mapsto x$</span> に対して、引き戻し <span class="tex2jax_process">$\gamma^*$</span> は
+<div class="math-block tex2jax_process">$$\gamma^*(F(x)\,dx) = F(\gamma(t))\,\gamma'(t)\,dt$$</div>
+<p>で定義される。この式こそが <strong><span class="tex2jax_process">$1$</span>-form の引き戻しの一般的な定義</strong> である。<span class="tex2jax_process">$\gamma'(t)$</span> が「実空間の測定器 <span class="tex2jax_process">$dx$</span> を時間軸の測定器 <span class="tex2jax_process">$dt$</span> に焼き直す」ためのつじつま係数になっている。
 </p>
-<p>で定義される。この式こそが <strong>$1$-form の引き戻しの一般的な定義</strong> である。$\gamma'(t)$ が「実空間の測定器 $dx$ を時間軸の測定器 $dt$ に焼き直す」ためのつじつま係数になっている。
+<strong>⑦ 物理量へ戻る。</strong> ここで運動方程式 <span class="tex2jax_process">$F = m\,dv/dt$</span> を使うと、
+<div class="math-block tex2jax_process">$$\gamma^*(F\,dx) = m\frac{dv}{dt}\,v\,dt = m v\,dv$$</div>
+<p>と読める（<span class="tex2jax_process">$m\frac{dv}{dt}\,dt$</span> は速度軸の測定器 <span class="tex2jax_process">$dv$</span> を時間軸へ引き戻したものだから）。よって
 </p>
-<strong>⑦ 物理量へ戻る。</strong> ここで運動方程式 $F = m\,dv/dt$ を使うと、
-<p>$$\gamma^*(F\,dx) = m\frac{dv}{dt}\,v\,dt = m v\,dv$$
-</p>
-<p>と読める（$m\frac{dv}{dt}\,dt$ は速度軸の測定器 $dv$ を時間軸へ引き戻したものだから）。よって
-</p>
-<p>$$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int_{v(t_0)}^{v(t_1)} m v\,dv = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
-</p>
+<div class="math-block tex2jax_process">$$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int_{v(t_0)}^{v(t_1)} m v\,dv = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$</div>
 <p>となる——運動エネルギー保存則である。
 </p>
-<blockquote><p>**注** （なぜ「引き戻し」という名前なのか）実空間にある測定器をパラメータ空間に「送る」のなら、それは「押し出し」ではないのか——そう感じる読者もいるだろう。我々の直感では、実空間が「現実」で、パラメータ空間は「計算用の道具」だからだ。しかし数学の写像 $\gamma$ は、つねに「パラメータ空間 $\to$ 実空間」という向きで定義される。数学の世界では、パラメータ空間のほうが出発地なのだ。だから、実空間からパラメータ空間へ逆行する測定器の移動は、写像の向きに逆らって「引き戻し（Pull-back）」と呼ばれる。直感とは逆だが、そういう命名規則なのだと割り切ってほしい。</p>
+<blockquote><p>**注** （なぜ「引き戻し」という名前なのか）実空間にある測定器をパラメータ空間に「送る」のなら、それは「押し出し」ではないのか——そう感じる読者もいるだろう。我々の直感では、実空間が「現実」で、パラメータ空間は「計算用の道具」だからだ。しかし数学の写像 <span class="tex2jax_process">$\gamma$</span> は、つねに「パラメータ空間 <span class="tex2jax_process">$\to$</span> 実空間」という向きで定義される。数学の世界では、パラメータ空間のほうが出発地なのだ。だから、実空間からパラメータ空間へ逆行する測定器の移動は、写像の向きに逆らって「引き戻し（Pull-back）」と呼ばれる。直感とは逆だが、そういう命名規則なのだと割り切ってほしい。</p>
 </p></blockquote>
-<blockquote><p>**注** （$dx$ は横ベクトル、$dt$ も横ベクトル）§4.1 の計算では、$dx$ も $dt$ も $dv$ も、すべてが「変位を食べてスカラーを返す」という同じ型を保っている。第1章 §1.1.3 以来の「横ベクトル×縦ベクトル→スカラー」の原則は、引き戻しのただ中でも崩れない。$\gamma^*(F\,dx)$ の結果も再び時間軸上の $1$-form（横ベクトル）であり、それを時間側の変位 $\Delta t$ に食わせればスカラー（仕事の小片）が得られる——この一貫性こそが、引き戻しの理解を支える。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$dx$</span> は横ベクトル、<span class="tex2jax_process">$dt$</span> も横ベクトル）§4.1 の計算では、<span class="tex2jax_process">$dx$</span> も <span class="tex2jax_process">$dt$</span> も <span class="tex2jax_process">$dv$</span> も、すべてが「変位を食べてスカラーを返す」という同じ型を保っている。第1章 §1.1.3 以来の「横ベクトル×縦ベクトル→スカラー」の原則は、引き戻しのただ中でも崩れない。<span class="tex2jax_process">$\gamma^*(F\,dx)$</span> の結果も再び時間軸上の <span class="tex2jax_process">$1$</span>-form（横ベクトル）であり、それを時間側の変位 <span class="tex2jax_process">$\Delta t$</span> に食わせればスカラー（仕事の小片）が得られる——この一貫性こそが、引き戻しの理解を支える。</p>
 </p></blockquote>
-<blockquote><p>**注** （$dx$ は横ベクトル、$dt$ も横ベクトル）§4.1 の計算では、$dx$ も $dt$ も $dv$ も、すべてが「変位を食べてスカラーを返す」という同じ型を保っている。第1章 §1.1.3 以来の「横ベクトル×縦ベクトル→スカラー」の原則は、引き戻しのただ中でも崩れない。$\gamma^*(F\,dx)$ の結果も再び時間軸上の $1$-form（横ベクトル）であり、それを時間側の変位 $\Delta t$ に食わせればスカラー（仕事の小片）が得られる——この一貫性こそが、引き戻しの理解を支える。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$dx$</span> は横ベクトル、<span class="tex2jax_process">$dt$</span> も横ベクトル）§4.1 の計算では、<span class="tex2jax_process">$dx$</span> も <span class="tex2jax_process">$dt$</span> も <span class="tex2jax_process">$dv$</span> も、すべてが「変位を食べてスカラーを返す」という同じ型を保っている。第1章 §1.1.3 以来の「横ベクトル×縦ベクトル→スカラー」の原則は、引き戻しのただ中でも崩れない。<span class="tex2jax_process">$\gamma^*(F\,dx)$</span> の結果も再び時間軸上の <span class="tex2jax_process">$1$</span>-form（横ベクトル）であり、それを時間側の変位 <span class="tex2jax_process">$\Delta t$</span> に食わせればスカラー（仕事の小片）が得られる——この一貫性こそが、引き戻しの理解を支える。</p>
 </p></blockquote>
 <h3 id="42-2-form-の引き戻し角運動量保存と面積速度">§4.2 2-form の引き戻し——角運動量保存と面積速度</h3>
 <strong>① 物理量から始める。</strong> 1-form で見た構造——積分値を保つために測定器を作り替える——は、そのまま 2-form にも拡張できる。§4.1 と正確に同じ <strong>7 つの手順</strong> をたどろう。
-<p>中心力場の中を運動する質点を考える。力が常に原点に向かうとき、角運動量 $L = m(x \dot{y} - y \dot{x})$ は時間に依らず一定である（角運動量保存則）。この保存則には美しい幾何学的意味がある——質点の位置ベクトルが掃く面積の速度（<strong>面積速度</strong>）が一定になるのだ（ケプラーの第二法則）。
+<p>中心力場の中を運動する質点を考える。力が常に原点に向かうとき、角運動量 <span class="tex2jax_process">$L = m(x \dot{y} - y \dot{x})$</span> は時間に依らず一定である（角運動量保存則）。この保存則には美しい幾何学的意味がある——質点の位置ベクトルが掃く面積の速度（<strong>面積速度</strong>）が一定になるのだ（ケプラーの第二法則）。
 </p>
-<p>質点の運動は $z=0$ 平面上で起こるとしてよい。時刻 $t_0$ から $t_1$ までに位置ベクトルが掃く扇形領域 $D$ の面積は
+<p>質点の運動は <span class="tex2jax_process">$z=0$</span> 平面上で起こるとしてよい。時刻 <span class="tex2jax_process">$t_0$</span> から <span class="tex2jax_process">$t_1$</span> までに位置ベクトルが掃く扇形領域 <span class="tex2jax_process">$D$</span> の面積は
 </p>
-<p>$$A = \iint_D dx \wedge dy$$
+<div class="math-block tex2jax_process">$$A = \iint_D dx \wedge dy$$</div>
+<p>と書ける。<span class="tex2jax_process">$dx \wedge dy$</span> は <span class="tex2jax_process">$xy$</span> 平面上の面積測定器（<span class="tex2jax_process">$2$</span>-form）である。
 </p>
-<p>と書ける。$dx \wedge dy$ は $xy$ 平面上の面積測定器（$2$-form）である。
-</p>
-<blockquote><p>**注** （物理学者の二次元）忘れないでほしい——本書は一貫して三次元空間の実在を前提としている。以下の角運動量の議論で $z=0$ と置くのは、計算を見やすくするための一時的な簡略化であり、我々は依然として三次元空間の中の一つの平面を眺めているにすぎない。</p>
+<blockquote><p>**注** （物理学者の二次元）忘れないでほしい——本書は一貫して三次元空間の実在を前提としている。以下の角運動量の議論で <span class="tex2jax_process">$z=0$</span> と置くのは、計算を見やすくするための一時的な簡略化であり、我々は依然として三次元空間の中の一つの平面を眺めているにすぎない。</p>
 </p></blockquote>
-<strong>② 素朴な置き換え——必ず間違える。</strong> 右辺の扇形は $(x,y)$ の式では書きづらい。そこで $(r,\theta)$ で書きたくなる。しかし、$dx \wedge dy$ をそのまま $dr \wedge d\theta$ に置き換えるとどうなるか。半径 $C$ の完全な円の面積を計算してみよう。正しい値は $\pi C^2$ である。ところが、素朴に置き換えると：
-<p>$$A_{\text{素朴}} = \iint dr \wedge d\theta = \int_0^{2\pi}\!\int_0^C dr\,d\theta = 2\pi C$$
+<strong>② 素朴な置き換え——必ず間違える。</strong> 右辺の扇形は <span class="tex2jax_process">$(x,y)$</span> の式では書きづらい。そこで <span class="tex2jax_process">$(r,\theta)$</span> で書きたくなる。しかし、<span class="tex2jax_process">$dx \wedge dy$</span> をそのまま <span class="tex2jax_process">$dr \wedge d\theta$</span> に置き換えるとどうなるか。半径 <span class="tex2jax_process">$C$</span> の完全な円の面積を計算してみよう。正しい値は <span class="tex2jax_process">$\pi C^2$</span> である。ところが、素朴に置き換えると：
+<div class="math-block tex2jax_process">$$A_{\text{素朴}} = \iint dr \wedge d\theta = \int_0^{2\pi}\!\int_0^C dr\,d\theta = 2\pi C$$</div>
+<p>これは <span class="tex2jax_process">$\pi C^2$</span> とはまったく違う。<span class="tex2jax_process">$dr \wedge d\theta$</span> のままでは、正しい面積が出ない。
 </p>
-<p>これは $\pi C^2$ とはまったく違う。$dr \wedge d\theta$ のままでは、正しい面積が出ない。
-</p>
-<strong>③ 有限マス目で原因を見る。</strong> §4.1 と同じことをする。$(r,\theta)$ 空間に、有限の大きさ $\Delta r \times \Delta\theta$ のグリッドを切る。座標 $(r, \theta)$ にある一マスが、$(x,y)$ 空間で占める面積を求める。
-<p>$\Delta r$ 方向の辺：$r$ だけ変えて $\theta$ を固定するから、差は正確に求まる：
-</p>
-<p>$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$
-</p>
-<p>$\Delta\theta$ 方向の辺：三角関数の差の公式を用いる：
-</p>
-<p>$$\begin{aligned}
+<strong>③ 有限マス目で原因を見る。</strong> §4.1 と同じことをする。<span class="tex2jax_process">$(r,\theta)$</span> 空間に、有限の大きさ <span class="tex2jax_process">$\Delta r \times \Delta\theta$</span> のグリッドを切る。座標 <span class="tex2jax_process">$(r, \theta)$</span> にある一マスが、<span class="tex2jax_process">$(x,y)$</span> 空間で占める面積を求める。
+<span class="tex2jax_process">$\Delta r$</span> 方向の辺：<span class="tex2jax_process">$r$</span> だけ変えて <span class="tex2jax_process">$\theta$</span> を固定するから、差は正確に求まる：
+<div class="math-block tex2jax_process">$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$</div>
+<span class="tex2jax_process">$\Delta\theta$</span> 方向の辺：三角関数の差の公式を用いる：
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
 = -2r\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr)\sin\tfrac{\Delta\theta}{2} \\[4pt]
 \Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
 = 2r\cos\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr)\sin\tfrac{\Delta\theta}{2}
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>二辺 <span class="tex2jax_process">$\mathbf{v}_r = (\Delta x_r, \Delta y_r)$</span> と <span class="tex2jax_process">$\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$</span> が張る平行四辺形の面積を行列式で求める：
 </p>
-<p>二辺 $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ と $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ が張る平行四辺形の面積を行列式で求める：
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
 &= 2r\Delta r\,\sin\tfrac{\Delta\theta}{2}\bigl[ \cos\theta\cos\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) + \sin\theta\sin\bigl(\theta+\tfrac{\Delta\theta}{2}\bigr) \bigr] \\
 &= r\Delta r\,\sin\Delta\theta
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>結果は <span class="tex2jax_process">$\det = r\Delta r\,\sin\Delta\theta$</span>。マス目全体を足し上げるリーマン和：
 </p>
-<p>結果は $\det = r\Delta r\,\sin\Delta\theta$。マス目全体を足し上げるリーマン和：
-</p>
-<p>$$A \approx \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j$$
-</p>
-<p>$\sin\Delta\theta_j$ は有限の $\Delta\theta_j$ に対して厳密な値である。総和の極限をとる最終段階で $\sin\Delta\theta_j \approx \Delta\theta_j$ と置き：
-</p>
-<p>$$A = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0}} \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j = \iint_D r\,dr\,d\theta$$
-</p>
-<blockquote><p>**注** （$\Delta r,\Delta\theta$ は微小である必要はない）ここまでの計算に、$\Delta r$ や $\Delta\theta$ が「十分小さい」という仮定は一切使っていない。上で求めた $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ は、$\Delta r,\Delta\theta$ がどれほど大きくても厳密に成り立つ式である。微小量への移行は、あくまで積分の最終段階——総和の極限をとるとき——で初めて行う。</p>
+<div class="math-block tex2jax_process">$$A \approx \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j$$</div>
+<span class="tex2jax_process">$\sin\Delta\theta_j$</span> は有限の <span class="tex2jax_process">$\Delta\theta_j$</span> に対して厳密な値である。総和の極限をとる最終段階で <span class="tex2jax_process">$\sin\Delta\theta_j \approx \Delta\theta_j$</span> と置き：
+<div class="math-block tex2jax_process">$$A = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0}} \sum_i\sum_j r_i\,\Delta r_i \,\sin\Delta\theta_j = \iint_D r\,dr\,d\theta$$</div>
+<blockquote><p>**注** （<span class="tex2jax_process">$\Delta r,\Delta\theta$</span> は微小である必要はない）ここまでの計算に、<span class="tex2jax_process">$\Delta r$</span> や <span class="tex2jax_process">$\Delta\theta$</span> が「十分小さい」という仮定は一切使っていない。上で求めた <span class="tex2jax_process">$\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$</span> は、<span class="tex2jax_process">$\Delta r,\Delta\theta$</span> がどれほど大きくても厳密に成り立つ式である。微小量への移行は、あくまで積分の最終段階——総和の極限をとるとき——で初めて行う。</p>
 </p></blockquote>
-<strong>④ 具体例の引き戻しを書く。</strong> 極座標への変換 $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$ に対して：
-<p>$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
+<strong>④ 具体例の引き戻しを書く。</strong> 極座標への変換 <span class="tex2jax_process">$\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$</span> に対して：
+<div class="math-block tex2jax_process">$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$</div>
+<p>これが <span class="tex2jax_process">$2$</span>-form の引き戻しの具体例である。この <span class="tex2jax_process">$r$</span> が、§4.1 の <span class="tex2jax_process">$\gamma'(t)$</span> に対応するつじつま係数である。
 </p>
-<p>これが $2$-form の引き戻しの具体例である。この $r$ が、§4.1 の $\gamma'(t)$ に対応するつじつま係数である。
+<strong>⑤ 係数付き <span class="tex2jax_process">$2$</span>-form の引き戻し。</strong> 任意の係数 <span class="tex2jax_process">$G(x,y)$</span> を持つ <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$G(x,y)\,dx \wedge dy$</span> に対して、同じ構造が成り立つ：
+<div class="math-block tex2jax_process">$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$</div>
+<p>係数 <span class="tex2jax_process">$G$</span> は座標を極座標に焼き直すだけ（<span class="tex2jax_process">$0$</span>-form の引き戻し）で、<span class="tex2jax_process">$dx \wedge dy$</span> の部分だけが <span class="tex2jax_process">$r\,dr \wedge d\theta$</span> に変わる。引き戻し <span class="tex2jax_process">$\Phi^*$</span> は「係数の焼き直し」と「測定器の焼き直し」に自然に分解されるのである。
 </p>
-<strong>⑤ 係数付き $2$-form の引き戻し。</strong> 任意の係数 $G(x,y)$ を持つ $2$-form $G(x,y)\,dx \wedge dy$ に対して、同じ構造が成り立つ：
-<p>$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$
+<strong>⑥ 一般の変換で定義する。</strong> より一般に、<span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\eta = G(x,y)\,dx \wedge dy$</span> と、平面間の変換 <span class="tex2jax_process">$\Phi(u,v) = (x(u,v), y(u,v))$</span> に対して、引き戻し <span class="tex2jax_process">$\Phi^*$</span> は
+<div class="math-block tex2jax_process">$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\; \bigl(\Delta x_u\,\Delta y_v - \Delta x_v\,\Delta y_u\bigr)\,du \wedge dv$$</div>
+<p>で定義される。ここで <span class="tex2jax_process">$\Delta x_u$</span> は <span class="tex2jax_process">$u$</span> だけを <span class="tex2jax_process">$\Delta u$</span> 増やしたときの <span class="tex2jax_process">$x$</span> の変化、<span class="tex2jax_process">$\Delta x_v$</span> は <span class="tex2jax_process">$v$</span> だけを <span class="tex2jax_process">$\Delta v$</span> 増やしたときの <span class="tex2jax_process">$x$</span> の変化である。<span class="tex2jax_process">$\bigl(\Delta x_u\,\Delta y_v - \Delta x_v\,\Delta y_u\bigr)$</span> が「実空間の面積測定器 <span class="tex2jax_process">$dx \wedge dy$</span> をパラメータ空間の面積測定器 <span class="tex2jax_process">$du \wedge dv$</span> に焼き直す」ためのつじつま係数であり、<span class="tex2jax_process">$2 \times 2$</span> 行列式の形をしている。この式こそが <strong><span class="tex2jax_process">$2$</span>-form の引き戻しの一般的な定義</strong> である。
 </p>
-<p>係数 $G$ は座標を極座標に焼き直すだけ（$0$-form の引き戻し）で、$dx \wedge dy$ の部分だけが $r\,dr \wedge d\theta$ に変わる。引き戻し $\Phi^*$ は「係数の焼き直し」と「測定器の焼き直し」に自然に分解されるのである。
+<strong>⑦ 物理量へ戻る。</strong> 扇形領域 <span class="tex2jax_process">$D$</span> の面積を、引き戻した測定器で積分すれば：
+<div class="math-block tex2jax_process">$$A = \iint_D dx \wedge dy = \iint_D r\,dr \wedge d\theta = \int_{\theta_0}^{\theta_1} \frac{1}{2}R(\theta)^2\,d\theta$$</div>
+<span class="tex2jax_process">$r$</span> で積分した結果、<span class="tex2jax_process">$\frac{1}{2}r^2$</span> が現れ、面積が <span class="tex2jax_process">$\theta$</span> 軸上の <span class="tex2jax_process">$1$</span>-form の線積分に還元された。さらに時間パラメータ <span class="tex2jax_process">$t$</span> へ引き戻す。質点の軌道を <span class="tex2jax_process">$r = R(t),\, \theta = \Theta(t)$</span> とすれば：
+<div class="math-block tex2jax_process">$$\frac{dA}{dt} = \frac{1}{2}r(t)^2\,\dot{\theta}(t)$$</div>
+<p>角運動量の定義 <span class="tex2jax_process">$L = m r^2 \dot{\theta}$</span> より、面積速度は
 </p>
-<strong>⑥ 一般の変換で定義する。</strong> より一般に、$2$-form $\eta = G(x,y)\,dx \wedge dy$ と、平面間の変換 $\Phi(u,v) = (x(u,v), y(u,v))$ に対して、引き戻し $\Phi^*$ は
-<p>$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\; \bigl(\Delta x_u\,\Delta y_v - \Delta x_v\,\Delta y_u\bigr)\,du \wedge dv$$
-</p>
-<p>で定義される。ここで $\Delta x_u$ は $u$ だけを $\Delta u$ 増やしたときの $x$ の変化、$\Delta x_v$ は $v$ だけを $\Delta v$ 増やしたときの $x$ の変化である。$\bigl(\Delta x_u\,\Delta y_v - \Delta x_v\,\Delta y_u\bigr)$ が「実空間の面積測定器 $dx \wedge dy$ をパラメータ空間の面積測定器 $du \wedge dv$ に焼き直す」ためのつじつま係数であり、$2 \times 2$ 行列式の形をしている。この式こそが <strong>$2$-form の引き戻しの一般的な定義</strong> である。
-</p>
-<strong>⑦ 物理量へ戻る。</strong> 扇形領域 $D$ の面積を、引き戻した測定器で積分すれば：
-<p>$$A = \iint_D dx \wedge dy = \iint_D r\,dr \wedge d\theta = \int_{\theta_0}^{\theta_1} \frac{1}{2}R(\theta)^2\,d\theta$$
-</p>
-<p>$r$ で積分した結果、$\frac{1}{2}r^2$ が現れ、面積が $\theta$ 軸上の $1$-form の線積分に還元された。さらに時間パラメータ $t$ へ引き戻す。質点の軌道を $r = R(t),\, \theta = \Theta(t)$ とすれば：
-</p>
-<p>$$\frac{dA}{dt} = \frac{1}{2}r(t)^2\,\dot{\theta}(t)$$
-</p>
-<p>角運動量の定義 $L = m r^2 \dot{\theta}$ より、面積速度は
-</p>
-<p>$$\frac{dA}{dt} = \frac{L}{2m}$$
-</p>
-<p>中心力場では $L$ が保存されるから、面積速度も一定——これがケプラーの第二法則であり、角運動量保存則の幾何学的表現である。§4.1 で $1$-form のつじつま係数 $\gamma'(t)$ がエネルギー保存を記述したのとまったく同じ構造が、$2$-form のつじつま係数 $r$ を通じて角運動量保存を記述している。
+<div class="math-block tex2jax_process">$$\frac{dA}{dt} = \frac{L}{2m}$$</div>
+<p>中心力場では <span class="tex2jax_process">$L$</span> が保存されるから、面積速度も一定——これがケプラーの第二法則であり、角運動量保存則の幾何学的表現である。§4.1 で <span class="tex2jax_process">$1$</span>-form のつじつま係数 <span class="tex2jax_process">$\gamma'(t)$</span> がエネルギー保存を記述したのとまったく同じ構造が、<span class="tex2jax_process">$2$</span>-form のつじつま係数 <span class="tex2jax_process">$r$</span> を通じて角運動量保存を記述している。
 </p>
 <h3 id="43-3-form-の引き戻し質量保存と体積分">§4.3 3-form の引き戻し——質量保存と体積分</h3>
 <strong>① 物理量から始める。</strong> 最後は体積分だ。§4.1、§4.2 と正確に同じ <strong>7 つの手順</strong> を、もう一度たどる。
-<p>密度 $\rho$ が一様な円柱（半径 $C$、高さ $H$）の質量を考えよう。$(x,y,z)$ 空間で直接計算すれば
+<p>密度 <span class="tex2jax_process">$\rho$</span> が一様な円柱（半径 <span class="tex2jax_process">$C$</span>、高さ <span class="tex2jax_process">$H$</span>）の質量を考えよう。<span class="tex2jax_process">$(x,y,z)$</span> 空間で直接計算すれば
 </p>
-<p>$$M = \rho \cdot (\text{体積}) = \rho \cdot \pi C^2 H$$
+<div class="math-block tex2jax_process">$$M = \rho \cdot (\text{体積}) = \rho \cdot \pi C^2 H$$</div>
+<p>である。この <span class="tex2jax_process">$M$</span> は——当然だが——どんな座標で計算しても変化してはならない。
 </p>
-<p>である。この $M$ は——当然だが——どんな座標で計算しても変化してはならない。
+<strong>② 素朴な置き換え——必ず間違える。</strong> 積分を円柱座標 <span class="tex2jax_process">$(r,\theta,z)$</span> で書きたい。円柱の範囲は <span class="tex2jax_process">$r \in [0, C],\; \theta \in [0, 2\pi],\; z \in [0, H]$</span> だから、<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> をそのまま <span class="tex2jax_process">$dr \wedge d\theta \wedge dz$</span> に置き換えて：
+<div class="math-block tex2jax_process">$$M_{\text{素朴}} = \rho \iiint dr\,d\theta\,dz = \rho \cdot C \cdot 2\pi \cdot H = 2\pi\rho C H$$</div>
+<p>これを正しい値 <span class="tex2jax_process">$\rho \pi C^2 H$</span> と比べると、<span class="tex2jax_process">$2\pi\rho C H \neq \rho \pi C^2 H$</span>。明らかに一致しない。
 </p>
-<strong>② 素朴な置き換え——必ず間違える。</strong> 積分を円柱座標 $(r,\theta,z)$ で書きたい。円柱の範囲は $r \in [0, C],\; \theta \in [0, 2\pi],\; z \in [0, H]$ だから、$dx \wedge dy \wedge dz$ をそのまま $dr \wedge d\theta \wedge dz$ に置き換えて：
-<p>$$M_{\text{素朴}} = \rho \iiint dr\,d\theta\,dz = \rho \cdot C \cdot 2\pi \cdot H = 2\pi\rho C H$$
-</p>
-<p>これを正しい値 $\rho \pi C^2 H$ と比べると、$2\pi\rho C H \neq \rho \pi C^2 H$。明らかに一致しない。
-</p>
-<strong>③ 有限マス目で原因を見る。</strong> $(r,\theta,z)$ 空間に、有限の大きさ $\Delta r \times \Delta\theta \times \Delta z$ のグリッドを切る。変換は $x = r\cos\theta,\; y = r\sin\theta,\; z = z$。$z$ 方向は変換を受けないから、体積は「$xy$ 平面内のマス目面積」$\times \Delta z$ である。$xy$ 平面内の面積は、§4.2 の手順そのままだ：
-<p>$$\det = r\Delta r\,\sin\Delta\theta$$
-</p>
+<strong>③ 有限マス目で原因を見る。</strong> <span class="tex2jax_process">$(r,\theta,z)$</span> 空間に、有限の大きさ <span class="tex2jax_process">$\Delta r \times \Delta\theta \times \Delta z$</span> のグリッドを切る。変換は <span class="tex2jax_process">$x = r\cos\theta,\; y = r\sin\theta,\; z = z$</span>。<span class="tex2jax_process">$z$</span> 方向は変換を受けないから、体積は「<span class="tex2jax_process">$xy$</span> 平面内のマス目面積」<span class="tex2jax_process">$\times \Delta z$</span> である。<span class="tex2jax_process">$xy$</span> 平面内の面積は、§4.2 の手順そのままだ：
+<div class="math-block tex2jax_process">$$\det = r\Delta r\,\sin\Delta\theta$$</div>
 <p>したがって、一マスの体積は
 </p>
-<p>$$\text{体積} = \bigl(r\Delta r\,\sin\Delta\theta\bigr) \times \Delta z$$
+<div class="math-block tex2jax_process">$$\text{体積} = \bigl(r\Delta r\,\sin\Delta\theta\bigr) \times \Delta z$$</div>
+<p>円柱全体の質量は、マス目 <span class="tex2jax_process">$(i,j,k)$</span> の寄与を足し上げたリーマン和である：
 </p>
-<p>円柱全体の質量は、マス目 $(i,j,k)$ の寄与を足し上げたリーマン和である：
+<div class="math-block tex2jax_process">$$M \approx \sum_i\sum_j\sum_k \rho\; r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k$$</div>
+<p>総和の極限をとる最終段階で <span class="tex2jax_process">$\sin\Delta\theta_j \approx \Delta\theta_j$</span> と置く：
 </p>
-<p>$$M \approx \sum_i\sum_j\sum_k \rho\; r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k$$
+<div class="math-block tex2jax_process">$$M = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0 \\ \Delta z_k \to 0}} \sum_i\sum_j\sum_k \rho\, r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k = \rho \iiint_{V'} r\,dr\,d\theta\,dz = \rho \cdot \pi C^2 H$$</div>
+<strong>④ 具体例の引き戻しを書く。</strong> 円柱座標への変換 <span class="tex2jax_process">$\Phi(r,\theta,z) = (r\cos\theta,\; r\sin\theta,\; z)$</span> に対して：
+<div class="math-block tex2jax_process">$$\Phi^*(dx \wedge dy \wedge dz) = r\,dr \wedge d\theta \wedge dz$$</div>
+<p>これが <span class="tex2jax_process">$3$</span>-form の引き戻しの具体例である。この <span class="tex2jax_process">$r$</span> が、§4.2 の <span class="tex2jax_process">$r$</span> をそのまま引き継いだつじつま係数である。
 </p>
-<p>総和の極限をとる最終段階で $\sin\Delta\theta_j \approx \Delta\theta_j$ と置く：
+<strong>⑤ 係数付き <span class="tex2jax_process">$3$</span>-form の引き戻し。</strong> 任意の密度 <span class="tex2jax_process">$\rho(x,y,z)$</span> を持つ <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\rho\,dx \wedge dy \wedge dz$</span> に対して、同じ構造が成り立つ：
+<div class="math-block tex2jax_process">$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(r\cos\theta,\, r\sin\theta,\, z)\; r\,dr \wedge d\theta \wedge dz$$</div>
+<p>係数 <span class="tex2jax_process">$\rho$</span> は座標を焼き直すだけ（<span class="tex2jax_process">$0$</span>-form の引き戻し）で、<span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の部分だけが <span class="tex2jax_process">$r\,dr \wedge d\theta \wedge dz$</span> に変わる。
 </p>
-<p>$$M = \lim_{\substack{\Delta r_i \to 0 \\ \Delta\theta_j \to 0 \\ \Delta z_k \to 0}} \sum_i\sum_j\sum_k \rho\, r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k = \rho \iiint_{V'} r\,dr\,d\theta\,dz = \rho \cdot \pi C^2 H$$
-</p>
-<strong>④ 具体例の引き戻しを書く。</strong> 円柱座標への変換 $\Phi(r,\theta,z) = (r\cos\theta,\; r\sin\theta,\; z)$ に対して：
-<p>$$\Phi^*(dx \wedge dy \wedge dz) = r\,dr \wedge d\theta \wedge dz$$
-</p>
-<p>これが $3$-form の引き戻しの具体例である。この $r$ が、§4.2 の $r$ をそのまま引き継いだつじつま係数である。
-</p>
-<strong>⑤ 係数付き $3$-form の引き戻し。</strong> 任意の密度 $\rho(x,y,z)$ を持つ $3$-form $\rho\,dx \wedge dy \wedge dz$ に対して、同じ構造が成り立つ：
-<p>$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(r\cos\theta,\, r\sin\theta,\, z)\; r\,dr \wedge d\theta \wedge dz$$
-</p>
-<p>係数 $\rho$ は座標を焼き直すだけ（$0$-form の引き戻し）で、$dx \wedge dy \wedge dz$ の部分だけが $r\,dr \wedge d\theta \wedge dz$ に変わる。
-</p>
-<strong>⑥ 一般の変換で定義する。</strong> より一般に、$3$-form $\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$ と、空間の変換 $\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$ に対して、引き戻し $\Phi^*$ は三個の方向すべてで辺ベクトルを求め、その $3 \times 3$ 行列式をとる：
-<p>$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(x(u,v,w), y(u,v,w), z(u,v,w))\ \det\!\begin{pmatrix}
+<strong>⑥ 一般の変換で定義する。</strong> より一般に、<span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$</span> と、空間の変換 <span class="tex2jax_process">$\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$</span> に対して、引き戻し <span class="tex2jax_process">$\Phi^*$</span> は三個の方向すべてで辺ベクトルを求め、その <span class="tex2jax_process">$3 \times 3$</span> 行列式をとる：
+<div class="math-block tex2jax_process">$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(x(u,v,w), y(u,v,w), z(u,v,w))\ \det\!\begin{pmatrix}
 \Delta x_u & \Delta x_v & \Delta x_w \\[2pt]
 \Delta y_u & \Delta y_v & \Delta y_w \\[2pt]
 \Delta z_u & \Delta z_v & \Delta z_w
-\end{pmatrix}\,du \wedge dv \wedge dw$$
+\end{pmatrix}\,du \wedge dv \wedge dw$$</div>
+<p>この <span class="tex2jax_process">$3 \times 3$</span> 行列式を <span class="tex2jax_process">$J(u,v,w)$</span> と書けば
 </p>
-<p>この $3 \times 3$ 行列式を $J(u,v,w)$ と書けば
+<div class="math-block tex2jax_process">$$\Phi^*(\rho\,dx \wedge dy \wedge dz) = \rho(\Phi(u,v,w))\,J\,du \wedge dv \wedge dw$$</div>
+<p>となる。この <span class="tex2jax_process">$3 \times 3$</span> 行列式 <span class="tex2jax_process">$J(u,v,w)$</span> が、<span class="tex2jax_process">$3$</span>-form のつじつま係数である。<span class="tex2jax_process">$J$</span> が負なら向きが反転していることを意味するから、体積積分の変数変換に絶対値 <span class="tex2jax_process">$|J|$</span> が現れる理由もここにある。<span class="tex2jax_process">$1$</span>-form なら <span class="tex2jax_process">$1 \times 1$</span> 行列式（スカラー <span class="tex2jax_process">$\gamma'(t)$</span>）、<span class="tex2jax_process">$2$</span>-form なら <span class="tex2jax_process">$2 \times 2$</span> 行列式（<span class="tex2jax_process">$\Delta x_u\Delta y_v - \Delta x_v\Delta y_u$</span>）、<span class="tex2jax_process">$3$</span>-form なら <span class="tex2jax_process">$3 \times 3$</span> 行列式（<span class="tex2jax_process">$J$</span>）——次数が上がるごとに、つじつま係数を司る行列式のサイズが一つずつ大きくなる。この式こそが <strong><span class="tex2jax_process">$3$</span>-form の引き戻しの一般的な定義</strong> である。
 </p>
-<p>$$\Phi^*(\rho\,dx \wedge dy \wedge dz) = \rho(\Phi(u,v,w))\,J\,du \wedge dv \wedge dw$$
-</p>
-<p>となる。この $3 \times 3$ 行列式 $J(u,v,w)$ が、$3$-form のつじつま係数である。$J$ が負なら向きが反転していることを意味するから、体積積分の変数変換に絶対値 $|J|$ が現れる理由もここにある。$1$-form なら $1 \times 1$ 行列式（スカラー $\gamma'(t)$）、$2$-form なら $2 \times 2$ 行列式（$\Delta x_u\Delta y_v - \Delta x_v\Delta y_u$）、$3$-form なら $3 \times 3$ 行列式（$J$）——次数が上がるごとに、つじつま係数を司る行列式のサイズが一つずつ大きくなる。この式こそが <strong>$3$-form の引き戻しの一般的な定義</strong> である。
-</p>
-<blockquote><p>**注** （ベクトル解析を学んだ読者へ）変数変換で「極座標にすると $r\,dr\,d\theta$ が出る」と習ったとき、多くの教科書は「$\theta$ 方向の弧の長さ $r\Delta\theta$ を考えて、$\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$」という幾何学的な説明をする。その説明に間違いはない。しかし本書の計算では弧の長さを一切考えていない。変換式と三角関数の公式、そして $\wedge$ に相当する行列式の計算だけが、正しいつじつま係数 $r$ を自動的に導いている。</p>
+<blockquote><p>**注** （ベクトル解析を学んだ読者へ）変数変換で「極座標にすると <span class="tex2jax_process">$r\,dr\,d\theta$</span> が出る」と習ったとき、多くの教科書は「<span class="tex2jax_process">$\theta$</span> 方向の弧の長さ <span class="tex2jax_process">$r\Delta\theta$</span> を考えて、<span class="tex2jax_process">$\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$</span>」という幾何学的な説明をする。その説明に間違いはない。しかし本書の計算では弧の長さを一切考えていない。変換式と三角関数の公式、そして <span class="tex2jax_process">$\wedge$</span> に相当する行列式の計算だけが、正しいつじつま係数 <span class="tex2jax_process">$r$</span> を自動的に導いている。</p>
 </p></blockquote>
 <strong>⑦ 物理量へ戻る。</strong> 引き戻した測定器で積分すれば
-<p>$$M = \rho \iiint_V dx \wedge dy \wedge dz = \rho \iiint_{V'} r\,dr \wedge d\theta \wedge dz = \rho \cdot \pi C^2 H$$
-</p>
-<p>正しい値に一致した。積分値を保つために、測定器 $dx \wedge dy \wedge dz$ は $(r,\theta,z)$ 空間では $r\,dr \wedge d\theta \wedge dz$ に作り替えられなければならなかったのである。§4.1 の $\gamma'(t)$ がエネルギー保存を、§4.2 の $r$ が角運動量保存を記述したのとまったく同じ構造で、§4.3 の $r$（一般には $J$）が質量保存を記述している。
+<div class="math-block tex2jax_process">$$M = \rho \iiint_V dx \wedge dy \wedge dz = \rho \iiint_{V'} r\,dr \wedge d\theta \wedge dz = \rho \cdot \pi C^2 H$$</div>
+<p>正しい値に一致した。積分値を保つために、測定器 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> は <span class="tex2jax_process">$(r,\theta,z)$</span> 空間では <span class="tex2jax_process">$r\,dr \wedge d\theta \wedge dz$</span> に作り替えられなければならなかったのである。§4.1 の <span class="tex2jax_process">$\gamma'(t)$</span> がエネルギー保存を、§4.2 の <span class="tex2jax_process">$r$</span> が角運動量保存を記述したのとまったく同じ構造で、§4.3 の <span class="tex2jax_process">$r$</span>（一般には <span class="tex2jax_process">$J$</span>）が質量保存を記述している。
 </p>
 <h3 id="44-引き戻しの性質--ここまでに確立したこと">§4.4 引き戻しの性質 —— ここまでに確立したこと</h3>
-<p>§4.1〜§4.3 で三つの具体例を通じて引き戻しを構成してきた。ここで、これらに共通する代数的な性質を整理しておく。あわせて、§4.3 で現れた $3 \times 3$ 行列式 $J$ を <strong>ヤコビアン（ヤコビ行列式）</strong> と定義する。もととなる行列
+<p>§4.1〜§4.3 で三つの具体例を通じて引き戻しを構成してきた。ここで、これらに共通する代数的な性質を整理しておく。あわせて、§4.3 で現れた <span class="tex2jax_process">$3 \times 3$</span> 行列式 <span class="tex2jax_process">$J$</span> を <strong>ヤコビアン（ヤコビ行列式）</strong> と定義する。もととなる行列
 </p>
-<p>$$\begin{pmatrix}
+<div class="math-block tex2jax_process">$$\begin{pmatrix}
 \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[4pt]
 \frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[4pt]
 \frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>を <strong>ヤコビ行列</strong> と呼び、その行列式 <span class="tex2jax_process">$\det$</span> がヤコビアン <span class="tex2jax_process">$J$</span> である。
 </p>
-<p>を <strong>ヤコビ行列</strong> と呼び、その行列式 $\det$ がヤコビアン $J$ である。
+<strong>① 0-form（スカラー場）の引き戻し。</strong> スカラー場 <span class="tex2jax_process">$f(x,y,z)$</span> を変換 <span class="tex2jax_process">$\Phi$</span> で引き戻すとは、単に座標をパラメータ表示に焼き直すことである：
+<div class="math-block tex2jax_process">$$\Phi^*(f) = f(\Phi(u,v,w))$$</div>
+<p>たとえば §4.1 で <span class="tex2jax_process">$F(x)\,dx$</span> の <span class="tex2jax_process">$F(x)$</span> を <span class="tex2jax_process">$F(\gamma(t))$</span> に焼き直した操作は、<span class="tex2jax_process">$F$</span> という <span class="tex2jax_process">$0$</span>-form の引き戻しにほかならない。
 </p>
-<strong>① 0-form（スカラー場）の引き戻し。</strong> スカラー場 $f(x,y,z)$ を変換 $\Phi$ で引き戻すとは、単に座標をパラメータ表示に焼き直すことである：
-<p>$$\Phi^*(f) = f(\Phi(u,v,w))$$
-</p>
-<p>たとえば §4.1 で $F(x)\,dx$ の $F(x)$ を $F(\gamma(t))$ に焼き直した操作は、$F$ という $0$-form の引き戻しにほかならない。
-</p>
-<strong>② 線形性。</strong> 二つの $k$-form $\omega, \eta$ とスカラー $a,b$ に対し
-<p>$$\Phi^*(a\omega + b\eta) = a\,\Phi^*(\omega) + b\,\Phi^*(\eta)$$
-</p>
+<strong>② 線形性。</strong> 二つの <span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega, \eta$</span> とスカラー <span class="tex2jax_process">$a,b$</span> に対し
+<div class="math-block tex2jax_process">$$\Phi^*(a\omega + b\eta) = a\,\Phi^*(\omega) + b\,\Phi^*(\eta)$$</div>
 <p>が成り立つ。これは測定器の和や定数倍が、引き戻しの前後で整合することを保証する。
 </p>
-<strong>③ ウェッジ積との整合性。</strong> $k$-form $\omega$ と $\ell$-form $\eta$ に対し
-<p>$$\Phi^*(\omega \wedge \eta) = \Phi^*(\omega) \wedge \Phi^*(\eta)$$
+<strong>③ ウェッジ積との整合性。</strong> <span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> と <span class="tex2jax_process">$\ell$</span>-form <span class="tex2jax_process">$\eta$</span> に対し
+<div class="math-block tex2jax_process">$$\Phi^*(\omega \wedge \eta) = \Phi^*(\omega) \wedge \Phi^*(\eta)$$</div>
+<p>が成り立つ。すなわち「組み立ててから引き戻す」のと「引き戻してから組み立てる」のは同じ結果を与える。§4.2 で <span class="tex2jax_process">$dx$</span> と <span class="tex2jax_process">$dy$</span> を個別に展開してから <span class="tex2jax_process">$\wedge$</span> で組み立てた操作が、まさにこの性質を実行していた。
 </p>
-<p>が成り立つ。すなわち「組み立ててから引き戻す」のと「引き戻してから組み立てる」のは同じ結果を与える。§4.2 で $dx$ と $dy$ を個別に展開してから $\wedge$ で組み立てた操作が、まさにこの性質を実行していた。
+<strong>④ 次数ごとのつじつま係数。</strong> <span class="tex2jax_process">$k$</span>-form の引き戻しでは、変換 <span class="tex2jax_process">$\Phi$</span> の <span class="tex2jax_process">$k$</span> 個の方向に関する辺ベクトルを並べた <span class="tex2jax_process">$k \times k$</span> 行列式がつじつま係数となる。本書の範囲では：
+<blockquote><p>- <span class="tex2jax_process">$k=1$</span>（<span class="tex2jax_process">$1$</span>-form）：<span class="tex2jax_process">$1 \times 1$</span> 行列式 → スカラー <span class="tex2jax_process">$\gamma'(t)$</span></p>
+- <span class="tex2jax_process">$k=2$</span>（<span class="tex2jax_process">$2$</span>-form）：<span class="tex2jax_process">$2 \times 2$</span> 行列式 → <span class="tex2jax_process">$\Delta x_u\Delta y_v - \Delta x_v\Delta y_u$</span>
+- <span class="tex2jax_process">$k=3$</span>（<span class="tex2jax_process">$3$</span>-form）：<span class="tex2jax_process">$3 \times 3$</span> 行列式 → <span class="tex2jax_process">$J$</span>（ヤコビアン）
+</p></blockquote>
+<blockquote><p>**注** （ヤコビアンの呼称について）本書では <span class="tex2jax_process">$3 \times 3$</span> 行列式 <span class="tex2jax_process">$J$</span> を特にヤコビアンと呼んでいる。<span class="tex2jax_process">$2 \times 2$</span> 行列式や <span class="tex2jax_process">$1 \times 1$</span> 行列式（すなわち <span class="tex2jax_process">$\gamma'(t)$</span>）もまたヤコビアンである。一般の <span class="tex2jax_process">$k$</span> 次元でも <span class="tex2jax_process">$k \times k$</span> 行列式をヤコビアンと呼ぶ。対応する <span class="tex2jax_process">$k \times k$</span> 行列はヤコビ行列である。しかし、おおむね断りがなければ「ヤコビアン」は <span class="tex2jax_process">$3 \times 3$</span> の体積換算率を指す、と覚えておけば十分である。</p>
+</p></blockquote>
+<p>次数が上がるごとに行列式のサイズが一つずつ大きくなる。この構造は <span class="tex2jax_process">$n$</span> 次元の一般の <span class="tex2jax_process">$k$</span>-form でもまったく同じである。<span class="tex2jax_process">$k$</span>-form の引き戻しとは、<strong><span class="tex2jax_process">$k$</span> 個の辺ベクトルを並べた <span class="tex2jax_process">$k \times k$</span> 行列式で、<span class="tex2jax_process">$k$</span> 次元のマス目ごとのつじつま係数を測る操作</strong>にほかならない。
 </p>
-<strong>④ 次数ごとのつじつま係数。</strong> $k$-form の引き戻しでは、変換 $\Phi$ の $k$ 個の方向に関する辺ベクトルを並べた $k \times k$ 行列式がつじつま係数となる。本書の範囲では：
-<blockquote><p>- $k=1$（$1$-form）：$1 \times 1$ 行列式 → スカラー $\gamma'(t)$</p>
-- $k=2$（$2$-form）：$2 \times 2$ 行列式 → $\Delta x_u\Delta y_v - \Delta x_v\Delta y_u$
-- $k=3$（$3$-form）：$3 \times 3$ 行列式 → $J$（ヤコビアン）
+<blockquote><p>**注** （外微分 <span class="tex2jax_process">$d$</span> との可換性——第5章への伏線）これらに加えて、引き戻しと外微分 <span class="tex2jax_process">$d$</span> のあいだには重要な関係</p>
+
 </p></blockquote>
-<blockquote><p>**注** （ヤコビアンの呼称について）本書では $3 \times 3$ 行列式 $J$ を特にヤコビアンと呼んでいる。$2 \times 2$ 行列式や $1 \times 1$ 行列式（すなわち $\gamma'(t)$）もまたヤコビアンである。一般の $k$ 次元でも $k \times k$ 行列式をヤコビアンと呼ぶ。対応する $k \times k$ 行列はヤコビ行列である。しかし、おおむね断りがなければ「ヤコビアン」は $3 \times 3$ の体積換算率を指す、と覚えておけば十分である。</p>
+<div class="math-block tex2jax_process">$$\Phi^*(d\omega) = d(\Phi^*\omega)$$</div>
+<blockquote><p>が成り立つ。すなわち「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は第5章で <span class="tex2jax_process">$d$</span> を正式に導入したのち、§5.9 で改めて取り上げる。</p>
 </p></blockquote>
-<p>次数が上がるごとに行列式のサイズが一つずつ大きくなる。この構造は $n$ 次元の一般の $k$-form でもまったく同じである。$k$-form の引き戻しとは、<strong>$k$ 個の辺ベクトルを並べた $k \times k$ 行列式で、$k$ 次元のマス目ごとのつじつま係数を測る操作</strong>にほかならない。
-</p>
-<blockquote><p>**注** （外微分 $d$ との可換性——第5章への伏線）これらに加えて、引き戻しと外微分 $d$ のあいだには重要な関係</p>
-$$\Phi^*(d\omega) = d(\Phi^*\omega)$$
-が成り立つ。すなわち「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は第5章で $d$ を正式に導入したのち、§5.9 で改めて取り上げる。
-</p></blockquote>
-<p>これ以上深く立ち入ることはしない——第 10 章で多様体の言葉による一般論に触れる——が、本書の $3$ 次元での経験は、その一般論を学ぶ際の確かな足場となるだろう。
+<p>これ以上深く立ち入ることはしない——第 10 章で多様体の言葉による一般論に触れる——が、本書の <span class="tex2jax_process">$3$</span> 次元での経験は、その一般論を学ぶ際の確かな足場となるだろう。
 </p>
 <hr />
 <h3 id="45-本章のまとめと第5章外微分への展望">§4.5 本章のまとめと第5章（外微分）への展望</h3>
 <p>第I部「積分記号の尻尾の正体」の三段が、これで完結した：
 </p>
 <ol>
-<li>**第1章**：$dx$ を行列（$1$-form）と見なし、積分を行列作用の極限と読む</li>
+<li>**第1章**：<span class="tex2jax_process">$dx$</span> を行列（<span class="tex2jax_process">$1$</span>-form）と見なし、積分を行列作用の極限と読む</li>
 </ol>
-<p>2. <strong>第2章</strong>：ウェッジ積 $\wedge$ で $2$-form・$3$-form を構成し、面積・体積を代数で測る
+<p>2. <strong>第2章</strong>：ウェッジ積 <span class="tex2jax_process">$\wedge$</span> で <span class="tex2jax_process">$2$</span>-form・<span class="tex2jax_process">$3$</span>-form を構成し、面積・体積を代数で測る
 <ol>
 <li>**第5章（本章）**：曲線・曲面・領域に形式を適用し集計する（積分）。引き戻しにより「積分値を保つために測定器を作り替える」という統一原理を、エネルギー保存・角運動量保存・質量保存の三つの具体例を通じて確立した</li>
 </ol>
 <p>本章で確立したのは、次の統一原理である：
 </p>
-<strong>$k$-form（はかり）が $k$-vector（図形）を食べてスカラーを返し、それを領域全体で集計する。</strong>次数が $0,1,2,3$ と変わっても、この構図は不変だった。曲線上の仕事も、曲面上の流量も、領域内の総質量も——すべて同じ言語で書ける。
-<p>引き戻しは「積分値を保つために測定器を作り替える」技術であり、その核心は §4.1〜§4.3 で見た発見的導出——「素朴にやって合わない → 有限マス目でつじつま係数を求める → 極限で一般形を得る」——に尽きる。$1$-form では速度 $\gamma'(t)$ が、$2$-form では $r$ が、$3$-form では $3 \times 3$ 行列式 $J$ が、いずれも変換式と行列式（$\wedge$）の計算から自動的に導かれた。既存の微分公式は一切必要なかった。
+<strong><span class="tex2jax_process">$k$</span>-form（はかり）が <span class="tex2jax_process">$k$</span>-vector（図形）を食べてスカラーを返し、それを領域全体で集計する。</strong>次数が <span class="tex2jax_process">$0,1,2,3$</span> と変わっても、この構図は不変だった。曲線上の仕事も、曲面上の流量も、領域内の総質量も——すべて同じ言語で書ける。
+<p>引き戻しは「積分値を保つために測定器を作り替える」技術であり、その核心は §4.1〜§4.3 で見た発見的導出——「素朴にやって合わない → 有限マス目でつじつま係数を求める → 極限で一般形を得る」——に尽きる。<span class="tex2jax_process">$1$</span>-form では速度 <span class="tex2jax_process">$\gamma'(t)$</span> が、<span class="tex2jax_process">$2$</span>-form では <span class="tex2jax_process">$r$</span> が、<span class="tex2jax_process">$3$</span>-form では <span class="tex2jax_process">$3 \times 3$</span> 行列式 <span class="tex2jax_process">$J$</span> が、いずれも変換式と行列式（<span class="tex2jax_process">$\wedge$</span>）の計算から自動的に導かれた。既存の微分公式は一切必要なかった。
 </p>
 <blockquote><p>**【ここまでのチェックポイント——第3章・第I部全体】**</p>
-- $1$-form $\omega$ の線積分 $\int_\gamma \omega$ は、$\gamma'(t)$ に $\omega$ を食わせて集計する操作。仕事は $\int_\gamma \omega$ で、$\mathbf{F}\cdot d\mathbf{r}$ と同じ量。積分値（＝エネルギー変化）は座標のとり方に依らず一定。
-- $2$-form $\eta$ の面積分 $\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$。係数1では各平面への「影」を測り、三つの影を合成すればスカラー面積が得られる。面積速度と角運動量保存（ケプラーの第二法則）に応用できる。
-- $3$-form $\Omega$ の体積分 $\iiint_V \Omega$。係数1でそのまま体積、係数 $\rho$ で総質量・総電荷。積分値（＝質量）は座標不変。
-- 引き戻し $\Phi^*$ は「積分値が不変となるように測定器をパラメータ空間用に焼き直す」操作。第1章 §1.4 の $dx = \cos\theta\,dr - r\sin\theta\,d\theta$ がその原型。
-- $1$-form → $\gamma'(t)$、$2$-form → $r$、$3$-form → $J$。いずれも変換式と行列式（$\wedge$）の計算だけが、幾何的直感なしに正しいつじつま係数を導く。
+- <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> の線積分 <span class="tex2jax_process">$\int_\gamma \omega$</span> は、<span class="tex2jax_process">$\gamma'(t)$</span> に <span class="tex2jax_process">$\omega$</span> を食わせて集計する操作。仕事は <span class="tex2jax_process">$\int_\gamma \omega$</span> で、<span class="tex2jax_process">$\mathbf{F}\cdot d\mathbf{r}$</span> と同じ量。積分値（＝エネルギー変化）は座標のとり方に依らず一定。
+- <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\eta$</span> の面積分 <span class="tex2jax_process">$\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$</span>。係数1では各平面への「影」を測り、三つの影を合成すればスカラー面積が得られる。面積速度と角運動量保存（ケプラーの第二法則）に応用できる。
+- <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\Omega$</span> の体積分 <span class="tex2jax_process">$\iiint_V \Omega$</span>。係数1でそのまま体積、係数 <span class="tex2jax_process">$\rho$</span> で総質量・総電荷。積分値（＝質量）は座標不変。
+- 引き戻し <span class="tex2jax_process">$\Phi^*$</span> は「積分値が不変となるように測定器をパラメータ空間用に焼き直す」操作。第1章 §1.4 の <span class="tex2jax_process">$dx = \cos\theta\,dr - r\sin\theta\,d\theta$</span> がその原型。
+- <span class="tex2jax_process">$1$</span>-form → <span class="tex2jax_process">$\gamma'(t)$</span>、<span class="tex2jax_process">$2$</span>-form → <span class="tex2jax_process">$r$</span>、<span class="tex2jax_process">$3$</span>-form → <span class="tex2jax_process">$J$</span>。いずれも変換式と行列式（<span class="tex2jax_process">$\wedge$</span>）の計算だけが、幾何的直感なしに正しいつじつま係数を導く。
 </p></blockquote>
 <hr />
-<p>ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 $d$</strong> を導入する。$d$ は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。
+<p>ここから先の<strong>第II部</strong>では、いよいよ<strong>外微分 <span class="tex2jax_process">$d$</span></strong> を導入する。<span class="tex2jax_process">$d$</span> は形式の次数を1つ上げる線形演算子であり、勾配・回転・発散が<strong>一つの操作のバリエーション</strong>であることが明らかになる。積分側の言葉がそろったいま、微分側の代数を完成させる準備が整ったのである。
 </p>
 <p>\newpage
 </p>
-<h1 id="第5章微分するとは何か--外微分-局所のズレと積分の逆">第5章：微分するとは何か —— 外微分 $d$：局所のズレと積分の逆</h1>
+<h1 id="第5章微分するとは何か--外微分-span-classtex2jaxprocessspan局所のズレと積分の逆">第5章：微分するとは何か —— 外微分 <span class="tex2jax_process">$d$</span>：局所のズレと積分の逆</h1>
 <h3 id="50-第II部の扉観測は積分法則は微分">§5.0 第II部の扉——観測は積分、法則は微分</h3>
-<p>　第3章で我々は、曲線・曲面・領域上の積分を $k$-form の言葉で定義した。曲線 $\gamma$ に沿った仕事は $\int_\gamma \omega$、曲面 $S$ を貫く流量は $\iint_S \eta$、領域 $V$ の総質量は $\iiint_V \Omega$ である。いずれも「$k$-form（はかり）を $k$-vector（図形）に食わせてスカラーを得、領域全体で集計する」という同一の原理に従っていた。
+<p>　第3章で我々は、曲線・曲面・領域上の積分を <span class="tex2jax_process">$k$</span>-form の言葉で定義した。曲線 <span class="tex2jax_process">$\gamma$</span> に沿った仕事は <span class="tex2jax_process">$\int_\gamma \omega$</span>、曲面 <span class="tex2jax_process">$S$</span> を貫く流量は <span class="tex2jax_process">$\iint_S \eta$</span>、領域 <span class="tex2jax_process">$V$</span> の総質量は <span class="tex2jax_process">$\iiint_V \Omega$</span> である。いずれも「<span class="tex2jax_process">$k$</span>-form（はかり）を <span class="tex2jax_process">$k$</span>-vector（図形）に食わせてスカラーを得、領域全体で集計する」という同一の原理に従っていた。
 </p>
 <p>ここで我々が手にした積分は、すべて<strong>領域全体にわたる</strong>量である（以下こうした量を<strong>大域的</strong>と呼ぶ）。仕事は曲線全体にわたる総和であり、流量は曲面全体を貫く総量であり、質量は領域全体での総計だ。それらは測定器の当て方と領域の選び方に依存する。
 </p>
@@ -2295,458 +2196,405 @@ $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
 </p>
 <blockquote><p>**積分された量から、どのようにして局所法則を取り出すのか。**</p>
 </p></blockquote>
-<p>この問いに答えるのが本章の主題——<strong>外微分 $d$</strong>——である。$d$ は $k$-form に作用して $(k+1)$-form を返す演算子であり、第3章で定義した積分と組み合わせることで「境界で測った大域的な積分」を「内部の局所的な変化の集積」へと翻訳する。いわば、<strong>$d$ は積分法則を微分法則に変換する装置</strong>なのである。
+<p>この問いに答えるのが本章の主題——<strong>外微分 <span class="tex2jax_process">$d$</span></strong>——である。<span class="tex2jax_process">$d$</span> は <span class="tex2jax_process">$k$</span>-form に作用して <span class="tex2jax_process">$(k+1)$</span>-form を返す演算子であり、第3章で定義した積分と組み合わせることで「境界で測った大域的な積分」を「内部の局所的な変化の集積」へと翻訳する。いわば、<strong><span class="tex2jax_process">$d$</span> は積分法則を微分法則に変換する装置</strong>なのである。
 </p>
-<p>本章の構成はこうだ。まず第1章で導入した $df$ を思い出し、それが $0$-form → $1$-form の「次元上げ」だったことを確認する（§5.1）。次に一般の $1$-form ではその逆演算が破綻することを見て（§5.2）、微小ループの解剖から $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ という「面積あたりのズレ」を発見する（§5.3）。この発見を手がかりに $d$ の定義へと至り（§5.4）、3次元への拡張（§5.5）、ストークスの定理（§5.6）へと進む。同じ論法を $2$-form にも適用し（§5.7）、$d^2=0$ の構造的意味を明らかにする（§5.8）。最後に、この $d$ がどのように物理法則を局所化するかを示し（§5.10）、次章のホッジ・スターへとつなぐ（§5.11）。
+<p>本章の構成はこうだ。まず第1章で導入した <span class="tex2jax_process">$df$</span> を思い出し、それが <span class="tex2jax_process">$0$</span>-form → <span class="tex2jax_process">$1$</span>-form の「次元上げ」だったことを確認する（§5.1）。次に一般の <span class="tex2jax_process">$1$</span>-form ではその逆演算が破綻することを見て（§5.2）、微小ループの解剖から <span class="tex2jax_process">$(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$</span> という「面積あたりのズレ」を発見する（§5.3）。この発見を手がかりに <span class="tex2jax_process">$d$</span> の定義へと至り（§5.4）、3次元への拡張（§5.5）、ストークスの定理（§5.6）へと進む。同じ論法を <span class="tex2jax_process">$2$</span>-form にも適用し（§5.7）、<span class="tex2jax_process">$d^2=0$</span> の構造的意味を明らかにする（§5.8）。最後に、この <span class="tex2jax_process">$d$</span> がどのように物理法則を局所化するかを示し（§5.10）、次章のホッジ・スターへとつなぐ（§5.11）。
 </p>
 <hr />
-<h3 id="51-再訪微分と積分は逆演算か">§5.1 $df$ 再訪——微分と積分は逆演算か</h3>
-<h4 id="511-は次元上げをしている">5.1.1 $df$ は「次元上げ」をしている</h4>
-<p>第1章 §1.2 で、我々は関数 $f(x,y,z)$ の全微分を横ベクトルとして定義した：
+<h3 id="51-span-classtex2jaxprocessspan-再訪微分と積分は逆演算か">§5.1 <span class="tex2jax_process">$df$</span> 再訪——微分と積分は逆演算か</h3>
+<h4 id="511-span-classtex2jaxprocessspan-は次元上げをしている">5.1.1 <span class="tex2jax_process">$df$</span> は「次元上げ」をしている</h4>
+<p>第1章 §1.2 で、我々は関数 <span class="tex2jax_process">$f(x,y,z)$</span> の全微分を横ベクトルとして定義した：
 </p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</div>
+<p>これは <strong><span class="tex2jax_process">$0$</span>-form（スカラー場 <span class="tex2jax_process">$f$</span>）を入力として <span class="tex2jax_process">$1$</span>-form（横ベクトル <span class="tex2jax_process">$df$</span>）を出力する</strong>操作である。次数が 0 から 1 へ上がった。
 </p>
-<p>これは <strong>$0$-form（スカラー場 $f$）を入力として $1$-form（横ベクトル $df$）を出力する</strong>操作である。次数が 0 から 1 へ上がった。
+<p>ここで思い出してほしいのは、<span class="tex2jax_process">$df(\mathbf{v})$</span> が変位 <span class="tex2jax_process">$\mathbf{v}$</span> に対する <span class="tex2jax_process">$f$</span> の一次変化量を返す、ということだ。<span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$</span> が十分小さいとき：
 </p>
-<p>ここで思い出してほしいのは、$df(\mathbf{v})$ が変位 $\mathbf{v}$ に対する $f$ の一次変化量を返す、ということだ。$\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ が十分小さいとき：
-</p>
-<p>$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
-</p>
-<p>$df$ 単独では「変化量そのもの」ではない——第1章 §1.1.6 の契約どおり、$df$ は演算子であり、変位ベクトルに作用して初めて数値が得られる。
-</p>
+<div class="math-block tex2jax_process">$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$</div>
+<span class="tex2jax_process">$df$</span> 単独では「変化量そのもの」ではない——第1章 §1.1.6 の契約どおり、<span class="tex2jax_process">$df$</span> は演算子であり、変位ベクトルに作用して初めて数値が得られる。
 <h4 id="512-線積分すると端点の差だけが残る">5.1.2 線積分すると端点の差だけが残る</h4>
-<p>この $df$ を曲線 $\gamma$ に沿って積分する。第3章 §3.3.1 の定義どおり、曲線を小区間に刻み、各ステップの変位 $\Delta\mathbf{r}_i$ に $df$ を食わせて足し上げる。
+<p>この <span class="tex2jax_process">$df$</span> を曲線 <span class="tex2jax_process">$\gamma$</span> に沿って積分する。第3章 §3.3.1 の定義どおり、曲線を小区間に刻み、各ステップの変位 <span class="tex2jax_process">$\Delta\mathbf{r}_i$</span> に <span class="tex2jax_process">$df$</span> を食わせて足し上げる。
 </p>
-<p>各区間で $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$ だから、全区間の和は：
+<p>各区間で <span class="tex2jax_process">$df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$</span> だから、全区間の和は：
 </p>
-<p>$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
-</p>
+<div class="math-block tex2jax_process">$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$</div>
 <p>この和を展開すると：
 </p>
-<p>$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
+<div class="math-block tex2jax_process">$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$</div>
+<p>隣り合う項 <span class="tex2jax_process">$f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$</span> がプラスとマイナスで打ち消し合う——<strong>望遠和（telescoping sum）</strong>だ。生き残るのは最初と最後だけ。刻みを無限に細かくする極限で：
 </p>
-<p>隣り合う項 $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ がプラスとマイナスで打ち消し合う——<strong>望遠和（telescoping sum）</strong>だ。生き残るのは最初と最後だけ。刻みを無限に細かくする極限で：
-</p>
-<p>$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
-</p>
-<p>ここで $A$ は曲線の始点、$B$ は終点である。
+<div class="math-block tex2jax_process">$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$</div>
+<p>ここで <span class="tex2jax_process">$A$</span> は曲線の始点、<span class="tex2jax_process">$B$</span> は終点である。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $\int_\gamma df = f(B) - f(A)$。積分の結果は経路の形状に一切依存せず、端点の値だけで決まる。
-- これは $df$ という特別な $1$-form だからこそ成立する。力学でいえば「保存力の仕事は経路によらない」という事実の数学的根拠だ。
+- <span class="tex2jax_process">$\int_\gamma df = f(B) - f(A)$</span>。積分の結果は経路の形状に一切依存せず、端点の値だけで決まる。
+- これは <span class="tex2jax_process">$df$</span> という特別な <span class="tex2jax_process">$1$</span>-form だからこそ成立する。力学でいえば「保存力の仕事は経路によらない」という事実の数学的根拠だ。
 </p></blockquote>
 <h4 id="513-第3章の例で確かめる">5.1.3 第3章の例で確かめる</h4>
-<p>第3章 §3.4.1 で我々は、$\omega = y\,dx + x\,dy$ を単位円 $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ に沿って積分し、結果が $0$ になることを計算した。あのときは係数に沿って愚直に積分したが、いまの言葉で見直すと話はもっと単純だ。
+<p>第3章 §3.4.1 で我々は、<span class="tex2jax_process">$\omega = y\,dx + x\,dy$</span> を単位円 <span class="tex2jax_process">$\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$</span> に沿って積分し、結果が <span class="tex2jax_process">$0$</span> になることを計算した。あのときは係数に沿って愚直に積分したが、いまの言葉で見直すと話はもっと単純だ。
 </p>
-<p>実は $y\,dx + x\,dy$ は $d(xy)$ にほかならない。なぜなら：
+<p>実は <span class="tex2jax_process">$y\,dx + x\,dy$</span> は <span class="tex2jax_process">$d(xy)$</span> にほかならない。なぜなら：
 </p>
-<p>$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
+<div class="math-block tex2jax_process">$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$</div>
+<p>したがって <span class="tex2jax_process">$\omega = df$</span>（<span class="tex2jax_process">$f = xy$</span>）であり、§5.1.2 の望遠和の理屈がそのまま使える。単位円は閉曲線だから <span class="tex2jax_process">$B = A$</span>、よって：
 </p>
-<p>したがって $\omega = df$（$f = xy$）であり、§5.1.2 の望遠和の理屈がそのまま使える。単位円は閉曲線だから $B = A$、よって：
+<div class="math-block tex2jax_process">$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$</div>
+<p>あのときの <span class="tex2jax_process">$\int_0^{2\pi} \cos 2t\,dt = 0$</span> という計算は、実は <span class="tex2jax_process">$\omega$</span> が <span class="tex2jax_process">$d(xy)$</span> という<strong>完全形式</strong>だったからこそ、機械的にゼロになったのである。
 </p>
-<p>$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$
-</p>
-<p>あのときの $\int_0^{2\pi} \cos 2t\,dt = 0$ という計算は、実は $\omega$ が $d(xy)$ という<strong>完全形式</strong>だったからこそ、機械的にゼロになったのである。
-</p>
-<blockquote><p>**注** （完全形式）$\omega = df$ と書ける $1$-form を**完全形式**（exact form）と呼ぶ。完全形式の閉曲線に沿った積分は、$f$ が一価関数である限り必ずゼロになる。しかし逆は真ではない——閉曲線でゼロになるからといって完全形式とは限らない。この点は §5.2 で詳しく見る。</p>
+<blockquote><p>**注** （完全形式）<span class="tex2jax_process">$\omega = df$</span> と書ける <span class="tex2jax_process">$1$</span>-form を**完全形式**（exact form）と呼ぶ。完全形式の閉曲線に沿った積分は、<span class="tex2jax_process">$f$</span> が一価関数である限り必ずゼロになる。しかし逆は真ではない——閉曲線でゼロになるからといって完全形式とは限らない。この点は §5.2 で詳しく見る。</p>
 </p></blockquote>
-<blockquote><p>**注** （$d$ と $\int$ の逆演算——どちらがどれだけ「完全」か）記号 $\circ$ を「続けて作用させる」の意味で使う（$f \circ g$ は「$g$ をしてから $f$」）。$\int_\gamma df = f(B)-f(A)$ は $\int \circ\, d$ がつねに境界値へ戻るという意味での逆演算である。いっぽう $d \circ \int$——積分してから外微分——は一般には元に戻らない。これが成り立つ $\omega$ が**完全形式**だ。つまり $d$ と $\int$ は $\int \circ\, d = \text{id}$（片側だけ恒等写像）という非対称な逆関係にある。この非対称性こそが、§5.2 以降で展開される外微分 $d$ の真価——「ズレ」を検出する力——の源泉になる。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\int$</span> の逆演算——どちらがどれだけ「完全」か）記号 <span class="tex2jax_process">$\circ$</span> を「続けて作用させる」の意味で使う（<span class="tex2jax_process">$f \circ g$</span> は「<span class="tex2jax_process">$g$</span> をしてから <span class="tex2jax_process">$f$</span>」）。<span class="tex2jax_process">$\int_\gamma df = f(B)-f(A)$</span> は <span class="tex2jax_process">$\int \circ\, d$</span> がつねに境界値へ戻るという意味での逆演算である。いっぽう <span class="tex2jax_process">$d \circ \int$</span>——積分してから外微分——は一般には元に戻らない。これが成り立つ <span class="tex2jax_process">$\omega$</span> が**完全形式**だ。つまり <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\int$</span> は <span class="tex2jax_process">$\int \circ\, d = \text{id}$</span>（片側だけ恒等写像）という非対称な逆関係にある。この非対称性こそが、§5.2 以降で展開される外微分 <span class="tex2jax_process">$d$</span> の真価——「ズレ」を検出する力——の源泉になる。</p>
 </p></blockquote>
 <hr />
 <h3 id="52-閉ループで姿を現すズレ">§5.2 閉ループで姿を現す「ズレ」</h3>
-<h4 id="521-一般の-form-ではどうか">5.2.1 一般の $1$-form ではどうか</h4>
-<p>では、一般の $1$-form
+<h4 id="521-一般の-span-classtex2jaxprocessspan-form-ではどうか">5.2.1 一般の <span class="tex2jax_process">$1$</span>-form ではどうか</h4>
+<p>では、一般の <span class="tex2jax_process">$1$</span>-form
 </p>
-<p>$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
+<div class="math-block tex2jax_process">$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$</div>
+<p>ではどうか。ここで <span class="tex2jax_process">$P, Q, R$</span> は場所ごとに変わる係数（スカラー場）であり、第3章 §3.4.1 で導入した「一般の <span class="tex2jax_process">$1$</span>-form」である。
 </p>
-<p>ではどうか。ここで $P, Q, R$ は場所ごとに変わる係数（スカラー場）であり、第3章 §3.4.1 で導入した「一般の $1$-form」である。
-</p>
-<blockquote><p>**注** （「一般の」とはどういうことか）§5.1 で扱った $df$ は、係数が $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ という特別な組み合わせだった——$f$ という一つの関数から偏微分で導かれた三つ組である。一方、ここでの「一般の」$\omega$ は $P, Q, R$ が**互いに無関係な、任意の三つのスカラー場**である。言い換えれば、$\omega = df$ と書けるとは限らない $1$-form のことを「一般の $1$-form」と呼んでいる。§5.1.3 の $y\,dx + x\,dy$ はたまたま $d(xy)$ と書ける完全形式だったが、そうでないもののほうがむしろ普通なのである。</p>
+<blockquote><p>**注** （「一般の」とはどういうことか）§5.1 で扱った <span class="tex2jax_process">$df$</span> は、係数が <span class="tex2jax_process">$\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$</span> という特別な組み合わせだった——<span class="tex2jax_process">$f$</span> という一つの関数から偏微分で導かれた三つ組である。一方、ここでの「一般の」<span class="tex2jax_process">$\omega$</span> は <span class="tex2jax_process">$P, Q, R$</span> が**互いに無関係な、任意の三つのスカラー場**である。言い換えれば、<span class="tex2jax_process">$\omega = df$</span> と書けるとは限らない <span class="tex2jax_process">$1$</span>-form のことを「一般の <span class="tex2jax_process">$1$</span>-form」と呼んでいる。§5.1.3 の <span class="tex2jax_process">$y\,dx + x\,dy$</span> はたまたま <span class="tex2jax_process">$d(xy)$</span> と書ける完全形式だったが、そうでないもののほうがむしろ普通なのである。</p>
 </p></blockquote>
-<p>$\omega$ は力を表すとは限らず、任意の「線に沿って測る測定器」を表す。
+<span class="tex2jax_process">$\omega$</span> は力を表すとは限らず、任意の「線に沿って測る測定器」を表す。
+<p>この <span class="tex2jax_process">$\omega$</span> に対して、§5.1 と同じ望遠和が成り立つ保証はない。それを判定する最も簡潔な方法は<strong>閉ループ</strong>——始点と終点が同じ曲線——で積分してみることだ。もし <span class="tex2jax_process">$\int_\gamma \omega$</span> が端点の値の差だけで書けるなら、閉ループでは <span class="tex2jax_process">$f(A)-f(A)=0$</span> とならなければならない。
 </p>
-<p>この $\omega$ に対して、§5.1 と同じ望遠和が成り立つ保証はない。それを判定する最も簡潔な方法は<strong>閉ループ</strong>——始点と終点が同じ曲線——で積分してみることだ。もし $\int_\gamma \omega$ が端点の値の差だけで書けるなら、閉ループでは $f(A)-f(A)=0$ とならなければならない。
+<p>閉ループに沿った線積分を <span class="tex2jax_process">$\oint_\gamma \omega$</span> と書く。一般には：
 </p>
-<p>閉ループに沿った線積分を $\oint_\gamma \omega$ と書く。一般には：
-</p>
-<p>$$\oint_\gamma \omega \neq 0$$
-</p>
+<div class="math-block tex2jax_process">$$\oint_\gamma \omega \neq 0$$</div>
 <p>である。摩擦力に逆らって物体を一周させれば仕事はゼロにならず、渦巻く水流に沿って一周すれば正味の仕事を受ける。この<strong>「閉じても帳尻が合わない」という事実こそが、循環や渦のような局所構造の証拠</strong>だ。
 </p>
 <blockquote><p>**注** （物理を知らなくても大丈夫）摩擦力や水流をまだ物理学で扱っていない読者も、ここで立ち止まる必要はない。いま重要なのは具体的な物理現象ではなく、「閉ループの積分がゼロにならないなら、その場には循環のような局所構造がある」という感覚だけである。物理での詳しい対応は後の章で触れる。</p>
 </p></blockquote>
 <h4 id="522-局所情報はどこに宿るか">5.2.2 局所情報はどこに宿るか</h4>
-<p>では、この「一周して残るズレ」はどこから来るのか。閉ループをいきなり大域的な大きさで考えていては、中のどの点がどれだけズレに寄与したのかわからない。第1章で $f'(x)$ を求めたときのことを思い出そう——我々は $\Delta f / \Delta x$ の $\Delta x \to 0$ の極限をとることで、<strong>一点での</strong>変化率を取り出した。
+<p>では、この「一周して残るズレ」はどこから来るのか。閉ループをいきなり大域的な大きさで考えていては、中のどの点がどれだけズレに寄与したのかわからない。第1章で <span class="tex2jax_process">$f'(x)$</span> を求めたときのことを思い出そう——我々は <span class="tex2jax_process">$\Delta f / \Delta x$</span> の <span class="tex2jax_process">$\Delta x \to 0$</span> の極限をとることで、<strong>一点での</strong>変化率を取り出した。
 </p>
-<p>同じ発想をここでも使う。ループをどんどん小さくしていったとき、一周の積分 $\oint \omega$ の値はどうなるか。もし $\oint \omega$ の主項がループの<strong>囲む面積</strong>に比例して小さくなるなら、面積あたりのズレ——単位面積あたりどれだけ帳尻が合わないか——という量が、その点に固有の値として決まるはずだ。
+<p>同じ発想をここでも使う。ループをどんどん小さくしていったとき、一周の積分 <span class="tex2jax_process">$\oint \omega$</span> の値はどうなるか。もし <span class="tex2jax_process">$\oint \omega$</span> の主項がループの<strong>囲む面積</strong>に比例して小さくなるなら、面積あたりのズレ——単位面積あたりどれだけ帳尻が合わないか——という量が、その点に固有の値として決まるはずだ。
 </p>
 <p>逆に、もし比例しなければ（たとえばループの周の長さに比例するなら）、面積あたりの量としては決まらず、「その点での性質」とは呼べない。つまり問題はこうだ：
 </p>
-<blockquote><p>**微小ループを一周したとき、$\oint \omega$ の主項は囲んだ面積に比例するのか。比例するなら、その比例係数は何か。**</p>
+<blockquote><p>**微小ループを一周したとき、<span class="tex2jax_process">$\oint \omega$</span> の主項は囲んだ面積に比例するのか。比例するなら、その比例係数は何か。**</p>
 </p></blockquote>
-<p>次節で実際に、$xy$ 平面に置いた微小長方形でこの問いに答える。
+<p>次節で実際に、<span class="tex2jax_process">$xy$</span> 平面に置いた微小長方形でこの問いに答える。
 </p>
 <hr />
 <h3 id="53-微小ループの解剖ズレは面積に比例する">§5.3 微小ループの解剖——ズレは面積に比例する</h3>
-<h4 id="531-平面の微小長方形">5.3.1 $xy$ 平面の微小長方形</h4>
-<p>空間内の点 $(x, y, z)$ を左下の頂点とし、$xy$ 平面に平行な微小長方形を考える。$x$ 方向の幅を $\Delta x$、$y$ 方向の幅を $\Delta y$ とする。この長方形の四辺を<strong>反時計回り（右手系）</strong>に一周し、$\omega = P\,dx + Q\,dy + R\,dz$ を積分する。
+<h4 id="531-span-classtex2jaxprocessspan-平面の微小長方形">5.3.1 <span class="tex2jax_process">$xy$</span> 平面の微小長方形</h4>
+<p>空間内の点 <span class="tex2jax_process">$(x, y, z)$</span> を左下の頂点とし、<span class="tex2jax_process">$xy$</span> 平面に平行な微小長方形を考える。<span class="tex2jax_process">$x$</span> 方向の幅を <span class="tex2jax_process">$\Delta x$</span>、<span class="tex2jax_process">$y$</span> 方向の幅を <span class="tex2jax_process">$\Delta y$</span> とする。この長方形の四辺を<strong>反時計回り（右手系）</strong>に一周し、<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> を積分する。
 </p>
-<p>各辺での積分を、テイラー展開の1次近似（$\Delta x, \Delta y$ が十分小さいとして）で評価しよう。
+<p>各辺での積分を、テイラー展開の1次近似（<span class="tex2jax_process">$\Delta x, \Delta y$</span> が十分小さいとして）で評価しよう。
 </p>
-<blockquote><p>**注** （テイラー展開について）「テイラー展開」という言葉に身構える必要はない。ここで使うのは多変数関数の1次近似——第1章 §1.2.1 で $\Delta f \approx f'(x)\,\Delta x$ とやったのと同じことだ。たとえば $Q(x+\Delta x, y)$ を $x$ 方向に $\Delta x$ だけずらした値は、$Q$ の $x$ に関する偏微分 $\frac{\partial Q}{\partial x}$ を使って $Q + \frac{\partial Q}{\partial x}\,\Delta x$ と近似できる。$\Delta x$ が十分小さければ、$\Delta x$ の2次以上の項（$(\Delta x)^2$ やそれ以上）は $\Delta x$ に比べて圧倒的に小さいため無視してよい——これが1次近似の意味である。</p>
+<blockquote><p>**注** （テイラー展開について）「テイラー展開」という言葉に身構える必要はない。ここで使うのは多変数関数の1次近似——第1章 §1.2.1 で <span class="tex2jax_process">$\Delta f \approx f'(x)\,\Delta x$</span> とやったのと同じことだ。たとえば <span class="tex2jax_process">$Q(x+\Delta x, y)$</span> を <span class="tex2jax_process">$x$</span> 方向に <span class="tex2jax_process">$\Delta x$</span> だけずらした値は、<span class="tex2jax_process">$Q$</span> の <span class="tex2jax_process">$x$</span> に関する偏微分 <span class="tex2jax_process">$\frac{\partial Q}{\partial x}$</span> を使って <span class="tex2jax_process">$Q + \frac{\partial Q}{\partial x}\,\Delta x$</span> と近似できる。<span class="tex2jax_process">$\Delta x$</span> が十分小さければ、<span class="tex2jax_process">$\Delta x$</span> の2次以上の項（<span class="tex2jax_process">$(\Delta x)^2$</span> やそれ以上）は <span class="tex2jax_process">$\Delta x$</span> に比べて圧倒的に小さいため無視してよい——これが1次近似の意味である。</p>
 </p></blockquote>
-<p>$z$ は一定なので $dz=0$、$R$ の項は寄与しない。
+<span class="tex2jax_process">$z$</span> は一定なので <span class="tex2jax_process">$dz=0$</span>、<span class="tex2jax_process">$R$</span> の項は寄与しない。
+<strong>辺1（下辺、右向き）</strong>：<span class="tex2jax_process">$(x, y)$</span> から <span class="tex2jax_process">$(x+\Delta x, y)$</span> へ。<span class="tex2jax_process">$y$</span> 一定なので <span class="tex2jax_process">$dy=0$</span>。<span class="tex2jax_process">$P$</span> はおよそ <span class="tex2jax_process">$P(x, y, z)$</span>。寄与は <span class="tex2jax_process">$P(x, y, z)\,\Delta x$</span>。
+<strong>辺2（右辺、上向き）</strong>：<span class="tex2jax_process">$(x+\Delta x, y)$</span> から <span class="tex2jax_process">$(x+\Delta x, y+\Delta y)$</span> へ。<span class="tex2jax_process">$dx=0$</span>。<span class="tex2jax_process">$Q$</span> を <span class="tex2jax_process">$x$</span> 方向に <span class="tex2jax_process">$\Delta x$</span> だけずれた位置で評価する：
+<div class="math-block tex2jax_process">$$Q(x+\Delta x, y, z) \approx Q(x, y, z) + \frac{\partial Q}{\partial x}\Delta x$$</div>
+<p>寄与は <span class="tex2jax_process">$\bigl(Q + \frac{\partial Q}{\partial x}\Delta x\bigr)\,\Delta y$</span>。
 </p>
-<strong>辺1（下辺、右向き）</strong>：$(x, y)$ から $(x+\Delta x, y)$ へ。$y$ 一定なので $dy=0$。$P$ はおよそ $P(x, y, z)$。寄与は $P(x, y, z)\,\Delta x$。
-<strong>辺2（右辺、上向き）</strong>：$(x+\Delta x, y)$ から $(x+\Delta x, y+\Delta y)$ へ。$dx=0$。$Q$ を $x$ 方向に $\Delta x$ だけずれた位置で評価する：
-<p>$$Q(x+\Delta x, y, z) \approx Q(x, y, z) + \frac{\partial Q}{\partial x}\Delta x$$
-寄与は $\bigl(Q + \frac{\partial Q}{\partial x}\Delta x\bigr)\,\Delta y$。
+<strong>辺3（上辺、左向き）</strong>：<span class="tex2jax_process">$(x+\Delta x, y+\Delta y)$</span> から <span class="tex2jax_process">$(x, y+\Delta y)$</span> へ。負の方向なので符号が反転。<span class="tex2jax_process">$P$</span> を <span class="tex2jax_process">$y$</span> 方向に <span class="tex2jax_process">$\Delta y$</span> だけずれた位置で：
+<div class="math-block tex2jax_process">$$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y$$</div>
+<p>寄与は <span class="tex2jax_process">$-\bigl(P + \frac{\partial P}{\partial y}\Delta y\bigr)\,\Delta x$</span>。
 </p>
-<strong>辺3（上辺、左向き）</strong>：$(x+\Delta x, y+\Delta y)$ から $(x, y+\Delta y)$ へ。負の方向なので符号が反転。$P$ を $y$ 方向に $\Delta y$ だけずれた位置で：
-<p>$$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y$$
-寄与は $-\bigl(P + \frac{\partial P}{\partial y}\Delta y\bigr)\,\Delta x$。
-</p>
-<strong>辺4（左辺、下向き）</strong>：$(x, y+\Delta y)$ から $(x, y)$ へ戻る。寄与は $-Q(x, y, z)\,\Delta y$。
+<strong>辺4（左辺、下向き）</strong>：<span class="tex2jax_process">$(x, y+\Delta y)$</span> から <span class="tex2jax_process">$(x, y)$</span> へ戻る。寄与は <span class="tex2jax_process">$-Q(x, y, z)\,\Delta y$</span>。
 <p>四辺の寄与を合計する：
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \oint \omega &\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \\
 &= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \\
 &= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
-\end{aligned}$$
-</p>
-<p>$P\Delta x$ と $Q\Delta y$ の項が美しく相殺し、残ったのは $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ だけだ。
-</p>
+\end{aligned}$$</div>
+<span class="tex2jax_process">$P\Delta x$</span> と <span class="tex2jax_process">$Q\Delta y$</span> の項が美しく相殺し、残ったのは <span class="tex2jax_process">$(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$</span> だけだ。
 <h4 id="532-決定的な事実">5.3.2 決定的な事実</h4>
 <p>この結果が告げていることはただ一つ：
 </p>
-<blockquote><p>**一周して残るズレの主項は、囲んだ面積 $\Delta x\,\Delta y$ に比例する。**</p>
+<blockquote><p>**一周して残るズレの主項は、囲んだ面積 <span class="tex2jax_process">$\Delta x\,\Delta y$</span> に比例する。**</p>
 </p></blockquote>
-<p>そして比例係数 $\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ こそが、点 $(x,y,z)$ における<strong>単位面積あたりのズレ</strong>——その点での「渦の強さ」を表す局所量——である。より正確には、微小長方形 $R_{\Delta x,\Delta y}$ について
+<p>そして比例係数 <span class="tex2jax_process">$\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$</span> こそが、点 <span class="tex2jax_process">$(x,y,z)$</span> における<strong>単位面積あたりのズレ</strong>——その点での「渦の強さ」を表す局所量——である。より正確には、微小長方形 <span class="tex2jax_process">$R_{\Delta x,\Delta y}$</span> について
 </p>
-<p>$$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\Delta x,\Delta y}}\omega = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$$
-</p>
+<div class="math-block tex2jax_process">$$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\Delta x,\Delta y}}\omega = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$$</div>
 <p>という極限で取り出される量である。
 </p>
-<p>これは第1章で $f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$ とやったのと同じ発想の「微分」だ。分母が「動いた距離」から「囲んだ面積」に変わっただけで、<strong>変化率を局所的に取り出す</strong>という精神は変わっていない。
+<p>これは第1章で <span class="tex2jax_process">$f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$</span> とやったのと同じ発想の「微分」だ。分母が「動いた距離」から「囲んだ面積」に変わっただけで、<strong>変化率を局所的に取り出す</strong>という精神は変わっていない。
 </p>
-<blockquote><p>**注** （なぜ $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ だけが残るか）$\frac{\partial P}{\partial x}$ や $\frac{\partial Q}{\partial y}$ は出てこない。$P$ の $x$ 方向の変化（$\frac{\partial P}{\partial x}$）は下辺と上辺で同じ向きに効くため相殺し、$Q$ の $y$ 方向の変化（$\frac{\partial Q}{\partial y}$）も右辺と左辺で相殺する。生き残るのは「$P$ の $y$ 方向の変化」と「$Q$ の $x$ 方向の変化」——互いに**直交する方向への偏微分の差**だけだ。この交叉性が、次節以降のすべての鍵になる。</p>
+<blockquote><p>**注** （なぜ <span class="tex2jax_process">$\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$</span> だけが残るか）<span class="tex2jax_process">$\frac{\partial P}{\partial x}$</span> や <span class="tex2jax_process">$\frac{\partial Q}{\partial y}$</span> は出てこない。<span class="tex2jax_process">$P$</span> の <span class="tex2jax_process">$x$</span> 方向の変化（<span class="tex2jax_process">$\frac{\partial P}{\partial x}$</span>）は下辺と上辺で同じ向きに効くため相殺し、<span class="tex2jax_process">$Q$</span> の <span class="tex2jax_process">$y$</span> 方向の変化（<span class="tex2jax_process">$\frac{\partial Q}{\partial y}$</span>）も右辺と左辺で相殺する。生き残るのは「<span class="tex2jax_process">$P$</span> の <span class="tex2jax_process">$y$</span> 方向の変化」と「<span class="tex2jax_process">$Q$</span> の <span class="tex2jax_process">$x$</span> 方向の変化」——互いに**直交する方向への偏微分の差**だけだ。この交叉性が、次節以降のすべての鍵になる。</p>
 </p></blockquote>
 <hr />
-<h3 id="54-の誕生面積あたりのズレを測る新しい測定器">§5.4 $d$ の誕生——面積あたりのズレを測る新しい測定器</h3>
+<h3 id="54-span-classtex2jaxprocessspan-の誕生面積あたりのズレを測る新しい測定器">§5.4 <span class="tex2jax_process">$d$</span> の誕生——面積あたりのズレを測る新しい測定器</h3>
 <h4 id="541-ウェッジ積の再確認">5.4.1 ウェッジ積の再確認</h4>
-<p>§5.3 で得た $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ を、第2章の言葉で言い直そう。第2章 §2.4.4 で我々は、$dx \wedge dy$ という面積測定器を定義した。これは2本のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を食わせると、それらが $xy$ 平面に落とす影の符号付き面積を返す装置だった：
+<p>§5.3 で得た <span class="tex2jax_process">$(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$</span> を、第2章の言葉で言い直そう。第2章 §2.4.4 で我々は、<span class="tex2jax_process">$dx \wedge dy$</span> という面積測定器を定義した。これは2本のベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> を食わせると、それらが <span class="tex2jax_process">$xy$</span> 平面に落とす影の符号付き面積を返す装置だった：
 </p>
-<p>$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$</div>
+<p>特に、<span class="tex2jax_process">$x$</span> 方向の変位 <span class="tex2jax_process">$\Delta x\,\hat{e}_x$</span> と <span class="tex2jax_process">$y$</span> 方向の変位 <span class="tex2jax_process">$\Delta y\,\hat{e}_y$</span> を食わせれば <span class="tex2jax_process">$(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$</span> である。
 </p>
-<p>特に、$x$ 方向の変位 $\Delta x\,\hat{e}_x$ と $y$ 方向の変位 $\Delta y\,\hat{e}_y$ を食わせれば $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$ である。
+<h4 id="542-span-classtex2jaxprocessspan-の定義">5.4.2 <span class="tex2jax_process">$d\omega$</span> の定義</h4>
+<p>§5.3 の結果をこの言葉で書けば、微小長方形の二辺 <span class="tex2jax_process">$\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$</span> に対して、ある<strong>新しい <span class="tex2jax_process">$2$</span>-form</strong> が <span class="tex2jax_process">$(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$</span> という主項を返したことになる。この <span class="tex2jax_process">$2$</span>-form を <span class="tex2jax_process">$\omega$</span> の<strong>外微分</strong>と呼び、<span class="tex2jax_process">$d\omega$</span> と書く：
 </p>
-<h4 id="542-の定義">5.4.2 $d\omega$ の定義</h4>
-<p>§5.3 の結果をこの言葉で書けば、微小長方形の二辺 $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ に対して、ある<strong>新しい $2$-form</strong> が $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ という主項を返したことになる。この $2$-form を $\omega$ の<strong>外微分</strong>と呼び、$d\omega$ と書く：
-</p>
-<p>$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
-</p>
-<p>$d\omega$ は $2$-form である——2本のベクトルを食べてスカラーを返す。その値は「食わせた2本が張る微小平行四辺形に対する、単位面積あたりの閉ループのズレ」を表す。
-</p>
+<div class="math-block tex2jax_process">$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</div>
+<span class="tex2jax_process">$d\omega$</span> は <span class="tex2jax_process">$2$</span>-form である——2本のベクトルを食べてスカラーを返す。その値は「食わせた2本が張る微小平行四辺形に対する、単位面積あたりの閉ループのズレ」を表す。
 <p>ここで起きていることを整理しよう：
 </p>
 <ul>
-<li>**入力**：$\omega = P\,dx + Q\,dy + R\,dz$（$1$-form、ベクトル1本を食べる線の測定器）</li>
+<li>**入力**：<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span>（<span class="tex2jax_process">$1$</span>-form、ベクトル1本を食べる線の測定器）</li>
 </ol>
 <ul>
-<li>**出力**：$d\omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$（$2$-form、ベクトル2本を食べる面の測定器）</li>
+<li>**出力**：<span class="tex2jax_process">$d\omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$</span>（<span class="tex2jax_process">$2$</span>-form、ベクトル2本を食べる面の測定器）</li>
 </ol>
 <ul>
-<li>**操作**：$d$ は次数を 1 から 2 へ**一つ上げる**</li>
+<li>**操作**：<span class="tex2jax_process">$d$</span> は次数を 1 から 2 へ**一つ上げる**</li>
 </ol>
-<p>これは §5.1 で見た $df$ とまったく同じ構造だ。$d$ は $0$-form $f$ に作用して $1$-form $df$ を返し、$1$-form $\omega$ に作用して $2$-form $d\omega$ を返す。<strong>$d$ の本質は「次数を1つ上げる」こと</strong>にある。
+<p>これは §5.1 で見た <span class="tex2jax_process">$df$</span> とまったく同じ構造だ。<span class="tex2jax_process">$d$</span> は <span class="tex2jax_process">$0$</span>-form <span class="tex2jax_process">$f$</span> に作用して <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$df$</span> を返し、<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> に作用して <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$d\omega$</span> を返す。<strong><span class="tex2jax_process">$d$</span> の本質は「次数を1つ上げる」こと</strong>にある。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $df$ は $0$-form → $1$-form の外微分だった。$\int_\gamma df = f(B)-f(A)$（端点のみに依存）。
-- 一般の $\omega$ では閉ループで $\oint \omega \neq 0$。このズレを調べるためにループを微小化する。
-- $xy$ 平面の微小長方形では $\oint \omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y +$ 高次の項。ズレの主項は面積に比例する。
+- <span class="tex2jax_process">$df$</span> は <span class="tex2jax_process">$0$</span>-form → <span class="tex2jax_process">$1$</span>-form の外微分だった。<span class="tex2jax_process">$\int_\gamma df = f(B)-f(A)$</span>（端点のみに依存）。
+- 一般の <span class="tex2jax_process">$\omega$</span> では閉ループで <span class="tex2jax_process">$\oint \omega \neq 0$</span>。このズレを調べるためにループを微小化する。
+- <span class="tex2jax_process">$xy$</span> 平面の微小長方形では <span class="tex2jax_process">$\oint \omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y +$</span> 高次の項。ズレの主項は面積に比例する。
 <!-- concept-scope: allow(wedge_product) -->
-- この比例係数を測る $2$-form を $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$ と定義する。$d$ は次数を上げる演算子。
+- この比例係数を測る <span class="tex2jax_process">$2$</span>-form を <span class="tex2jax_process">$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$</span> と定義する。<span class="tex2jax_process">$d$</span> は次数を上げる演算子。
 </p></blockquote>
 <hr />
-<h3 id="55-一般の-form-の外微分3次元への拡張">§5.5 一般の $1$-form の外微分——3次元への拡張</h3>
-<h4 id="551-平面と-平面">5.5.1 $yz$ 平面と $zx$ 平面</h4>
-<p>§5.3–§5.4 では $xy$ 平面のループだけを考えた。しかし 3次元空間には面の向きが3種類ある。$yz$ 平面の微小長方形では同様の計算で $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$ が、$zx$ 平面では $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$ が得られる。それぞれ $dy \wedge dz$ と $dz \wedge dx$ に対応する。
+<h3 id="55-一般の-span-classtex2jaxprocessspan-form-の外微分3次元への拡張">§5.5 一般の <span class="tex2jax_process">$1$</span>-form の外微分——3次元への拡張</h3>
+<h4 id="551-span-classtex2jaxprocessspan-平面と-span-classtex2jaxprocessspan-平面">5.5.1 <span class="tex2jax_process">$yz$</span> 平面と <span class="tex2jax_process">$zx$</span> 平面</h4>
+<p>§5.3–§5.4 では <span class="tex2jax_process">$xy$</span> 平面のループだけを考えた。しかし 3次元空間には面の向きが3種類ある。<span class="tex2jax_process">$yz$</span> 平面の微小長方形では同様の計算で <span class="tex2jax_process">$(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$</span> が、<span class="tex2jax_process">$zx$</span> 平面では <span class="tex2jax_process">$(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$</span> が得られる。それぞれ <span class="tex2jax_process">$dy \wedge dz$</span> と <span class="tex2jax_process">$dz \wedge dx$</span> に対応する。
 </p>
 <p>直感から導かれる完全な式はこうだ：
 </p>
-<p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
-</p>
-<blockquote><p>**注** （$2$-form は傾いた平行四辺形を測る）この $d\omega$ は $2$-form——**2本のベクトルを食べる測定器**——である。食わせる2本は、$xy$ 平面に平行とは限らない。3次元空間の中に斜めに浮かぶ微小平行四辺形の二辺 $\mathbf{v}_1, \mathbf{v}_2$ を食わせれば、その面に対する単位面積あたりの閉ループのズレを返す。§5.3 でやったのとまったく同じこと——測定する面が座標平面に平行とは限らなくなっただけだ。2本のベクトルから平行四辺形の面積（と向き）を取り出すしくみは、第2章 §2.4 で $dy \wedge dz$ 等を反対称行列として構成したときにすでに確かめてある。</p>
+<div class="math-block tex2jax_process">$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</div>
+<blockquote><p>**注** （<span class="tex2jax_process">$2$</span>-form は傾いた平行四辺形を測る）この <span class="tex2jax_process">$d\omega$</span> は <span class="tex2jax_process">$2$</span>-form——**2本のベクトルを食べる測定器**——である。食わせる2本は、<span class="tex2jax_process">$xy$</span> 平面に平行とは限らない。3次元空間の中に斜めに浮かぶ微小平行四辺形の二辺 <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> を食わせれば、その面に対する単位面積あたりの閉ループのズレを返す。§5.3 でやったのとまったく同じこと——測定する面が座標平面に平行とは限らなくなっただけだ。2本のベクトルから平行四辺形の面積（と向き）を取り出すしくみは、第2章 §2.4 で <span class="tex2jax_process">$dy \wedge dz$</span> 等を反対称行列として構成したときにすでに確かめてある。</p>
 </p></blockquote>
-<h4 id="552-代数的導出ライプニッツ則と">5.5.2 代数的導出——ライプニッツ則と $d(dx)=0$</h4>
-<p>上記の式は、各平面で別々にループ計算をしても当然導ける。しかし、$xy$平面の例から得た直感を使って次のような計算ルールを作り上げれば機械的に導ける。やってみよう。
+<h4 id="552-代数的導出ライプニッツ則と-span-classtex2jaxprocessspan">5.5.2 代数的導出——ライプニッツ則と <span class="tex2jax_process">$d(dx)=0$</span></h4>
+<p>上記の式は、各平面で別々にループ計算をしても当然導ける。しかし、<span class="tex2jax_process">$xy$</span>平面の例から得た直感を使って次のような計算ルールを作り上げれば機械的に導ける。やってみよう。
 </p>
-<blockquote><p>**注** （定義と定理——数学者のいじわる）多くの数学書では、ライプニッツ則と $d(dx)=0$ を $d$ の**定義**としてしまう。物理学者である筆者にはそれではわからない——我々は微小ループの解剖から出発した。これから確かめるのは、その幾何的な $d$ と代数的な計算ルールが整合することだ。ルールは計算の便宜、**意味は §5.3 にある**。もっとも、高次元まで見据えたときこの代数的定義の簡潔さに悔しさを覚えることも、認めないわけにはいかない。</p>
+<blockquote><p>**注** （定義と定理——数学者のいじわる）多くの数学書では、ライプニッツ則と <span class="tex2jax_process">$d(dx)=0$</span> を <span class="tex2jax_process">$d$</span> の**定義**としてしまう。物理学者である筆者にはそれではわからない——我々は微小ループの解剖から出発した。これから確かめるのは、その幾何的な <span class="tex2jax_process">$d$</span> と代数的な計算ルールが整合することだ。ルールは計算の便宜、**意味は §5.3 にある**。もっとも、高次元まで見据えたときこの代数的定義の簡潔さに悔しさを覚えることも、認めないわけにはいかない。</p>
 </p></blockquote>
-<p>まず、$\omega = P\,dx + Q\,dy + R\,dz$ に対し、$d\omega$ を $d(P\,dx) + d(Q\,dy) + d(R\,dz)$ であることは問題ないだろう。これは傾いた平行四辺形のループを考えるということだ。問題は $d(P\,dx)$ ——係数 $P$ のついた $1$-form に $d$ をどう作用させるか——である。
+<p>まず、<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> に対し、<span class="tex2jax_process">$d\omega$</span> を <span class="tex2jax_process">$d(P\,dx) + d(Q\,dy) + d(R\,dz)$</span> であることは問題ないだろう。これは傾いた平行四辺形のループを考えるということだ。問題は <span class="tex2jax_process">$d(P\,dx)$</span> ——係数 <span class="tex2jax_process">$P$</span> のついた <span class="tex2jax_process">$1$</span>-form に <span class="tex2jax_process">$d$</span> をどう作用させるか——である。
 </p>
-<p>ここで、§5.3–§5.4 で得た幾何的な $d$ がすでに教えてくれていることがある。$\omega = P\,dx$（$Q=R=0$）の場合、§5.3 の微小ループ計算を $xy$ 平面だけでなく $zx$ 平面でも行えば、$d(P\,dx)$ は $yz$ 面に成分を持たず、
+<p>ここで、§5.3–§5.4 で得た幾何的な <span class="tex2jax_process">$d$</span> がすでに教えてくれていることがある。<span class="tex2jax_process">$\omega = P\,dx$</span>（<span class="tex2jax_process">$Q=R=0$</span>）の場合、§5.3 の微小ループ計算を <span class="tex2jax_process">$xy$</span> 平面だけでなく <span class="tex2jax_process">$zx$</span> 平面でも行えば、<span class="tex2jax_process">$d(P\,dx)$</span> は <span class="tex2jax_process">$yz$</span> 面に成分を持たず、
 </p>
-<p>$$d(P\,dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+<div class="math-block tex2jax_process">$$d(P\,dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$</div>
+<p>となるはずだ（<span class="tex2jax_process">$xy$</span> 面のループでは <span class="tex2jax_process">$(0 - \frac{\partial P}{\partial y}) = -\frac{\partial P}{\partial y}$</span>、<span class="tex2jax_process">$zx$</span> 面では <span class="tex2jax_process">$(\frac{\partial P}{\partial z} - 0) = \frac{\partial P}{\partial z}$</span>）。
 </p>
-<p>となるはずだ（$xy$ 面のループでは $(0 - \frac{\partial P}{\partial y}) = -\frac{\partial P}{\partial y}$、$zx$ 面では $(\frac{\partial P}{\partial z} - 0) = \frac{\partial P}{\partial z}$）。
+<p>さて、ここで <span class="tex2jax_process">$dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$</span> を思い出そう（§5.1）。これと <span class="tex2jax_process">$dx$</span> のウェッジ積をとると：
 </p>
-<p>さて、ここで $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$ を思い出そう（§5.1）。これと $dx$ のウェッジ積をとると：
+<div class="math-block tex2jax_process">$$dP \wedge dx = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$</div>
+<p>（<span class="tex2jax_process">$dx \wedge dx = 0$</span> により <span class="tex2jax_process">$\frac{\partial P}{\partial x}$</span> の項は消えた）
 </p>
-<p>$$dP \wedge dx = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+<p>幾何的計算と<strong>完全に一致する</strong>！ すなわち、少なくとも <span class="tex2jax_process">$P\,dx$</span> という形の項について：
 </p>
-<p>（$dx \wedge dx = 0$ により $\frac{\partial P}{\partial x}$ の項は消えた）
+<div class="math-block tex2jax_process">$$d(P\,dx) = dP \wedge dx$$</div>
+<p>が成り立つ。幾何的結果とライプニッツ則 <span class="tex2jax_process">$d(P\,dx) = dP \wedge dx + P\,d(dx)$</span> を見比べれば、余分な項 <span class="tex2jax_process">$P\,d(dx)$</span> はゼロでなければならない。<span class="tex2jax_process">$P$</span> は任意の関数だから、これが常に成り立つためには <span class="tex2jax_process">$d(dx)=0$</span> でなければならない——すなわち <span class="tex2jax_process">$d(dx) = 0$</span> が要請される。
 </p>
-<p>幾何的計算と<strong>完全に一致する</strong>！ すなわち、少なくとも $P\,dx$ という形の項について：
+<p>この観察を一般化すると、次の<strong>次数付きライプニッツ則</strong>に到達する。<span class="tex2jax_process">$P$</span> は <span class="tex2jax_process">$0$</span>-form、<span class="tex2jax_process">$dx$</span> は <span class="tex2jax_process">$1$</span>-form であり、<span class="tex2jax_process">$0$</span>-form と <span class="tex2jax_process">$1$</span>-form の「積」に対する <span class="tex2jax_process">$d$</span> の振る舞いは：
 </p>
-<p>$$d(P\,dx) = dP \wedge dx$$
+<div class="math-block tex2jax_process">$$d(P\,dx) = (dP) \wedge dx + P\,d(dx)$$</div>
+<span class="tex2jax_process">$dP$</span> は既知——§5.1 より <span class="tex2jax_process">$dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$</span>。問題は <span class="tex2jax_process">$d(dx)$</span> の値だ。
+<p>ここで、座標関数 <span class="tex2jax_process">$x$</span> の外微分は <span class="tex2jax_process">$dx$</span> である（<span class="tex2jax_process">$d(x) = dx$</span>）。デカルト座標の <span class="tex2jax_process">$dx$</span> は、場所によって係数が変わらない基準の測定器である。つまり <span class="tex2jax_process">$dx$</span> 自身を微小ループで一周させても、面積あたりのズレは出てこない。同じことが <span class="tex2jax_process">$dy,dz$</span> にも成り立つ。したがって座標基底については次を計算ルールとして置く：
 </p>
-<p>が成り立つ。幾何的結果とライプニッツ則 $d(P\,dx) = dP \wedge dx + P\,d(dx)$ を見比べれば、余分な項 $P\,d(dx)$ はゼロでなければならない。$P$ は任意の関数だから、これが常に成り立つためには $d(dx)=0$ でなければならない——すなわち $d(dx) = 0$ が要請される。
-</p>
-<p>この観察を一般化すると、次の<strong>次数付きライプニッツ則</strong>に到達する。$P$ は $0$-form、$dx$ は $1$-form であり、$0$-form と $1$-form の「積」に対する $d$ の振る舞いは：
-</p>
-<p>$$d(P\,dx) = (dP) \wedge dx + P\,d(dx)$$
-</p>
-<p>$dP$ は既知——§5.1 より $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$。問題は $d(dx)$ の値だ。
-</p>
-<p>ここで、座標関数 $x$ の外微分は $dx$ である（$d(x) = dx$）。デカルト座標の $dx$ は、場所によって係数が変わらない基準の測定器である。つまり $dx$ 自身を微小ループで一周させても、面積あたりのズレは出てこない。同じことが $dy,dz$ にも成り立つ。したがって座標基底については次を計算ルールとして置く：
-</p>
-<p>$$d(dx) = d(dy) = d(dz) = 0$$
-</p>
+<div class="math-block tex2jax_process">$$d(dx) = d(dy) = d(dz) = 0$$</div>
 <p>すると：
 </p>
-<p>$$d(P\,dx) = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx + P\,0$$
-</p>
-<p>$\wedge$ の反対称性（$dx \wedge dx = 0$、$dy \wedge dx = -dx \wedge dy$）を使って：
-</p>
-<p>$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
-</p>
+<div class="math-block tex2jax_process">$$d(P\,dx) = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx + P\,0$$</div>
+<span class="tex2jax_process">$\wedge$</span> の反対称性（<span class="tex2jax_process">$dx \wedge dx = 0$</span>、<span class="tex2jax_process">$dy \wedge dx = -dx \wedge dy$</span>）を使って：
+<div class="math-block tex2jax_process">$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$</div>
 <p>同様に：
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d(Q\,dy) &= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \\
 d(R\,dz) &= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>三つを足し合わせ、基底 <span class="tex2jax_process">$dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$</span> の順に整理する（この巡回順は次章の右手系との整合のための布石である）：
 </p>
-<p>三つを足し合わせ、基底 $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ の順に整理する（この巡回順は次章の右手系との整合のための布石である）：
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d\omega &= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \\
 &= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
-\end{aligned}$$
-</p>
-<p>これは §5.3 で幾何的に導いた $xy$ 成分 $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ を含み、$yz$ と $zx$ の成分も同じ交叉パターンで揃っている。
+\end{aligned}$$</div>
+<p>これは §5.3 で幾何的に導いた <span class="tex2jax_process">$xy$</span> 成分 <span class="tex2jax_process">$(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$</span> を含み、<span class="tex2jax_process">$yz$</span> と <span class="tex2jax_process">$zx$</span> の成分も同じ交叉パターンで揃っている。
 </p>
 <h4 id="553-係数のパターン">5.5.3 係数のパターン</h4>
-<p>係数の並び方に注目してほしい。$(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ は、$(P, Q, R)$ の偏微分を<strong>自分以外の軸方向に関して交叉させ、差をとった</strong>ものである。巡回的な対称性がある：
+<p>係数の並び方に注目してほしい。<span class="tex2jax_process">$(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$</span> は、<span class="tex2jax_process">$(P, Q, R)$</span> の偏微分を<strong>自分以外の軸方向に関して交叉させ、差をとった</strong>ものである。巡回的な対称性がある：
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 dy \wedge dz &\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
 dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \\
 dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
-\end{aligned}$$
-</p>
-<blockquote><p>**注** （既習者への補助線）ベクトル解析を既習の読者には、この3つの係数の並びに見覚えがあるだろう。本書ではその名前に依存せず、まず $d$ という操作そのものを組み立てる。対応関係は後の章で整理する。</p>
+\end{aligned}$$</div>
+<blockquote><p>**注** （既習者への補助線）ベクトル解析を既習の読者には、この3つの係数の並びに見覚えがあるだろう。本書ではその名前に依存せず、まず <span class="tex2jax_process">$d$</span> という操作そのものを組み立てる。対応関係は後の章で整理する。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 一般の $1$-form $\omega$ の外微分 $d\omega$ は $2$-form であり、係数は偏微分の交叉差 $(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$。
-- 計算ルールは (1) 線形性、(2) ライプニッツ則 $d(P\,dx) = dP \wedge dx + P \wedge d(dx)$、(3) $d(dx)=d(dy)=d(dz)=0$ の三つ。
+- 一般の <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> の外微分 <span class="tex2jax_process">$d\omega$</span> は <span class="tex2jax_process">$2$</span>-form であり、係数は偏微分の交叉差 <span class="tex2jax_process">$(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$</span>。
+- 計算ルールは (1) 線形性、(2) ライプニッツ則 <span class="tex2jax_process">$d(P\,dx) = dP \wedge dx + P \wedge d(dx)$</span>、(3) <span class="tex2jax_process">$d(dx)=d(dy)=d(dz)=0$</span> の三つ。
 - 結果は §5.3 の微小ループ計算と完全に整合する。
 </p></blockquote>
 <hr />
 <h3 id="56-集積すれば境界だけが残るストークスの定理">§5.6 集積すれば境界だけが残る——ストークスの定理</h3>
 <h4 id="561-面をタイル貼りする">5.6.1 面をタイル貼りする</h4>
-<p>§5.3 では<strong>ひとつの</strong>微小長方形の周りで $\oint \omega$ を計算し、その主項が $d\omega$ と面積の積になることを見た。では、この微小長方形を<strong>面全体に敷き詰めて</strong>、全部足し合わせたらどうなるか。
+<p>§5.3 では<strong>ひとつの</strong>微小長方形の周りで <span class="tex2jax_process">$\oint \omega$</span> を計算し、その主項が <span class="tex2jax_process">$d\omega$</span> と面積の積になることを見た。では、この微小長方形を<strong>面全体に敷き詰めて</strong>、全部足し合わせたらどうなるか。
 </p>
-<p>曲面 $S$ を小さな座標パッチに分け、それぞれのパラメータ平面上で微小長方形に刻む（第3章 §3.2 の面素の考え方そのものだ）。各微小長方形について、四辺を反時計回りに一周した $\omega$ の積分は、面素に $d\omega$ を食わせた値を主項として持つ。
+<p>曲面 <span class="tex2jax_process">$S$</span> を小さな座標パッチに分け、それぞれのパラメータ平面上で微小長方形に刻む（第3章 §3.2 の面素の考え方そのものだ）。各微小長方形について、四辺を反時計回りに一周した <span class="tex2jax_process">$\omega$</span> の積分は、面素に <span class="tex2jax_process">$d\omega$</span> を食わせた値を主項として持つ。
 </p>
 <h4 id="562-内部の辺は相殺する">5.6.2 内部の辺は相殺する</h4>
-<p>ここで決定的な幾何学的観察がある。<strong>隣り合う二つの長方形が共有する辺</strong>に注目しよう。左の長方形にとってその辺は「上向き」、右の長方形にとっては「下向き」にたどられる。経路が逆向きだから、$\omega$ の線積分はこの辺の上で<strong>完全に打ち消し合う</strong>。
+<p>ここで決定的な幾何学的観察がある。<strong>隣り合う二つの長方形が共有する辺</strong>に注目しよう。左の長方形にとってその辺は「上向き」、右の長方形にとっては「下向き」にたどられる。経路が逆向きだから、<span class="tex2jax_process">$\omega$</span> の線積分はこの辺の上で<strong>完全に打ち消し合う</strong>。
 </p>
-<p>この相殺は面 $S$ の内部の<strong>すべての共有辺</strong>で起こる。いくら細かく分割して足し合わせても、内部の辺の寄与はプラスマイナスで消えるのだ。
+<p>この相殺は面 <span class="tex2jax_process">$S$</span> の内部の<strong>すべての共有辺</strong>で起こる。いくら細かく分割して足し合わせても、内部の辺の寄与はプラスマイナスで消えるのだ。
 </p>
 <h4 id="563-生き残るのは境界だけ">5.6.3 生き残るのは境界だけ</h4>
-<p>すると、最終的に相殺されずに生き残る辺はどこか——<strong>隣の長方形が存在しない辺</strong>、すなわち面 $S$ の<strong>境界 $\partial S$</strong> に沿った辺だけである。
+<p>すると、最終的に相殺されずに生き残る辺はどこか——<strong>隣の長方形が存在しない辺</strong>、すなわち面 <span class="tex2jax_process">$S$</span> の<strong>境界 <span class="tex2jax_process">$\partial S$</span></strong> に沿った辺だけである。
 </p>
 <p>つまり：
 </p>
-<p>$$\oint_{\partial S} \omega = \iint_S d\omega$$
-</p>
-<p>左辺は「面の境界という1次元の閉曲線に沿った $\omega$ の線積分」、右辺は「面の内部に敷き詰めた無数の微小ループのズレ密度の総和」である。分割を細かくする極限で、内部辺の相殺だけが残り、両者が一致する。
+<div class="math-block tex2jax_process">$$\oint_{\partial S} \omega = \iint_S d\omega$$</div>
+<p>左辺は「面の境界という1次元の閉曲線に沿った <span class="tex2jax_process">$\omega$</span> の線積分」、右辺は「面の内部に敷き詰めた無数の微小ループのズレ密度の総和」である。分割を細かくする極限で、内部辺の相殺だけが残り、両者が一致する。
 </p>
 <p>これが<strong>ケルビン–ストークスの定理</strong>（単にストークスの定理とも呼ばれる）だ。
 </p>
-<p>$\omega = P\,dx + Q\,dy + R\,dz$ の成分をあらわに書けば：
+<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> の成分をあらわに書けば：
+<div class="math-block tex2jax_process">$$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$</div>
+<p>第2章以来の行列の言葉で書くなら、右辺の <span class="tex2jax_process">$2$</span>-form は反対称行列 <span class="tex2jax_process">$\mathbf{J}^T - \mathbf{J}$</span> で表される。<span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> を面素の二辺とすれば <span class="tex2jax_process">$(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$</span>。付録 C.3 に全成分を書き下してあるので、必要に応じて参照されたい。
 </p>
-<p>$$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$
+<p>この定理の構造は驚くほど単純だ。<strong>大域的な境界で測った積分</strong> <span class="tex2jax_process">$=$</span> <strong>内部の局所的なズレ（<span class="tex2jax_process">$d\omega$</span>）の集積</strong>。<span class="tex2jax_process">$d$</span> とは、境界 <span class="tex2jax_process">$\partial S$</span> における <span class="tex2jax_process">$\omega$</span> の情報を、内部 <span class="tex2jax_process">$S$</span> における <span class="tex2jax_process">$d\omega$</span> の情報へと<strong>翻訳</strong>する装置なのである。
 </p>
-<p>第2章以来の行列の言葉で書くなら、右辺の $2$-form は反対称行列 $\mathbf{J}^T - \mathbf{J}$ で表される。$\mathbf{v}_1, \mathbf{v}_2$ を面素の二辺とすれば $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$。付録 C.3 に全成分を書き下してあるので、必要に応じて参照されたい。
-</p>
-<p>この定理の構造は驚くほど単純だ。<strong>大域的な境界で測った積分</strong> $=$ <strong>内部の局所的なズレ（$d\omega$）の集積</strong>。$d$ とは、境界 $\partial S$ における $\omega$ の情報を、内部 $S$ における $d\omega$ の情報へと<strong>翻訳</strong>する装置なのである。
-</p>
-<blockquote><p>**注** （第3章との対応）第3章 §3.2.1 で曲面積分を定義したとき、我々は面素 $(\mathbf{r}_u\Delta u,\;\mathbf{r}_v\Delta v)$ に $dx \wedge dy$ を食わせていた。ここでも同じく、曲面を小さな面素に分け、各面素で測定器を作用させ、内部で相殺する寄与を整理している。</p>
+<blockquote><p>**注** （第3章との対応）第3章 §3.2.1 で曲面積分を定義したとき、我々は面素 <span class="tex2jax_process">$(\mathbf{r}_u\Delta u,\;\mathbf{r}_v\Delta v)$</span> に <span class="tex2jax_process">$dx \wedge dy$</span> を食わせていた。ここでも同じく、曲面を小さな面素に分け、各面素で測定器を作用させ、内部で相殺する寄与を整理している。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 面 $S$ を微小ループで敷き詰めると、内部の辺は相殺し、境界 $\partial S$ の寄与だけが残る。
-- $\int_{\partial S} \omega = \int_S d\omega$。大域的な境界積分が局所的な外微分の積分に等しい。
+- 面 <span class="tex2jax_process">$S$</span> を微小ループで敷き詰めると、内部の辺は相殺し、境界 <span class="tex2jax_process">$\partial S$</span> の寄与だけが残る。
+- <span class="tex2jax_process">$\int_{\partial S} \omega = \int_S d\omega$</span>。大域的な境界積分が局所的な外微分の積分に等しい。
 - 第3章の曲面積分と同じく、面を小さなパッチに分け、各パッチで測定器を作用させて集計している。
 </p></blockquote>
 <hr />
-<h3 id="57-同じことをもう一段-form-の外微分と発散">§5.7 同じことをもう一段——$2$-form の外微分と発散</h3>
-<h4 id="571-form-は面の測定器">5.7.1 $2$-form は面の測定器</h4>
-<p>第3章 §3.4.2 で、一般の $2$-form を次の形で書いた：
+<h3 id="57-同じことをもう一段span-classtex2jaxprocessspan-form-の外微分と発散">§5.7 同じことをもう一段——<span class="tex2jax_process">$2$</span>-form の外微分と発散</h3>
+<h4 id="571-span-classtex2jaxprocessspan-form-は面の測定器">5.7.1 <span class="tex2jax_process">$2$</span>-form は面の測定器</h4>
+<p>第3章 §3.4.2 で、一般の <span class="tex2jax_process">$2$</span>-form を次の形で書いた：
 </p>
-<p>$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
-</p>
-<p>これは「面に沿って流量を測る測定器」である。第2章 §2.4.5 で見たように、3つの基底 $2$-form がそれぞれ $yz$ 平面、$zx$ 平面、$xy$ 平面への影の面積を測る。
+<div class="math-block tex2jax_process">$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$</div>
+<p>これは「面に沿って流量を測る測定器」である。第2章 §2.4.5 で見たように、3つの基底 <span class="tex2jax_process">$2$</span>-form がそれぞれ <span class="tex2jax_process">$yz$</span> 平面、<span class="tex2jax_process">$zx$</span> 平面、<span class="tex2jax_process">$xy$</span> 平面への影の面積を測る。
 </p>
 <h4 id="572-微小直方体の表面で測る">5.7.2 微小直方体の表面で測る</h4>
-<p>§5.3 と同じ精神で、今度は空間内の微小直方体 $[x, x+\Delta x] \times [y, y+\Delta y] \times [z, z+\Delta z]$ の<strong>6つの面すべて</strong>で $\eta$ を積分する。向きは外向きに合わせる。
+<p>§5.3 と同じ精神で、今度は空間内の微小直方体 <span class="tex2jax_process">$[x, x+\Delta x] \times [y, y+\Delta y] \times [z, z+\Delta z]$</span> の<strong>6つの面すべて</strong>で <span class="tex2jax_process">$\eta$</span> を積分する。向きは外向きに合わせる。
 </p>
-<p>たとえば $C\,dx \wedge dy$ の項について、$z$ に垂直な底面と上面だけを考える：
+<p>たとえば <span class="tex2jax_process">$C\,dx \wedge dy$</span> の項について、<span class="tex2jax_process">$z$</span> に垂直な底面と上面だけを考える：
 </p>
 <ul>
-<li>**底面**（$z$、外向きは $-z$ 方向）：$C(x,y,z)$ に $-dx \wedge dy$ の向きで評価 → およそ $-C(x,y,z)\,\Delta x\,\Delta y$</li>
+<li>**底面**（<span class="tex2jax_process">$z$</span>、外向きは <span class="tex2jax_process">$-z$</span> 方向）：<span class="tex2jax_process">$C(x,y,z)$</span> に <span class="tex2jax_process">$-dx \wedge dy$</span> の向きで評価 → およそ <span class="tex2jax_process">$-C(x,y,z)\,\Delta x\,\Delta y$</span></li>
 </ol>
 <ul>
-<li>**上面**（$z+\Delta z$、外向きは $+z$ 方向）：$C(x,y,z+\Delta z) \approx C + \frac{\partial C}{\partial z}\Delta z$ → およそ $(C + \frac{\partial C}{\partial z}\Delta z)\,\Delta x\,\Delta y$</li>
+<li>**上面**（<span class="tex2jax_process">$z+\Delta z$</span>、外向きは <span class="tex2jax_process">$+z$</span> 方向）：<span class="tex2jax_process">$C(x,y,z+\Delta z) \approx C + \frac{\partial C}{\partial z}\Delta z$</span> → およそ <span class="tex2jax_process">$(C + \frac{\partial C}{\partial z}\Delta z)\,\Delta x\,\Delta y$</span></li>
 </ol>
-<p>和をとると $C\Delta x\Delta y$ が相殺し、$\frac{\partial C}{\partial z}\,\Delta x\,\Delta y\,\Delta z$ が残る。$A\,dy \wedge dz$ の項は $x$ に垂直な面から $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$ を、$B\,dz \wedge dx$ の項は $y$ に垂直な面から $\frac{\partial B}{\partial y}\,\Delta x\,\Delta y\,\Delta z$ を与える。
+<p>和をとると <span class="tex2jax_process">$C\Delta x\Delta y$</span> が相殺し、<span class="tex2jax_process">$\frac{\partial C}{\partial z}\,\Delta x\,\Delta y\,\Delta z$</span> が残る。<span class="tex2jax_process">$A\,dy \wedge dz$</span> の項は <span class="tex2jax_process">$x$</span> に垂直な面から <span class="tex2jax_process">$\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$</span> を、<span class="tex2jax_process">$B\,dz \wedge dx$</span> の項は <span class="tex2jax_process">$y$</span> に垂直な面から <span class="tex2jax_process">$\frac{\partial B}{\partial y}\,\Delta x\,\Delta y\,\Delta z$</span> を与える。
 </p>
 <p>全6面の合計は：
 </p>
-<p>$$\iint_{\partial (\text{直方体})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$
+<div class="math-block tex2jax_process">$$\iint_{\partial (\text{直方体})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$</div>
+<p>ここでも同じ構造だ——<strong>表面で測ったズレの主項は、囲んだ体積に比例する</strong>。比例係数 <span class="tex2jax_process">$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$</span> が「単位体積あたりの湧き出し」を表す。
 </p>
-<p>ここでも同じ構造だ——<strong>表面で測ったズレの主項は、囲んだ体積に比例する</strong>。比例係数 $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ が「単位体積あたりの湧き出し」を表す。
+<h4 id="573-span-classtex2jaxprocessspan-の定義と代数的導出">5.7.3 <span class="tex2jax_process">$d\eta$</span> の定義と代数的導出</h4>
+<p>直方体の三辺 <span class="tex2jax_process">$\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$</span> を食わせる <span class="tex2jax_process">$3$</span>-form として：
 </p>
-<h4 id="573-の定義と代数的導出">5.7.3 $d\eta$ の定義と代数的導出</h4>
-<p>直方体の三辺 $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ を食わせる $3$-form として：
+<div class="math-block tex2jax_process">$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$</div>
+<p>この式は、§5.5.2 の代数的ルールからも導ける。その前に、§5.5.2 でやったのと同じく、幾何的な結果がライプニッツ則と整合することを <span class="tex2jax_process">$A\,dy \wedge dz$</span> の項で確かめておこう。
 </p>
-<p>$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+<p>§5.7.2 の幾何計算によれば、<span class="tex2jax_process">$A\,dy \wedge dz$</span> の寄与は <span class="tex2jax_process">$\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$</span> だった。これを <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の言葉で書けば <span class="tex2jax_process">$\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$</span> である。
 </p>
-<p>この式は、§5.5.2 の代数的ルールからも導ける。その前に、§5.5.2 でやったのと同じく、幾何的な結果がライプニッツ則と整合することを $A\,dy \wedge dz$ の項で確かめておこう。
+<p>一方、<span class="tex2jax_process">$d(A\,dy \wedge dz)$</span> にライプニッツ則を適用すると：
 </p>
-<p>§5.7.2 の幾何計算によれば、$A\,dy \wedge dz$ の寄与は $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$ だった。これを $dx \wedge dy \wedge dz$ の言葉で書けば $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$ である。
+<div class="math-block tex2jax_process">$$d(A\,dy \wedge dz) = dA \wedge dy \wedge dz + A\,d(dy \wedge dz)$$</div>
+<p>ここで <span class="tex2jax_process">$d(dy \wedge dz)$</span> は、§5.5.2 と同じく <span class="tex2jax_process">$d(dy)=d(dz)=0$</span> を使って：
 </p>
-<p>一方、$d(A\,dy \wedge dz)$ にライプニッツ則を適用すると：
-</p>
-<p>$$d(A\,dy \wedge dz) = dA \wedge dy \wedge dz + A\,d(dy \wedge dz)$$
-</p>
-<p>ここで $d(dy \wedge dz)$ は、§5.5.2 と同じく $d(dy)=d(dz)=0$ を使って：
-</p>
-<p>$$d(dy \wedge dz) = d(dy) \wedge dz - dy \wedge d(dz) = 0 \wedge dz - dy \wedge 0 = 0$$
-</p>
+<div class="math-block tex2jax_process">$$d(dy \wedge dz) = d(dy) \wedge dz - dy \wedge d(dz) = 0 \wedge dz - dy \wedge 0 = 0$$</div>
 <p>したがって第2項は消え、第1項だけが残る：
 </p>
-<p>$$dA \wedge dy \wedge dz = (\frac{\partial A}{\partial x}\,dx + \frac{\partial A}{\partial y}\,dy + \frac{\partial A}{\partial z}\,dz) \wedge dy \wedge dz$$
-</p>
-<p>$\wedge$ の反対称性（$dy \wedge dy = 0$、$dz \wedge dz = 0$）により $\frac{\partial A}{\partial y}$ と $\frac{\partial A}{\partial z}$ の項は消え、$\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$ だけが残る。これは §5.7.2 の幾何計算と<strong>完全に一致する</strong>。
-</p>
-<p>$B\,dz \wedge dx$、$C\,dx \wedge dy$ の項も同様で、三つを足し合わせれば：
-</p>
-<p>$$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
-</p>
-<p>$d$ は $2$-form → $3$-form の昇格を果たした。
-</p>
+<div class="math-block tex2jax_process">$$dA \wedge dy \wedge dz = (\frac{\partial A}{\partial x}\,dx + \frac{\partial A}{\partial y}\,dy + \frac{\partial A}{\partial z}\,dz) \wedge dy \wedge dz$$</div>
+<span class="tex2jax_process">$\wedge$</span> の反対称性（<span class="tex2jax_process">$dy \wedge dy = 0$</span>、<span class="tex2jax_process">$dz \wedge dz = 0$</span>）により <span class="tex2jax_process">$\frac{\partial A}{\partial y}$</span> と <span class="tex2jax_process">$\frac{\partial A}{\partial z}$</span> の項は消え、<span class="tex2jax_process">$\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$</span> だけが残る。これは §5.7.2 の幾何計算と<strong>完全に一致する</strong>。
+<span class="tex2jax_process">$B\,dz \wedge dx$</span>、<span class="tex2jax_process">$C\,dx \wedge dy$</span> の項も同様で、三つを足し合わせれば：
+<div class="math-block tex2jax_process">$$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$</div>
+<span class="tex2jax_process">$d$</span> は <span class="tex2jax_process">$2$</span>-form → <span class="tex2jax_process">$3$</span>-form の昇格を果たした。
 <h4 id="574-ガウスの定理">5.7.4 ガウスの定理</h4>
-<p>§5.6 と同じタイル貼りの論法——今度は立体 $V$ を微小直方体で埋め尽くす——により、内部の面は相殺し、外面 $\partial V$ だけが残る：
+<p>§5.6 と同じタイル貼りの論法——今度は立体 <span class="tex2jax_process">$V$</span> を微小直方体で埋め尽くす——により、内部の面は相殺し、外面 <span class="tex2jax_process">$\partial V$</span> だけが残る：
 </p>
-<p>$$\iint_{\partial V} \eta = \iiint_V d\eta$$
+<div class="math-block tex2jax_process">$$\iint_{\partial V} \eta = \iiint_V d\eta$$</div>
+<p>これが<strong>ガウスの定理</strong>である。ストークスの定理と、次元が一つずつずれただけで<strong>まったく同じ形</strong>をしている。並べてみれば一目瞭然だ：<span class="tex2jax_process">$\omega$</span>（<span class="tex2jax_process">$1$</span>-form）<span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$d\omega$</span>（<span class="tex2jax_process">$2$</span>-form）<span class="tex2jax_process">$\to$</span> 面 <span class="tex2jax_process">$S$</span>、<span class="tex2jax_process">$\eta$</span>（<span class="tex2jax_process">$2$</span>-form）<span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$d\eta$</span>（<span class="tex2jax_process">$3$</span>-form）<span class="tex2jax_process">$\to$</span> 立体 <span class="tex2jax_process">$V$</span>。
 </p>
-<p>これが<strong>ガウスの定理</strong>である。ストークスの定理と、次元が一つずつずれただけで<strong>まったく同じ形</strong>をしている。並べてみれば一目瞭然だ：$\omega$（$1$-form）$\to$ $d\omega$（$2$-form）$\to$ 面 $S$、$\eta$（$2$-form）$\to$ $d\eta$（$3$-form）$\to$ 立体 $V$。
-</p>
-<p>$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$ の成分をあらわに書けば：
-</p>
-<p>$$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\bigr) = \iiint_V (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
-</p>
-<blockquote><p>**注** （既習者への補助線）ベクトル解析を既習の読者には、$\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z}$ にも見覚えがあるだろう。本書ではまず $2$-form の外微分としてこの量を得た、という順序を大切にする。名前との対応は後の章で整理する。</p>
+<span class="tex2jax_process">$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$</span> の成分をあらわに書けば：
+<div class="math-block tex2jax_process">$$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\bigr) = \iiint_V (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$</div>
+<blockquote><p>**注** （既習者への補助線）ベクトル解析を既習の読者には、<span class="tex2jax_process">$\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z}$</span> にも見覚えがあるだろう。本書ではまず <span class="tex2jax_process">$2$</span>-form の外微分としてこの量を得た、という順序を大切にする。名前との対応は後の章で整理する。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $2$-form $\eta$ の外微分 $d\eta$ は $3$-form で、係数は $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$。
-- 導出は §5.5 と同じ代数的ルール（ライプニッツ則 $+$ $d(dx)=0$）で機械的にできる。
-- $\iint_{\partial V} \eta = \iiint_V d\eta$。ストークス（$1$-form→面）とガウス（$2$-form→立体）は次数が違うだけで同じ構造。
+- <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\eta$</span> の外微分 <span class="tex2jax_process">$d\eta$</span> は <span class="tex2jax_process">$3$</span>-form で、係数は <span class="tex2jax_process">$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$</span>。
+- 導出は §5.5 と同じ代数的ルール（ライプニッツ則 <span class="tex2jax_process">$+$</span> <span class="tex2jax_process">$d(dx)=0$</span>）で機械的にできる。
+- <span class="tex2jax_process">$\iint_{\partial V} \eta = \iiint_V d\eta$</span>。ストークス（<span class="tex2jax_process">$1$</span>-form→面）とガウス（<span class="tex2jax_process">$2$</span>-form→立体）は次数が違うだけで同じ構造。
 </p></blockquote>
 <hr />
-<h3 id="58-二度測れば必ずゼロ">§5.8 $d^2 = 0$——二度測れば必ずゼロ</h3>
-<h4 id="581">5.8.1 $d(df) = 0$</h4>
-<p>§5.1 で $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ を定義した。これをさらにもう一度外微分してみる。§5.5 の公式で $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$ とすれば：
+<h3 id="58-span-classtex2jaxprocessspan二度測れば必ずゼロ">§5.8 <span class="tex2jax_process">$d^2 = 0$</span>——二度測れば必ずゼロ</h3>
+<h4 id="581-span-classtex2jaxprocessspan">5.8.1 <span class="tex2jax_process">$d(df) = 0$</span></h4>
+<p>§5.1 で <span class="tex2jax_process">$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$</span> を定義した。これをさらにもう一度外微分してみる。§5.5 の公式で <span class="tex2jax_process">$P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$</span> とすれば：
 </p>
-<p>$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$
+<div class="math-block tex2jax_process">$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$</div>
+<p>混合偏微分の対称性（<span class="tex2jax_process">$f$</span> が <span class="tex2jax_process">$C^2$</span> 級（2階連続微分可能）なら <span class="tex2jax_process">$\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$</span> など。第1章 §1.2 参照）により、すべての係数がゼロになる：
 </p>
-<p>混合偏微分の対称性（$f$ が $C^2$ 級（2階連続微分可能）なら $\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$ など。第1章 §1.2 参照）により、すべての係数がゼロになる：
-</p>
-<p>$$d(df) = 0$$
-</p>
-<blockquote><p>**注** （数学者へのエクスキューズ——$d^2=0$ と $C^2$ 条件）本書では「$f$ が $C^2$ 級（2階連続微分可能）なら混合偏微分が可換、ゆえに $d(df)=0$」という順序で進めた。しかし微分形式の公理的な立場では、**$d^2=0$ こそが $d$ の定義の一部**であり、$d(df)=0$ は定理ではなく要請である。逆に言えば、$d^2=0$ を課すことが「混合偏微分の対称性が成り立つ関数クラス（＝$C^2$ 級の関数）を相手にしている」という宣言に相当する。どちらの順序で学んでも、両者が同値な条件として噛み合うことに変わりはない。</p>
+<div class="math-block tex2jax_process">$$d(df) = 0$$</div>
+<blockquote><p>**注** （数学者へのエクスキューズ——<span class="tex2jax_process">$d^2=0$</span> と <span class="tex2jax_process">$C^2$</span> 条件）本書では「<span class="tex2jax_process">$f$</span> が <span class="tex2jax_process">$C^2$</span> 級（2階連続微分可能）なら混合偏微分が可換、ゆえに <span class="tex2jax_process">$d(df)=0$</span>」という順序で進めた。しかし微分形式の公理的な立場では、**<span class="tex2jax_process">$d^2=0$</span> こそが <span class="tex2jax_process">$d$</span> の定義の一部**であり、<span class="tex2jax_process">$d(df)=0$</span> は定理ではなく要請である。逆に言えば、<span class="tex2jax_process">$d^2=0$</span> を課すことが「混合偏微分の対称性が成り立つ関数クラス（＝<span class="tex2jax_process">$C^2$</span> 級の関数）を相手にしている」という宣言に相当する。どちらの順序で学んでも、両者が同値な条件として噛み合うことに変わりはない。</p>
 </p></blockquote>
-<h4 id="582">5.8.2 $d(d\omega) = 0$</h4>
-<p>§5.5 の $d\omega$ に §5.7 の公式を適用する。$A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ として：
+<h4 id="582-span-classtex2jaxprocessspan">5.8.2 <span class="tex2jax_process">$d(d\omega) = 0$</span></h4>
+<p>§5.5 の <span class="tex2jax_process">$d\omega$</span> に §5.7 の公式を適用する。<span class="tex2jax_process">$A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$</span> として：
 </p>
-<p>$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$
-</p>
+<div class="math-block tex2jax_process">$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$</div>
 <p>括弧内を展開：
 </p>
-<p>$$\frac{\partial^2 R}{\partial y \partial x} - \frac{\partial^2 Q}{\partial z \partial x} + \frac{\partial^2 P}{\partial z \partial y} - \frac{\partial^2 R}{\partial x \partial y} + \frac{\partial^2 Q}{\partial x \partial z} - \frac{\partial^2 P}{\partial y \partial z}$$
+<div class="math-block tex2jax_process">$$\frac{\partial^2 R}{\partial y \partial x} - \frac{\partial^2 Q}{\partial z \partial x} + \frac{\partial^2 P}{\partial z \partial y} - \frac{\partial^2 R}{\partial x \partial y} + \frac{\partial^2 Q}{\partial x \partial z} - \frac{\partial^2 P}{\partial y \partial z}$$</div>
+<p>混合偏微分の対称性（<span class="tex2jax_process">$\frac{\partial^2 R}{\partial y \partial x}=\frac{\partial^2 R}{\partial x \partial y}$</span> など）により、6項が3組の相殺を起こし、合計はゼロ：
 </p>
-<p>混合偏微分の対称性（$\frac{\partial^2 R}{\partial y \partial x}=\frac{\partial^2 R}{\partial x \partial y}$ など）により、6項が3組の相殺を起こし、合計はゼロ：
-</p>
-<p>$$d(d\omega) = 0$$
-</p>
+<div class="math-block tex2jax_process">$$d(d\omega) = 0$$</div>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $d^2 = 0$：外微分を2回続けると必ずゼロ。混合偏微分の対称性とウェッジの反対称性が相殺を起こす。
-- 既習者が知るいくつかの「二度微分すると消える」恒等式は、この $d^2=0$ の別表現として後の章で整理される。
+- <span class="tex2jax_process">$d^2 = 0$</span>：外微分を2回続けると必ずゼロ。混合偏微分の対称性とウェッジの反対称性が相殺を起こす。
+- 既習者が知るいくつかの「二度微分すると消える」恒等式は、この <span class="tex2jax_process">$d^2=0$</span> の別表現として後の章で整理される。
 </p></blockquote>
 <hr />
 <h3 id="59-外微分の統合一つの式一つのルール">§5.9 外微分の統合——一つの式、一つのルール</h3>
 <h4 id="591-ストークスとガウスは同じ式だった">5.9.1 ストークスとガウスは同じ式だった</h4>
-<p>§5.6 で得たストークスの定理 $\oint_{\partial S}\omega = \iint_S d\omega$ と、§5.7 で得たガウスの定理 $\iint_{\partial V}\eta = \iiint_V d\eta$。並べてみると、$\oint$、$\iint$、$\iiint$ と積分記号の数が違うだけで、構造は同一だ。$M$ が曲線なら $\int$（1次元）、曲面なら $\iint$（2次元）、立体なら $\iiint$（3次元）——つまり積分記号の重なりは $M$ の次元で決まるにすぎない。
+<p>§5.6 で得たストークスの定理 <span class="tex2jax_process">$\oint_{\partial S}\omega = \iint_S d\omega$</span> と、§5.7 で得たガウスの定理 <span class="tex2jax_process">$\iint_{\partial V}\eta = \iiint_V d\eta$</span>。並べてみると、<span class="tex2jax_process">$\oint$</span>、<span class="tex2jax_process">$\iint$</span>、<span class="tex2jax_process">$\iiint$</span> と積分記号の数が違うだけで、構造は同一だ。<span class="tex2jax_process">$M$</span> が曲線なら <span class="tex2jax_process">$\int$</span>（1次元）、曲面なら <span class="tex2jax_process">$\iint$</span>（2次元）、立体なら <span class="tex2jax_process">$\iiint$</span>（3次元）——つまり積分記号の重なりは <span class="tex2jax_process">$M$</span> の次元で決まるにすぎない。
 </p>
 <p>そこで、次元によらず統一的に：
 </p>
-<p>$$\int_{\partial M} \omega = \int_M d\omega$$
+<div class="math-block tex2jax_process">$$\int_{\partial M} \omega = \int_M d\omega$$</div>
+<p>と書く。<span class="tex2jax_process">$\omega$</span> は <span class="tex2jax_process">$k$</span>-form、<span class="tex2jax_process">$M$</span> は <span class="tex2jax_process">$(k+1)$</span> 次元領域、<span class="tex2jax_process">$\partial M$</span> はその <span class="tex2jax_process">$k$</span> 次元の境界である。<span class="tex2jax_process">$k=0$</span> なら <span class="tex2jax_process">$\int_{\partial M} f = f(B)-f(A) = \int_M df$</span> という微積分学の基本定理に、<span class="tex2jax_process">$k=1$</span> ならストークスの定理に、<span class="tex2jax_process">$k=2$</span> ならガウスの定理になる。すべてがこの一本の式に吸収される。
 </p>
-<p>と書く。$\omega$ は $k$-form、$M$ は $(k+1)$ 次元領域、$\partial M$ はその $k$ 次元の境界である。$k=0$ なら $\int_{\partial M} f = f(B)-f(A) = \int_M df$ という微積分学の基本定理に、$k=1$ ならストークスの定理に、$k=2$ ならガウスの定理になる。すべてがこの一本の式に吸収される。
+<p>この統一形の威力は §5.8 の <span class="tex2jax_process">$d^2=0$</span> との組み合わせでさらに際立つ。<span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> の <span class="tex2jax_process">$\omega$</span> を <span class="tex2jax_process">$d\omega$</span> に置き換えれば：
 </p>
-<p>この統一形の威力は §5.8 の $d^2=0$ との組み合わせでさらに際立つ。$\int_{\partial M} \omega = \int_M d\omega$ の $\omega$ を $d\omega$ に置き換えれば：
+<div class="math-block tex2jax_process">$$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\omega) = 0$$</div>
+<p>つまり <strong>「境界の境界は常に空」</strong>（<span class="tex2jax_process">$\partial(\partial M) = \emptyset$</span>）という幾何学的事実と、<strong><span class="tex2jax_process">$d^2=0$</span></strong> は互いに呼応している。<span class="tex2jax_process">$d^2=0$</span> はこの位相的な真理の、微分形式による代数的な写し絵なのである。
 </p>
-<p>$$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\omega) = 0$$
-</p>
-<p>つまり <strong>「境界の境界は常に空」</strong>（$\partial(\partial M) = \emptyset$）という幾何学的事実と、<strong>$d^2=0$</strong> は互いに呼応している。$d^2=0$ はこの位相的な真理の、微分形式による代数的な写し絵なのである。
-</p>
-<blockquote><p>**注** （3次元までで十分）本書の舞台は 3次元空間だから、$M$ の次元は1・2・3のいずれかであり、$\omega$ は $0$-form・$1$-form・$2$-form のいずれかである。$k=3$（$M$ が4次元）には立ち入らない。しかしこの式が $k$ によらず成立するという事実は、頭の片隅に置いておいて損はない。</p>
+<blockquote><p>**注** （3次元までで十分）本書の舞台は 3次元空間だから、<span class="tex2jax_process">$M$</span> の次元は1・2・3のいずれかであり、<span class="tex2jax_process">$\omega$</span> は <span class="tex2jax_process">$0$</span>-form・<span class="tex2jax_process">$1$</span>-form・<span class="tex2jax_process">$2$</span>-form のいずれかである。<span class="tex2jax_process">$k=3$</span>（<span class="tex2jax_process">$M$</span> が4次元）には立ち入らない。しかしこの式が <span class="tex2jax_process">$k$</span> によらず成立するという事実は、頭の片隅に置いておいて損はない。</p>
 </p></blockquote>
-<h4 id="592-一般の-form-の外微分">5.9.2 一般の $k$-form の外微分</h4>
-<p>同様に、$d$ の作用も次数によらず一つのパターンにまとまる。任意の $k$-form $\omega$ が係数 $a_{i_1\cdots i_k}$ と基底 $dx^{i_1}\wedge\cdots\wedge dx^{i_k}$ の和で書かれているとき：
+<h4 id="592-一般の-span-classtex2jaxprocessspan-form-の外微分">5.9.2 一般の <span class="tex2jax_process">$k$</span>-form の外微分</h4>
+<p>同様に、<span class="tex2jax_process">$d$</span> の作用も次数によらず一つのパターンにまとまる。任意の <span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> が係数 <span class="tex2jax_process">$a_{i_1\cdots i_k}$</span> と基底 <span class="tex2jax_process">$dx^{i_1}\wedge\cdots\wedge dx^{i_k}$</span> の和で書かれているとき：
 </p>
-<p>$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x^j}\,dx^j \Bigr) \wedge dx^{i_1}\wedge\cdots\wedge dx^{i_k}$$
-</p>
-<p>本書で必要なのは $k=0,1,2$ の三つの場合だけであり、それぞれ §5.1（$df$）、§5.5（$d\omega$）、§5.7（$d\eta$）で具体的に書き下した。上の一般形は「どの次数でも、係数を全微分してウェッジでつなぐ」という単一の原理に従っていることの確認にすぎない。
+<div class="math-block tex2jax_process">$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x^j}\,dx^j \Bigr) \wedge dx^{i_1}\wedge\cdots\wedge dx^{i_k}$$</div>
+<p>本書で必要なのは <span class="tex2jax_process">$k=0,1,2$</span> の三つの場合だけであり、それぞれ §5.1（<span class="tex2jax_process">$df$</span>）、§5.5（<span class="tex2jax_process">$d\omega$</span>）、§5.7（<span class="tex2jax_process">$d\eta$</span>）で具体的に書き下した。上の一般形は「どの次数でも、係数を全微分してウェッジでつなぐ」という単一の原理に従っていることの確認にすぎない。
 </p>
 <h4 id="593-計算ルールまとめ">5.9.3 計算ルールまとめ</h4>
-<p>本章で構築した外微分 $d$ の全計算は、以下の 4 つのルールに集約される：
+<p>本章で構築した外微分 <span class="tex2jax_process">$d$</span> の全計算は、以下の 4 つのルールに集約される：
 </p>
 <ol>
-<li>**$0$-form への作用**：$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$（第1章 §1.2 以来の定義）</li>
+<li>**<span class="tex2jax_process">$0$</span>-form への作用**：<span class="tex2jax_process">$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$</span>（第1章 §1.2 以来の定義）</li>
 </ol>
-<p>2. <strong>線形性</strong>：$d(\omega_1 + \omega_2) = d\omega_1 + d\omega_2$
+<p>2. <strong>線形性</strong>：<span class="tex2jax_process">$d(\omega_1 + \omega_2) = d\omega_1 + d\omega_2$</span>
 <ol>
-<li>**次数付きライプニッツ則**：$d(f\,\omega) = df \wedge \omega + f\,d\omega$</li>
+<li>**次数付きライプニッツ則**：<span class="tex2jax_process">$d(f\,\omega) = df \wedge \omega + f\,d\omega$</span></li>
 </ol>
-<p>4. <strong>座標基底の外微分はゼロ</strong>：$d(dx) = d(dy) = d(dz) = 0$
+<p>4. <strong>座標基底の外微分はゼロ</strong>：<span class="tex2jax_process">$d(dx) = d(dy) = d(dz) = 0$</span>
 </p>
-<p>ルール4 は、座標基底 $dx,dy,dz$ 自身には位置による係数の変化がなく、微小ループで測っても局所的なズレを生まない、という幾何的事実を反映している。§5.8 の $d^2=0$ とも整合する。
+<p>ルール4 は、座標基底 <span class="tex2jax_process">$dx,dy,dz$</span> 自身には位置による係数の変化がなく、微小ループで測っても局所的なズレを生まない、という幾何的事実を反映している。§5.8 の <span class="tex2jax_process">$d^2=0$</span> とも整合する。
 </p>
-<p>これら4つのルールさえあれば、$0$-form から $3$-form までの任意の形式の外微分が機械的に計算できる。実際に、本章で扱ったすべての計算はこのルールの組み合わせにすぎない。
+<p>これら4つのルールさえあれば、<span class="tex2jax_process">$0$</span>-form から <span class="tex2jax_process">$3$</span>-form までの任意の形式の外微分が機械的に計算できる。実際に、本章で扱ったすべての計算はこのルールの組み合わせにすぎない。
 </p>
-<blockquote><p>**注** （引き戻しとの可換性——§3.5.4 の伏線回収）第3章 §3.5.4 で予告したように、引き戻し $\Phi^*$ と外微分 $d$ のあいだには</p>
-$$\Phi^*(d\omega) = d(\Phi^*\omega)$$
-という可換関係が成り立つ。「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は、これまでの4ルールからは直接導けないが、$d$ が「局所的なズレを測る」操作であり、$\Phi^*$ が「座標を焼き直す」操作であることを思い出せば自然に納得できる——局所的なズレの構造は、座標のとり方に依存しないのだ。この事実は、第11章で一般の多様体上の微分形式を考える際の重要な足場となる。
+<blockquote><p>**注** （引き戻しとの可換性——§3.5.4 の伏線回収）第3章 §3.5.4 で予告したように、引き戻し <span class="tex2jax_process">$\Phi^*$</span> と外微分 <span class="tex2jax_process">$d$</span> のあいだには</p>
+
+</p></blockquote>
+<div class="math-block tex2jax_process">$$\Phi^*(d\omega) = d(\Phi^*\omega)$$</div>
+<blockquote><p>という可換関係が成り立つ。「微分してから引き戻す」のと「引き戻してから微分する」のは同じ結果を与える。この性質は、これまでの4ルールからは直接導けないが、<span class="tex2jax_process">$d$</span> が「局所的なズレを測る」操作であり、<span class="tex2jax_process">$\Phi^*$</span> が「座標を焼き直す」操作であることを思い出せば自然に納得できる——局所的なズレの構造は、座標のとり方に依存しないのだ。この事実は、第11章で一般の多様体上の微分形式を考える際の重要な足場となる。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- $\int_{\partial M} \omega = \int_M d\omega$ 一本で、微積分学の基本定理・ストークスの定理・ガウスの定理を統合できる。
-- $d$ の計算は 4 ルール（$df$、線形性、ライプニッツ則、$d(dx)=0$）に集約される。
-- $d^2=0$ と $\partial(\partial M)=\emptyset$ は代数的真理と幾何学的真理の呼応。
+- <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> 一本で、微積分学の基本定理・ストークスの定理・ガウスの定理を統合できる。
+- <span class="tex2jax_process">$d$</span> の計算は 4 ルール（<span class="tex2jax_process">$df$</span>、線形性、ライプニッツ則、<span class="tex2jax_process">$d(dx)=0$</span>）に集約される。
+- <span class="tex2jax_process">$d^2=0$</span> と <span class="tex2jax_process">$\partial(\partial M)=\emptyset$</span> は代数的真理と幾何学的真理の呼応。
 </p></blockquote>
 <hr />
 <h3 id="510-積分から微分方程式へ物理法則の局所化">§5.10 積分から微分方程式へ——物理法則の局所化</h3>
@@ -2755,137 +2603,120 @@ $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
 </p>
 <blockquote><p>**積分された量から、どのようにして局所法則を取り出すのか。**</p>
 </p></blockquote>
-<p>答えは、これまでに得た二つの道具——<strong>ストークスの定理</strong>と<strong>外微分 $d$</strong> ——にある。
+<p>答えは、これまでに得た二つの道具——<strong>ストークスの定理</strong>と<strong>外微分 <span class="tex2jax_process">$d$</span></strong> ——にある。
 </p>
 <p>物理学の多くの基本法則は、まず<strong>積分の形</strong>で発見される。ある領域の境界で測った量が、内部にある源の総和に等しい、という形だ：
 </p>
-<p>$$\int_{\partial M} \omega = \int_M \eta$$
+<div class="math-block tex2jax_process">$$\int_{\partial M} \omega = \int_M \eta$$</div>
+<p>左辺は境界で測った積分（大域的な観測量）、右辺は内部の源の積分（大域的な総量）。<span class="tex2jax_process">$\omega$</span> と <span class="tex2jax_process">$\eta$</span> は、それぞれ適切な次数の微分形式である。
 </p>
-<p>左辺は境界で測った積分（大域的な観測量）、右辺は内部の源の積分（大域的な総量）。$\omega$ と $\eta$ は、それぞれ適切な次数の微分形式である。
+<p>ここにストークスの定理を左辺に適用する。<span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> だから：
 </p>
-<p>ここにストークスの定理を左辺に適用する。$\int_{\partial M} \omega = \int_M d\omega$ だから：
-</p>
-<p>$$\int_M d\omega = \int_M \eta$$
-</p>
+<div class="math-block tex2jax_process">$$\int_M d\omega = \int_M \eta$$</div>
 <p>移項して：
 </p>
-<p>$$\int_M (d\omega - \eta) = 0$$
-</p>
-<p>ここが決定的な瞬間だ。この等式が<strong>任意の領域 $M$</strong> について成り立つならば、被積分関数は各点で恒等的にゼロでなければならない。なぜなら、もし $d\omega - \eta \neq 0$ となる点があれば、その点の周りの微小領域で積分がゼロでなくなり矛盾するからだ。
+<div class="math-block tex2jax_process">$$\int_M (d\omega - \eta) = 0$$</div>
+<p>ここが決定的な瞬間だ。この等式が<strong>任意の領域 <span class="tex2jax_process">$M$</span></strong> について成り立つならば、被積分関数は各点で恒等的にゼロでなければならない。なぜなら、もし <span class="tex2jax_process">$d\omega - \eta \neq 0$</span> となる点があれば、その点の周りの微小領域で積分がゼロでなくなり矛盾するからだ。
 </p>
 <p>したがって：
 </p>
-<p>$$d\omega = \eta$$
-</p>
-<p>これが<strong>積分法則から抽出された局所微分法則</strong>である。$d$ はまさに「積分方程式を微分方程式に変換する演算子」として機能したのだ。
+<div class="math-block tex2jax_process">$$d\omega = \eta$$</div>
+<p>これが<strong>積分法則から抽出された局所微分法則</strong>である。<span class="tex2jax_process">$d$</span> はまさに「積分方程式を微分方程式に変換する演算子」として機能したのだ。
 </p>
 <h4 id="5102-物理の実例">5.10.2 物理の実例</h4>
 <p>この構図は電磁気学の基本法則にも現れる。たとえば、閉じた曲線に沿って測る量と、その曲線が囲む面を貫く量が関係する法則は、左辺をストークスの定理で面積分に直すことで局所的な関係へ移る。また、閉曲面で測る量と内部の総量が関係する法則は、ガウスの定理を通じて体積の各点での関係へ移る。
 </p>
-<p>ここでは、電場や磁場をどの次数の形式として読むか、時間変化をどう入れるか、単位系をどう扱うかには踏み込まない。重要なのは、物理法則の多くが「境界での積分 $=$ 内部の総量」という姿をとり、$d$ がその法則を局所化する共通の機構を与える、という点である。
+<p>ここでは、電場や磁場をどの次数の形式として読むか、時間変化をどう入れるか、単位系をどう扱うかには踏み込まない。重要なのは、物理法則の多くが「境界での積分 <span class="tex2jax_process">$=$</span> 内部の総量」という姿をとり、<span class="tex2jax_process">$d$</span> がその法則を局所化する共通の機構を与える、という点である。
 </p>
 <blockquote><p>**【ここまでのチェックポイント】**</p>
-- 物理法則はしばしば $\int_{\partial M} \omega = \int_M \eta$ の形で与えられる。
-- ストークスの定理で $\int_{\partial M} \omega = \int_M d\omega$ と書き換え、任意の $M$ で成立することから $d\omega = \eta$（局所法則）を得る。
-- $d$ は積分法則を微分法則に変換する演算子である。
+- 物理法則はしばしば <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M \eta$</span> の形で与えられる。
+- ストークスの定理で <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> と書き換え、任意の <span class="tex2jax_process">$M$</span> で成立することから <span class="tex2jax_process">$d\omega = \eta$</span>（局所法則）を得る。
+- <span class="tex2jax_process">$d$</span> は積分法則を微分法則に変換する演算子である。
 </p></blockquote>
 <hr />
 <h3 id="511-第II部への展望ホッジ・スターへの伏線">§5.11 第II部への展望——ホッジ・スターへの伏線</h3>
-<p>本章で我々は、外微分 $d$ という強力な演算子を手に入れた。$d$ は：
+<p>本章で我々は、外微分 <span class="tex2jax_process">$d$</span> という強力な演算子を手に入れた。<span class="tex2jax_process">$d$</span> は：
 </p>
 <ul>
-<li>$0$-form $\to$ $1$-form：$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$</li>
+<li><span class="tex2jax_process">$0$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$1$</span>-form：<span class="tex2jax_process">$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$</span></li>
 </ol>
 <ul>
-<li>$1$-form $\to$ $2$-form：$d\omega = (\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z})\,dy\wedge dz + (\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x})\,dz\wedge dx + (\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})\,dx\wedge dy$</li>
+<li><span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$2$</span>-form：<span class="tex2jax_process">$d\omega = (\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z})\,dy\wedge dz + (\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x})\,dz\wedge dx + (\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})\,dx\wedge dy$</span></li>
 </ol>
 <ul>
-<li>$2$-form $\to$ $3$-form：$d\eta = (\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z})\,dx\wedge dy\wedge dz$</li>
+<li><span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$3$</span>-form：<span class="tex2jax_process">$d\eta = (\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z})\,dx\wedge dy\wedge dz$</span></li>
 </ol>
-<p>次数を一段ずつ上げるたびに、係数は異なるパターンで組み替わる。そして $d^2=0$ が、これらの階層の間に矛盾が入り込めないことを保証する。
+<p>次数を一段ずつ上げるたびに、係数は異なるパターンで組み替わる。そして <span class="tex2jax_process">$d^2=0$</span> が、これらの階層の間に矛盾が入り込めないことを保証する。
 </p>
-<p>しかし、ここで一つの非対称性が目につく。$0$-form と $3$-form は独立成分が 1 つ、$1$-form と $2$-form は独立成分が 3 つ——$1, 3, 3, 1$ という対称性がある（第2章 §2.5.9–§2.5.10 で見た）。この対称性は偶然ではない。デカルト座標の 3 次元空間では、長さ・面積・体積を測る規則を加えることで、同じ情報量の形式どうしを結びつける「辞書」が現れる。
+<p>しかし、ここで一つの非対称性が目につく。<span class="tex2jax_process">$0$</span>-form と <span class="tex2jax_process">$3$</span>-form は独立成分が 1 つ、<span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form は独立成分が 3 つ——<span class="tex2jax_process">$1, 3, 3, 1$</span> という対称性がある（第2章 §2.5.9–§2.5.10 で見た）。この対称性は偶然ではない。デカルト座標の 3 次元空間では、長さ・面積・体積を測る規則を加えることで、同じ情報量の形式どうしを結びつける「辞書」が現れる。
 </p>
-<p>その辞書が、次章で導入するホッジ・スター $\ast$ である。ただし、$\ast$ は単なる記号の置き換えではない。どの方向をどの面に対応させるか、面積や体積をどう測るか、向きをどう決めるかに依存する。そのため本章では、具体的な対応式はまだ使わない。
+<p>その辞書が、次章で導入するホッジ・スター <span class="tex2jax_process">$\ast$</span> である。ただし、<span class="tex2jax_process">$\ast$</span> は単なる記号の置き換えではない。どの方向をどの面に対応させるか、面積や体積をどう測るか、向きをどう決めるかに依存する。そのため本章では、具体的な対応式はまだ使わない。
 </p>
-<p>ここまでで構築したのは、あくまで $d$ である。$d$ は次数を一つ上げ、局所的なズレを取り出し、積分法則を局所法則へ変換する。次章では、そこに「測り方」の規則を加えることで、これまで見慣れていたベクトル解析の各演算との対応が見えてくる。
+<p>ここまでで構築したのは、あくまで <span class="tex2jax_process">$d$</span> である。<span class="tex2jax_process">$d$</span> は次数を一つ上げ、局所的なズレを取り出し、積分法則を局所法則へ変換する。次章では、そこに「測り方」の規則を加えることで、これまで見慣れていたベクトル解析の各演算との対応が見えてくる。
 </p>
-<p>次章では、この $\ast$ を定義し、$d$ と $\ast$ を両輪として第II部の核心——ナブラの解体——へと進む。
+<p>次章では、この <span class="tex2jax_process">$\ast$</span> を定義し、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> を両輪として第II部の核心——ナブラの解体——へと進む。
 </p>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント — 第5章全体】**</p>
-- 外微分 $d$ は $k$-form を $(k+1)$-form に写す演算子。$0$-form $\to$ $1$-form（$df$）、$1$-form $\to$ $2$-form、$2$-form $\to$ $3$-form。
-- 計算ルールは 4 つ：$df$ の定義、線形性、ライプニッツ則 $d(f\omega) = df\wedge\omega + f\,d\omega$、$d(dx)=d(dy)=d(dz)=0$。
-- 幾何学的起源は §5.3 の微小ループ解剖：閉ループのズレが面積に比例し、その比例係数が $d\omega$。
-- ストークスの定理 $\int_{\partial M} \omega = \int_M d\omega$ は、境界と内部をつなぐ普遍的な橋。
-- $d^2 = 0$ は混合偏微分の対称性に由来し、幾何学的には $\partial(\partial M) = \emptyset$ に対応。
-- $d$ は積分法則を局所微分法則へ変換する演算子——物理学の定式化に不可欠な役割を果たす。
-- 次章では、長さ・面積・体積を測る規則を加え、ホッジ・スター $\ast$ を通じて $d$ とベクトル解析の演算との対応を整理する。
+- 外微分 <span class="tex2jax_process">$d$</span> は <span class="tex2jax_process">$k$</span>-form を <span class="tex2jax_process">$(k+1)$</span>-form に写す演算子。<span class="tex2jax_process">$0$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$1$</span>-form（<span class="tex2jax_process">$df$</span>）、<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$2$</span>-form、<span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$3$</span>-form。
+- 計算ルールは 4 つ：<span class="tex2jax_process">$df$</span> の定義、線形性、ライプニッツ則 <span class="tex2jax_process">$d(f\omega) = df\wedge\omega + f\,d\omega$</span>、<span class="tex2jax_process">$d(dx)=d(dy)=d(dz)=0$</span>。
+- 幾何学的起源は §5.3 の微小ループ解剖：閉ループのズレが面積に比例し、その比例係数が <span class="tex2jax_process">$d\omega$</span>。
+- ストークスの定理 <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> は、境界と内部をつなぐ普遍的な橋。
+- <span class="tex2jax_process">$d^2 = 0$</span> は混合偏微分の対称性に由来し、幾何学的には <span class="tex2jax_process">$\partial(\partial M) = \emptyset$</span> に対応。
+- <span class="tex2jax_process">$d$</span> は積分法則を局所微分法則へ変換する演算子——物理学の定式化に不可欠な役割を果たす。
+- 次章では、長さ・面積・体積を測る規則を加え、ホッジ・スター <span class="tex2jax_process">$\ast$</span> を通じて <span class="tex2jax_process">$d$</span> とベクトル解析の演算との対応を整理する。
 </p></blockquote>
 <hr />
 <h2 id="付録C外微分の行列表示">付録C：外微分の行列表示</h2>
-<p>本章本文は基底 $dx, dy, dz$ とウェッジ積の代数で進めた。ここでは第2章以来の本書の真骨頂——<strong>成分をひとつ残らず行列に並べる</strong>——によって、外微分を行列表示の言葉で書き直す。
+<p>本章本文は基底 <span class="tex2jax_process">$dx, dy, dz$</span> とウェッジ積の代数で進めた。ここでは第2章以来の本書の真骨頂——<strong>成分をひとつ残らず行列に並べる</strong>——によって、外微分を行列表示の言葉で書き直す。
 </p>
-<h3 id="C1-form-の-行ベクトル">C.1 $0$-form：$df$ の $1 \times 3$ 行ベクトル</h3>
-<p>$f = f(x,y,z)$ に対し、第1章 §1.2 の定義どおり：
+<h3 id="C1-span-classtex2jaxprocessspan-formspan-classtex2jaxprocessspan-の-span-classtex2jaxprocessspan-行ベクトル">C.1 <span class="tex2jax_process">$0$</span>-form：<span class="tex2jax_process">$df$</span> の <span class="tex2jax_process">$1 \times 3$</span> 行ベクトル</h3>
+<span class="tex2jax_process">$f = f(x,y,z)$</span> に対し、第1章 §1.2 の定義どおり：
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$</div>
+<p>行ベクトル（<span class="tex2jax_process">$1 \times 3$</span> 行列）として：
 </p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
-</p>
-<p>行ベクトル（$1 \times 3$ 行列）として：
-</p>
-<p>$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
-</p>
+<div class="math-block tex2jax_process">$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</div>
 <p>である。
 </p>
-<h3 id="C2-form係数のヤコビ行列">C.2 $1$-form：係数のヤコビ行列 $\mathbf{J}$</h3>
-<p>$\omega = P\,dx + Q\,dy + R\,dz$ に対し、係数 $(P,Q,R)$ の偏微分を<strong>すべて</strong>並べた $3 \times 3$ 行列を：
-</p>
-<p>$$\mathbf{J} := \begin{pmatrix}
+<h3 id="C2-span-classtex2jaxprocessspan-form係数のヤコビ行列-span-classtex2jaxprocessspan">C.2 <span class="tex2jax_process">$1$</span>-form：係数のヤコビ行列 <span class="tex2jax_process">$\mathbf{J}$</span></h3>
+<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> に対し、係数 <span class="tex2jax_process">$(P,Q,R)$</span> の偏微分を<strong>すべて</strong>並べた <span class="tex2jax_process">$3 \times 3$</span> 行列を：
+<div class="math-block tex2jax_process">$$\mathbf{J} := \begin{pmatrix}
 \frac{\partial P}{\partial x} & \frac{\partial P}{\partial y} & \frac{\partial P}{\partial z} \\
 \frac{\partial Q}{\partial x} & \frac{\partial Q}{\partial y} & \frac{\partial Q}{\partial z} \\
 \frac{\partial R}{\partial x} & \frac{\partial R}{\partial y} & \frac{\partial R}{\partial z}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>とする。これは <span class="tex2jax_process">$(P,Q,R)$</span> を「縦に積んだ」ベクトル場のヤコビ行列にあたる。§5.1 で「単なる偏微分の行列では足りない」と述べたのは、まさにこの <span class="tex2jax_process">$\mathbf{J}$</span> が反対称でないからだ。
 </p>
-<p>とする。これは $(P,Q,R)$ を「縦に積んだ」ベクトル場のヤコビ行列にあたる。§5.1 で「単なる偏微分の行列では足りない」と述べたのは、まさにこの $\mathbf{J}$ が反対称でないからだ。
-</p>
-<h3 id="C3">C.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</h3>
+<h3 id="C3-span-classtex2jaxprocessspan">C.3 <span class="tex2jax_process">$d\omega = \mathbf{J}^T - \mathbf{J}$</span></h3>
 <p>§5.5 の結果は：
 </p>
-<p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+<div class="math-block tex2jax_process">$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</div>
+<p>第2章 §2.4.4 の流儀に従い、任意の縦ベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> に対して <span class="tex2jax_process">$(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$</span> となる反対称行列 <span class="tex2jax_process">$\mathbf{M}$</span> を求めよう。
 </p>
-<p>第2章 §2.4.4 の流儀に従い、任意の縦ベクトル $\mathbf{v}_1, \mathbf{v}_2$ に対して $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$ となる反対称行列 $\mathbf{M}$ を求めよう。
-</p>
-<p>$\mathbf{J}^T - \mathbf{J}$ の成分を書き下す：
-</p>
-<p>$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
+<span class="tex2jax_process">$\mathbf{J}^T - \mathbf{J}$</span> の成分を書き下す：
+<div class="math-block tex2jax_process">$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
 0 & \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} & \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \\
 \frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} & 0 & \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
 \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>すなわち、2章で求めた<span class="tex2jax_process">$2$</span>-formの行列表示と照らし合わせて：
 </p>
-<p>すなわち、2章で求めた$2$-formの行列表示と照らし合わせて：
+<div class="math-block tex2jax_process">$$d\omega = \mathbf{J}^T - \mathbf{J}$$</div>
+<p>となり、<strong>外微分 <span class="tex2jax_process">$d\omega$</span> の行列表示は、転置から係数のヤコビ行列を引いた反対称行列である。</strong>
 </p>
-<p>$$d\omega = \mathbf{J}^T - \mathbf{J}$$
-</p>
-<p>となり、<strong>外微分 $d\omega$ の行列表示は、転置から係数のヤコビ行列を引いた反対称行列である。</strong>
-</p>
-<h3 id="C4-form-とヤコビ行列のトレース">C.4 $2$-form：$d\eta$ とヤコビ行列のトレース</h3>
-<p>$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$ に対し、係数 $(A,B,C)$ のヤコビ行列を：
-</p>
-<p>$$\mathbf{J}_\eta := \begin{pmatrix}
+<h3 id="C4-span-classtex2jaxprocessspan-formspan-classtex2jaxprocessspan-とヤコビ行列のトレース">C.4 <span class="tex2jax_process">$2$</span>-form：<span class="tex2jax_process">$d\eta$</span> とヤコビ行列のトレース</h3>
+<span class="tex2jax_process">$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$</span> に対し、係数 <span class="tex2jax_process">$(A,B,C)$</span> のヤコビ行列を：
+<div class="math-block tex2jax_process">$$\mathbf{J}_\eta := \begin{pmatrix}
 \frac{\partial A}{\partial x} & \frac{\partial A}{\partial y} & \frac{\partial A}{\partial z} \\
 \frac{\partial B}{\partial x} & \frac{\partial B}{\partial y} & \frac{\partial B}{\partial z} \\
 \frac{\partial C}{\partial x} & \frac{\partial C}{\partial y} & \frac{\partial C}{\partial z}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>とすると、§5.7 の結果 <span class="tex2jax_process">$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$</span> の係数は <span class="tex2jax_process">$\mathbf{J}_\eta$</span> の<strong>トレース</strong>（対角成分の和）に一致する：
 </p>
-<p>とすると、§5.7 の結果 $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$ の係数は $\mathbf{J}_\eta$ の<strong>トレース</strong>（対角成分の和）に一致する：
-</p>
-<p>$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$
-</p>
-<h4 id="C41-の27成分3枚の行列に展開する">C.4.1 $d\eta$ の27成分——3枚の行列に展開する</h4>
-<p>$\eta$ の反対称成分は $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$（他は符号反転または $0$）である。$d\eta$ の成分 $d\eta_{abc} = \frac{\partial \eta_{bc}}{\partial x^a}$ は $a,b,c \in \{x,y,z\}$ で $3^3=27$ 個。$a$ を固定した $3 \times 3$ 行列3枚に並べると：
-</p>
-<p>$$d\eta_{x,\cdot,\cdot} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$</div>
+<h4 id="C41-span-classtex2jaxprocessspan-の27成分3枚の行列に展開する">C.4.1 <span class="tex2jax_process">$d\eta$</span> の27成分——3枚の行列に展開する</h4>
+<span class="tex2jax_process">$\eta$</span> の反対称成分は <span class="tex2jax_process">$\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$</span>（他は符号反転または <span class="tex2jax_process">$0$</span>）である。<span class="tex2jax_process">$d\eta$</span> の成分 <span class="tex2jax_process">$d\eta_{abc} = \frac{\partial \eta_{bc}}{\partial x^a}$</span> は <span class="tex2jax_process">$a,b,c \in \{x,y,z\}$</span> で <span class="tex2jax_process">$3^3=27$</span> 個。<span class="tex2jax_process">$a$</span> を固定した <span class="tex2jax_process">$3 \times 3$</span> 行列3枚に並べると：
+<div class="math-block tex2jax_process">$$d\eta_{x,\cdot,\cdot} = \begin{pmatrix}
 0 & \frac{\partial C}{\partial x} & -\frac{\partial B}{\partial x} \\
 -\frac{\partial C}{\partial x} & 0 & \frac{\partial A}{\partial x} \\
 \frac{\partial B}{\partial x} & -\frac{\partial A}{\partial x} & 0
@@ -2899,40 +2730,34 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 0 & \frac{\partial C}{\partial z} & -\frac{\partial B}{\partial z} \\
 -\frac{\partial C}{\partial z} & 0 & \frac{\partial A}{\partial z} \\
 \frac{\partial B}{\partial z} & -\frac{\partial A}{\partial z} & 0
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>この <span class="tex2jax_process">$27$</span> 成分が <span class="tex2jax_process">$dx^a \wedge dx^b \wedge dx^c$</span> のウェッジ積と縮約するとき、添字の重複がある項（対角成分や <span class="tex2jax_process">$b=c$</span> 等）は <span class="tex2jax_process">$dx \wedge dx = 0$</span> で消え、生き残るのは <span class="tex2jax_process">$a,b,c$</span> がすべて異なる <span class="tex2jax_process">$6$</span> 項（<span class="tex2jax_process">$3!$</span> の順列）だけ。それぞれを符号つきで和をとると、因子 <span class="tex2jax_process">$\frac{1}{2}$</span> の補正も入って
 </p>
-<p>この $27$ 成分が $dx^a \wedge dx^b \wedge dx^c$ のウェッジ積と縮約するとき、添字の重複がある項（対角成分や $b=c$ 等）は $dx \wedge dx = 0$ で消え、生き残るのは $a,b,c$ がすべて異なる $6$ 項（$3!$ の順列）だけ。それぞれを符号つきで和をとると、因子 $\frac{1}{2}$ の補正も入って
+<div class="math-block tex2jax_process">$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$</div>
+<p>すなわち <span class="tex2jax_process">$d\eta$</span> は <span class="tex2jax_process">$27$</span> 成分のうち <span class="tex2jax_process">$6$</span> 項が生き残り、ペアで足し合わさって <span class="tex2jax_process">$\mathbf{J}_\eta$</span> のトレースへ収束する。
 </p>
-<p>$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$
-</p>
-<p>すなわち $d\eta$ は $27$ 成分のうち $6$ 項が生き残り、ペアで足し合わさって $\mathbf{J}_\eta$ のトレースへ収束する。
-</p>
-<p>$3$-form は基底が $dx \wedge dy \wedge dz$ の 1 つだけなので、行列としてはスカラー係数に縮退している。
-</p>
-<h3 id="C5-とヘッセ行列">C.5 $d^2 f = 0$ とヘッセ行列</h3>
-<p>$0$-form $f$ のヘッセ行列：
-</p>
-<p>$$\mathbf{H}_f := \begin{pmatrix}
+<span class="tex2jax_process">$3$</span>-form は基底が <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> の 1 つだけなので、行列としてはスカラー係数に縮退している。
+<h3 id="C5-span-classtex2jaxprocessspan-とヘッセ行列">C.5 <span class="tex2jax_process">$d^2 f = 0$</span> とヘッセ行列</h3>
+<span class="tex2jax_process">$0$</span>-form <span class="tex2jax_process">$f$</span> のヘッセ行列：
+<div class="math-block tex2jax_process">$$\mathbf{H}_f := \begin{pmatrix}
 \frac{\partial^2 f}{\partial x^2} & \frac{\partial^2 f}{\partial x \partial y} & \frac{\partial^2 f}{\partial x \partial z} \\
 \frac{\partial^2 f}{\partial y \partial x} & \frac{\partial^2 f}{\partial y^2} & \frac{\partial^2 f}{\partial y \partial z} \\
 \frac{\partial^2 f}{\partial z \partial x} & \frac{\partial^2 f}{\partial z \partial y} & \frac{\partial^2 f}{\partial z^2}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>は <span class="tex2jax_process">$f$</span> の 2 階偏導関数を並べたものだ。<span class="tex2jax_process">$f$</span> が <span class="tex2jax_process">$C^2$</span> 級なら <span class="tex2jax_process">$\mathbf{H}_f$</span> は対称行列（<span class="tex2jax_process">$\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$</span> など）である。
 </p>
-<p>は $f$ の 2 階偏導関数を並べたものだ。$f$ が $C^2$ 級なら $\mathbf{H}_f$ は対称行列（$\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$ など）である。
-</p>
-<p>$d(df) = 0$ は §5.5 の $d\omega$ 公式で $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ とおいたもの。$\mathbf{J} = \mathbf{H}_f$ であり、$\mathbf{H}_f$ が対称だから $\mathbf{J}^T - \mathbf{J} = 0$、したがって $d(df) = 0$。行列の言葉では「ヘッセ行列の反対称成分がゼロ」と言い換えられる。
-</p>
+<span class="tex2jax_process">$d(df) = 0$</span> は §5.5 の <span class="tex2jax_process">$d\omega$</span> 公式で <span class="tex2jax_process">$(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$</span> とおいたもの。<span class="tex2jax_process">$\mathbf{J} = \mathbf{H}_f$</span> であり、<span class="tex2jax_process">$\mathbf{H}_f$</span> が対称だから <span class="tex2jax_process">$\mathbf{J}^T - \mathbf{J} = 0$</span>、したがって <span class="tex2jax_process">$d(df) = 0$</span>。行列の言葉では「ヘッセ行列の反対称成分がゼロ」と言い換えられる。
 <p>\newpage
 </p>
-<h1 id="第6章計量-とホッジ・スター--内積の召喚と次数の反転">第6章：計量 $g$ とホッジ・スター $\ast$ — 内積の召喚と次数の反転</h1>
+<h1 id="第6章計量-span-classtex2jaxprocessspan-とホッジ・スター-span-classtex2jaxprocessspan--内積の召喚と次数の反転">第6章：計量 <span class="tex2jax_process">$g$</span> とホッジ・スター <span class="tex2jax_process">$\ast$</span> — 内積の召喚と次数の反転</h1>
 <h3 id="60-言い訳の終焉内積を解放する">§6.0 言い訳の終焉——内積を解放する</h3>
-<p>　第2章で球の表面積 $4\pi R^2$ を導出したとき、第3章で弧長を二乗和の平方根として測ったとき——本書ではこれまで長さや面積を計算するたびに「数学者からは計量がないと怒られるだろうが、知らん顔で押し通そう」といったエクスキューズを書き連ねてきた。
+<p>　第2章で球の表面積 <span class="tex2jax_process">$4\pi R^2$</span> を導出したとき、第3章で弧長を二乗和の平方根として測ったとき——本書ではこれまで長さや面積を計算するたびに「数学者からは計量がないと怒られるだろうが、知らん顔で押し通そう」といったエクスキューズを書き連ねてきた。
 </p>
 <p>読者もそろそろくどいと感じている頃だろう。正直に言えば、筆者も飽きてきた。
 </p>
-<p>そもそも我々は、実空間 $(x,y,z)$ という直交デカルト座標の上で計算している。この空間ではピタゴラスの定理が成り立つ。そこに誰の許可が必要だと言うのか。そろそろ気兼ねなく、<strong>内積</strong>を使わせてもらおう。
+<p>そもそも我々は、実空間 <span class="tex2jax_process">$(x,y,z)$</span> という直交デカルト座標の上で計算している。この空間ではピタゴラスの定理が成り立つ。そこに誰の許可が必要だと言うのか。そろそろ気兼ねなく、<strong>内積</strong>を使わせてもらおう。
 </p>
-<p>内積とは何か。すでに我々はこれと何度も遭遇している。第2章で向き付き面積を得たとき、3つの影の成分 $A_{yz}, A_{zx}, A_{xy}$ の二乗和の平方根をとれば小学校の面積に一致すると言った——あの「二乗和」こそ、自分自身との内積（の平方根）である。より一般に、実空間の $n$-form（横ベクトル）の対応する成分同士を掛けて足し合わせたスカラー量、または $n$-vector（縦ベクトル）の対応する成分同士を掛けて足し合わせたスカラー量のことを、<strong>内積</strong>と呼ぶ。
+<p>内積とは何か。すでに我々はこれと何度も遭遇している。第2章で向き付き面積を得たとき、3つの影の成分 <span class="tex2jax_process">$A_{yz}, A_{zx}, A_{xy}$</span> の二乗和の平方根をとれば小学校の面積に一致すると言った——あの「二乗和」こそ、自分自身との内積（の平方根）である。より一般に、実空間の <span class="tex2jax_process">$n$</span>-form（横ベクトル）の対応する成分同士を掛けて足し合わせたスカラー量、または <span class="tex2jax_process">$n$</span>-vector（縦ベクトル）の対応する成分同士を掛けて足し合わせたスカラー量のことを、<strong>内積</strong>と呼ぶ。
 </p>
 <p>……以上だ。おそらく多くの読者は高校数学で内積を習っているだろうから、「何を当たり前のことを」と思っていることだろう。しかし、本書では居心地が悪い思いをしながらも、今まで内積を正面から定義してこなかった。それには理由がある。
 </p>
@@ -2942,91 +2767,80 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 </p>
 <p>つまり、ここで本当に区別したいのは、「横ベクトル×縦ベクトルでスカラーを得る操作」と「同じ種類のベクトル同士で内積をとる操作」である。
 </p>
-<blockquote><p>**注** （なぜ横と縦をここまで分けるのか）計量や内積を前面に出さなくても、かなり遠くまで進められる、という立場がある。たとえば、初等的な $n$-form の積分や、多くの学部レベルの物理計算では、その見方がよく働く。筆者はその立場も尊重している。一方で、長さ・角度・内積・ホッジ・スター $\ast$ を使う計量つきの見方も、物理では強力である。筆者個人としては、問題に応じてこの二つの見方を行き来できることが理想だと考えている。そして行き来するためには、まず「横ベクトル×縦ベクトルで測る操作」と「同種ベクトル同士で内積をとる操作」を混同しないことが必要になる。本書が横ベクトルと縦ベクトルをしつこく分けてきたのは、そのためである。</p>
+<blockquote><p>**注** （なぜ横と縦をここまで分けるのか）計量や内積を前面に出さなくても、かなり遠くまで進められる、という立場がある。たとえば、初等的な <span class="tex2jax_process">$n$</span>-form の積分や、多くの学部レベルの物理計算では、その見方がよく働く。筆者はその立場も尊重している。一方で、長さ・角度・内積・ホッジ・スター <span class="tex2jax_process">$\ast$</span> を使う計量つきの見方も、物理では強力である。筆者個人としては、問題に応じてこの二つの見方を行き来できることが理想だと考えている。そして行き来するためには、まず「横ベクトル×縦ベクトルで測る操作」と「同種ベクトル同士で内積をとる操作」を混同しないことが必要になる。本書が横ベクトルと縦ベクトルをしつこく分けてきたのは、そのためである。</p>
 </p></blockquote>
 <p>第1章以来、我々は横ベクトル×縦ベクトルでスカラーを得る計算を山ほどやってきた。では、それと内積は何が違うのか。
 </p>
 <p>結論から言えば、<strong>まったく別物</strong>だ。横ベクトル掛ける縦ベクトルは「横と縦という異種のベクトル間」の計算である。対して内積は「横と横」あるいは「縦と縦」という<strong>同種のベクトル間</strong>の計算だ。
 </p>
-<p>そう、事は読者が思ったよりも深遠だ。実空間という特別な舞台では、この二つがたまたま同じ数値を返すことが多いために混同されてきた——その混同の上に、ベクトル解析という巨大な体系が築かれている。本章の目標は、この区別を明確にした上で、内積の自然な一般化として計量 $g$ を導き、そこからホッジ・スター $\ast$ の正体を暴くことである。
+<p>そう、事は読者が思ったよりも深遠だ。実空間という特別な舞台では、この二つがたまたま同じ数値を返すことが多いために混同されてきた——その混同の上に、ベクトル解析という巨大な体系が築かれている。本章の目標は、この区別を明確にした上で、内積の自然な一般化として計量 <span class="tex2jax_process">$g$</span> を導き、そこからホッジ・スター <span class="tex2jax_process">$\ast$</span> の正体を暴くことである。
 </p>
 <hr />
-<h3 id="61-パラメータ空間の内積計量-の正体">§6.1 パラメータ空間の内積——計量 $g$ の正体</h3>
+<h3 id="61-パラメータ空間の内積計量-span-classtex2jaxprocessspan-の正体">§6.1 パラメータ空間の内積——計量 <span class="tex2jax_process">$g$</span> の正体</h3>
 <h4 id="611-実空間の内積">6.1.1 実空間の内積</h4>
-<p>実空間 $(x,y,z)$ における二つの縦ベクトルを成分で書こう。
+<p>実空間 <span class="tex2jax_process">$(x,y,z)$</span> における二つの縦ベクトルを成分で書こう。
 </p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$</div>
+<p>同じ添字の成分同士を掛けて総和をとる操作を、本書では<strong>内積</strong>（ドット積）と定義し、記号 <span class="tex2jax_process">$\cdot$</span> で表す。
 </p>
-<p>同じ添字の成分同士を掛けて総和をとる操作を、本書では<strong>内積</strong>（ドット積）と定義し、記号 $\cdot$ で表す。
-</p>
-<p>$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
-</p>
-<p>$xyz$ 座標での内積は、対応する成分同士を掛けて足し合わせるだけで計算できる。
-</p>
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$</div>
+<span class="tex2jax_process">$xyz$</span> 座標での内積は、対応する成分同士を掛けて足し合わせるだけで計算できる。
 <h4 id="612-内積を測定器として読み直す">6.1.2 内積を測定器として読み直す</h4>
 <p>ここで、同じ計算を「測定器」の言葉で読み直しておこう。内積は一見すると、これまで扱ってきた測定器とは別系統の演算に見える。しかし実は、内積もまた「あるものを測定器に変え、別のものに作用させてスカラーを得る」操作として読むことができる。
 </p>
-<p>その入り口が転置である。$\mathbf{v}_1$ を転置すると、縦ベクトルは横ベクトルになる。
+<p>その入り口が転置である。<span class="tex2jax_process">$\mathbf{v}_1$</span> を転置すると、縦ベクトルは横ベクトルになる。
 </p>
-<p>$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$</div>
+<p>これは、ペアになる縦ベクトル <span class="tex2jax_process">$\mathbf{v}_2$</span> を食べて、「<span class="tex2jax_process">$\mathbf{v}_1$</span> との内積はいくらか」を測る測定器である。
 </p>
-<p>これは、ペアになる縦ベクトル $\mathbf{v}_2$ を食べて、「$\mathbf{v}_1$ との内積はいくらか」を測る測定器である。
-</p>
-<p>$$\mathbf{v}_1^T\mathbf{v}_2
+<div class="math-block tex2jax_process">$$\mathbf{v}_1^T\mathbf{v}_2
 = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
 \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
-= x_1x_2 + y_1y_2 + z_1z_2$$
+= x_1x_2 + y_1y_2 + z_1z_2$$</div>
+<p>つまり、実空間の直交デカルト座標では、縦ベクトル <span class="tex2jax_process">$\mathbf{v}_1$</span> を転置するだけで、そのベクトルと内積をとるための横ベクトル——測定器——が得られる。
 </p>
-<p>つまり、実空間の直交デカルト座標では、縦ベクトル $\mathbf{v}_1$ を転置するだけで、そのベクトルと内積をとるための横ベクトル——測定器——が得られる。
-</p>
-<blockquote><p>**注** （添字の上げ下げの正体）テンソル解析では、ベクトル成分と測定器側の成分を、上付き添字・下付き添字で区別する流儀がある。そして計量 $g$ を使って添字を上げ下げする、と説明される。本書の言葉で言えば、その正体は「縦ベクトルを、内積を測る横ベクトルへ変換する」操作である。直交デカルト座標では $g=I$ なので転置だけで済むが、次に見るようにパラメータ空間では途中に $\mathbf{g}=J^T J$ を挟む必要が出てくる。</p>
+<blockquote><p>**注** （添字の上げ下げの正体）テンソル解析では、ベクトル成分と測定器側の成分を、上付き添字・下付き添字で区別する流儀がある。そして計量 <span class="tex2jax_process">$g$</span> を使って添字を上げ下げする、と説明される。本書の言葉で言えば、その正体は「縦ベクトルを、内積を測る横ベクトルへ変換する」操作である。直交デカルト座標では <span class="tex2jax_process">$g=I$</span> なので転置だけで済むが、次に見るようにパラメータ空間では途中に <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> を挟む必要が出てくる。</p>
 </p></blockquote>
 <h4 id="613-パラメータ空間で内積をとるには">6.1.3 パラメータ空間で内積をとるには</h4>
-<p>では、同じ読み替えをパラメータ空間 $(r,\theta,z)$ で行うとどうなるか。
+<p>では、同じ読み替えをパラメータ空間 <span class="tex2jax_process">$(r,\theta,z)$</span> で行うとどうなるか。
 </p>
-<p>実空間の直交デカルト座標では、$\mathbf{v}_1^T$ がそのまま「$\mathbf{v}_1$ との内積を測る測定器」だった。だからパラメータ空間でも、$\mathbf{v}_1^T$ をそのまま測定器にしたくなる。しかしそれでは、$\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$ を計算してしまうだけで、実空間での正しい内積にはならない。実空間とパラメータ空間のメモリの対応が場所によって異なるからである。
+<p>実空間の直交デカルト座標では、<span class="tex2jax_process">$\mathbf{v}_1^T$</span> がそのまま「<span class="tex2jax_process">$\mathbf{v}_1$</span> との内積を測る測定器」だった。だからパラメータ空間でも、<span class="tex2jax_process">$\mathbf{v}_1^T$</span> をそのまま測定器にしたくなる。しかしそれでは、<span class="tex2jax_process">$\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$</span> を計算してしまうだけで、実空間での正しい内積にはならない。実空間とパラメータ空間のメモリの対応が場所によって異なるからである。
 </p>
 <p>では、パラメータ空間の縦ベクトルを、実空間の内積を正しく測る横ベクトルに変えるには、何を挟めばよいか。
 </p>
-<p>第1章 §1.4 で我々は、パラメータ空間の変位を実空間の変位に変換する規則を知っている——ヤコビ行列 $J$ を掛ければよい。
+<p>第1章 §1.4 で我々は、パラメータ空間の変位を実空間の変位に変換する規則を知っている——ヤコビ行列 <span class="tex2jax_process">$J$</span> を掛ければよい。
 </p>
-<p>$$J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J = \begin{pmatrix}
 \frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
 \frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
 \frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>円柱座標の換算式 <span class="tex2jax_process">$x = r\cos\theta,\; y = r\sin\theta,\; z = z$</span> から偏微分を計算すれば：
 </p>
-<p>円柱座標の換算式 $x = r\cos\theta,\; y = r\sin\theta,\; z = z$ から偏微分を計算すれば：
-</p>
-<p>$$J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J = \begin{pmatrix}
 \cos\theta & -r\sin\theta & 0 \\
 \sin\theta & r\cos\theta & 0 \\
 0 & 0 & 1
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>パラメータ空間のベクトル <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> を成分で書く。
 </p>
-<p>パラメータ空間のベクトル $\mathbf{v}_1, \mathbf{v}_2$ を成分で書く。
+<div class="math-block tex2jax_process">$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$</div>
+<p>これらを実空間へ引き戻すと、それぞれ <span class="tex2jax_process">$J\mathbf{v}_1, J\mathbf{v}_2$</span> になる。実空間で「<span class="tex2jax_process">$J\mathbf{v}_1$</span> との内積」を測る測定器は、前節の読み方では <span class="tex2jax_process">$(J\mathbf{v}_1)^T$</span> である。したがって、求めたい内積は次の形で書ける。
 </p>
-<p>$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$\text{内積} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$</div>
+<p>ここで転置の規則を使うと、<span class="tex2jax_process">$(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$</span> だから、
 </p>
-<p>これらを実空間へ引き戻すと、それぞれ $J\mathbf{v}_1, J\mathbf{v}_2$ になる。実空間で「$J\mathbf{v}_1$ との内積」を測る測定器は、前節の読み方では $(J\mathbf{v}_1)^T$ である。したがって、求めたい内積は次の形で書ける。
+<div class="math-block tex2jax_process">$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$</div>
+<p>ここで <span class="tex2jax_process">$J^T J$</span> を実際に計算してみよう。<span class="tex2jax_process">$J^T$</span> は <span class="tex2jax_process">$J$</span> の行と列を入れ替えたものだ。
 </p>
-<p>$$\text{内積} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$
-</p>
-<p>ここで転置の規則を使うと、$(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$ だから、
-</p>
-<p>$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
-</p>
-<p>ここで $J^T J$ を実際に計算してみよう。$J^T$ は $J$ の行と列を入れ替えたものだ。
-</p>
-<p>$$J^T = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J^T = \begin{pmatrix}
 \cos\theta & \sin\theta & 0 \\
 -r\sin\theta & r\cos\theta & 0 \\
 0 & 0 & 1
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <p>したがって、
 </p>
-<p>$$J^T J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J^T J = \begin{pmatrix}
 \cos\theta & \sin\theta & 0 \\
 -r\sin\theta & r\cos\theta & 0 \\
 0 & 0 & 1
@@ -3040,134 +2854,117 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 1 & 0 & 0 \\
 0 & r^2 & 0 \\
 0 & 0 & 1
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$\cos^2\theta + \sin^2\theta = 1$</span> という代数的恒等式がすべての幾何を代行し、対角成分に <span class="tex2jax_process">$1, r^2, 1$</span> が残る。<span class="tex2jax_process">$\theta$</span> 方向の弧の長さなど一度も考えていない——行列の積と転置の性質だけを使った、純粋に代数的な変形だ。
+<strong>これで、新しい測定器が出てきた。</strong> パラメータ空間の縦ベクトル <span class="tex2jax_process">$\mathbf{v}_1$</span> から、実空間での内積を正しく測る横ベクトルを作るには、単に転置するのではなく、右側に <span class="tex2jax_process">$J^T J$</span> を掛ければよい。
+<div class="math-block tex2jax_process">$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$</div>
+<p>そしてこの測定器を <span class="tex2jax_process">$\mathbf{v}_2$</span> に作用させれば、実空間での内積と同じ値が得られる。
 </p>
-<p>$\cos^2\theta + \sin^2\theta = 1$ という代数的恒等式がすべての幾何を代行し、対角成分に $1, r^2, 1$ が残る。$\theta$ 方向の弧の長さなど一度も考えていない——行列の積と転置の性質だけを使った、純粋に代数的な変形だ。
+<p>この <span class="tex2jax_process">$J^T J$</span> を、数学では<strong>計量行列 <span class="tex2jax_process">$\mathbf{g}$</span></strong>と呼ぶ。
 </p>
-<strong>これで、新しい測定器が出てきた。</strong> パラメータ空間の縦ベクトル $\mathbf{v}_1$ から、実空間での内積を正しく測る横ベクトルを作るには、単に転置するのではなく、右側に $J^T J$ を掛ければよい。
-<p>$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$
+<div class="math-block tex2jax_process">$$\mathbf{g} = J^T J$$</div>
+<span class="tex2jax_process">$xyz$</span> 座標では、そもそも「引き戻す」という操作を通らず、成分の積和だけで内積を計算していた。パラメータ空間に来ると、まず <span class="tex2jax_process">$J$</span> で実空間へ戻し、その後で成分の積和をとる。この二段階を行列の形に畳み込むと、中央に <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> が現れる——そしてその中身は、ヤコビ行列 <span class="tex2jax_process">$J$</span> さえ知っていれば、偏微分と行列の積だけで機械的に求まる。新しい幾何学の公理など、どこにも入り込む余地はない。
+<p>念のため、具体的な数値で確認しておこう。<span class="tex2jax_process">$r=2,\; \theta=\pi/3$</span> の地点を考える。このとき <span class="tex2jax_process">$\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$</span> だから、
 </p>
-<p>そしてこの測定器を $\mathbf{v}_2$ に作用させれば、実空間での内積と同じ値が得られる。
-</p>
-<p>この $J^T J$ を、数学では<strong>計量行列 $\mathbf{g}$</strong>と呼ぶ。
-</p>
-<p>$$\mathbf{g} = J^T J$$
-</p>
-<p>$xyz$ 座標では、そもそも「引き戻す」という操作を通らず、成分の積和だけで内積を計算していた。パラメータ空間に来ると、まず $J$ で実空間へ戻し、その後で成分の積和をとる。この二段階を行列の形に畳み込むと、中央に $\mathbf{g}=J^T J$ が現れる——そしてその中身は、ヤコビ行列 $J$ さえ知っていれば、偏微分と行列の積だけで機械的に求まる。新しい幾何学の公理など、どこにも入り込む余地はない。
-</p>
-<p>念のため、具体的な数値で確認しておこう。$r=2,\; \theta=\pi/3$ の地点を考える。このとき $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$ だから、
-</p>
-<p>$$J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J = \begin{pmatrix}
 1/2 & -\sqrt{3} & 0 \\
 \sqrt{3}/2 & 1 & 0 \\
 0 & 0 & 1
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>パラメータ空間で <span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$</span> という <span class="tex2jax_process">$\theta$</span> 方向の単位変位を考える。<span class="tex2jax_process">$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$</span> であり、いま <span class="tex2jax_process">$r=2$</span> だから <span class="tex2jax_process">$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$</span>。パラメータ空間で内積（長さの二乗）を計算すると：
 </p>
-<p>パラメータ空間で $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ という $\theta$ 方向の単位変位を考える。$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$ であり、いま $r=2$ だから $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$。パラメータ空間で内積（長さの二乗）を計算すると：
-</p>
-<p>$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
 \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
-\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$</div>
+<p>一方、同じ <span class="tex2jax_process">$\mathbf{v}$</span> を実空間に引き戻すと：
 </p>
-<p>一方、同じ $\mathbf{v}$ を実空間に引き戻すと：
-</p>
-<p>$$J\mathbf{v} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J\mathbf{v} = \begin{pmatrix}
 1/2 & -\sqrt{3} & 0 \\
 \sqrt{3}/2 & 1 & 0 \\
 0 & 0 & 1
 \end{pmatrix}
-\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$</div>
+<p>実空間での内積（長さの二乗）は <span class="tex2jax_process">$(-\sqrt{3})^2 + 1^2 + 0^2 = 4$</span>。確かに一致している。<span class="tex2jax_process">$\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$</span>（<span class="tex2jax_process">$r$</span> 方向の単位変位）でも同様に、<span class="tex2jax_process">$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$</span>、<span class="tex2jax_process">$(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$</span> で一致する。<span class="tex2jax_process">$\mathbf{g} = J^T J$</span> はこうして、パラメータ空間と実空間の内積を矛盾なく繫いでいる。
 </p>
-<p>実空間での内積（長さの二乗）は $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$。確かに一致している。$\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$（$r$ 方向の単位変位）でも同様に、$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$、$(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ で一致する。$\mathbf{g} = J^T J$ はこうして、パラメータ空間と実空間の内積を矛盾なく繫いでいる。
+<p>なお、ここでは円柱座標 <span class="tex2jax_process">$(r,\theta,z)$</span> で計算したが、球座標 <span class="tex2jax_process">$(r,\theta,\phi)$</span> の場合も同様に <span class="tex2jax_process">$J$</span> から <span class="tex2jax_process">$\mathbf{g}$</span> が求まる。
 </p>
-<p>なお、ここでは円柱座標 $(r,\theta,z)$ で計算したが、球座標 $(r,\theta,\phi)$ の場合も同様に $J$ から $\mathbf{g}$ が求まる。
+<div class="math-block tex2jax_process">$$\mathbf{g}_{\text{球座標}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$</div>
+<p>対角成分に <span class="tex2jax_process">$r^2$</span> と <span class="tex2jax_process">$r^2\sin^2\theta$</span> が現れるが、これらもすべて連鎖律だけから機械的に導かれる換算係数である。
 </p>
-<p>$$\mathbf{g}_{\text{球座標}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
-</p>
-<p>対角成分に $r^2$ と $r^2\sin^2\theta$ が現れるが、これらもすべて連鎖律だけから機械的に導かれる換算係数である。
-</p>
-<p>この $g$ を仲立ちにすることで、どの座標系でも一貫して内積（長さ・角度）を計算できる。また、後半で扱うホッジ・スター $\ast$ の仕様も、この内積のルールから自然に読み解ける。
+<p>この <span class="tex2jax_process">$g$</span> を仲立ちにすることで、どの座標系でも一貫して内積（長さ・角度）を計算できる。また、後半で扱うホッジ・スター <span class="tex2jax_process">$\ast$</span> の仕様も、この内積のルールから自然に読み解ける。
 </p>
 <hr />
-<h3 id="62-による縦ベクトルと横ベクトルの変換">§6.2 $g$ による縦ベクトルと横ベクトルの変換</h3>
-<h4 id="621-は横ベクトルである">6.2.1 $\mathbf{v}^T \mathbf{g}$ は横ベクトルである</h4>
-<p>§6.1 で導いた内積の式 $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ を、もう一度見てみよう。行列の積は左から順に実行できるから、この式は「まず $\mathbf{v}_1^T \mathbf{g}$ を計算し、その結果に $\mathbf{v}_2$ を掛ける」と読むことができる。
+<h3 id="62-span-classtex2jaxprocessspan-による縦ベクトルと横ベクトルの変換">§6.2 <span class="tex2jax_process">$g$</span> による縦ベクトルと横ベクトルの変換</h3>
+<h4 id="621-span-classtex2jaxprocessspan-は横ベクトルである">6.2.1 <span class="tex2jax_process">$\mathbf{v}^T \mathbf{g}$</span> は横ベクトルである</h4>
+<p>§6.1 で導いた内積の式 <span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$</span> を、もう一度見てみよう。行列の積は左から順に実行できるから、この式は「まず <span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{g}$</span> を計算し、その結果に <span class="tex2jax_process">$\mathbf{v}_2$</span> を掛ける」と読むことができる。
 </p>
-<p>$\mathbf{v}_1$ は縦ベクトルだが、転置された $\mathbf{v}_1^T$ は横ベクトルだ。横ベクトルに正方行列を掛けると、結果は再び横ベクトルになる。つまり、$\mathbf{v}_1^T \mathbf{g}$ という部分だけを取り出せば、
+<span class="tex2jax_process">$\mathbf{v}_1$</span> は縦ベクトルだが、転置された <span class="tex2jax_process">$\mathbf{v}_1^T$</span> は横ベクトルだ。横ベクトルに正方行列を掛けると、結果は再び横ベクトルになる。つまり、<span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{g}$</span> という部分だけを取り出せば、
+<div class="math-block tex2jax_process">$$\omega = \mathbf{v}^T \mathbf{g}$$</div>
+<p>これは <span class="tex2jax_process">$1 \times 3$</span> の<strong>横ベクトル</strong>である。計量 <span class="tex2jax_process">$g$</span> とは、内積の行列形式から自然に現れた、<strong>縦ベクトルを横ベクトルに変換する装置</strong>なのだ。
 </p>
-<p>$$\omega = \mathbf{v}^T \mathbf{g}$$
-</p>
-<p>これは $1 \times 3$ の<strong>横ベクトル</strong>である。計量 $g$ とは、内積の行列形式から自然に現れた、<strong>縦ベクトルを横ベクトルに変換する装置</strong>なのだ。
-</p>
-<blockquote><p>**注** （第2章で密輸していたもの）第2章で $2$-form の行列表現を探したとき、我々はすでに $\mathbf{v}_1^T M \mathbf{v}_2$ という形を使っていた。あのときは「縦ベクトルを横に寝かせる操作は数学的には行儀が悪い」とだけ断って、深入りせずに押し通した。いま見ている $\mathbf{v}^T\mathbf{g}$ は、そのとき密輸していた操作の正体である。実空間では $\mathbf{g}=I$ なので、転置だけで縦ベクトルが横ベクトルに見えてしまう。しかしパラメータ空間では、実空間の内積を再現するように縦ベクトルを測定器としての横ベクトルへ変えるには、計量 $\mathbf{g}$ を明示的に通す必要がある。</p>
+<blockquote><p>**注** （第2章で密輸していたもの）第2章で <span class="tex2jax_process">$2$</span>-form の行列表現を探したとき、我々はすでに <span class="tex2jax_process">$\mathbf{v}_1^T M \mathbf{v}_2$</span> という形を使っていた。あのときは「縦ベクトルを横に寝かせる操作は数学的には行儀が悪い」とだけ断って、深入りせずに押し通した。いま見ている <span class="tex2jax_process">$\mathbf{v}^T\mathbf{g}$</span> は、そのとき密輸していた操作の正体である。実空間では <span class="tex2jax_process">$\mathbf{g}=I$</span> なので、転置だけで縦ベクトルが横ベクトルに見えてしまう。しかしパラメータ空間では、実空間の内積を再現するように縦ベクトルを測定器としての横ベクトルへ変えるには、計量 <span class="tex2jax_process">$\mathbf{g}$</span> を明示的に通す必要がある。</p>
 </p></blockquote>
-<p>この変換の意味を考えよう。第1章以来、我々は「測られる図形（縦ベクトル $\mathbf{v}$）」と「測る装置（横ベクトル $\omega$）」を区別してきた。両者は異なる世界の住人だった。しかし $g$ を経由することで、図形の側にいた縦ベクトルが、はかりの側——横ベクトル——へと姿を変える。同じ矢印でも、場所によって「はかりとしての感度」が変わるのは、$\mathbf{g}$ がその場所ごとの目盛りの違いをすべて吸収してくれるからだ。
+<p>この変換の意味を考えよう。第1章以来、我々は「測られる図形（縦ベクトル <span class="tex2jax_process">$\mathbf{v}$</span>）」と「測る装置（横ベクトル <span class="tex2jax_process">$\omega$</span>）」を区別してきた。両者は異なる世界の住人だった。しかし <span class="tex2jax_process">$g$</span> を経由することで、図形の側にいた縦ベクトルが、はかりの側——横ベクトル——へと姿を変える。同じ矢印でも、場所によって「はかりとしての感度」が変わるのは、<span class="tex2jax_process">$\mathbf{g}$</span> がその場所ごとの目盛りの違いをすべて吸収してくれるからだ。
 </p>
-<p>実空間（$\mathbf{g}=I$）では $\omega = \mathbf{v}^T$ であり、縦ベクトルの成分がそのまま横ベクトルの成分になる。パラメータ空間では $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$ なので、$\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$。$\theta$ 成分だけ $r^2$ 倍されるのは、$\theta$ 方向の目盛りが $r$ 倍に伸びていることの反映だ。
+<p>実空間（<span class="tex2jax_process">$\mathbf{g}=I$</span>）では <span class="tex2jax_process">$\omega = \mathbf{v}^T$</span> であり、縦ベクトルの成分がそのまま横ベクトルの成分になる。パラメータ空間では <span class="tex2jax_process">$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$</span> なので、<span class="tex2jax_process">$\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$</span>。<span class="tex2jax_process">$\theta$</span> 成分だけ <span class="tex2jax_process">$r^2$</span> 倍されるのは、<span class="tex2jax_process">$\theta$</span> 方向の目盛りが <span class="tex2jax_process">$r$</span> 倍に伸びていることの反映だ。
 </p>
-<p>$g$ がなければ、「測られる図形」と「測る装置」は互いに変換不能である。$g$ は両者を繫ぐ唯一の仲介者なのだ。
+<span class="tex2jax_process">$g$</span> がなければ、「測られる図形」と「測る装置」は互いに変換不能である。<span class="tex2jax_process">$g$</span> は両者を繫ぐ唯一の仲介者なのだ。
+<h4 id="622-計量が与えるもの平行-span-classtex2jaxprocessspan-面体の幾何学的な大きさ">6.2.2 計量が与えるもの——平行 <span class="tex2jax_process">$k$</span> 面体の幾何学的な大きさ</h4>
+<p>計量 <span class="tex2jax_process">$g$</span> の最も基本的な役割は、<span class="tex2jax_process">$k$</span> 本のベクトルが貼る<strong>平行 <span class="tex2jax_process">$k$</span> 面体の実際の幾何学的な大きさ</strong>（長さ・面積・体積）を定義することである。
 </p>
-<h4 id="622-計量が与えるもの平行-面体の幾何学的な大きさ">6.2.2 計量が与えるもの——平行 $k$ 面体の幾何学的な大きさ</h4>
-<p>計量 $g$ の最も基本的な役割は、$k$ 本のベクトルが貼る<strong>平行 $k$ 面体の実際の幾何学的な大きさ</strong>（長さ・面積・体積）を定義することである。
+<p>本書のこれまでの章では、<span class="tex2jax_process">$k$</span>-form に <span class="tex2jax_process">$k$</span> 本のベクトルを食わせることで「向き付きの数え上げ」を行ってきた。<span class="tex2jax_process">$dx(\mathbf{v})$</span> は <span class="tex2jax_process">$\mathbf{v}$</span> の <span class="tex2jax_process">$x$</span> 成分という数、<span class="tex2jax_process">$dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$</span> は <span class="tex2jax_process">$\mathbf{v}_1, \mathbf{v}_2$</span> が張る平行四辺形の向き付き面積という数である。しかしこれらはあくまで影の測量であり、ベクトルたちが実際に何メートルの線分を張り、何平方メートルの平行四辺形を張っているか——<strong>幾何学的な本当の大きさ</strong>——は、計量 <span class="tex2jax_process">$g$</span> が与えられて初めて決まる。
 </p>
-<p>本書のこれまでの章では、$k$-form に $k$ 本のベクトルを食わせることで「向き付きの数え上げ」を行ってきた。$dx(\mathbf{v})$ は $\mathbf{v}$ の $x$ 成分という数、$dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ は $\mathbf{v}_1, \mathbf{v}_2$ が張る平行四辺形の向き付き面積という数である。しかしこれらはあくまで影の測量であり、ベクトルたちが実際に何メートルの線分を張り、何平方メートルの平行四辺形を張っているか——<strong>幾何学的な本当の大きさ</strong>——は、計量 $g$ が与えられて初めて決まる。
+<span class="tex2jax_process">$k=1$</span>（1本のベクトル <span class="tex2jax_process">$\mathbf{v}$</span> が張る線分）の場合、その長さの二乗は自分自身との内積で定義される。これは §6.1 ですでに導いた通りだ。
+<div class="math-block tex2jax_process">$$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$</div>
+<p>実空間 <span class="tex2jax_process">$(\mathbf{g}=I)$</span> では <span class="tex2jax_process">$|\mathbf{v}|^2 = \Delta x^2 + \Delta y^2 + \Delta z^2$</span>。円柱座標のパラメータ空間では <span class="tex2jax_process">$|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$</span>。
 </p>
-<p>$k=1$（1本のベクトル $\mathbf{v}$ が張る線分）の場合、その長さの二乗は自分自身との内積で定義される。これは §6.1 ですでに導いた通りだ。
-</p>
-<p>$$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
-</p>
-<p>実空間 $(\mathbf{g}=I)$ では $|\mathbf{v}|^2 = \Delta x^2 + \Delta y^2 + \Delta z^2$。円柱座標のパラメータ空間では $|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$。
-</p>
-<p>$k=0$（0本のベクトル、すなわち点）の場合、$0$-form であるスカラー場 $f$ の「大きさ」は単にその絶対値 $|f|$ である。
-</p>
-<p>$k=2$（2本のベクトルが張る平行四辺形の面積）および $k=3$（3本のベクトルが張る平行六面体の体積）についても、同じことだ。第2章 §2.4.7 で見たように、$dx \wedge dy, dy \wedge dz, dz \wedge dx$ という3つの基底 $2$-form の係数 $A_{xy}, A_{yz}, A_{zx}$ の二乗和の平方根 $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ が、平行四辺形の符号なし面積を与える。$xyz$ 座標でこの計算に必要なのは基底 $2$-form の係数だけであり、それ以外の情報はいらない。
-</p>
-<blockquote><p>**注** （なぜ $k=2$ ではベクトル表示しないのか）$k=1$ では $\mathbf{v}$ という縦ベクトルの内積 $\mathbf{v}^T\mathbf{g}\,\mathbf{v}$ として長さを書いた。$k=2$ での同様の内積——行列同士の内積（本章付録D のフロベニウス積）——はまだ定義していない。さらに、$2$-form の係数を $3$ 成分のベクトルとして表示するには、次数を変換するホッジ・スター $\ast$ も必要になる。ここではまだ、面を面のまま、すなわち $2$-form の係数として扱っている。</p>
+<span class="tex2jax_process">$k=0$</span>（0本のベクトル、すなわち点）の場合、<span class="tex2jax_process">$0$</span>-form であるスカラー場 <span class="tex2jax_process">$f$</span> の「大きさ」は単にその絶対値 <span class="tex2jax_process">$|f|$</span> である。
+<span class="tex2jax_process">$k=2$</span>（2本のベクトルが張る平行四辺形の面積）および <span class="tex2jax_process">$k=3$</span>（3本のベクトルが張る平行六面体の体積）についても、同じことだ。第2章 §2.4.7 で見たように、<span class="tex2jax_process">$dx \wedge dy, dy \wedge dz, dz \wedge dx$</span> という3つの基底 <span class="tex2jax_process">$2$</span>-form の係数 <span class="tex2jax_process">$A_{xy}, A_{yz}, A_{zx}$</span> の二乗和の平方根 <span class="tex2jax_process">$\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$</span> が、平行四辺形の符号なし面積を与える。<span class="tex2jax_process">$xyz$</span> 座標でこの計算に必要なのは基底 <span class="tex2jax_process">$2$</span>-form の係数だけであり、それ以外の情報はいらない。
+<blockquote><p>**注** （なぜ <span class="tex2jax_process">$k=2$</span> ではベクトル表示しないのか）<span class="tex2jax_process">$k=1$</span> では <span class="tex2jax_process">$\mathbf{v}$</span> という縦ベクトルの内積 <span class="tex2jax_process">$\mathbf{v}^T\mathbf{g}\,\mathbf{v}$</span> として長さを書いた。<span class="tex2jax_process">$k=2$</span> での同様の内積——行列同士の内積（本章付録D のフロベニウス積）——はまだ定義していない。さらに、<span class="tex2jax_process">$2$</span>-form の係数を <span class="tex2jax_process">$3$</span> 成分のベクトルとして表示するには、次数を変換するホッジ・スター <span class="tex2jax_process">$\ast$</span> も必要になる。ここではまだ、面を面のまま、すなわち <span class="tex2jax_process">$2$</span>-form の係数として扱っている。</p>
 </p></blockquote>
-<p>計量 $g$ の役割は、この「$xyz$ での計算」をパラメータ空間のような目盛りの歪んだ座標系へ一般化することである。いずれの場合も、<strong>$g$ が決まれば、あらゆる次数の平行 $k$ 面体に一貫した幾何学的な大きさが定義できる</strong>——これが計量の最も根本的な役割である。
+<p>計量 <span class="tex2jax_process">$g$</span> の役割は、この「<span class="tex2jax_process">$xyz$</span> での計算」をパラメータ空間のような目盛りの歪んだ座標系へ一般化することである。いずれの場合も、<strong><span class="tex2jax_process">$g$</span> が決まれば、あらゆる次数の平行 <span class="tex2jax_process">$k$</span> 面体に一貫した幾何学的な大きさが定義できる</strong>——これが計量の最も根本的な役割である。
 </p>
 <h4 id="623-内積の性質">6.2.3 内積の性質</h4>
-<p>第5章で外微分 $d$ の性質（線形性・次数を上げる・$d^2=0$・ライプニッツ則）をまとめたのと同じように、内積についても、ここまでの計算から浮かび上がる性質を整理しておこう。これらは特定の座標系に依存しない。
+<p>第5章で外微分 <span class="tex2jax_process">$d$</span> の性質（線形性・次数を上げる・<span class="tex2jax_process">$d^2=0$</span>・ライプニッツ則）をまとめたのと同じように、内積についても、ここまでの計算から浮かび上がる性質を整理しておこう。これらは特定の座標系に依存しない。
 </p>
 <ol>
-<li>**対称性**：$\mathbf{v}_1 \cdot \mathbf{v}_2 = \mathbf{v}_2 \cdot \mathbf{v}_1$。これを §6.1 で導いた行列の形 $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ に当てはめてみよう。$\mathbf{v}_2 \cdot \mathbf{v}_1 = \mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1$ だが、スカラーは転置しても変わらないから $\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1 = (\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1)^T = \mathbf{v}_1^T \mathbf{g}^T \mathbf{v}_2$。これが $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ と等しくなるには $\mathbf{g} = \mathbf{g}^T$ でなければならない。つまり、内積の対称性から、$\mathbf{g}$ は必ず**対称行列**になることが導かれる。</li>
+<li>**対称性**：<span class="tex2jax_process">$\mathbf{v}_1 \cdot \mathbf{v}_2 = \mathbf{v}_2 \cdot \mathbf{v}_1$</span>。これを §6.1 で導いた行列の形 <span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$</span> に当てはめてみよう。<span class="tex2jax_process">$\mathbf{v}_2 \cdot \mathbf{v}_1 = \mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1$</span> だが、スカラーは転置しても変わらないから <span class="tex2jax_process">$\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1 = (\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1)^T = \mathbf{v}_1^T \mathbf{g}^T \mathbf{v}_2$</span>。これが <span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$</span> と等しくなるには <span class="tex2jax_process">$\mathbf{g} = \mathbf{g}^T$</span> でなければならない。つまり、内積の対称性から、<span class="tex2jax_process">$\mathbf{g}$</span> は必ず**対称行列**になることが導かれる。</li>
 </ol>
 <ol>
-<li>**線形性**（双線形性）：$(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$。各引数について線形。これは $(a\mathbf{v}_1 + b\mathbf{v}_2)^T \mathbf{g} \,\mathbf{v}_3 = a\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_3 + b\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_3$ という、行列の積の分配法則そのものである。</li>
+<li>**線形性**（双線形性）：<span class="tex2jax_process">$(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$</span>。各引数について線形。これは <span class="tex2jax_process">$(a\mathbf{v}_1 + b\mathbf{v}_2)^T \mathbf{g} \,\mathbf{v}_3 = a\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_3 + b\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_3$</span> という、行列の積の分配法則そのものである。</li>
 </ol>
 <ol>
-<li>**正定値性**：$\mathbf{v} \cdot \mathbf{v} > 0$（$\mathbf{v} \neq \mathbf{0}$）。「長さの二乗」が正であることを保証する。特殊相対論のように符号が混ざる場合はこの限りではないが、本書の舞台である3次元実空間ではつねに成り立つ。</li>
+<li>**正定値性**：<span class="tex2jax_process">$\mathbf{v} \cdot \mathbf{v} > 0$</span>（<span class="tex2jax_process">$\mathbf{v} \neq \mathbf{0}$</span>）。「長さの二乗」が正であることを保証する。特殊相対論のように符号が混ざる場合はこの限りではないが、本書の舞台である3次元実空間ではつねに成り立つ。</li>
 </ol>
 <blockquote><p>**注** （対称行列と反対称行列の対比）</p>
-第2章で面積の計量器が反対称行列（$M = -M^T$）を要請したことと、
-ここで内積が対称行列（$\mathbf{g} = \mathbf{g}^T$）を要請することは、
+第2章で面積の計量器が反対称行列（<span class="tex2jax_process">$M = -M^T$</span>）を要請したことと、
+ここで内積が対称行列（<span class="tex2jax_process">$\mathbf{g} = \mathbf{g}^T$</span>）を要請することは、
 ちょうど対をなしている。前者は「重なればゼロ」、後者は「順番によらず同じ値」という、どちらもごく自然な要請から導かれる。行列の世界では、反対称が向き付きの数え上げ（符号付きの面積・体積）を、対称が向きなしの大きさ（符号なし面積・体積）と角度を司る。
 </p></blockquote>
 <h4 id="624-計量行列の幾何を成分に宿らせる">6.2.4 計量行列の幾何を成分に宿らせる</h4>
-<p>$\mathbf{g}$ の対角成分は「その軸方向の一歩が長さにどれだけ効くか」、非対角成分は「異なる軸方向の一歩が互いにどれだけ干渉するか」を表す。円柱座標の $\mathbf{g}$ が対角行列だったのは、$r,\theta,z$ の各軸が互いに直交しているからだ。いずれにせよ、$\mathbf{g}$ という一個の行列が、その場所での「ものさしの性質」のすべてを成分として担っている。
-</p>
-<blockquote><p>**注** （数学者の内積——公理と行列の順序逆転）標準的な線形代数の教科書では、まず上記の3性質を公理として定義し、その後に「これらを満たす演算は、ある基底を選べば必ず対称行列 $\mathbf{g}$ を用いた $\mathbf{v}^T \mathbf{g} \mathbf{w}$ の形で書ける」という定理を導く。論理の順番が我々とは逆だ。数学者にとって行列表示は一表現に過ぎないが、物理学者にとっては**この行列 $\mathbf{g}$ こそが空間の目盛りそのもの**であり、すべての測定の出発点である。どちらが正しいかではない。数学者は抽象を、我々は実装を見ている。向いている方向が違うだけだ。</p>
+<span class="tex2jax_process">$\mathbf{g}$</span> の対角成分は「その軸方向の一歩が長さにどれだけ効くか」、非対角成分は「異なる軸方向の一歩が互いにどれだけ干渉するか」を表す。円柱座標の <span class="tex2jax_process">$\mathbf{g}$</span> が対角行列だったのは、<span class="tex2jax_process">$r,\theta,z$</span> の各軸が互いに直交しているからだ。いずれにせよ、<span class="tex2jax_process">$\mathbf{g}$</span> という一個の行列が、その場所での「ものさしの性質」のすべてを成分として担っている。
+<blockquote><p>**注** （数学者の内積——公理と行列の順序逆転）標準的な線形代数の教科書では、まず上記の3性質を公理として定義し、その後に「これらを満たす演算は、ある基底を選べば必ず対称行列 <span class="tex2jax_process">$\mathbf{g}$</span> を用いた <span class="tex2jax_process">$\mathbf{v}^T \mathbf{g} \mathbf{w}$</span> の形で書ける」という定理を導く。論理の順番が我々とは逆だ。数学者にとって行列表示は一表現に過ぎないが、物理学者にとっては**この行列 <span class="tex2jax_process">$\mathbf{g}$</span> こそが空間の目盛りそのもの**であり、すべての測定の出発点である。どちらが正しいかではない。数学者は抽象を、我々は実装を見ている。向いている方向が違うだけだ。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント — §6.0–§6.2】**</p>
 - 内積とは、同種のベクトル間（横×横、または縦×縦）で成分の積和をとる演算。横×縦とは別物。
-- パラメータ空間での内積は、実空間へ引き戻してから計算する。その過程で $J^T J$ が自然に現れる。これが計量 $g$ の正体。
-- $g$ は縦ベクトルを横ベクトルに変換する。$g$ を仲立ちに、あらゆる次数の平行 $k$ 面体の幾何学的な大きさが定義できる。
-- 内積の性質（対称性・線形性・正定値性）から $g$ の対称性が導かれる。これは面積測定器 $\wedge$ の反対称性と対をなす。
+- パラメータ空間での内積は、実空間へ引き戻してから計算する。その過程で <span class="tex2jax_process">$J^T J$</span> が自然に現れる。これが計量 <span class="tex2jax_process">$g$</span> の正体。
+- <span class="tex2jax_process">$g$</span> は縦ベクトルを横ベクトルに変換する。<span class="tex2jax_process">$g$</span> を仲立ちに、あらゆる次数の平行 <span class="tex2jax_process">$k$</span> 面体の幾何学的な大きさが定義できる。
+- 内積の性質（対称性・線形性・正定値性）から <span class="tex2jax_process">$g$</span> の対称性が導かれる。これは面積測定器 <span class="tex2jax_process">$\wedge$</span> の反対称性と対をなす。
 </p></blockquote>
 <hr />
-<h3 id="63-ホッジ・スター-二つの方法を繫ぐ対応">§6.3 ホッジ・スター $\ast$ ——二つの方法を繫ぐ対応</h3>
+<h3 id="63-ホッジ・スター-span-classtex2jaxprocessspan-二つの方法を繫ぐ対応">§6.3 ホッジ・スター <span class="tex2jax_process">$\ast$</span> ——二つの方法を繫ぐ対応</h3>
 <h4 id="631-スカラーを得る二つの方法">6.3.1 スカラーを得る二つの方法</h4>
-<p>ここまでで $g = J^T J$ の正体が明らかになり、内積をどの座標系でも計算できるようになった。ここで、より大きな構図を見ておこう。
+<p>ここまでで <span class="tex2jax_process">$g = J^T J$</span> の正体が明らかになり、内積をどの座標系でも計算できるようになった。ここで、より大きな構図を見ておこう。
 </p>
-<p>物理の式を眺めると、スカラー量を作るやり方が一つではないことに気づく。ある場を線や面に沿って積分するときは、「測るもの」が「測られるもの」に作用して数を返す、という書き方が自然に現れる。一方で、仕事率やエネルギー密度のような量は、しばしば $\mathbf{E}\cdot\mathbf{J}$ や $\mathbf{A}\cdot(\nabla\times\mathbf{A})$ のように、同じ種類の矢印同士の内積として書かれる。
+<p>物理の式を眺めると、スカラー量を作るやり方が一つではないことに気づく。ある場を線や面に沿って積分するときは、「測るもの」が「測られるもの」に作用して数を返す、という書き方が自然に現れる。一方で、仕事率やエネルギー密度のような量は、しばしば <span class="tex2jax_process">$\mathbf{E}\cdot\mathbf{J}$</span> や <span class="tex2jax_process">$\mathbf{A}\cdot(\nabla\times\mathbf{A})$</span> のように、同じ種類の矢印同士の内積として書かれる。
 </p>
 <p>つまり世の中の物理記法には、少なくとも見かけ上、スカラーを得る二つの流儀が併存している。本書の言葉で言えば、それは次の二つである。
 </p>
 <ul>
-<li>**方法①（微分形式の方法 / dの方法）**：測る装置（横ベクトル：$1$-form など）と、測られる図形（縦ベクトル：ベクトル場など）を用意し、横×縦の計算でスカラーを得る。この計算で使うのは、形式がベクトルを食べてスカラーを返すという、作用と評価の論理である。</li>
+<li>**方法①（微分形式の方法 / dの方法）**：測る装置（横ベクトル：<span class="tex2jax_process">$1$</span>-form など）と、測られる図形（縦ベクトル：ベクトル場など）を用意し、横×縦の計算でスカラーを得る。この計算で使うのは、形式がベクトルを食べてスカラーを返すという、作用と評価の論理である。</li>
 </ol>
 <ul>
-<li>**方法②（ベクトル解析の方法 / ∇の方法）**：すべての量を「同じ種類の矢印」に統一し、同種ベクトル間の内積（縦×縦、または横×横）でスカラーを得る。この計算では、同種ベクトル同士を比べるために計量 $g$ を挟む。多くの読者は学校教育を通じてこちらの方法に慣れ親しんでいるだろう。</li>
+<li>**方法②（ベクトル解析の方法 / ∇の方法）**：すべての量を「同じ種類の矢印」に統一し、同種ベクトル間の内積（縦×縦、または横×横）でスカラーを得る。この計算では、同種ベクトル同士を比べるために計量 <span class="tex2jax_process">$g$</span> を挟む。多くの読者は学校教育を通じてこちらの方法に慣れ親しんでいるだろう。</li>
 </ol>
 <blockquote><p>**注** （二つの方法の呼び方——筆者の苦悩）筆者はこの二つの流儀を教科書でどう呼ぶか長らく悩んだ。方法①を「微分形式の方法」と呼ぶのが一般的だが、本書では「dの方法」とも呼んでいる。なぜなら、微分形式を知らない読者にとっては、dという記号の方が親しみやすいからだ。筆者は個人的に「トポロジーの方法」とも呼んでいる。トポロジーや幾何学の文脈で育った読者には、そちらの呼び方の方がしっくりくるだろう。同様に、方法②を「ベクトル解析の方法」と呼ぶのが一般的だが、本書では「∇の方法」とも呼んでいる。∇（ナブラ）という記号は、物理学を学んだ読者にとって最も馴染み深い記号だからだ。筆者は個人的に「内積の方法」とも呼んでいる。内積の構造が核心に据わっていることを強調したいときに使う。どれも同じ二つの流儀を指している。</p>
 
@@ -3175,24 +2972,22 @@ d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
 </p></blockquote>
 <p>実は、どちらの方法を採用しても、最終的に得られる物理的な結果は同じになる。これは単なる表現の違いだ。
 </p>
-<p>しかしここに実務上の問題が生じる。方法②の枠組みでは、本来「面」で測るべき量（$2$-form）も「線」で測る量（$1$-form）も、すべて同じ「$3$ 成分の矢印」として扱われる。方法①における面積や体積の概念を、方法②の「矢印同士の内積」の枠組みで扱うには、次数の異なる形式どうしを結びつける対応が必要になる。
+<p>しかしここに実務上の問題が生じる。方法②の枠組みでは、本来「面」で測るべき量（<span class="tex2jax_process">$2$</span>-form）も「線」で測る量（<span class="tex2jax_process">$1$</span>-form）も、すべて同じ「<span class="tex2jax_process">$3$</span> 成分の矢印」として扱われる。方法①における面積や体積の概念を、方法②の「矢印同士の内積」の枠組みで扱うには、次数の異なる形式どうしを結びつける対応が必要になる。
 </p>
-<p>$k$-form の独立成分数には、特徴的な対称性があった。第2章 §2.5.9 で見たように、$3$ 次元空間では $0$-form が $1$ 成分、$1$-form が $3$ 成分、$2$-form も $3$ 成分、$3$-form が $1$ 成分——真ん中を折り目にして、$1, 3, 3, 1$ と左右対称になっている。独立成分数が同じ $1$-form と $2$-form、$0$-form と $3$-form のあいだには、何らかの対応関係が存在するはずだ。その対応を与える装置こそが、<strong>ホッジ・スター $\ast$</strong>である。
-</p>
-<p>$\ast$ は、内積の情報（すなわち $g$）を使って、ある形式に対し、それと組み合わせれば体積になる相手を対応させる。本書ではこの $\ast$ を、行列表現を使って具体的に構成していく。
-</p>
-<blockquote><p>**注** （二つの方法のあいだで）方法①と方法②のどちらか一方だけを使う必要はない。筆者の理想は、両方を自由に行き来できることだ。本書が方法①（微分形式）から出発したのは、空間の歪みに依存しない強固な土台を築くためである。その上で、必要に応じて方法②の言葉でも同じ量を読めるようにする——その橋渡しをするのが $\ast$ だ。</p>
+<span class="tex2jax_process">$k$</span>-form の独立成分数には、特徴的な対称性があった。第2章 §2.5.9 で見たように、<span class="tex2jax_process">$3$</span> 次元空間では <span class="tex2jax_process">$0$</span>-form が <span class="tex2jax_process">$1$</span> 成分、<span class="tex2jax_process">$1$</span>-form が <span class="tex2jax_process">$3$</span> 成分、<span class="tex2jax_process">$2$</span>-form も <span class="tex2jax_process">$3$</span> 成分、<span class="tex2jax_process">$3$</span>-form が <span class="tex2jax_process">$1$</span> 成分——真ん中を折り目にして、<span class="tex2jax_process">$1, 3, 3, 1$</span> と左右対称になっている。独立成分数が同じ <span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form、<span class="tex2jax_process">$0$</span>-form と <span class="tex2jax_process">$3$</span>-form のあいだには、何らかの対応関係が存在するはずだ。その対応を与える装置こそが、<strong>ホッジ・スター <span class="tex2jax_process">$\ast$</span></strong>である。
+<span class="tex2jax_process">$\ast$</span> は、内積の情報（すなわち <span class="tex2jax_process">$g$</span>）を使って、ある形式に対し、それと組み合わせれば体積になる相手を対応させる。本書ではこの <span class="tex2jax_process">$\ast$</span> を、行列表現を使って具体的に構成していく。
+<blockquote><p>**注** （二つの方法のあいだで）方法①と方法②のどちらか一方だけを使う必要はない。筆者の理想は、両方を自由に行き来できることだ。本書が方法①（微分形式）から出発したのは、空間の歪みに依存しない強固な土台を築くためである。その上で、必要に応じて方法②の言葉でも同じ量を読めるようにする——その橋渡しをするのが <span class="tex2jax_process">$\ast$</span> だ。</p>
 </p></blockquote>
-<blockquote><p>**注** （ベクトル解析を知っている読者へ）通常のベクトル解析で面の向きや外積として扱われる操作の多くは、この $\ast$ が与える対応として読み直せる。ただし本章では、それらを既知の公式として使うのではなく、$g$ と第2章の基底 $2$-form から作り直す。</p>
+<blockquote><p>**注** （ベクトル解析を知っている読者へ）通常のベクトル解析で面の向きや外積として扱われる操作の多くは、この <span class="tex2jax_process">$\ast$</span> が与える対応として読み直せる。ただし本章では、それらを既知の公式として使うのではなく、<span class="tex2jax_process">$g$</span> と第2章の基底 <span class="tex2jax_process">$2$</span>-form から作り直す。</p>
 </p></blockquote>
-<h4 id="632-行列から-を構成する">6.3.2 行列から $\ast$ を構成する</h4>
-<p>付録Aで、我々は $2$-form を行列表示する方法を学んだ。$dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ という $3$ つの基底 $2$-form は、それぞれ $3 \times 3$ の反対称行列で表現できるのだった。
+<h4 id="632-行列から-span-classtex2jaxprocessspan-を構成する">6.3.2 行列から <span class="tex2jax_process">$\ast$</span> を構成する</h4>
+<p>付録Aで、我々は <span class="tex2jax_process">$2$</span>-form を行列表示する方法を学んだ。<span class="tex2jax_process">$dy \wedge dz$</span>, <span class="tex2jax_process">$dz \wedge dx$</span>, <span class="tex2jax_process">$dx \wedge dy$</span> という <span class="tex2jax_process">$3$</span> つの基底 <span class="tex2jax_process">$2$</span>-form は、それぞれ <span class="tex2jax_process">$3 \times 3$</span> の反対称行列で表現できるのだった。
 </p>
-<p>さて、ここで素朴な問いを立てよう。任意の $1$-form $\omega = P\,dx + Q\,dy + R\,dz$ は、本書の流儀により係数の横ベクトル $\begin{pmatrix} P & Q & R \end{pmatrix}$ として書ける。この横ベクトルの各成分を、対応する基底 $2$-form の行列の係数として分配する——つまり、$P$ を $dy \wedge dz$ の行列に、$Q$ を $dz \wedge dx$ の行列に、$R$ を $dx \wedge dy$ の行列に掛けて足し合わせる——操作を考えよう。
+<p>さて、ここで素朴な問いを立てよう。任意の <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> は、本書の流儀により係数の横ベクトル <span class="tex2jax_process">$\begin{pmatrix} P & Q & R \end{pmatrix}$</span> として書ける。この横ベクトルの各成分を、対応する基底 <span class="tex2jax_process">$2$</span>-form の行列の係数として分配する——つまり、<span class="tex2jax_process">$P$</span> を <span class="tex2jax_process">$dy \wedge dz$</span> の行列に、<span class="tex2jax_process">$Q$</span> を <span class="tex2jax_process">$dz \wedge dx$</span> の行列に、<span class="tex2jax_process">$R$</span> を <span class="tex2jax_process">$dx \wedge dy$</span> の行列に掛けて足し合わせる——操作を考えよう。
 </p>
 <p>行列で書けば、
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \ast\omega
 = P
 \begin{pmatrix}
@@ -3214,251 +3009,218 @@ R
 -1 & 0 & 0 \\
 0 & 0 & 0
 \end{pmatrix}
-$$
-</p>
-<p>これは、横ベクトルの成分を3枚の反対称行列へそのまま分配する、単純な線形結合に他ならない。これを $\ast$ という記号で書こう。
+$$</div>
+<p>これは、横ベクトルの成分を3枚の反対称行列へそのまま分配する、単純な線形結合に他ならない。これを <span class="tex2jax_process">$\ast$</span> という記号で書こう。
 </p>
 <p>実際に計算すると、
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \ast\omega =
 \begin{pmatrix}
 0 & R & -Q \\
 -R & 0 & P \\
 Q & -P & 0
 \end{pmatrix}
-$$
+$$</div>
+<p>この <span class="tex2jax_process">$3 \times 3$</span> の反対称行列が、<span class="tex2jax_process">$\ast\omega$</span> の行列表現である。元の <span class="tex2jax_process">$1$</span>-form の係数 <span class="tex2jax_process">$P, Q, R$</span> が、行列の決まった位置にそのまま収まっている。第2章 §2.4.9 で見たクロス積の成分と同じ並びがここにも現れている。
 </p>
-<p>この $3 \times 3$ の反対称行列が、$\ast\omega$ の行列表現である。元の $1$-form の係数 $P, Q, R$ が、行列の決まった位置にそのまま収まっている。第2章 §2.4.9 で見たクロス積の成分と同じ並びがここにも現れている。
-</p>
-<blockquote><p>**注** （$\ast$ の幾何学的意味）$\ast\omega$ が表す $2$-form は、$\omega$ の係数ベクトル $(P, Q, R)$ に直交する平面を測る面積測定器である。$x$ 軸方向の線分（$dx$）に対応するのは $x$ 軸に垂直な面（$dy \wedge dz$）。ベクトル解析で $3$ 成分の矢印として扱われる量は、本書の言葉ではこの面積測定器の情報を読み替えたものだ。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$\ast$</span> の幾何学的意味）<span class="tex2jax_process">$\ast\omega$</span> が表す <span class="tex2jax_process">$2$</span>-form は、<span class="tex2jax_process">$\omega$</span> の係数ベクトル <span class="tex2jax_process">$(P, Q, R)$</span> に直交する平面を測る面積測定器である。<span class="tex2jax_process">$x$</span> 軸方向の線分（<span class="tex2jax_process">$dx$</span>）に対応するのは <span class="tex2jax_process">$x$</span> 軸に垂直な面（<span class="tex2jax_process">$dy \wedge dz$</span>）。ベクトル解析で <span class="tex2jax_process">$3$</span> 成分の矢印として扱われる量は、本書の言葉ではこの面積測定器の情報を読み替えたものだ。</p>
 </p></blockquote>
-<h4 id="633-実空間での-辞書">6.3.3 実空間での $\ast$ 辞書</h4>
-<p>§6.3.2 で行ったのは、$1$-form の係数を $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ という三つの面積測定器へ分配することだった。同じ手順を基底 $1$-form に対して繰り返す。すなわち、$dx$ なら第1成分だけを、$dy$ なら第2成分だけを、$dz$ なら第3成分だけを取り出せばよい。
+<h4 id="633-実空間での-span-classtex2jaxprocessspan-辞書">6.3.3 実空間での <span class="tex2jax_process">$\ast$</span> 辞書</h4>
+<p>§6.3.2 で行ったのは、<span class="tex2jax_process">$1$</span>-form の係数を <span class="tex2jax_process">$dy \wedge dz$</span>, <span class="tex2jax_process">$dz \wedge dx$</span>, <span class="tex2jax_process">$dx \wedge dy$</span> という三つの面積測定器へ分配することだった。同じ手順を基底 <span class="tex2jax_process">$1$</span>-form に対して繰り返す。すなわち、<span class="tex2jax_process">$dx$</span> なら第1成分だけを、<span class="tex2jax_process">$dy$</span> なら第2成分だけを、<span class="tex2jax_process">$dz$</span> なら第3成分だけを取り出せばよい。
 </p>
-<p>成分をすべて追いたい読者は付録Dの行列表示を確認してほしい。ここでは結果だけを $dx,dy,dz$ の言葉で書けば、次の簡潔な辞書になる。
+<p>成分をすべて追いたい読者は付録Dの行列表示を確認してほしい。ここでは結果だけを <span class="tex2jax_process">$dx,dy,dz$</span> の言葉で書けば、次の簡潔な辞書になる。
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast(1) &= dx \wedge dy \wedge dz, \qquad &\ast(dx \wedge dy \wedge dz) &= 1 \\
 \ast(dx) &= dy \wedge dz, \qquad &\ast(dy \wedge dz) &= dx \\
 \ast(dy) &= dz \wedge dx, \qquad &\ast(dz \wedge dx) &= dy \\
 \ast(dz) &= dx \wedge dy, \qquad &\ast(dx \wedge dy) &= dz
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>この辞書の意味するところは単純だ。<span class="tex2jax_process">$x$</span> 軸方向の線分（<span class="tex2jax_process">$dx$</span>）に対応するのは、<span class="tex2jax_process">$x$</span> 軸に垂直な面（<span class="tex2jax_process">$dy \wedge dz$</span>）である。同様に <span class="tex2jax_process">$y \leftrightarrow dz \wedge dx$</span>、<span class="tex2jax_process">$z \leftrightarrow dx \wedge dy$</span>。そしてスカラー <span class="tex2jax_process">$1$</span>（<span class="tex2jax_process">$0$</span>-form）と体積要素 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span>（<span class="tex2jax_process">$3$</span>-form）が互いに対応する。これがまさに、第2章で見た独立成分数 <span class="tex2jax_process">$1, 3, 3, 1$</span> の対称性の現れである。
 </p>
-<p>この辞書の意味するところは単純だ。$x$ 軸方向の線分（$dx$）に対応するのは、$x$ 軸に垂直な面（$dy \wedge dz$）である。同様に $y \leftrightarrow dz \wedge dx$、$z \leftrightarrow dx \wedge dy$。そしてスカラー $1$（$0$-form）と体積要素 $dx \wedge dy \wedge dz$（$3$-form）が互いに対応する。これがまさに、第2章で見た独立成分数 $1, 3, 3, 1$ の対称性の現れである。
-</p>
-<blockquote><p>**注** （なぜこの辞書でよいのか）$\ast dx = dy \wedge dz$ となるのは、$dx,dy,dz$ が正規直交基底（互いに直交し、長さ $1$）であり、かつ空間の向きを $dx \wedge dy \wedge dz$ が正となる右手系にとっているからだ。この条件のもとでは、上の辞書が一意的に定まる。パラメータ空間まで考慮すると、$\ast$ の辞書は計量 $g$ と空間の向きの選び方に依存する——言い換えると、$g$ が $I$ でなければ、辞書の係数はもっと複雑になる。</p>
+<blockquote><p>**注** （なぜこの辞書でよいのか）<span class="tex2jax_process">$\ast dx = dy \wedge dz$</span> となるのは、<span class="tex2jax_process">$dx,dy,dz$</span> が正規直交基底（互いに直交し、長さ <span class="tex2jax_process">$1$</span>）であり、かつ空間の向きを <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> が正となる右手系にとっているからだ。この条件のもとでは、上の辞書が一意的に定まる。パラメータ空間まで考慮すると、<span class="tex2jax_process">$\ast$</span> の辞書は計量 <span class="tex2jax_process">$g$</span> と空間の向きの選び方に依存する——言い換えると、<span class="tex2jax_process">$g$</span> が <span class="tex2jax_process">$I$</span> でなければ、辞書の係数はもっと複雑になる。</p>
 </p></blockquote>
-<h4 id="634">6.3.4 $\ast\ast = \mathrm{id}$</h4>
-<p>上の辞書から直ちにわかるように、$\ast$ を二度続けて作用させると元に戻る：
+<h4 id="634-span-classtex2jaxprocessspan">6.3.4 <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span></h4>
+<p>上の辞書から直ちにわかるように、<span class="tex2jax_process">$\ast$</span> を二度続けて作用させると元に戻る：
 </p>
-<p>$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx$$
-</p>
-<p>一般に、3次元デカルト実空間では $\ast\ast = \mathrm{id}$（恒等演算子）が成り立つ。$\ast$ を $1$ 回適用すれば形式の次数が反転し、$2$ 回適用すれば元に戻る。
+<div class="math-block tex2jax_process">$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx$$</div>
+<p>一般に、3次元デカルト実空間では <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span>（恒等演算子）が成り立つ。<span class="tex2jax_process">$\ast$</span> を <span class="tex2jax_process">$1$</span> 回適用すれば形式の次数が反転し、<span class="tex2jax_process">$2$</span> 回適用すれば元に戻る。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — §6.3】**</p>
-- スカラーを得る方法には二つある。方法①は横×縦の作用でスカラーを得る。方法②は同種ベクトルの内積として読み、そこに計量 $g$ が現れる。
-- 第2章で見た $1,3,3,1$ の対称性は、独立成分数が同じ $1$-form と $2$-form のあいだに対応をつけられることを示唆している。
-- ホッジ・スター $\ast$ は、$1$-form の係数をそのまま $2$-form の基底行列に分配する演算として構成できる。行列表現は外積行列に一致する。
-- 実空間での $\ast$ 辞書：$\ast dx = dy \wedge dz$ など。$\ast\ast = \mathrm{id}$。
+- スカラーを得る方法には二つある。方法①は横×縦の作用でスカラーを得る。方法②は同種ベクトルの内積として読み、そこに計量 <span class="tex2jax_process">$g$</span> が現れる。
+- 第2章で見た <span class="tex2jax_process">$1,3,3,1$</span> の対称性は、独立成分数が同じ <span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form のあいだに対応をつけられることを示唆している。
+- ホッジ・スター <span class="tex2jax_process">$\ast$</span> は、<span class="tex2jax_process">$1$</span>-form の係数をそのまま <span class="tex2jax_process">$2$</span>-form の基底行列に分配する演算として構成できる。行列表現は外積行列に一致する。
+- 実空間での <span class="tex2jax_process">$\ast$</span> 辞書：<span class="tex2jax_process">$\ast dx = dy \wedge dz$</span> など。<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span>。
 </p></blockquote>
-<h4 id="635-の性質">6.3.5 $\ast$ の性質</h4>
-<p>§6.2.3 で内積の性質を、第5章で外微分 $d$ の性質をまとめたのに倣い、$\ast$ についてもここまでの構成から浮かび上がる性質を整理しておく。
+<h4 id="635-span-classtex2jaxprocessspan-の性質">6.3.5 <span class="tex2jax_process">$\ast$</span> の性質</h4>
+<p>§6.2.3 で内積の性質を、第5章で外微分 <span class="tex2jax_process">$d$</span> の性質をまとめたのに倣い、<span class="tex2jax_process">$\ast$</span> についてもここまでの構成から浮かび上がる性質を整理しておく。
 </p>
 <ol>
-<li>**次数の反転**：3次元空間において、$\ast$ は $0$-form $\leftrightarrow$ $3$-form を、$1$-form $\leftrightarrow$ $2$-form を対応させる。一般に $k$-form を $(3-k)$-form へ送る。</li>
+<li>**次数の反転**：3次元空間において、<span class="tex2jax_process">$\ast$</span> は <span class="tex2jax_process">$0$</span>-form <span class="tex2jax_process">$\leftrightarrow$</span> <span class="tex2jax_process">$3$</span>-form を、<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\leftrightarrow$</span> <span class="tex2jax_process">$2$</span>-form を対応させる。一般に <span class="tex2jax_process">$k$</span>-form を <span class="tex2jax_process">$(3-k)$</span>-form へ送る。</li>
 </ol>
 <ol>
-<li>**線形性**：$\ast(\omega_1 + \omega_2) = \ast\omega_1 + \ast\omega_2$。§6.3.2 で見たように、$\ast$ は係数を基底行列に分配するだけの操作であり、線形性は自明である。</li>
+<li>**線形性**：<span class="tex2jax_process">$\ast(\omega_1 + \omega_2) = \ast\omega_1 + \ast\omega_2$</span>。§6.3.2 で見たように、<span class="tex2jax_process">$\ast$</span> は係数を基底行列に分配するだけの操作であり、線形性は自明である。</li>
 </ol>
 <ol>
-<li>**$\ast\ast = \mathrm{id}$**：二度作用させると元に戻る（§6.3.4）。これは正規直交基底かつ右手系という条件のもとで成り立ち、付録D の D.6 節ではフロベニウス積を通じて代数的にも確認できる。</li>
+<li>**<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span>**：二度作用させると元に戻る（§6.3.4）。これは正規直交基底かつ右手系という条件のもとで成り立ち、付録D の D.6 節ではフロベニウス積を通じて代数的にも確認できる。</li>
 </ol>
 <ol>
-<li>**計量 $g$ への依存**：$\ast$ の辞書は空間の計量 $g$ によって決まる。デカルト座標（$g=I$）では §6.3.3 の簡潔な辞書で済むが、一般の座標系では $\ast$ の係数は場所の関数になる。この一般の場合については第9章で詳しく扱う。</li>
+<li>**計量 <span class="tex2jax_process">$g$</span> への依存**：<span class="tex2jax_process">$\ast$</span> の辞書は空間の計量 <span class="tex2jax_process">$g$</span> によって決まる。デカルト座標（<span class="tex2jax_process">$g=I$</span>）では §6.3.3 の簡潔な辞書で済むが、一般の座標系では <span class="tex2jax_process">$\ast$</span> の係数は場所の関数になる。この一般の場合については第9章で詳しく扱う。</li>
 </ol>
-<p>これらの性質は、$\ast$ が単なる「辞書」ではなく、計量と向きを備えた空間における<strong>次数の折り返し構造</strong>そのものであることを示している。
+<p>これらの性質は、<span class="tex2jax_process">$\ast$</span> が単なる「辞書」ではなく、計量と向きを備えた空間における<strong>次数の折り返し構造</strong>そのものであることを示している。
 </p>
 <hr />
 <h3 id="64-対応の実例微分形式とベクトル解析">§6.4 対応の実例——微分形式とベクトル解析</h3>
-<h4 id="641-ジュール熱-二つの経路">6.4.1 ジュール熱 $P=VI$ ——二つの経路</h4>
-<p>$\ast$ が具体的にどのように微分形式と同種ベクトルの内積表示を繫いでいるか、実際の計算で確かめよう。
-</p>
-<blockquote><p>**注** （電磁気学を知らなくてよい）ここから先、説明のために電磁気学の用語を天下り的に使う。まだ物理を学んでいない読者や、ベクトル解析で電磁気学を学んだ読者も、数式の意味を完全に理解する必要はない。$\ast$ が計算の構造の中でどう働くかを見てほしい。</p>
+<h4 id="641-ジュール熱-span-classtex2jaxprocessspan-二つの経路">6.4.1 ジュール熱 <span class="tex2jax_process">$P=VI$</span> ——二つの経路</h4>
+<span class="tex2jax_process">$\ast$</span> が具体的にどのように微分形式と同種ベクトルの内積表示を繫いでいるか、実際の計算で確かめよう。
+<blockquote><p>**注** （電磁気学を知らなくてよい）ここから先、説明のために電磁気学の用語を天下り的に使う。まだ物理を学んでいない読者や、ベクトル解析で電磁気学を学んだ読者も、数式の意味を完全に理解する必要はない。<span class="tex2jax_process">$\ast$</span> が計算の構造の中でどう働くかを見てほしい。</p>
 </p></blockquote>
-<p>高校物理で学ぶ「電力 = 電圧 × 電流（$P=VI$）」を、空間の各点で起こる現象として見直す。
+<p>高校物理で学ぶ「電力 = 電圧 × 電流（<span class="tex2jax_process">$P=VI$</span>）」を、空間の各点で起こる現象として見直す。
 </p>
 <ul>
-<li>電圧の起源である**電場 $E$** は、線分に沿って数え上げる **$1$-form** である。</li>
+<li>電圧の起源である**電場 <span class="tex2jax_process">$E$</span>** は、線分に沿って数え上げる **<span class="tex2jax_process">$1$</span>-form** である。</li>
 </ol>
 <ul>
-<li>電流の起源である**電流密度 $J$** は、面を貫く電荷を数え上げる **$2$-form** である。</li>
+<li>電流の起源である**電流密度 <span class="tex2jax_process">$J$</span>** は、面を貫く電荷を数え上げる **<span class="tex2jax_process">$2$</span>-form** である。</li>
 </ol>
-<p>まず、<strong>方法①（微分形式）</strong>で計算してみよう。$1$-form $E$ と $2$-form $J$ のウェッジ積をとる。
+<p>まず、<strong>方法①（微分形式）</strong>で計算してみよう。<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$E$</span> と <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$J$</span> のウェッジ積をとる。
 </p>
-<p>$$E \wedge J$$
+<div class="math-block tex2jax_process">$$E \wedge J$$</div>
+<span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form のウェッジ積は <span class="tex2jax_process">$3$</span>-form（体積密度）になる。これは「単位体積あたりの電力（W/m³）」を意味する。これを空間領域で積分（<span class="tex2jax_process">$\int_V E \wedge J$</span>）すれば、空間全体の消費電力（ワット）が得られる。この経路で使っているのは、<span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form をウェッジ積で <span class="tex2jax_process">$3$</span>-form にする操作だけである。
+<p>次に、<strong>方法②（同種ベクトルの内積）</strong>で同じ計算をどう行うか見てみよう。<span class="tex2jax_process">$E$</span> と <span class="tex2jax_process">$J$</span> をどちらも <span class="tex2jax_process">$1$</span>-form のように扱って内積をとるには、面を測る <span class="tex2jax_process">$J$</span> を <span class="tex2jax_process">$\ast$</span> で線を測る形式へ変換する：
 </p>
-<p>$1$-form と $2$-form のウェッジ積は $3$-form（体積密度）になる。これは「単位体積あたりの電力（W/m³）」を意味する。これを空間領域で積分（$\int_V E \wedge J$）すれば、空間全体の消費電力（ワット）が得られる。この経路で使っているのは、$1$-form と $2$-form をウェッジ積で $3$-form にする操作だけである。
+<div class="math-block tex2jax_process">$$\text{ベクトル } J \longleftrightarrow \ast J$$</div>
+<p>これで <span class="tex2jax_process">$E$</span> と <span class="tex2jax_process">$\ast J$</span> という二つの <span class="tex2jax_process">$1$</span>-form が揃った。これらの内積（ドット積）をとる。微分形式で <span class="tex2jax_process">$1$</span>-form の内積を書くには、一方に <span class="tex2jax_process">$\ast$</span> をかけて <span class="tex2jax_process">$2$</span>-form にし、ウェッジ積で <span class="tex2jax_process">$3$</span>-form にしてから、全体に <span class="tex2jax_process">$\ast$</span> で <span class="tex2jax_process">$0$</span>-form に落とす：
 </p>
-<p>次に、<strong>方法②（同種ベクトルの内積）</strong>で同じ計算をどう行うか見てみよう。$E$ と $J$ をどちらも $1$-form のように扱って内積をとるには、面を測る $J$ を $\ast$ で線を測る形式へ変換する：
+<div class="math-block tex2jax_process">$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$</div>
+<p>ここで <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> により、内側の <span class="tex2jax_process">$\ast(\ast J) = J$</span> となる：
 </p>
-<p>$$\text{ベクトル } J \longleftrightarrow \ast J$$
+<div class="math-block tex2jax_process">$$\ast(E \wedge J)$$</div>
+<p>カッコの中身 <span class="tex2jax_process">$E \wedge J$</span> は、方法①で得た <span class="tex2jax_process">$3$</span>-form と全く同じものだ。外側の <span class="tex2jax_process">$\ast$</span> は、<span class="tex2jax_process">$3$</span>-form から体積要素 <span class="tex2jax_process">$dx \wedge dy \wedge dz$</span> を剥ぎ取り、スカラー値を取り出している。スカラー <span class="tex2jax_process">$E \cdot J$</span> に微小体積 <span class="tex2jax_process">$dV$</span> を掛け直して積分する書き方は、この <span class="tex2jax_process">$3$</span>-form が持っていた体積要素を後から補っている、と読める。
 </p>
-<p>これで $E$ と $\ast J$ という二つの $1$-form が揃った。これらの内積（ドット積）をとる。微分形式で $1$-form の内積を書くには、一方に $\ast$ をかけて $2$-form にし、ウェッジ積で $3$-form にしてから、全体に $\ast$ で $0$-form に落とす：
+<strong>つまり、<span class="tex2jax_process">$\ast$</span> は方法①の <span class="tex2jax_process">$3$</span>-form と方法②のスカラー表示を矛盾なく繫いでいる。</strong> <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> があるからこそ、どちらの経路を通っても同じ結果に至るのだ。
+<h4 id="642-ヘリシティ-span-classtex2jaxprocessspan-span-classtex2jaxprocessspan-の往復">6.4.2 ヘリシティ <span class="tex2jax_process">$A \cdot (\nabla \times A)$</span> ——<span class="tex2jax_process">$\ast$</span> の往復</h4>
+<p>もう一つの例で、<span class="tex2jax_process">$\ast$</span> の働きをさらに見てみよう。<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\alpha$</span> と、その外微分 <span class="tex2jax_process">$d\alpha$</span> を組み合わせた次の <span class="tex2jax_process">$3$</span>-form を考える：
 </p>
-<p>$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
+<div class="math-block tex2jax_process">$$\alpha \wedge d\alpha$$</div>
+<p>この形は、方法②の言葉で書けば、ベクトル場 <span class="tex2jax_process">$\mathbf{A}$</span> とその回転の内積として現れる。
 </p>
-<p>ここで $\ast\ast = \mathrm{id}$ により、内側の $\ast(\ast J) = J$ となる：
+<div class="math-block tex2jax_process">$$\mathbf{A} \cdot (\nabla \times \mathbf{A})$$</div>
+<p>ここで <span class="tex2jax_process">$\mathbf{A}$</span> に対応する <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$\alpha$</span> と書く。<span class="tex2jax_process">$d\alpha$</span> はまず <span class="tex2jax_process">$2$</span>-form として得られ、方法②の言葉では <span class="tex2jax_process">$\ast d\alpha$</span> という <span class="tex2jax_process">$1$</span>-form と対応する。
 </p>
-<p>$$\ast(E \wedge J)$$
+<p>まず<strong>方法①</strong>で計算する。<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\alpha$</span> と <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$d\alpha$</span> のウェッジ積：
 </p>
-<p>カッコの中身 $E \wedge J$ は、方法①で得た $3$-form と全く同じものだ。外側の $\ast$ は、$3$-form から体積要素 $dx \wedge dy \wedge dz$ を剥ぎ取り、スカラー値を取り出している。スカラー $E \cdot J$ に微小体積 $dV$ を掛け直して積分する書き方は、この $3$-form が持っていた体積要素を後から補っている、と読める。
+<div class="math-block tex2jax_process">$$\alpha \wedge d\alpha$$</div>
+<span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form のウェッジ積は <span class="tex2jax_process">$3$</span>-form。この経路では、<span class="tex2jax_process">$\alpha$</span> と <span class="tex2jax_process">$d\alpha$</span> をそのままウェッジ積で組み合わせている。
+<p>次に<strong>方法②</strong>で同じ計算の内部構造を見る。同種ベクトルの内積として読むには、<span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$d\alpha$</span> をそのまま置けないので、<span class="tex2jax_process">$\ast d\alpha$</span> という <span class="tex2jax_process">$1$</span>-form を対応させる：
 </p>
-<strong>つまり、$\ast$ は方法①の $3$-form と方法②のスカラー表示を矛盾なく繫いでいる。</strong> $\ast\ast = \mathrm{id}$ があるからこそ、どちらの経路を通っても同じ結果に至るのだ。
-<h4 id="642-ヘリシティ--の往復">6.4.2 ヘリシティ $A \cdot (\nabla \times A)$ ——$\ast$ の往復</h4>
-<p>もう一つの例で、$\ast$ の働きをさらに見てみよう。$1$-form $\alpha$ と、その外微分 $d\alpha$ を組み合わせた次の $3$-form を考える：
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{A} \longleftrightarrow \ast d\alpha$$</div>
+<p>これで <span class="tex2jax_process">$\alpha$</span> と <span class="tex2jax_process">$\ast d\alpha$</span> という二つの <span class="tex2jax_process">$1$</span>-form が揃った。内積をとる：
 </p>
-<p>$$\alpha \wedge d\alpha$$
+<div class="math-block tex2jax_process">$$\mathbf{A} \cdot (\nabla \times \mathbf{A}) \longleftrightarrow \ast(\alpha \wedge \ast(\ast d\alpha))$$</div>
+<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> により内側の <span class="tex2jax_process">$\ast(\ast d\alpha) = d\alpha$</span>。したがって、
+<div class="math-block tex2jax_process">$$\ast(\alpha \wedge d\alpha)$$</div>
+<p>カッコの中身は、方法①の <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\alpha \wedge d\alpha$</span> と同じものだ。外側の <span class="tex2jax_process">$\ast$</span> が体積要素を剥ぎ取り、スカラー値を取り出している。
 </p>
-<p>この形は、方法②の言葉で書けば、ベクトル場 $\mathbf{A}$ とその回転の内積として現れる。
-</p>
-<p>$$\mathbf{A} \cdot (\nabla \times \mathbf{A})$$
-</p>
-<p>ここで $\mathbf{A}$ に対応する $1$-form を $\alpha$ と書く。$d\alpha$ はまず $2$-form として得られ、方法②の言葉では $\ast d\alpha$ という $1$-form と対応する。
-</p>
-<p>まず<strong>方法①</strong>で計算する。$1$-form $\alpha$ と $2$-form $d\alpha$ のウェッジ積：
-</p>
-<p>$$\alpha \wedge d\alpha$$
-</p>
-<p>$1$-form と $2$-form のウェッジ積は $3$-form。この経路では、$\alpha$ と $d\alpha$ をそのままウェッジ積で組み合わせている。
-</p>
-<p>次に<strong>方法②</strong>で同じ計算の内部構造を見る。同種ベクトルの内積として読むには、$2$-form $d\alpha$ をそのまま置けないので、$\ast d\alpha$ という $1$-form を対応させる：
-</p>
-<p>$$\nabla \times \mathbf{A} \longleftrightarrow \ast d\alpha$$
-</p>
-<p>これで $\alpha$ と $\ast d\alpha$ という二つの $1$-form が揃った。内積をとる：
-</p>
-<p>$$\mathbf{A} \cdot (\nabla \times \mathbf{A}) \longleftrightarrow \ast(\alpha \wedge \ast(\ast d\alpha))$$
-</p>
-<p>$\ast\ast = \mathrm{id}$ により内側の $\ast(\ast d\alpha) = d\alpha$。したがって、
-</p>
-<p>$$\ast(\alpha \wedge d\alpha)$$
-</p>
-<p>カッコの中身は、方法①の $3$-form $\alpha \wedge d\alpha$ と同じものだ。外側の $\ast$ が体積要素を剥ぎ取り、スカラー値を取り出している。
-</p>
-<strong>ここで注目すべきは、$\ast$ が $2$ 回現れて、$\ast\ast = \mathrm{id}$ により打ち消し合っていることだ。</strong> 方法②の内部では、$d\alpha$（$2$-form）に対応する $1$-form として $\ast d\alpha$ を使い、内積をとるために再び $\ast$ を呼び出している。この往復が、$\ast\ast = \mathrm{id}$ によって帳消しになるのである。
-<blockquote><p>**注** （$\ast$ の往復が起きる理由）ベクトル解析は「形式の次数」という概念を持たず、すべてを「$3$ 成分の矢印」として統一的に扱う。$2$-form を矢印として読むには $\ast$ で対応する $1$-form を作る必要があり、内積計算のためにはまた $\ast$ で元の次数へ戻る必要がある。$\ast$ とは、この二つの表し方を結ぶ一つの対応なのである。</p>
+<strong>ここで注目すべきは、<span class="tex2jax_process">$\ast$</span> が <span class="tex2jax_process">$2$</span> 回現れて、<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> により打ち消し合っていることだ。</strong> 方法②の内部では、<span class="tex2jax_process">$d\alpha$</span>（<span class="tex2jax_process">$2$</span>-form）に対応する <span class="tex2jax_process">$1$</span>-form として <span class="tex2jax_process">$\ast d\alpha$</span> を使い、内積をとるために再び <span class="tex2jax_process">$\ast$</span> を呼び出している。この往復が、<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> によって帳消しになるのである。
+<blockquote><p>**注** （<span class="tex2jax_process">$\ast$</span> の往復が起きる理由）ベクトル解析は「形式の次数」という概念を持たず、すべてを「<span class="tex2jax_process">$3$</span> 成分の矢印」として統一的に扱う。<span class="tex2jax_process">$2$</span>-form を矢印として読むには <span class="tex2jax_process">$\ast$</span> で対応する <span class="tex2jax_process">$1$</span>-form を作る必要があり、内積計算のためにはまた <span class="tex2jax_process">$\ast$</span> で元の次数へ戻る必要がある。<span class="tex2jax_process">$\ast$</span> とは、この二つの表し方を結ぶ一つの対応なのである。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント — §6.4】**</p>
-- ジュール熱の計算では、方法①（$E \wedge J$）と方法②（$E \cdot J = \ast(E \wedge J)$）が $\ast$ を通じて一致する。
-- ヘリシティの計算では、$\ast$ が $2$ 回使われ $\ast\ast = \mathrm{id}$ で打ち消し合う。方法①（$\alpha \wedge d\alpha$）と方法②（$\mathbf{A} \cdot (\nabla \times \mathbf{A})$）は同じ結果を与える。
-- $\ast$ は微分形式とベクトル解析を繫ぐ対応であり、$\ast\ast = \mathrm{id}$ が往復の整合性を保証している。
+- ジュール熱の計算では、方法①（<span class="tex2jax_process">$E \wedge J$</span>）と方法②（<span class="tex2jax_process">$E \cdot J = \ast(E \wedge J)$</span>）が <span class="tex2jax_process">$\ast$</span> を通じて一致する。
+- ヘリシティの計算では、<span class="tex2jax_process">$\ast$</span> が <span class="tex2jax_process">$2$</span> 回使われ <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> で打ち消し合う。方法①（<span class="tex2jax_process">$\alpha \wedge d\alpha$</span>）と方法②（<span class="tex2jax_process">$\mathbf{A} \cdot (\nabla \times \mathbf{A})$</span>）は同じ結果を与える。
+- <span class="tex2jax_process">$\ast$</span> は微分形式とベクトル解析を繫ぐ対応であり、<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> が往復の整合性を保証している。
 </p></blockquote>
 <hr />
 <h3 id="65-ナブラの三兄弟を解体する">§6.5 ナブラの三兄弟を解体する</h3>
-<p>ここまでで $d$（第5章）と $\ast$（本章）という二つの演算子が揃った。この二つを組み合わせることで、勾配（grad）、回転（rot）、発散（div）という三つの演算が、一つの統一的な枠組みで書けるようになる。
+<p>ここまでで <span class="tex2jax_process">$d$</span>（第5章）と <span class="tex2jax_process">$\ast$</span>（本章）という二つの演算子が揃った。この二つを組み合わせることで、勾配（grad）、回転（rot）、発散（div）という三つの演算が、一つの統一的な枠組みで書けるようになる。
 </p>
-<blockquote><p>**注** （ベクトル解析を知っている読者へ）ここで定義する grad, rot, div は、ベクトル解析で $\nabla f,\; \nabla \times \mathbf{F},\; \nabla \cdot \mathbf{F}$ と書かれるものと同一である。ベクトル解析をまだ学んでいない読者は、単に $d$ と $\ast$ の組み合わせとして理解すれば十分だ。</p>
+<blockquote><p>**注** （ベクトル解析を知っている読者へ）ここで定義する grad, rot, div は、ベクトル解析で <span class="tex2jax_process">$\nabla f,\; \nabla \times \mathbf{F},\; \nabla \cdot \mathbf{F}$</span> と書かれるものと同一である。ベクトル解析をまだ学んでいない読者は、単に <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の組み合わせとして理解すれば十分だ。</p>
 </p></blockquote>
-<p>以降、ベクトル場 $\mathbf{F} = (F_x, F_y, F_z)$ に対応する $1$-form を $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ と書く。
+<p>以降、ベクトル場 <span class="tex2jax_process">$\mathbf{F} = (F_x, F_y, F_z)$</span> に対応する <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$\omega = F_x\,dx + F_y\,dy + F_z\,dz$</span> と書く。
 </p>
-<h4 id="651-勾配">6.5.1 勾配 $\mathrm{grad}\,f = df$</h4>
-<p>これはすでに知っている。$0$-form（スカラー場）$f$ の外微分 $df$ は $1$-form であり、その係数は偏微分係数である：
+<h4 id="651-勾配-span-classtex2jaxprocessspan">6.5.1 勾配 <span class="tex2jax_process">$\mathrm{grad}\,f = df$</span></h4>
+<p>これはすでに知っている。<span class="tex2jax_process">$0$</span>-form（スカラー場）<span class="tex2jax_process">$f$</span> の外微分 <span class="tex2jax_process">$df$</span> は <span class="tex2jax_process">$1$</span>-form であり、その係数は偏微分係数である：
 </p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$</div>
+<p>この横ベクトルの成分 <span class="tex2jax_process">$(\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$</span> を<strong>勾配</strong>と呼び、<span class="tex2jax_process">$\mathrm{grad}\,f$</span> と書く。
 </p>
-<p>この横ベクトルの成分 $(\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ を<strong>勾配</strong>と呼び、$\mathrm{grad}\,f$ と書く。
+<div class="math-block tex2jax_process">$$\mathrm{grad}\,f = df$$</div>
+<span class="tex2jax_process">$d$</span> は次数を <span class="tex2jax_process">$0 \to 1$</span> に上げる。これが勾配の正体である。勾配では、<span class="tex2jax_process">$0$</span>-form から <span class="tex2jax_process">$1$</span>-form への外微分だけが現れる。
+<h4 id="652-回転-span-classtex2jaxprocessspan">6.5.2 回転 <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$</span></h4>
+<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> に <span class="tex2jax_process">$d$</span> を作用させると <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$d\omega$</span> が得られる。その係数は第5章で導いたとおり：
+<div class="math-block tex2jax_process">$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$</div>
+<p>ここに <span class="tex2jax_process">$\ast$</span> を作用させると、<span class="tex2jax_process">$2$</span>-form が <span class="tex2jax_process">$1$</span>-form に変換される。§6.3.3 の辞書を使えば：
 </p>
-<p>$$\mathrm{grad}\,f = df$$
+<div class="math-block tex2jax_process">$$\ast(d\omega) = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dx + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dy + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dz$$</div>
+<p>この <span class="tex2jax_process">$1$</span>-form の係数 <span class="tex2jax_process">$(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$</span> を<strong>回転</strong>と呼び、<span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F}$</span> と書く。
 </p>
-<p>$d$ は次数を $0 \to 1$ に上げる。これが勾配の正体である。勾配では、$0$-form から $1$-form への外微分だけが現れる。
+<div class="math-block tex2jax_process">$$\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$$</div>
+<span class="tex2jax_process">$\ast\,d$</span> は <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$1$</span>-form という、次数を上げてから下げる操作である。この「上げて下げる」が、まさに回転の代数構造だ。
+<h4 id="653-発散-span-classtex2jaxprocessspan">6.5.3 発散 <span class="tex2jax_process">$\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$</span></h4>
+<p>さらに <span class="tex2jax_process">$\ast\,d\,\ast$</span> と三つの演算子を連ねる。まず <span class="tex2jax_process">$\ast\,\omega$</span> で <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$2$</span>-form に変換し、<span class="tex2jax_process">$d$</span> で <span class="tex2jax_process">$3$</span>-form に上げ、最後に <span class="tex2jax_process">$\ast$</span> で <span class="tex2jax_process">$0$</span>-form（スカラー場）に落とす：
 </p>
-<h4 id="652-回転">6.5.2 回転 $\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$</h4>
-<p>$1$-form $\omega$ に $d$ を作用させると $2$-form $d\omega$ が得られる。その係数は第5章で導いたとおり：
+<div class="math-block tex2jax_process">$$\ast(d(\ast\omega)) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</div>
+<p>このスカラー場を<strong>発散</strong>と呼び、<span class="tex2jax_process">$\mathrm{div}\,\mathbf{F}$</span> と書く。
 </p>
-<p>$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
-</p>
-<p>ここに $\ast$ を作用させると、$2$-form が $1$-form に変換される。§6.3.3 の辞書を使えば：
-</p>
-<p>$$\ast(d\omega) = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dx + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dy + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dz$$
-</p>
-<p>この $1$-form の係数 $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ を<strong>回転</strong>と呼び、$\mathrm{rot}\,\mathbf{F}$ と書く。
-</p>
-<p>$$\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$$
-</p>
-<p>$\ast\,d$ は $1$-form $\to$ $2$-form $\to$ $1$-form という、次数を上げてから下げる操作である。この「上げて下げる」が、まさに回転の代数構造だ。
-</p>
-<h4 id="653-発散">6.5.3 発散 $\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$</h4>
-<p>さらに $\ast\,d\,\ast$ と三つの演算子を連ねる。まず $\ast\,\omega$ で $1$-form を $2$-form に変換し、$d$ で $3$-form に上げ、最後に $\ast$ で $0$-form（スカラー場）に落とす：
-</p>
-<p>$$\ast(d(\ast\omega)) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
-</p>
-<p>このスカラー場を<strong>発散</strong>と呼び、$\mathrm{div}\,\mathbf{F}$ と書く。
-</p>
-<p>$$\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$$
-</p>
-<p>$\ast\,d\,\ast$ は $1$-form $\to$ $2$-form $\to$ $3$-form $\to$ $0$-form という、次数を上げ続けてから一気に落とす操作である。
-</p>
-<blockquote><p>**注** （ベクトル解析を知っている読者へ）円柱座標や球座標での rot や div の公式が長くなる理由は、ここで明らかになったはずだ。rot は $\ast$ を $1$ 回、div は $\ast$ を $2$ 回使っている。$\ast$ の辞書は計量 $g$ に依存し、$g$ は $g = J^T J$ という場所の関数である。公式の複雑さは、裏で $\ast$ と $g$ が繰り返し適用されていることの結果に過ぎない。</p>
+<div class="math-block tex2jax_process">$$\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$$</div>
+<span class="tex2jax_process">$\ast\,d\,\ast$</span> は <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$3$</span>-form <span class="tex2jax_process">$\to$</span> <span class="tex2jax_process">$0$</span>-form という、次数を上げ続けてから一気に落とす操作である。
+<blockquote><p>**注** （ベクトル解析を知っている読者へ）円柱座標や球座標での rot や div の公式が長くなる理由は、ここで明らかになったはずだ。rot は <span class="tex2jax_process">$\ast$</span> を <span class="tex2jax_process">$1$</span> 回、div は <span class="tex2jax_process">$\ast$</span> を <span class="tex2jax_process">$2$</span> 回使っている。<span class="tex2jax_process">$\ast$</span> の辞書は計量 <span class="tex2jax_process">$g$</span> に依存し、<span class="tex2jax_process">$g$</span> は <span class="tex2jax_process">$g = J^T J$</span> という場所の関数である。公式の複雑さは、裏で <span class="tex2jax_process">$\ast$</span> と <span class="tex2jax_process">$g$</span> が繰り返し適用されていることの結果に過ぎない。</p>
 </p></blockquote>
-<h4 id="654-の当然の帰結">6.5.4 $d^2 = 0$ の当然の帰結</h4>
-<p>第5章で学んだ $d^2 = 0$ を思い出そう。この一つの事実から、二つの恒等式が自動的に導かれる。
+<h4 id="654-span-classtex2jaxprocessspan-の当然の帰結">6.5.4 <span class="tex2jax_process">$d^2 = 0$</span> の当然の帰結</h4>
+<p>第5章で学んだ <span class="tex2jax_process">$d^2 = 0$</span> を思い出そう。この一つの事実から、二つの恒等式が自動的に導かれる。
 </p>
-<p>$\mathrm{rot}(\mathrm{grad}\,f) = 0$ は、$\ast\,d\,(df) = \ast\,(d^2 f) = 0$ に他ならない。
-</p>
-<p>$\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$ も同様に、$\ast\,d\,\ast(\ast\,d\,\omega) = \ast\,d\,(d\,\omega) = \ast\,(d^2 \omega) = 0$ である。
-</p>
-<p>これらは「たまたま計算したらゼロになった」のではない。$d^2 = 0$ という一つの代数的真理が、ナブラの組み合わせの上に異なる二つの顔で現れているだけだ。
+<span class="tex2jax_process">$\mathrm{rot}(\mathrm{grad}\,f) = 0$</span> は、<span class="tex2jax_process">$\ast\,d\,(df) = \ast\,(d^2 f) = 0$</span> に他ならない。
+<span class="tex2jax_process">$\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</span> も同様に、<span class="tex2jax_process">$\ast\,d\,\ast(\ast\,d\,\omega) = \ast\,d\,(d\,\omega) = \ast\,(d^2 \omega) = 0$</span> である。
+<p>これらは「たまたま計算したらゼロになった」のではない。<span class="tex2jax_process">$d^2 = 0$</span> という一つの代数的真理が、ナブラの組み合わせの上に異なる二つの顔で現れているだけだ。
 </p>
 <hr />
 <h3 id="66-第II部の結び--第III部へ">§6.6 第II部の結び —— 第III部へ</h3>
-<p>我々は第5章で外微分 $d$ を、本章で計量 $g$ とホッジ・スター $\ast$ を手に入れた。この二つの演算子の組み合わせとして：
+<p>我々は第5章で外微分 <span class="tex2jax_process">$d$</span> を、本章で計量 <span class="tex2jax_process">$g$</span> とホッジ・スター <span class="tex2jax_process">$\ast$</span> を手に入れた。この二つの演算子の組み合わせとして：
 </p>
-<p>| 演算 | 分解 | 次数の遷移 | $\ast$ の使用回数 |
+<p>| 演算 | 分解 | 次数の遷移 | <span class="tex2jax_process">$\ast$</span> の使用回数 |
 |---|---|---|---|
-| $\mathrm{grad}$ | $d$ | $0 \to 1$ | 0回 |
-| $\mathrm{rot}$ | $\ast\,d$ | $1 \to 2 \to 1$ | 1回 |
-| $\mathrm{div}$ | $\ast\,d\,\ast$ | $1 \to 2 \to 3 \to 0$ | 2回 |
+| <span class="tex2jax_process">$\mathrm{grad}$</span> | <span class="tex2jax_process">$d$</span> | <span class="tex2jax_process">$0 \to 1$</span> | 0回 |
+| <span class="tex2jax_process">$\mathrm{rot}$</span> | <span class="tex2jax_process">$\ast\,d$</span> | <span class="tex2jax_process">$1 \to 2 \to 1$</span> | 1回 |
+| <span class="tex2jax_process">$\mathrm{div}$</span> | <span class="tex2jax_process">$\ast\,d\,\ast$</span> | <span class="tex2jax_process">$1 \to 2 \to 3 \to 0$</span> | 2回 |
 </p>
-<p>ナブラ $\nabla$ という一見謎めいた記号の正体は、$d$ と $\ast$ という二つの基本的な演算子の組み合わせに過ぎなかったのである。
+<p>ナブラ <span class="tex2jax_process">$\nabla$</span> という一見謎めいた記号の正体は、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> という二つの基本的な演算子の組み合わせに過ぎなかったのである。
 </p>
-<blockquote><p>**注** （ベクトル解析を知っている読者へ）微分形式で書けば grad = $d$、rot = $\ast d$、div = $\ast d \ast$ の三行で済む。通常の公式が座標系ごとに長く見えるのは、形式の次数をすべて $3$ 成分の矢印として表す過程で、$\ast$ と $g$ の計算が表に出るからである。その構造が見えていれば、公式を別々の暗記事項として扱わずに済む。</p>
+<blockquote><p>**注** （ベクトル解析を知っている読者へ）微分形式で書けば grad = <span class="tex2jax_process">$d$</span>、rot = <span class="tex2jax_process">$\ast d$</span>、div = <span class="tex2jax_process">$\ast d \ast$</span> の三行で済む。通常の公式が座標系ごとに長く見えるのは、形式の次数をすべて <span class="tex2jax_process">$3$</span> 成分の矢印として表す過程で、<span class="tex2jax_process">$\ast$</span> と <span class="tex2jax_process">$g$</span> の計算が表に出るからである。その構造が見えていれば、公式を別々の暗記事項として扱わずに済む。</p>
 </p></blockquote>
-<p>第III部では、この視点をさらに推し進める。第8章では第5章で得たストークスの定理 $\int_{\partial M} \omega = \int_M d\omega$ を、$\ast$ の辞書を通じて再考し、微積分学の基本定理・ケルビン–ストークスの定理・ガウスの発散定理がこの一本に集約されることを確認する。第9章では、円柱座標や球座標といったパラメータ空間での $\ast$ の辞書を具体的に構成し、実戦的な計算の道具立てを整える。
+<p>第III部では、この視点をさらに推し進める。第8章では第5章で得たストークスの定理 <span class="tex2jax_process">$\int_{\partial M} \omega = \int_M d\omega$</span> を、<span class="tex2jax_process">$\ast$</span> の辞書を通じて再考し、微積分学の基本定理・ケルビン–ストークスの定理・ガウスの発散定理がこの一本に集約されることを確認する。第9章では、円柱座標や球座標といったパラメータ空間での <span class="tex2jax_process">$\ast$</span> の辞書を具体的に構成し、実戦的な計算の道具立てを整える。
 </p>
-<blockquote><p>**注** （計量の符号を一つ変えるだけで）本章では正定値計量（$\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$）を前提とした。しかし特殊相対性理論の舞台である $4$ 次元時空では、時間成分だけ符号が反転した $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$ のような不定計量が登場する。本書は $3$ 次元デカルト実空間に固定しているためこれ以上踏み込まないが、本章で学んだ「行列 $\mathbf{g}$ を挟む」という発想は、そのまま $4$ 次元時空へと拡張可能である。必要になったとき、読者はこの章に立ち返ってほしい。</p>
+<blockquote><p>**注** （計量の符号を一つ変えるだけで）本章では正定値計量（<span class="tex2jax_process">$\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$</span> for <span class="tex2jax_process">$\mathbf{v} \neq 0$</span>）を前提とした。しかし特殊相対性理論の舞台である <span class="tex2jax_process">$4$</span> 次元時空では、時間成分だけ符号が反転した <span class="tex2jax_process">$\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$</span> のような不定計量が登場する。本書は <span class="tex2jax_process">$3$</span> 次元デカルト実空間に固定しているためこれ以上踏み込まないが、本章で学んだ「行列 <span class="tex2jax_process">$\mathbf{g}$</span> を挟む」という発想は、そのまま <span class="tex2jax_process">$4$</span> 次元時空へと拡張可能である。必要になったとき、読者はこの章に立ち返ってほしい。</p>
 </p></blockquote>
 <hr />
 <blockquote><p>**【ここまでのチェックポイント — 第6章全体】**</p>
 - 内積とは、同種のベクトル間（横×横、または縦×縦）で成分の積和をとる演算。横×縦の計算とは別物である。
-- 実空間では内積の行列は単位行列 $I$。パラメータ空間では $\mathbf{g}=J^T J$ により連鎖律だけから求まる。すなわち計量 $g$ とは、実空間へ引き戻して内積をとったとき、中央に現れる行列に他ならない。
-- $\mathbf{v}^T \mathbf{g}$ は縦ベクトルを横ベクトルに変換する。$g$ がなければ物体と計器は互いに変換不能である。
-- スカラーを得る方法には二つある：方法①（横×縦）と方法②（同種ベクトルの内積）。ホッジ・スター $\ast$ は両者を繫ぐ対応である。
-- $\ast$ は、$1$-form の係数を行列として $2$-form の基底に分配することで構成できる。実空間での辞書は $\ast dx = dy \wedge dz$ などであり、$\ast\ast = \mathrm{id}$ を満たす。
-- ジュール熱とヘリシティの計算例は、方法①と方法②が $\ast$ と $\ast\ast = \mathrm{id}$ を通じて同じ結果を与えることを示している。
-- $\mathrm{grad} = d$、$\mathrm{rot} = \ast\,d$、$\mathrm{div} = \ast\,d\,\ast$ であり、$d^2=0$ から $\mathrm{rot}(\mathrm{grad})=0$ と $\mathrm{div}(\mathrm{rot})=0$ が当然の帰結として導かれる。
+- 実空間では内積の行列は単位行列 <span class="tex2jax_process">$I$</span>。パラメータ空間では <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> により連鎖律だけから求まる。すなわち計量 <span class="tex2jax_process">$g$</span> とは、実空間へ引き戻して内積をとったとき、中央に現れる行列に他ならない。
+- <span class="tex2jax_process">$\mathbf{v}^T \mathbf{g}$</span> は縦ベクトルを横ベクトルに変換する。<span class="tex2jax_process">$g$</span> がなければ物体と計器は互いに変換不能である。
+- スカラーを得る方法には二つある：方法①（横×縦）と方法②（同種ベクトルの内積）。ホッジ・スター <span class="tex2jax_process">$\ast$</span> は両者を繫ぐ対応である。
+- <span class="tex2jax_process">$\ast$</span> は、<span class="tex2jax_process">$1$</span>-form の係数を行列として <span class="tex2jax_process">$2$</span>-form の基底に分配することで構成できる。実空間での辞書は <span class="tex2jax_process">$\ast dx = dy \wedge dz$</span> などであり、<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> を満たす。
+- ジュール熱とヘリシティの計算例は、方法①と方法②が <span class="tex2jax_process">$\ast$</span> と <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> を通じて同じ結果を与えることを示している。
+- <span class="tex2jax_process">$\mathrm{grad} = d$</span>、<span class="tex2jax_process">$\mathrm{rot} = \ast\,d$</span>、<span class="tex2jax_process">$\mathrm{div} = \ast\,d\,\ast$</span> であり、<span class="tex2jax_process">$d^2=0$</span> から <span class="tex2jax_process">$\mathrm{rot}(\mathrm{grad})=0$</span> と <span class="tex2jax_process">$\mathrm{div}(\mathrm{rot})=0$</span> が当然の帰結として導かれる。
 </p></blockquote>
 <hr />
 <h2 id="付録Dフロベニウス積とホッジ・スターの完全な行列表現">付録D：フロベニウス積とホッジ・スターの完全な行列表現</h2>
-<p>§6.3.2 では $1$-form の係数を「行列の縦ベクトル」に掛ける見方で $\ast_{1\to2}$ を導入し、§6.3.3 で簡略版の辞書を与えた。この付録では、縦ベクトルとフロベニウス積だけを使って $\ast_{1\to2}$ と $\ast_{2\to1}$ を構成し直し、両者が<strong>互いに転置</strong>であることを示す。
+<p>§6.3.2 では <span class="tex2jax_process">$1$</span>-form の係数を「行列の縦ベクトル」に掛ける見方で <span class="tex2jax_process">$\ast_{1\to2}$</span> を導入し、§6.3.3 で簡略版の辞書を与えた。この付録では、縦ベクトルとフロベニウス積だけを使って <span class="tex2jax_process">$\ast_{1\to2}$</span> と <span class="tex2jax_process">$\ast_{2\to1}$</span> を構成し直し、両者が<strong>互いに転置</strong>であることを示す。
 </p>
 <h3 id="D1-行列の内積フロベニウス積">D.1 行列の内積——フロベニウス積</h3>
-<p>$3 \times 3$ 行列 $A, B$ の<strong>内積</strong>を次で定義する。
-</p>
-<p>$$A \cdot B = \frac{1}{2}\operatorname{tr}(A^T B) = \frac{1}{2}\sum_{i=1}^{3}\sum_{j=1}^{3} A_{ij}B_{ij}$$
-</p>
-<blockquote><p>**注** （トレース）$\operatorname{tr}$ は行列の**トレース**（対角成分の和）である。第5章付録C で外微分の行列表現を扱った際に登場した。$\operatorname{tr}(A^T B)$ は「$A$ を転置して $B$ を掛け、対角成分を足し合わせる」三手順の操作だ。$\frac{1}{2}\sum A_{ij}B_{ij}$ と等価だから、成分で考えたいときは後者の表式を使えばよい。</p>
+<span class="tex2jax_process">$3 \times 3$</span> 行列 <span class="tex2jax_process">$A, B$</span> の<strong>内積</strong>を次で定義する。
+<div class="math-block tex2jax_process">$$A \cdot B = \frac{1}{2}\operatorname{tr}(A^T B) = \frac{1}{2}\sum_{i=1}^{3}\sum_{j=1}^{3} A_{ij}B_{ij}$$</div>
+<blockquote><p>**注** （トレース）<span class="tex2jax_process">$\operatorname{tr}$</span> は行列の**トレース**（対角成分の和）である。第5章付録C で外微分の行列表現を扱った際に登場した。<span class="tex2jax_process">$\operatorname{tr}(A^T B)$</span> は「<span class="tex2jax_process">$A$</span> を転置して <span class="tex2jax_process">$B$</span> を掛け、対角成分を足し合わせる」三手順の操作だ。<span class="tex2jax_process">$\frac{1}{2}\sum A_{ij}B_{ij}$</span> と等価だから、成分で考えたいときは後者の表式を使えばよい。</p>
 </p></blockquote>
-<p>§6.2.3 で縦ベクトル同士の内積を $\mathbf{v}_1 \cdot \mathbf{v}_2$ と書いたのと同じ記法である。行列もまた「同じ種類のもの」どうしであり、対応する成分同士を掛けて総和をとる。$i$ と $j$ の二つの添字にわたって次々と縮約していくことから、これを<strong>フロベニウス積</strong>または<strong>連続縮約</strong>と呼ぶ。
+<p>§6.2.3 で縦ベクトル同士の内積を <span class="tex2jax_process">$\mathbf{v}_1 \cdot \mathbf{v}_2$</span> と書いたのと同じ記法である。行列もまた「同じ種類のもの」どうしであり、対応する成分同士を掛けて総和をとる。<span class="tex2jax_process">$i$</span> と <span class="tex2jax_process">$j$</span> の二つの添字にわたって次々と縮約していくことから、これを<strong>フロベニウス積</strong>または<strong>連続縮約</strong>と呼ぶ。
 </p>
-<blockquote><p>**注** （係数 $1/2$ について）フロベニウス積には $\operatorname{tr}(A^T B)$（$1/2$ なし）を採用する流儀もある。しかし反対称行列では $M_{23}$ と $M_{32} = -M_{23}$ のようなペア成分の両方を拾ってしまい、内積が $2$ 倍される。本書では $1/2$ を定義に織り込む。これにより、$2$-form $M$ の自分自身との内積 $M \cdot M = M_{23}^2 + M_{31}^2 + M_{12}^2$ がそのまま §6.2.2 の「平行四辺形の符号なし面積の二乗」に一致する。</p>
+<blockquote><p>**注** （係数 <span class="tex2jax_process">$1/2$</span> について）フロベニウス積には <span class="tex2jax_process">$\operatorname{tr}(A^T B)$</span>（<span class="tex2jax_process">$1/2$</span> なし）を採用する流儀もある。しかし反対称行列では <span class="tex2jax_process">$M_{23}$</span> と <span class="tex2jax_process">$M_{32} = -M_{23}$</span> のようなペア成分の両方を拾ってしまい、内積が <span class="tex2jax_process">$2$</span> 倍される。本書では <span class="tex2jax_process">$1/2$</span> を定義に織り込む。これにより、<span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$M$</span> の自分自身との内積 <span class="tex2jax_process">$M \cdot M = M_{23}^2 + M_{31}^2 + M_{12}^2$</span> がそのまま §6.2.2 の「平行四辺形の符号なし面積の二乗」に一致する。</p>
 </p></blockquote>
-<blockquote><p>**注** （抽象化の引力）§6.2.3 で「数学者はすぐに抽象化したがる」とぼやいたが、こうして実際に手を動かしてみると彼らの言い分も分からなくもない。縦ベクトルの内積には $\mathbf{v}_1^T \mathbf{v}_2$ を、行列の内積には $\frac{1}{2}\operatorname{tr}(A^T B)$ を——表示が変わるたびに内積を一から定義し直すのは、考えてみれば相当に大変だ。これらをまとめて「内積とは、ある公理を満たす演算である」と一言で済ませたい欲求に飲まれそうな自分に気付く。それでも本書は最後まで表示を明示する方針を崩さない。ここまで来ると意地である。</p>
+<blockquote><p>**注** （抽象化の引力）§6.2.3 で「数学者はすぐに抽象化したがる」とぼやいたが、こうして実際に手を動かしてみると彼らの言い分も分からなくもない。縦ベクトルの内積には <span class="tex2jax_process">$\mathbf{v}_1^T \mathbf{v}_2$</span> を、行列の内積には <span class="tex2jax_process">$\frac{1}{2}\operatorname{tr}(A^T B)$</span> を——表示が変わるたびに内積を一から定義し直すのは、考えてみれば相当に大変だ。これらをまとめて「内積とは、ある公理を満たす演算である」と一言で済ませたい欲求に飲まれそうな自分に気付く。それでも本書は最後まで表示を明示する方針を崩さない。ここまで来ると意地である。</p>
 </p></blockquote>
-<h3 id="D2-行列の縦ベクトル">D.2 $\ast_{1\to2}$ ——行列の縦ベクトル</h3>
-<p>基底 $2$-form に対応する3枚の反対称行列を $E_1, E_2, E_3$ と名付ける。添字 $1,2,3$ は $dx,dy,dz$ の順である。
+<h3 id="D2-span-classtex2jaxprocessspan-行列の縦ベクトル">D.2 <span class="tex2jax_process">$\ast_{1\to2}$</span> ——行列の縦ベクトル</h3>
+<p>基底 <span class="tex2jax_process">$2$</span>-form に対応する3枚の反対称行列を <span class="tex2jax_process">$E_1, E_2, E_3$</span> と名付ける。添字 <span class="tex2jax_process">$1,2,3$</span> は <span class="tex2jax_process">$dx,dy,dz$</span> の順である。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 E_1 = \begin{pmatrix}
 0 & 0 & 0 \\
 0 & 0 & 1 \\
@@ -3474,21 +3236,18 @@ E_3 = \begin{pmatrix}
 -1 & 0 & 0 \\
 0 & 0 & 0
 \end{pmatrix}
-$$
-</p>
+$$</div>
 <p>この3枚の行列を縦に積み上げる。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \ast_{1\to2} = \begin{pmatrix}
 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} \\[1em]
 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} \\[1em]
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
-$$
-</p>
-<p>$\ast_{1\to2}$ は<strong>行列の縦ベクトル</strong>である。$1$-form $\omega = \begin{pmatrix} P & Q & R \end{pmatrix}$（横ベクトル）を左から掛ければ、第 $k$ 成分が $E_k$ を係数倍した線形結合となって $3\times 3$ 行列が得られる。
-</p>
-<p>$$
+$$</div>
+<span class="tex2jax_process">$\ast_{1\to2}$</span> は<strong>行列の縦ベクトル</strong>である。<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega = \begin{pmatrix} P & Q & R \end{pmatrix}$</span>（横ベクトル）を左から掛ければ、第 <span class="tex2jax_process">$k$</span> 成分が <span class="tex2jax_process">$E_k$</span> を係数倍した線形結合となって <span class="tex2jax_process">$3\times 3$</span> 行列が得られる。
+<div class="math-block tex2jax_process">$$
 \ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}
 = P E_1 + Q E_2 + R E_3
 = \begin{pmatrix}
@@ -3496,129 +3255,108 @@ $$
 -R & 0 & P \\
 Q & -P & 0
 \end{pmatrix}
-$$
-</p>
-<blockquote><p>**注** （第2章の $\widehat{\epsilon}$ との関係）この $E_1, E_2, E_3$ は、付録Aで $\epsilon_{1,\cdot,\cdot}, \epsilon_{2,\cdot,\cdot}, \epsilon_{3,\cdot,\cdot}$ として書き下した行列と同一である。$\ast_{1\to2}$ の本質は、エディントンのイプシロン $\epsilon_{ijk}$ の第一添字を縦ベクトルの成分方向に、残りの二添字を $3\times 3$ 行列の方向に配置したものだ。第2章で体積測定器 $\widehat{\epsilon}$ として導入したあの3枚組が、ここでホッジ・スターとして再登場している。</p>
+$$</div>
+<blockquote><p>**注** （第2章の <span class="tex2jax_process">$\widehat{\epsilon}$</span> との関係）この <span class="tex2jax_process">$E_1, E_2, E_3$</span> は、付録Aで <span class="tex2jax_process">$\epsilon_{1,\cdot,\cdot}, \epsilon_{2,\cdot,\cdot}, \epsilon_{3,\cdot,\cdot}$</span> として書き下した行列と同一である。<span class="tex2jax_process">$\ast_{1\to2}$</span> の本質は、エディントンのイプシロン <span class="tex2jax_process">$\epsilon_{ijk}$</span> の第一添字を縦ベクトルの成分方向に、残りの二添字を <span class="tex2jax_process">$3\times 3$</span> 行列の方向に配置したものだ。第2章で体積測定器 <span class="tex2jax_process">$\widehat{\epsilon}$</span> として導入したあの3枚組が、ここでホッジ・スターとして再登場している。</p>
 </p></blockquote>
-<h3 id="D3-フロベニウス積による係数抽出">D.3 $\ast_{2\to1}$ ——フロベニウス積による係数抽出</h3>
-<p>逆向きの変換 $\ast_{2\to1}$ は、$E_1, E_2, E_3$ とのフロベニウス積で構成する。$M$ を任意の $3\times 3$ 行列（反対称とは限らない）とする。
+<h3 id="D3-span-classtex2jaxprocessspan-フロベニウス積による係数抽出">D.3 <span class="tex2jax_process">$\ast_{2\to1}$</span> ——フロベニウス積による係数抽出</h3>
+<p>逆向きの変換 <span class="tex2jax_process">$\ast_{2\to1}$</span> は、<span class="tex2jax_process">$E_1, E_2, E_3$</span> とのフロベニウス積で構成する。<span class="tex2jax_process">$M$</span> を任意の <span class="tex2jax_process">$3\times 3$</span> 行列（反対称とは限らない）とする。
 </p>
-<p>$$\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$$
-</p>
-<p>$E_k \cdot M = \operatorname{tr}(E_k^T M)$ は C.1 のフロベニウス積である。
-</p>
+<div class="math-block tex2jax_process">$$\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$$</div>
+<span class="tex2jax_process">$E_k \cdot M = \operatorname{tr}(E_k^T M)$</span> は C.1 のフロベニウス積である。
 <h3 id="D4-転置関係">D.4 転置関係</h3>
-<p>$\ast_{1\to2}$ と $\ast_{2\to1}$ が互いに転置であることは、C.2 と C.3 の定義から直ちに従う。任意の $1$-form $\omega$ と任意の $3\times 3$ 行列 $M$ に対し、
-</p>
-<p>$$
+<span class="tex2jax_process">$\ast_{1\to2}$</span> と <span class="tex2jax_process">$\ast_{2\to1}$</span> が互いに転置であることは、C.2 と C.3 の定義から直ちに従う。任意の <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> と任意の <span class="tex2jax_process">$3\times 3$</span> 行列 <span class="tex2jax_process">$M$</span> に対し、
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \ast_{1\to2}(\omega) \cdot M
 &= (P E_1 + Q E_2 + R E_3) \cdot M \\
 &= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
 \end{aligned}
-$$
-</p>
+$$</div>
 <p>一方、
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \omega \cdot \ast_{2\to1}(M)
 &= \begin{pmatrix} P & Q & R \end{pmatrix} \cdot
 \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix} \\
 &= P (E_1 \cdot M) + Q (E_2 \cdot M) + R (E_3 \cdot M)
 \end{aligned}
-$$
+$$</div>
+<p>両辺は等しい。左辺の <span class="tex2jax_process">$\cdot$</span> はフロベニウス積、右辺の <span class="tex2jax_process">$\cdot$</span> はベクトルの内積である。<strong>すなわち、<span class="tex2jax_process">$\ast_{2\to1}$</span> は <span class="tex2jax_process">$\ast_{1\to2}$</span> の転置である。</strong>
 </p>
-<p>両辺は等しい。左辺の $\cdot$ はフロベニウス積、右辺の $\cdot$ はベクトルの内積である。<strong>すなわち、$\ast_{2\to1}$ は $\ast_{1\to2}$ の転置である。</strong>
-</p>
-<blockquote><p>**注** （転置／随伴）一般に、二つの線形演算子 $L$ と $L^T$ が $L(x) \cdot y = x \cdot L^T(y)$ を満たすとき、$L^T$ を $L$ の転置（随伴）と呼ぶ。上で示した等式 $\ast_{1\to2}(\omega) \cdot M = \omega \cdot \ast_{2\to1}(M)$ はこの条件そのものだ。</p>
+<blockquote><p>**注** （転置／随伴）一般に、二つの線形演算子 <span class="tex2jax_process">$L$</span> と <span class="tex2jax_process">$L^T$</span> が <span class="tex2jax_process">$L(x) \cdot y = x \cdot L^T(y)$</span> を満たすとき、<span class="tex2jax_process">$L^T$</span> を <span class="tex2jax_process">$L$</span> の転置（随伴）と呼ぶ。上で示した等式 <span class="tex2jax_process">$\ast_{1\to2}(\omega) \cdot M = \omega \cdot \ast_{2\to1}(M)$</span> はこの条件そのものだ。</p>
 </p></blockquote>
-<p>実際、すべての成分を書き下せばその関係は一目瞭然だ。$\ast_{1\to2}$ が $3$ 枚の行列からなる縦ベクトルなら、その転置である $\ast_{2\to1}$ は同じ $3$ 枚の行列からなる横ベクトルである。
+<p>実際、すべての成分を書き下せばその関係は一目瞭然だ。<span class="tex2jax_process">$\ast_{1\to2}$</span> が <span class="tex2jax_process">$3$</span> 枚の行列からなる縦ベクトルなら、その転置である <span class="tex2jax_process">$\ast_{2\to1}$</span> は同じ <span class="tex2jax_process">$3$</span> 枚の行列からなる横ベクトルである。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \ast_{2\to1} = \begin{pmatrix}
 \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
 \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 \end{pmatrix}
-$$
+$$</div>
+<span class="tex2jax_process">$\ast_{1\to2}$</span> では縦に積まれていた <span class="tex2jax_process">$E_1, E_2, E_3$</span> が、ここでは横に並んでいる。作用の仕方も対称的だ。<span class="tex2jax_process">$\ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}$</span> は横ベクトル <span class="tex2jax_process">$\omega$</span> と縦ベクトル <span class="tex2jax_process">$\ast_{1\to2}$</span> の積であり、各 <span class="tex2jax_process">$E_k$</span> を係数倍して足し合わせる。一方 <span class="tex2jax_process">$\ast_{2\to1}$</span> は横ベクトルであるから、<span class="tex2jax_process">$M$</span> に作用させるときは各成分 <span class="tex2jax_process">$E_k$</span> と <span class="tex2jax_process">$M$</span> のフロベニウス積をとる——これが C.3 の定義 <span class="tex2jax_process">$\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$</span> に他ならない。縦と横、加重和と内積抽出——この対称性が <span class="tex2jax_process">$\ast$</span> のすべてを支配している。
+<h3 id="D5-span-classtex2jaxprocessspan-の成分">D.5 <span class="tex2jax_process">$E_k \cdot M$</span> の成分</h3>
+<p>C.3 の定義が実際に <span class="tex2jax_process">$M$</span> から何を取り出すかは、<span class="tex2jax_process">$E_k$</span> の非ゼロ成分を数えればわかる。フロベニウス積は成分ごとの積の総和に <span class="tex2jax_process">$1/2$</span> を掛けたものだから、非ゼロ成分だけ見れば十分だ。
 </p>
-<p>$\ast_{1\to2}$ では縦に積まれていた $E_1, E_2, E_3$ が、ここでは横に並んでいる。作用の仕方も対称的だ。$\ast_{1\to2}(\omega) = \omega \,\ast_{1\to2}$ は横ベクトル $\omega$ と縦ベクトル $\ast_{1\to2}$ の積であり、各 $E_k$ を係数倍して足し合わせる。一方 $\ast_{2\to1}$ は横ベクトルであるから、$M$ に作用させるときは各成分 $E_k$ と $M$ のフロベニウス積をとる——これが C.3 の定義 $\ast_{2\to1}(M) = \begin{pmatrix} E_1 \cdot M & E_2 \cdot M & E_3 \cdot M \end{pmatrix}$ に他ならない。縦と横、加重和と内積抽出——この対称性が $\ast$ のすべてを支配している。
+<span class="tex2jax_process">$E_1$</span> の非ゼロ成分は <span class="tex2jax_process">$(2,3)=1$</span> と <span class="tex2jax_process">$(3,2)=-1$</span> のみ。したがって
+<div class="math-block tex2jax_process">$$E_1 \cdot M = \frac{1}{2}\bigl(1 \cdot M_{23} + (-1) \cdot M_{32}\bigr) = \frac{1}{2}(M_{23} - M_{32})$$</div>
+<p>同様に、<span class="tex2jax_process">$E_2$</span> は <span class="tex2jax_process">$(1,3)=-1$</span> と <span class="tex2jax_process">$(3,1)=1$</span>、<span class="tex2jax_process">$E_3$</span> は <span class="tex2jax_process">$(1,2)=1$</span> と <span class="tex2jax_process">$(2,1)=-1$</span> であるから、
 </p>
-<h3 id="D5-の成分">D.5 $E_k \cdot M$ の成分</h3>
-<p>C.3 の定義が実際に $M$ から何を取り出すかは、$E_k$ の非ゼロ成分を数えればわかる。フロベニウス積は成分ごとの積の総和に $1/2$ を掛けたものだから、非ゼロ成分だけ見れば十分だ。
-</p>
-<p>$E_1$ の非ゼロ成分は $(2,3)=1$ と $(3,2)=-1$ のみ。したがって
-</p>
-<p>$$E_1 \cdot M = \frac{1}{2}\bigl(1 \cdot M_{23} + (-1) \cdot M_{32}\bigr) = \frac{1}{2}(M_{23} - M_{32})$$
-</p>
-<p>同様に、$E_2$ は $(1,3)=-1$ と $(3,1)=1$、$E_3$ は $(1,2)=1$ と $(2,1)=-1$ であるから、
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 E_2 \cdot M &= \frac{1}{2}\bigl((-1) \cdot M_{13} + 1 \cdot M_{31}\bigr) = \frac{1}{2}(M_{31} - M_{13}) \\
 E_3 \cdot M &= \frac{1}{2}\bigl(1 \cdot M_{12} + (-1) \cdot M_{21}\bigr) = \frac{1}{2}(M_{12} - M_{21})
 \end{aligned}
-$$
+$$</div>
+<span class="tex2jax_process">$M$</span> が<strong>反対称行列</strong>（<span class="tex2jax_process">$2$</span>-form）ならば <span class="tex2jax_process">$M_{21} = -M_{12},\; M_{31} = -M_{13},\; M_{32} = -M_{23}$</span> だから、
+<div class="math-block tex2jax_process">$$\ast_{2\to1}(M) = \begin{pmatrix} M_{23} & M_{31} & M_{12} \end{pmatrix}$$</div>
+<span class="tex2jax_process">$1/2$</span> が反対称ペアの二重拾いを打ち消し、ちょうど係数そのものが抜き出される。これは §6.3.3 の簡略版辞書 <span class="tex2jax_process">$\ast(dy \wedge dz) = dx$</span> 等と完全に一致する。
+<h3 id="D6-span-classtex2jaxprocessspan-の二回作用">D.6 <span class="tex2jax_process">$\ast$</span> の二回作用</h3>
+<p>C.2 と C.3 の定義のもとで <span class="tex2jax_process">$\ast$</span> を二回作用させるとどうなるか。<span class="tex2jax_process">$\ast_{1\to2}(\omega) = P E_1 + Q E_2 + R E_3$</span> に <span class="tex2jax_process">$\ast_{2\to1}$</span> を作用させると、
 </p>
-<p>$M$ が<strong>反対称行列</strong>（$2$-form）ならば $M_{21} = -M_{12},\; M_{31} = -M_{13},\; M_{32} = -M_{23}$ だから、
-</p>
-<p>$$\ast_{2\to1}(M) = \begin{pmatrix} M_{23} & M_{31} & M_{12} \end{pmatrix}$$
-</p>
-<p>$1/2$ が反対称ペアの二重拾いを打ち消し、ちょうど係数そのものが抜き出される。これは §6.3.3 の簡略版辞書 $\ast(dy \wedge dz) = dx$ 等と完全に一致する。
-</p>
-<h3 id="D6-の二回作用">D.6 $\ast$ の二回作用</h3>
-<p>C.2 と C.3 の定義のもとで $\ast$ を二回作用させるとどうなるか。$\ast_{1\to2}(\omega) = P E_1 + Q E_2 + R E_3$ に $\ast_{2\to1}$ を作用させると、
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \ast_{2\to1}(\ast_{1\to2}(\omega))
 = \begin{pmatrix}
 E_1 \cdot (P E_1 + Q E_2 + R E_3) &
 E_2 \cdot (P E_1 + Q E_2 + R E_3) &
 E_3 \cdot (P E_1 + Q E_2 + R E_3)
 \end{pmatrix}
-$$
-</p>
+$$</div>
 <p>フロベニウス積の線形性より、
 </p>
-<p>$$= \begin{pmatrix}
+<div class="math-block tex2jax_process">$$= \begin{pmatrix}
 P(E_1 \cdot E_1) + Q(E_1 \cdot E_2) + R(E_1 \cdot E_3) &
 P(E_2 \cdot E_1) + Q(E_2 \cdot E_2) + R(E_2 \cdot E_3) &
 P(E_3 \cdot E_1) + Q(E_3 \cdot E_2) + R(E_3 \cdot E_3)
-\end{pmatrix}$$
-</p>
-<p>$E_i \cdot E_j$ を C.5 と同様に非ゼロ成分だけで調べる。
-</p>
-<p>$$
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$E_i \cdot E_j$</span> を C.5 と同様に非ゼロ成分だけで調べる。
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 E_1 \cdot E_1 &= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1 \\
 E_2 \cdot E_2 &= \frac{1}{2}\bigl((-1)^2 + 1^2\bigr) = 1 \\
 E_3 \cdot E_3 &= \frac{1}{2}\bigl(1^2 + (-1)^2\bigr) = 1
 \end{aligned}
-$$
-</p>
-<p>$i \neq j$ では $E_i$ と $E_j$ に非ゼロ成分の重なりがまったくないため、$E_i \cdot E_j = 0$。したがって $E_i \cdot E_j = \delta_{ij}$ であり、
-</p>
-<p>$$\ast_{2\to1}(\ast_{1\to2}(\omega)) = \begin{pmatrix} P & Q & R \end{pmatrix} = \omega$$
-</p>
-<p>$\ast\ast = \mathrm{id}$ が、§6.3.3 の辞書とも完全に整合する形で導かれた。$1/2$ を定義に織り込んだことで、$\ast_{1\to2}$ と $\ast_{2\to1}$ は文字どおり互いに逆演算子になっている。
-</p>
+$$</div>
+<span class="tex2jax_process">$i \neq j$</span> では <span class="tex2jax_process">$E_i$</span> と <span class="tex2jax_process">$E_j$</span> に非ゼロ成分の重なりがまったくないため、<span class="tex2jax_process">$E_i \cdot E_j = 0$</span>。したがって <span class="tex2jax_process">$E_i \cdot E_j = \delta_{ij}$</span> であり、
+<div class="math-block tex2jax_process">$$\ast_{2\to1}(\ast_{1\to2}(\omega)) = \begin{pmatrix} P & Q & R \end{pmatrix} = \omega$$</div>
+<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> が、§6.3.3 の辞書とも完全に整合する形で導かれた。<span class="tex2jax_process">$1/2$</span> を定義に織り込んだことで、<span class="tex2jax_process">$\ast_{1\to2}$</span> と <span class="tex2jax_process">$\ast_{2\to1}$</span> は文字どおり互いに逆演算子になっている。
 <blockquote><p>**【ここまでのチェックポイント — 付録D】**</p>
-- フロベニウス積 $A \cdot B = \operatorname{tr}(A^T B)$ は行列の成分ごとの積和（連続縮約）。
-- $\ast_{1\to2}$ は3枚の反対称行列からなる**行列の縦ベクトル**。第2章の $\widehat{\epsilon}$ の三枚組と同一の構造。
-- $\ast_{2\to1}$ は $E_k$ とのフロベニウス積による係数抽出。C.4 の等式一発で $\ast_{2\to1}$ が $\ast_{1\to2}$ の**転置**であることが示される。
-- $E_k \cdot M$ は $E_k$ の非ゼロ成分を数えるだけで計算でき、反対称 $M$ では係数が $2$ 倍される。
-- $E_i \cdot E_j = 2\delta_{ij}$ より $\ast_{2\to1}(\ast_{1\to2}(\omega)) = 2\omega$。§6.3.3 の簡略辞書はこの $2$ 倍を吸収済み。
+- フロベニウス積 <span class="tex2jax_process">$A \cdot B = \operatorname{tr}(A^T B)$</span> は行列の成分ごとの積和（連続縮約）。
+- <span class="tex2jax_process">$\ast_{1\to2}$</span> は3枚の反対称行列からなる**行列の縦ベクトル**。第2章の <span class="tex2jax_process">$\widehat{\epsilon}$</span> の三枚組と同一の構造。
+- <span class="tex2jax_process">$\ast_{2\to1}$</span> は <span class="tex2jax_process">$E_k$</span> とのフロベニウス積による係数抽出。C.4 の等式一発で <span class="tex2jax_process">$\ast_{2\to1}$</span> が <span class="tex2jax_process">$\ast_{1\to2}$</span> の**転置**であることが示される。
+- <span class="tex2jax_process">$E_k \cdot M$</span> は <span class="tex2jax_process">$E_k$</span> の非ゼロ成分を数えるだけで計算でき、反対称 <span class="tex2jax_process">$M$</span> では係数が <span class="tex2jax_process">$2$</span> 倍される。
+- <span class="tex2jax_process">$E_i \cdot E_j = 2\delta_{ij}$</span> より <span class="tex2jax_process">$\ast_{2\to1}(\ast_{1\to2}(\omega)) = 2\omega$</span>。§6.3.3 の簡略辞書はこの <span class="tex2jax_process">$2$</span> 倍を吸収済み。
 </p></blockquote>
 <p>\newpage
 </p>
 <h1 id="第7章ベクトル解析--ナブラの登場">第7章：ベクトル解析 —— ナブラの登場</h1>
 <h3 id="70-ナブラの登場">§7.0 ナブラの登場</h3>
-<p>　本書のタイトルは「ナブラ解体新書」である。しかし第1章から第6章まで、ナブラ $\nabla$ を正面から定義したことは一度もない、という建前だ。grad、rot、div という言葉すら、§5.5 で $d$ と $\ast$ の組み合わせとして登場したきりだ。
+<p>　本書のタイトルは「ナブラ解体新書」である。しかし第1章から第6章まで、ナブラ <span class="tex2jax_process">$\nabla$</span> を正面から定義したことは一度もない、という建前だ。grad、rot、div という言葉すら、§5.5 で <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の組み合わせとして登場したきりだ。
 </p>
-<p>代わりに何をしてきたか。$dx$ は横ベクトル、$2$-form は反対称行列、$d$ は次数を上げる演算——いわば「裏方」の道具をひたすら積み上げてきた。読者の中には「いつになったら $\nabla$ が出てくるんだ」と思っていた人もいるだろう。正直に言えば、筆者もそろそろタイトル詐欺が気になってきた。
+<p>代わりに何をしてきたか。<span class="tex2jax_process">$dx$</span> は横ベクトル、<span class="tex2jax_process">$2$</span>-form は反対称行列、<span class="tex2jax_process">$d$</span> は次数を上げる演算——いわば「裏方」の道具をひたすら積み上げてきた。読者の中には「いつになったら <span class="tex2jax_process">$\nabla$</span> が出てくるんだ」と思っていた人もいるだろう。正直に言えば、筆者もそろそろタイトル詐欺が気になってきた。
 </p>
-<p>本章では、ついに $\nabla$ を定義する。そして標準的なベクトル解析——勾配・発散・回転・ラプラシアン・諸恒等式——を、天下りのまま一気に展開する。$d$ も $\ast$ も $\wedge$ も一切使わない。これは多くの読者が大学1-2年で（おそらく挫折しながら）学んだ、あのベクトル解析そのものである。
+<p>本章では、ついに <span class="tex2jax_process">$\nabla$</span> を定義する。そして標準的なベクトル解析——勾配・発散・回転・ラプラシアン・諸恒等式——を、天下りのまま一気に展開する。<span class="tex2jax_process">$d$</span> も <span class="tex2jax_process">$\ast$</span> も <span class="tex2jax_process">$\wedge$</span> も一切使わない。これは多くの読者が大学1-2年で（おそらく挫折しながら）学んだ、あのベクトル解析そのものである。
 </p>
 <blockquote><p>**注** （なぜ今なのか）第6章まで form の道具を積んだのは、本章の「公式だらけのベクトル解析」と第8章の「二つの演算子で一本化された世界」を対比するためだ。本章を読み終えたとき「公式が多すぎる」と感じたら、それでよい。その違和感が、第III部への推進力になる。</p>
 </p></blockquote>
@@ -3627,32 +3365,29 @@ $$
 <hr />
 <h3 id="71-ドット積とクロス積">§7.1 ドット積とクロス積</h3>
 <h4 id="711-ドット積">7.1.1 ドット積</h4>
-<p>二つの縦ベクトル $\mathbf{a} = (a_x, a_y, a_z)^T$, $\mathbf{b} = (b_x, b_y, b_z)^T$ の<strong>ドット積</strong>（内積）を次で定義する。
+<p>二つの縦ベクトル <span class="tex2jax_process">$\mathbf{a} = (a_x, a_y, a_z)^T$</span>, <span class="tex2jax_process">$\mathbf{b} = (b_x, b_y, b_z)^T$</span> の<strong>ドット積</strong>（内積）を次で定義する。
 </p>
-<p>$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
-</p>
-<p>§5.2.3 で見たように、これは実空間 $(x,y,z)$ で $\mathbf{g} = I$ とした場合の内積 $\mathbf{a}^T \mathbf{g} \,\mathbf{b}$ に等しい。本書ではすでに縦ベクトルと横ベクトルの積として何度も使ってきた操作だ。
+<div class="math-block tex2jax_process">$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$</div>
+<p>§5.2.3 で見たように、これは実空間 <span class="tex2jax_process">$(x,y,z)$</span> で <span class="tex2jax_process">$\mathbf{g} = I$</span> とした場合の内積 <span class="tex2jax_process">$\mathbf{a}^T \mathbf{g} \,\mathbf{b}$</span> に等しい。本書ではすでに縦ベクトルと横ベクトルの積として何度も使ってきた操作だ。
 </p>
 <h4 id="712-クロス積">7.1.2 クロス積</h4>
-<p>二つの縦ベクトル $\mathbf{a}, \mathbf{b}$ の<strong>クロス積</strong>（外積）を次で定義する。
+<p>二つの縦ベクトル <span class="tex2jax_process">$\mathbf{a}, \mathbf{b}$</span> の<strong>クロス積</strong>（外積）を次で定義する。
 </p>
-<p>$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
 a_y b_z - a_z b_y \\
 a_z b_x - a_x b_z \\
 a_x b_y - a_y b_x
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <p>この結果は再び縦ベクトルである。クロス積の成分の並びには規則性があり、次の反対称行列を使うと簡潔に書ける。
 </p>
-<p>$$\mathbf{a} \times = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{a} \times = \begin{pmatrix}
 0 & -a_z & a_y \\
 a_z & 0 & -a_x \\
 -a_y & a_x & 0
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>この <span class="tex2jax_process">$3\times 3$</span> 行列をベクトル <span class="tex2jax_process">$\mathbf{b}$</span> に左から掛ければ、
 </p>
-<p>この $3\times 3$ 行列をベクトル $\mathbf{b}$ に左から掛ければ、
-</p>
-<p>$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
 0 & -a_z & a_y \\
 a_z & 0 & -a_x \\
 -a_y & a_x & 0
@@ -3662,519 +3397,458 @@ b_x \\ b_y \\ b_z
 a_y b_z - a_z b_y \\
 a_z b_x - a_x b_z \\
 a_x b_y - a_y b_x
-\end{pmatrix}$$
-</p>
-<p>となる。この $(\mathbf{a} \times)$ を $\mathbf{a}$ の<strong>外積行列</strong>と呼ぶ。第2章 §2.4.9 で $2$-form の行列表現として現れ、§5.3.2 では $\ast$ の出力として再登場した行列と、まったく同じ形である。本章ではこれを純粋に「ベクトルにベクトルを掛けてベクトルを得る演算」として使う。
+\end{pmatrix}$$</div>
+<p>となる。この <span class="tex2jax_process">$(\mathbf{a} \times)$</span> を <span class="tex2jax_process">$\mathbf{a}$</span> の<strong>外積行列</strong>と呼ぶ。第2章 §2.4.9 で <span class="tex2jax_process">$2$</span>-form の行列表現として現れ、§5.3.2 では <span class="tex2jax_process">$\ast$</span> の出力として再登場した行列と、まったく同じ形である。本章ではこれを純粋に「ベクトルにベクトルを掛けてベクトルを得る演算」として使う。
 </p>
 <p>クロス積には次の基本的な性質がある。
 </p>
 <ol>
-<li>**反可換性**：$\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$</li>
+<li>**反可換性**：<span class="tex2jax_process">$\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$</span></li>
 </ol>
-<p>2. <strong>自分自身とのクロス積はゼロ</strong>：$\mathbf{a} \times \mathbf{a} = \mathbf{0}$
+<p>2. <strong>自分自身とのクロス積はゼロ</strong>：<span class="tex2jax_process">$\mathbf{a} \times \mathbf{a} = \mathbf{0}$</span>
 <ol>
-<li>**直交性**：$(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$、$(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$</li>
+<li>**直交性**：<span class="tex2jax_process">$(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$</span>、<span class="tex2jax_process">$(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$</span></li>
 </ol>
-<p>性質3は、クロス積が $\mathbf{a}$ にも $\mathbf{b}$ にも直交するベクトルを生み出すことを意味する。これがいわゆる「右手の法則」の正体だ。
+<p>性質3は、クロス積が <span class="tex2jax_process">$\mathbf{a}$</span> にも <span class="tex2jax_process">$\mathbf{b}$</span> にも直交するベクトルを生み出すことを意味する。これがいわゆる「右手の法則」の正体だ。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — §7.1】**</p>
-- ドット積 $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$。実空間では $\mathbf{a}^T \mathbf{b}$ に等しい。
-- クロス積 $\mathbf{a}\times\mathbf{b}$ は外積行列 $(\mathbf{a}\times)$ を使って $(\mathbf{a}\times)\,\mathbf{b}$ と書ける。
+- ドット積 <span class="tex2jax_process">$\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$</span>。実空間では <span class="tex2jax_process">$\mathbf{a}^T \mathbf{b}$</span> に等しい。
+- クロス積 <span class="tex2jax_process">$\mathbf{a}\times\mathbf{b}$</span> は外積行列 <span class="tex2jax_process">$(\mathbf{a}\times)$</span> を使って <span class="tex2jax_process">$(\mathbf{a}\times)\,\mathbf{b}$</span> と書ける。
 - クロス積は反可換、自分自身とはゼロ、結果は二つのベクトルに直交する。
 </p></blockquote>
 <hr />
-<h3 id="72-と勾配">§7.2 $\nabla$ と勾配</h3>
-<h4 id="721-の定義">7.2.1 $\nabla$ の定義</h4>
-<p>ナブラ $\nabla$ を、偏微分演算子を縦に並べた形式的なベクトルとして定義する。
+<h3 id="72-span-classtex2jaxprocessspan-と勾配">§7.2 <span class="tex2jax_process">$\nabla$</span> と勾配</h3>
+<h4 id="721-span-classtex2jaxprocessspan-の定義">7.2.1 <span class="tex2jax_process">$\nabla$</span> の定義</h4>
+<p>ナブラ <span class="tex2jax_process">$\nabla$</span> を、偏微分演算子を縦に並べた形式的なベクトルとして定義する。
 </p>
-<p>$$\nabla = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\nabla = \begin{pmatrix}
 \frac{\partial}{\partial x} \\[0.5em]
 \frac{\partial}{\partial y} \\[0.5em]
 \frac{\partial}{\partial z}
-\end{pmatrix}$$
-</p>
-<p>$\nabla$ は「ベクトル」だが、その成分は数ではなく<strong>微分演算子</strong>である。$\nabla$ は単独では意味を持たず、何かに作用して初めて値が定まる。
-</p>
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$\nabla$</span> は「ベクトル」だが、その成分は数ではなく<strong>微分演算子</strong>である。<span class="tex2jax_process">$\nabla$</span> は単独では意味を持たず、何かに作用して初めて値が定まる。
 <h4 id="722-勾配">7.2.2 勾配</h4>
-<p>スカラー場 $f(x,y,z)$ に $\nabla$ を作用させたものを<strong>勾配</strong>と呼び、$\mathrm{grad}\,f$ または $\nabla f$ と書く。
+<p>スカラー場 <span class="tex2jax_process">$f(x,y,z)$</span> に <span class="tex2jax_process">$\nabla$</span> を作用させたものを<strong>勾配</strong>と呼び、<span class="tex2jax_process">$\mathrm{grad}\,f$</span> または <span class="tex2jax_process">$\nabla f$</span> と書く。
 </p>
-<p>$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
 \frac{\partial f}{\partial x} \\[0.5em]
 \frac{\partial f}{\partial y} \\[0.5em]
 \frac{\partial f}{\partial z}
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>勾配の各成分は、<span class="tex2jax_process">$f$</span> の各座標方向の変化率である。幾何学的には、<span class="tex2jax_process">$\nabla f$</span> は <span class="tex2jax_process">$f$</span> が最も急に増加する方向を指すベクトル場になる。
 </p>
-<p>勾配の各成分は、$f$ の各座標方向の変化率である。幾何学的には、$\nabla f$ は $f$ が最も急に増加する方向を指すベクトル場になる。
-</p>
-<blockquote><p>**注** （勾配は横ベクトルか縦ベクトルか）§5.5 では $\mathrm{grad}\,f = df$ と書き、$df$ は係数の横ベクトルだった。本章では $\nabla f$ を縦ベクトルとして扱う。これは単なる転置の違いではない。$\nabla f$（縦）は「空間の各点に矢印を立てる」見方——実空間が変化しているとみなす立場——に立ち、$df$（横）は「微分そのもの（form）が変化している」とみなす立場に立つ。出発点の絵は異なるが、線積分で集計すれば同じスカラー量を与える。この一致は偶然ではない。</p>
+<blockquote><p>**注** （勾配は横ベクトルか縦ベクトルか）§5.5 では <span class="tex2jax_process">$\mathrm{grad}\,f = df$</span> と書き、<span class="tex2jax_process">$df$</span> は係数の横ベクトルだった。本章では <span class="tex2jax_process">$\nabla f$</span> を縦ベクトルとして扱う。これは単なる転置の違いではない。<span class="tex2jax_process">$\nabla f$</span>（縦）は「空間の各点に矢印を立てる」見方——実空間が変化しているとみなす立場——に立ち、<span class="tex2jax_process">$df$</span>（横）は「微分そのもの（form）が変化している」とみなす立場に立つ。出発点の絵は異なるが、線積分で集計すれば同じスカラー量を与える。この一致は偶然ではない。</p>
 </p></blockquote>
-<strong>例</strong>：$f(x,y,z) = x^2 + y^2 + z^2$ の勾配。
-<p>$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$
-</p>
+<strong>例</strong>：<span class="tex2jax_process">$f(x,y,z) = x^2 + y^2 + z^2$</span> の勾配。
+<div class="math-block tex2jax_process">$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$</div>
 <p>このベクトル場は原点から放射状に外向きで、原点から離れるほど大きくなる。
 </p>
 <hr />
 <h3 id="73-発散">§7.3 発散</h3>
-<p>ベクトル場 $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)^T$ に対して、$\nabla$ とのドット積をとったものを<strong>発散</strong>と呼ぶ。
+<p>ベクトル場 <span class="tex2jax_process">$\mathbf{F}(x,y,z) = (F_x, F_y, F_z)^T$</span> に対して、<span class="tex2jax_process">$\nabla$</span> とのドット積をとったものを<strong>発散</strong>と呼ぶ。
 </p>
-<p>$$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+<div class="math-block tex2jax_process">$$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</div>
+<p>形式的には「<span class="tex2jax_process">$\nabla$</span> と <span class="tex2jax_process">$\mathbf{F}$</span> のドット積」だが、<span class="tex2jax_process">$\nabla$</span> の各成分が微分演算子であるため、結果はスカラー場になる。
 </p>
-<p>形式的には「$\nabla$ と $\mathbf{F}$ のドット積」だが、$\nabla$ の各成分が微分演算子であるため、結果はスカラー場になる。
+<p>発散は行列の言葉でも書ける。<span class="tex2jax_process">$\mathbf{F}$</span> のヤコビ行列 <span class="tex2jax_process">$\mathbf{J}_\mathbf{F}$</span> を考える。
 </p>
-<p>発散は行列の言葉でも書ける。$\mathbf{F}$ のヤコビ行列 $\mathbf{J}_\mathbf{F}$ を考える。
-</p>
-<p>$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
 \frac{\partial F_x}{\partial x} & \frac{\partial F_x}{\partial y} & \frac{\partial F_x}{\partial z} \\[0.3em]
 \frac{\partial F_y}{\partial x} & \frac{\partial F_y}{\partial y} & \frac{\partial F_y}{\partial z} \\[0.3em]
 \frac{\partial F_z}{\partial x} & \frac{\partial F_z}{\partial y} & \frac{\partial F_z}{\partial z}
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <p>この行列の<strong>トレース</strong>（対角成分の和）が発散に一致する。
 </p>
-<p>$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+<div class="math-block tex2jax_process">$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</div>
+<p>物理的には、<span class="tex2jax_process">$\mathrm{div}\,\mathbf{F}$</span> はその点での「湧き出し」の強さを表す。正なら湧き出し、負なら吸い込み、ゼロならその点では湧き出しも吸い込みもない。
 </p>
-<p>物理的には、$\mathrm{div}\,\mathbf{F}$ はその点での「湧き出し」の強さを表す。正なら湧き出し、負なら吸い込み、ゼロならその点では湧き出しも吸い込みもない。
-</p>
-<strong>例</strong>：$\mathbf{F} = (x, y, z)^T$ の発散。
-<p>$$\nabla \cdot \mathbf{F} = \frac{\partial x}{\partial x} + \frac{\partial y}{\partial y} + \frac{\partial z}{\partial z} = 1 + 1 + 1 = 3$$
-</p>
-<strong>例</strong>：$\mathbf{F} = (-y, x, 0)^T$ の発散。
-<p>$$\nabla \cdot \mathbf{F} = \frac{\partial (-y)}{\partial x} + \frac{\partial x}{\partial y} + \frac{\partial 0}{\partial z} = 0 + 0 + 0 = 0$$
-</p>
+<strong>例</strong>：<span class="tex2jax_process">$\mathbf{F} = (x, y, z)^T$</span> の発散。
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{\partial x}{\partial x} + \frac{\partial y}{\partial y} + \frac{\partial z}{\partial z} = 1 + 1 + 1 = 3$$</div>
+<strong>例</strong>：<span class="tex2jax_process">$\mathbf{F} = (-y, x, 0)^T$</span> の発散。
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{\partial (-y)}{\partial x} + \frac{\partial x}{\partial y} + \frac{\partial 0}{\partial z} = 0 + 0 + 0 = 0$$</div>
 <p>この場は回転しているが、湧き出してはいない。
 </p>
 <hr />
 <h3 id="74-回転">§7.4 回転</h3>
-<p>ベクトル場 $\mathbf{F}$ に対して、$\nabla$ とのクロス積をとったものを<strong>回転</strong>（ローテーション）と呼ぶ。
+<p>ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> に対して、<span class="tex2jax_process">$\nabla$</span> とのクロス積をとったものを<strong>回転</strong>（ローテーション）と呼ぶ。
 </p>
-<p>$$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
 \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.5em]
 \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <p>外積行列を使えば次のようにも書ける。
 </p>
-<p>$$\mathrm{rot}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathrm{rot}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
 0 & -\frac{\partial}{\partial z} & \frac{\partial}{\partial y} \\[0.3em]
 \frac{\partial}{\partial z} & 0 & -\frac{\partial}{\partial x} \\[0.3em]
 -\frac{\partial}{\partial y} & \frac{\partial}{\partial x} & 0
 \end{pmatrix}\begin{pmatrix}
 F_x \\ F_y \\ F_z
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>物理的には、<span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F}$</span> はその点での「渦」の強さと向きを表す。渦の軸方向を向き、大きさが渦の強さに対応する。
 </p>
-<p>物理的には、$\mathrm{rot}\,\mathbf{F}$ はその点での「渦」の強さと向きを表す。渦の軸方向を向き、大きさが渦の強さに対応する。
-</p>
-<strong>例</strong>：$\mathbf{F} = (-y, x, 0)^T$ の回転。
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
+<strong>例</strong>：<span class="tex2jax_process">$\mathbf{F} = (-y, x, 0)^T$</span> の回転。
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \\[0.3em]
 \frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \\[0.3em]
 \frac{\partial x}{\partial x} - \frac{\partial (-y)}{\partial y}
 \end{pmatrix} = \begin{pmatrix}
 0 - 0 \\ 0 - 0 \\ 1 - (-1)
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$</div>
+<p>この場は <span class="tex2jax_process">$z$</span> 軸まわりに一様に回転しており、渦の強さは <span class="tex2jax_process">$2$</span> である。
 </p>
-<p>この場は $z$ 軸まわりに一様に回転しており、渦の強さは $2$ である。
-</p>
-<strong>例</strong>：$\mathbf{F} = (x, y, z)^T$ の回転。
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
+<strong>例</strong>：<span class="tex2jax_process">$\mathbf{F} = (x, y, z)^T$</span> の回転。
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \\[0.3em]
 \frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \\[0.3em]
 \frac{\partial y}{\partial x} - \frac{\partial x}{\partial y}
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
-</p>
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$</div>
 <p>放射状の場には渦がない——直感とも一致する。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — §7.2–§7.4】**</p>
-- $\nabla = (\partial_x, \partial_y, \partial_z)^T$ は偏微分演算子を縦に並べた形式的ベクトル。
-- $\mathrm{grad}\,f = \nabla f$（勾配）：スカラー場 → ベクトル場。
-- $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}$（発散）：ベクトル場 → スカラー場。ヤコビ行列のトレースに等しい。
-- $\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$（回転）：ベクトル場 → ベクトル場。外積行列で書ける。
+- <span class="tex2jax_process">$\nabla = (\partial_x, \partial_y, \partial_z)^T$</span> は偏微分演算子を縦に並べた形式的ベクトル。
+- <span class="tex2jax_process">$\mathrm{grad}\,f = \nabla f$</span>（勾配）：スカラー場 → ベクトル場。
+- <span class="tex2jax_process">$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}$</span>（発散）：ベクトル場 → スカラー場。ヤコビ行列のトレースに等しい。
+- <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$</span>（回転）：ベクトル場 → ベクトル場。外積行列で書ける。
 </p></blockquote>
 <hr />
 <h3 id="75-ラプラシアン">§7.5 ラプラシアン</h3>
 <p>勾配（スカラー→ベクトル）と発散（ベクトル→スカラー）を連続して作用させると、スカラー場からスカラー場への演算が得られる。これを<strong>ラプラシアン</strong>と呼ぶ。
 </p>
-<p>$$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f) = \nabla \cdot (\nabla f) = \frac{\partial^2 f}{\partial x^2} + \frac{\partial^2 f}{\partial y^2} + \frac{\partial^2 f}{\partial z^2}$$
+<div class="math-block tex2jax_process">$$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f) = \nabla \cdot (\nabla f) = \frac{\partial^2 f}{\partial x^2} + \frac{\partial^2 f}{\partial y^2} + \frac{\partial^2 f}{\partial z^2}$$</div>
+<p>記号 <span class="tex2jax_process">$\nabla^2$</span> は <span class="tex2jax_process">$\nabla \cdot \nabla$</span> の略記であり、<span class="tex2jax_process">$\Delta f$</span> と書く流儀もある。
 </p>
-<p>記号 $\nabla^2$ は $\nabla \cdot \nabla$ の略記であり、$\Delta f$ と書く流儀もある。
+<strong>例</strong>：<span class="tex2jax_process">$f(x,y,z) = x^2 + y^2 + z^2$</span> のラプラシアン。
+<div class="math-block tex2jax_process">$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$</div>
+<p>ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> に対しても、成分ごとにラプラシアンを作用させたものを<strong>ベクトルラプラシアン</strong>と呼ぶ。
 </p>
-<strong>例</strong>：$f(x,y,z) = x^2 + y^2 + z^2$ のラプラシアン。
-<p>$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$
-</p>
-<p>ベクトル場 $\mathbf{F}$ に対しても、成分ごとにラプラシアンを作用させたものを<strong>ベクトルラプラシアン</strong>と呼ぶ。
-</p>
-<p>$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$
-</p>
-<p>ラプラシアンは物理の至るところに現れる。熱伝導方程式、波動方程式、ポアソン方程式——いずれも $\nabla^2$ を中心に据えた方程式である。
+<div class="math-block tex2jax_process">$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$</div>
+<p>ラプラシアンは物理の至るところに現れる。熱伝導方程式、波動方程式、ポアソン方程式——いずれも <span class="tex2jax_process">$\nabla^2$</span> を中心に据えた方程式である。
 </p>
 <hr />
 <h3 id="76-恒等式">§7.6 恒等式</h3>
 <p>ここまでに定義した三つの演算の間には、二つの重要な恒等式が成り立つ。どちらも「二度作用させるとゼロになる」という形をしている。
 </p>
-<h4 id="761">7.6.1 $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</h4>
+<h4 id="761-span-classtex2jaxprocessspan">7.6.1 <span class="tex2jax_process">$\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</span></h4>
 <p>勾配でベクトル場を得て、その回転をとると必ずゼロベクトルになる。
 </p>
-<p>$$\nabla \times (\nabla f) = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\nabla \times (\nabla f) = \begin{pmatrix}
 \frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \\[0.5em]
 \frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \\[0.5em]
 \frac{\partial}{\partial x}\frac{\partial f}{\partial y} - \frac{\partial}{\partial y}\frac{\partial f}{\partial x}
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
-</p>
-<p>各成分で、偏微分の順序交換 $\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$ により打ち消し合う。これは $f$ がなめらか（二階連続微分可能）であれば常に成り立つ。
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$</div>
+<p>各成分で、偏微分の順序交換 <span class="tex2jax_process">$\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$</span> により打ち消し合う。これは <span class="tex2jax_process">$f$</span> がなめらか（二階連続微分可能）であれば常に成り立つ。
 </p>
 <p>物理的意味：「勾配場には渦がない」。重力場や静電場がこれに当たる。
 </p>
-<h4 id="762">7.6.2 $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</h4>
+<h4 id="762-span-classtex2jaxprocessspan">7.6.2 <span class="tex2jax_process">$\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</span></h4>
 <p>回転でベクトル場を得て、その発散をとると必ずゼロになる。
 </p>
-<p>$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$
-</p>
-<p>展開すると、$\frac{\partial^2 F_z}{\partial x\partial y}$ と $-\frac{\partial^2 F_z}{\partial y\partial x}$ のように、やはり偏微分の順序交換により項がペアで打ち消し合い、総和は $0$ になる。
+<div class="math-block tex2jax_process">$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$</div>
+<p>展開すると、<span class="tex2jax_process">$\frac{\partial^2 F_z}{\partial x\partial y}$</span> と <span class="tex2jax_process">$-\frac{\partial^2 F_z}{\partial y\partial x}$</span> のように、やはり偏微分の順序交換により項がペアで打ち消し合い、総和は <span class="tex2jax_process">$0$</span> になる。
 </p>
 <p>物理的意味：「渦場に湧き出しはない」。磁場がこれに当たる（モノポールが存在しないことの数学的表現）。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — §7.5–§7.6】**</p>
-- $\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$ はスカラー場のラプラシアン。熱伝導や波動を記述する。
-- $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$：勾配場に渦はない。
-- $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$：渦場に湧き出しはない。
-- いずれも偏微分の順序交換 $\partial_i\partial_j = \partial_j\partial_i$ からの当然の帰結。
+- <span class="tex2jax_process">$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$</span> はスカラー場のラプラシアン。熱伝導や波動を記述する。
+- <span class="tex2jax_process">$\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$</span>：勾配場に渦はない。
+- <span class="tex2jax_process">$\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$</span>：渦場に湧き出しはない。
+- いずれも偏微分の順序交換 <span class="tex2jax_process">$\partial_i\partial_j = \partial_j\partial_i$</span> からの当然の帰結。
 </p></blockquote>
 <hr />
 <h3 id="77-ナブラの公式集">§7.7 ナブラの公式集</h3>
-<p>実用的な計算のために、$\nabla$ を含む積の微分則と代表的なベクトル恒等式をまとめておく。以下、$f, g$ はスカラー場、$\mathbf{F}, \mathbf{G}$ はベクトル場とする。
+<p>実用的な計算のために、<span class="tex2jax_process">$\nabla$</span> を含む積の微分則と代表的なベクトル恒等式をまとめておく。以下、<span class="tex2jax_process">$f, g$</span> はスカラー場、<span class="tex2jax_process">$\mathbf{F}, \mathbf{G}$</span> はベクトル場とする。
 </p>
 <h4 id="771-積の微分則">7.7.1 積の微分則</h4>
 <strong>勾配の積</strong>：
-<p>$$\nabla(fg) = f\,\nabla g + g\,\nabla f$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla(fg) = f\,\nabla g + g\,\nabla f$$</div>
 <strong>発散の積</strong>：
-<p>$$\nabla \cdot (f\mathbf{F}) = (\nabla f) \cdot \mathbf{F} + f\,(\nabla \cdot \mathbf{F})$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \cdot (f\mathbf{F}) = (\nabla f) \cdot \mathbf{F} + f\,(\nabla \cdot \mathbf{F})$$</div>
 <strong>回転の積</strong>：
-<p>$$\nabla \times (f\mathbf{F}) = (\nabla f) \times \mathbf{F} + f\,(\nabla \times \mathbf{F})$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \times (f\mathbf{F}) = (\nabla f) \times \mathbf{F} + f\,(\nabla \times \mathbf{F})$$</div>
 <strong>クロス積の発散</strong>：
-<p>$$\nabla \cdot (\mathbf{F} \times \mathbf{G}) = (\nabla \times \mathbf{F}) \cdot \mathbf{G} - \mathbf{F} \cdot (\nabla \times \mathbf{G})$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \cdot (\mathbf{F} \times \mathbf{G}) = (\nabla \times \mathbf{F}) \cdot \mathbf{G} - \mathbf{F} \cdot (\nabla \times \mathbf{G})$$</div>
 <h4 id="772-二回作用の恒等式">7.7.2 二回作用の恒等式</h4>
 <p>スカラー場の勾配の回転と、ベクトル場の回転の発散は §7.6 で導いた。公式集として再掲する。
 </p>
 <strong>勾配の回転はゼロ</strong>：
-<p>$$\nabla \times (\nabla f) = \mathbf{0}$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \times (\nabla f) = \mathbf{0}$$</div>
 <strong>回転の発散はゼロ</strong>：
-<p>$$\nabla \cdot (\nabla \times \mathbf{F}) = 0$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \cdot (\nabla \times \mathbf{F}) = 0$$</div>
 <strong>回転の回転</strong>：
-<p>$$\nabla \times (\nabla \times \mathbf{F}) = \nabla(\nabla \cdot \mathbf{F}) - \nabla^2 \mathbf{F}$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \times (\nabla \times \mathbf{F}) = \nabla(\nabla \cdot \mathbf{F}) - \nabla^2 \mathbf{F}$$</div>
 <p>これはラプラシアンを発散と回転に分解する式である。導出には BAC-CAB 則（§7.7.4）を使う。
 </p>
 <strong>スカラー場の勾配の発散</strong>（= ラプラシアン）：
-<p>$$\nabla \cdot (\nabla f) = \nabla^2 f$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \cdot (\nabla f) = \nabla^2 f$$</div>
 <p>§7.5 の定義そのもの。
 </p>
 <h4 id="773-スカラー三重積">7.7.3 スカラー三重積</h4>
-<p>三つの縦ベクトル $\mathbf{A}, \mathbf{B}, \mathbf{C}$ のスカラー三重積は、$\mathbf{A}$ と $\mathbf{B}\times\mathbf{C}$ のドット積で定義される。
+<p>三つの縦ベクトル <span class="tex2jax_process">$\mathbf{A}, \mathbf{B}, \mathbf{C}$</span> のスカラー三重積は、<span class="tex2jax_process">$\mathbf{A}$</span> と <span class="tex2jax_process">$\mathbf{B}\times\mathbf{C}$</span> のドット積で定義される。
 </p>
-<p>$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$
+<div class="math-block tex2jax_process">$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$</div>
+<p>この値は <span class="tex2jax_process">$\mathbf{A}, \mathbf{B}, \mathbf{C}$</span> の張る平行六面体の符号付き体積に等しい。巡回置換に対して不変であり、二つのベクトルを入れ替えると符号が反転する。
 </p>
-<p>この値は $\mathbf{A}, \mathbf{B}, \mathbf{C}$ の張る平行六面体の符号付き体積に等しい。巡回置換に対して不変であり、二つのベクトルを入れ替えると符号が反転する。
-</p>
-<p>$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C}) = \mathbf{B} \cdot (\mathbf{C} \times \mathbf{A}) = \mathbf{C} \cdot (\mathbf{A} \times \mathbf{B})$$
-</p>
+<div class="math-block tex2jax_process">$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C}) = \mathbf{B} \cdot (\mathbf{C} \times \mathbf{A}) = \mathbf{C} \cdot (\mathbf{A} \times \mathbf{B})$$</div>
 <h4 id="774-ベクトル三重積BAC-CAB-則">7.7.4 ベクトル三重積（BAC-CAB 則）</h4>
-<p>$$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot \mathbf{C}) - \mathbf{C}(\mathbf{A} \cdot \mathbf{B})$$
-</p>
+<div class="math-block tex2jax_process">$$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot \mathbf{C}) - \mathbf{C}(\mathbf{A} \cdot \mathbf{B})$$</div>
 <p>クロス積を二重に使うときに現れる。右辺の各項はスカラー倍されたベクトルであり、BAC-CAB の語呂で記憶される。
 </p>
-<blockquote><p>**注** （なぜ公式を列挙したのか）ここに並べた公式は、大学のベクトル解析の試験で暗記を強いられる代表格である。では、$d$ と $\ast$ で書き直せば公式の数が劇的に減るかというと、そうでもない。微分形式の側でも、$d(f\omega) = df\wedge\omega + f d\omega$ のような規則はそれなりにある。</p>
+<blockquote><p>**注** （なぜ公式を列挙したのか）ここに並べた公式は、大学のベクトル解析の試験で暗記を強いられる代表格である。では、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> で書き直せば公式の数が劇的に減るかというと、そうでもない。微分形式の側でも、<span class="tex2jax_process">$d(f\omega) = df\wedge\omega + f d\omega$</span> のような規則はそれなりにある。</p>
 
-ベクトル解析の真の問題は、公式の数ではない。**すべてが同じ「$3$ 成分の矢印」に見えてしまうこと**だ。$\nabla f$ も $\nabla \times \mathbf{F}$ も $\nabla^2\mathbf{F}$ も、どれも画面上ではただの矢印の束である。しかし $\nabla f$ は勾配（ポテンシャルの傾き）、$\nabla \times \mathbf{F}$ は渦の軸——矢印の幾何的意味はまったく異なる。お絵かきと直感に頼っていると、問題が複雑になった瞬間に区別がつかなくなる。微分形式は、$0$-form、$1$-form、$2$-form、$3$-form と測定器の次数を明示することで、この混同を原理的に防ぐ。$d$ は常に次数を $+1$ し、$\ast$ は常に次数を反転させる——少数の規則に型の情報が載っているから、矢印を見なくても式の形だけで何をしているかがわかる。これが、第8章以降で form の言葉に立ち戻る理由である。
+ベクトル解析の真の問題は、公式の数ではない。**すべてが同じ「<span class="tex2jax_process">$3$</span> 成分の矢印」に見えてしまうこと**だ。<span class="tex2jax_process">$\nabla f$</span> も <span class="tex2jax_process">$\nabla \times \mathbf{F}$</span> も <span class="tex2jax_process">$\nabla^2\mathbf{F}$</span> も、どれも画面上ではただの矢印の束である。しかし <span class="tex2jax_process">$\nabla f$</span> は勾配（ポテンシャルの傾き）、<span class="tex2jax_process">$\nabla \times \mathbf{F}$</span> は渦の軸——矢印の幾何的意味はまったく異なる。お絵かきと直感に頼っていると、問題が複雑になった瞬間に区別がつかなくなる。微分形式は、<span class="tex2jax_process">$0$</span>-form、<span class="tex2jax_process">$1$</span>-form、<span class="tex2jax_process">$2$</span>-form、<span class="tex2jax_process">$3$</span>-form と測定器の次数を明示することで、この混同を原理的に防ぐ。<span class="tex2jax_process">$d$</span> は常に次数を <span class="tex2jax_process">$+1$</span> し、<span class="tex2jax_process">$\ast$</span> は常に次数を反転させる——少数の規則に型の情報が載っているから、矢印を見なくても式の形だけで何をしているかがわかる。これが、第8章以降で form の言葉に立ち戻る理由である。
 </p></blockquote>
-<blockquote><p>**注** （ここだけの話）$\mathrm{grad}=d$, $\mathrm{rot}=\ast d$, $\mathrm{div}=\ast d\ast$ と対応を書き下すのは、実はベクトル解析を解体するための妥協案という側面がある。</p>
+<blockquote><p>**注** （ここだけの話）<span class="tex2jax_process">$\mathrm{grad}=d$</span>, <span class="tex2jax_process">$\mathrm{rot}=\ast d$</span>, <span class="tex2jax_process">$\mathrm{div}=\ast d\ast$</span> と対応を書き下すのは、実はベクトル解析を解体するための妥協案という側面がある。</p>
 
-多くの微分形式の啓蒙書は、きれいに書ける範囲だけを見せて「微分形式は美しい」と問題をすり替える。だが実態は違うと筆者は考える。たとえば §7.7.4 のベクトル三重積 $\mathbf{A}\times(\mathbf{B}\times\mathbf{C})$ をこの枠組みで書き直すと、$\ast(\alpha \wedge \ast(\beta \wedge \gamma))$ のように $\ast$ の入れ子が発生し、むしろベクトル解析よりも不格好な姿を晒すことになる。
+多くの微分形式の啓蒙書は、きれいに書ける範囲だけを見せて「微分形式は美しい」と問題をすり替える。だが実態は違うと筆者は考える。たとえば §7.7.4 のベクトル三重積 <span class="tex2jax_process">$\mathbf{A}\times(\mathbf{B}\times\mathbf{C})$</span> をこの枠組みで書き直すと、<span class="tex2jax_process">$\ast(\alpha \wedge \ast(\beta \wedge \gamma))$</span> のように <span class="tex2jax_process">$\ast$</span> の入れ子が発生し、むしろベクトル解析よりも不格好な姿を晒すことになる。
 
-では、なぜ一部の微分形式の啓蒙者たちは美しさを強調するのか。本当のことを言えば、微分形式の世界には本来 $\ast$ などいらないからだ。計量という「ものさし」を召喚する前の、$d$ と $\wedge$ だけで編まれた世界——そこには、誰もまだ「内積」など定義していない純粋な外微分の風景が広がっている。そして、問題なくマクスウェル方程式を構成できる。
+では、なぜ一部の微分形式の啓蒙者たちは美しさを強調するのか。本当のことを言えば、微分形式の世界には本来 <span class="tex2jax_process">$\ast$</span> などいらないからだ。計量という「ものさし」を召喚する前の、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\wedge$</span> だけで編まれた世界——そこには、誰もまだ「内積」など定義していない純粋な外微分の風景が広がっている。そして、問題なくマクスウェル方程式を構成できる。
 
 そして、本書のこの「微分形式によるベクトル解析」の計算を汚い、問題のすり替えだ、と読者が思えたなら、それは正しい。しかしその時、君はもうベクトル解析の初学者を卒業している。
 </p></blockquote>
 <hr />
 <h3 id="78-積分定理ストークス・ガウス・グリーン">§7.8 積分定理——ストークス・ガウス・グリーン</h3>
-<p>ベクトル解析の最も重要な仕事は、微分演算（grad, div, rot）と積分を結びつけることにある。以下に三つの積分定理を、$\nabla$ の言葉で示す。
+<p>ベクトル解析の最も重要な仕事は、微分演算（grad, div, rot）と積分を結びつけることにある。以下に三つの積分定理を、<span class="tex2jax_process">$\nabla$</span> の言葉で示す。
 </p>
 <h4 id="781-ストークスの定理">7.8.1 ストークスの定理</h4>
-<p>曲面 $S$ とその境界である閉曲線 $C = \partial S$ に対し、
+<p>曲面 <span class="tex2jax_process">$S$</span> とその境界である閉曲線 <span class="tex2jax_process">$C = \partial S$</span> に対し、
 </p>
-<p>$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+<div class="math-block tex2jax_process">$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$</div>
+<p>左辺は曲線 <span class="tex2jax_process">$C$</span> に沿った <span class="tex2jax_process">$\mathbf{F}$</span> の線積分（循環）、右辺は曲面 <span class="tex2jax_process">$S$</span> 上の回転の法線成分の面積分である。「境界での循環は、内部の渦の総和に等しい」という意味を持つ。<span class="tex2jax_process">$\mathbf{n}$</span> は曲面の単位法線ベクトルで、<span class="tex2jax_process">$C$</span> の向きに対して右ねじの関係で選ぶ。
 </p>
-<p>左辺は曲線 $C$ に沿った $\mathbf{F}$ の線積分（循環）、右辺は曲面 $S$ 上の回転の法線成分の面積分である。「境界での循環は、内部の渦の総和に等しい」という意味を持つ。$\mathbf{n}$ は曲面の単位法線ベクトルで、$C$ の向きに対して右ねじの関係で選ぶ。
-</p>
-<blockquote><p>**注** （グリーンの定理）$S$ が $xy$ 平面内の領域 $D$ で、$\mathbf{F} = (P, Q, 0)^T$ の場合、ストークスの定理は次の形になる。これはグリーンの定理と呼ばれる。</p>
+<blockquote><p>**注** （グリーンの定理）<span class="tex2jax_process">$S$</span> が <span class="tex2jax_process">$xy$</span> 平面内の領域 <span class="tex2jax_process">$D$</span> で、<span class="tex2jax_process">$\mathbf{F} = (P, Q, 0)^T$</span> の場合、ストークスの定理は次の形になる。これはグリーンの定理と呼ばれる。</p>
 
-$$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$
+
 </p></blockquote>
+<div class="math-block tex2jax_process">$$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$</div>
 <h4 id="782-ガウスの発散定理">7.8.2 ガウスの発散定理</h4>
-<p>立体 $V$ とその境界である閉曲面 $S = \partial V$ に対し、
+<p>立体 <span class="tex2jax_process">$V$</span> とその境界である閉曲面 <span class="tex2jax_process">$S = \partial V$</span> に対し、
 </p>
-<p>$$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
-</p>
-<p>左辺は閉曲面 $S$ を通る $\mathbf{F}$ の外向きの流束、右辺は立体 $V$ 内の発散の体積分である。「境界を通る流れの総和は、内部の湧き出しの総和に等しい」という意味を持つ。
+<div class="math-block tex2jax_process">$$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$</div>
+<p>左辺は閉曲面 <span class="tex2jax_process">$S$</span> を通る <span class="tex2jax_process">$\mathbf{F}$</span> の外向きの流束、右辺は立体 <span class="tex2jax_process">$V$</span> 内の発散の体積分である。「境界を通る流れの総和は、内部の湧き出しの総和に等しい」という意味を持つ。
 </p>
 <h4 id="783-三つの定理の共通構造">7.8.3 三つの定理の共通構造</h4>
 <p>ストークスの定理とガウスの発散定理を並べて見ると、共通のパターンが浮かぶ。
 </p>
 <p>| 定理 | 境界での積分 | 内部での積分 | 微分演算 |
 |---|---|---|---|
-| ストークス | $\displaystyle\oint_C \mathbf{F}\cdot d\mathbf{r}$ | $\displaystyle\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ | rot |
-| ガウス | $\displaystyle\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS$ | $\displaystyle\iiint_V (\nabla\cdot\mathbf{F})\,dV$ | div |
+| ストークス | <span class="tex2jax_process">$\displaystyle\oint_C \mathbf{F}\cdot d\mathbf{r}$</span> | <span class="tex2jax_process">$\displaystyle\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$</span> | rot |
+| ガウス | <span class="tex2jax_process">$\displaystyle\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS$</span> | <span class="tex2jax_process">$\displaystyle\iiint_V (\nabla\cdot\mathbf{F})\,dV$</span> | div |
 </p>
-<p>いずれも「境界で測った量 = 内部の微分量の総和」という形をしている。§7.6 の $\mathrm{div}(\mathrm{rot})=0$ は、この枠組みでは「渦場には湧き出しがないから、閉曲面で囲んでも中から出てくるものはない」と読める。
+<p>いずれも「境界で測った量 = 内部の微分量の総和」という形をしている。§7.6 の <span class="tex2jax_process">$\mathrm{div}(\mathrm{rot})=0$</span> は、この枠組みでは「渦場には湧き出しがないから、閉曲面で囲んでも中から出てくるものはない」と読める。
 </p>
-<p>しかし、ここには一つの不満が残る。ストークスとガウスは、grad / rot / div という異なる演算子を使うため、<strong>別々の定理として暗記しなければならない</strong>。第5章で $\int_{\partial M}\omega = \int_M d\omega$ という一本の式がこれらすべてを統合していたことを思い出してほしい。第8章では、$\nabla$ の世界の積分定理をこの一本の形に読み替える辞書を完成させる。
+<p>しかし、ここには一つの不満が残る。ストークスとガウスは、grad / rot / div という異なる演算子を使うため、<strong>別々の定理として暗記しなければならない</strong>。第5章で <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> という一本の式がこれらすべてを統合していたことを思い出してほしい。第8章では、<span class="tex2jax_process">$\nabla$</span> の世界の積分定理をこの一本の形に読み替える辞書を完成させる。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — §7.8】**</p>
-- ストークスの定理：$\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$
-- ガウスの発散定理：$\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
+- ストークスの定理：<span class="tex2jax_process">$\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$</span>
+- ガウスの発散定理：<span class="tex2jax_process">$\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$</span>
 - グリーンの定理はストークスの定理の平面版。
-- 三定理は「境界の積分 = 内部の微分の積分」という共通構造を持つが、$\nabla$ の言葉では別々の定理として扱わざるを得ない。
+- 三定理は「境界の積分 = 内部の微分の積分」という共通構造を持つが、<span class="tex2jax_process">$\nabla$</span> の言葉では別々の定理として扱わざるを得ない。
 </p></blockquote>
 <hr />
 <h3 id="79-第III部へ--矢印を見るな測定器を見ろ">§7.9 第III部へ —— 矢印を見るな、測定器を見ろ</h3>
-<p>第5章と第6章で、我々は二つの演算子を手に入れた。外微分 $d$ ——次数を一つ上げ、局所的なズレを測る。ホッジ・スター $\ast$ ——計量に基づいて次数を反転させる。§5.5 では、この二つの組み合わせだけで $\mathrm{grad} = d$, $\mathrm{rot} = \ast d$, $\mathrm{div} = \ast d \ast$ と書けることを見た。
+<p>第5章と第6章で、我々は二つの演算子を手に入れた。外微分 <span class="tex2jax_process">$d$</span> ——次数を一つ上げ、局所的なズレを測る。ホッジ・スター <span class="tex2jax_process">$\ast$</span> ——計量に基づいて次数を反転させる。§5.5 では、この二つの組み合わせだけで <span class="tex2jax_process">$\mathrm{grad} = d$</span>, <span class="tex2jax_process">$\mathrm{rot} = \ast d$</span>, <span class="tex2jax_process">$\mathrm{div} = \ast d \ast$</span> と書けることを見た。
 </p>
-<p>一方、本章では $\nabla$ とドット積・クロス積だけを使って同じ対象を記述した。$\nabla f$ も $\nabla\times\mathbf{F}$ も $\nabla\cdot\mathbf{F}$ も、画面上ではすべて矢印（かスカラー）だ。しかし、それぞれが担う幾何的意味はまったく異なる。そして問題が複雑になるほど、矢印だけを見て区別するのは難しくなる。
+<p>一方、本章では <span class="tex2jax_process">$\nabla$</span> とドット積・クロス積だけを使って同じ対象を記述した。<span class="tex2jax_process">$\nabla f$</span> も <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> も <span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> も、画面上ではすべて矢印（かスカラー）だ。しかし、それぞれが担う幾何的意味はまったく異なる。そして問題が複雑になるほど、矢印だけを見て区別するのは難しくなる。
 </p>
-<p>第III部では、この状況を整理する。$\nabla f$ を $df$ に、$\nabla\times\mathbf{F}$ を $\ast d\omega$ に、$\nabla\cdot\mathbf{F}$ を $\ast d\ast\omega$ に読み替える辞書を完成させる。そうすれば、式の形そのものが「いま何をしているか」を教えてくれる。矢印の絵に頼らず、測定器（$n$-form）の代数で考える——それが第III部の目標だ。
+<p>第III部では、この状況を整理する。<span class="tex2jax_process">$\nabla f$</span> を <span class="tex2jax_process">$df$</span> に、<span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> を <span class="tex2jax_process">$\ast d\omega$</span> に、<span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> を <span class="tex2jax_process">$\ast d\ast\omega$</span> に読み替える辞書を完成させる。そうすれば、式の形そのものが「いま何をしているか」を教えてくれる。矢印の絵に頼らず、測定器（<span class="tex2jax_process">$n$</span>-form）の代数で考える——それが第III部の目標だ。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — 第7章全体】**</p>
-- $\nabla = (\partial_x, \partial_y, \partial_z)^T$ を定義し、勾配・発散・回転・ラプラシアンを導入した。
-- $\mathrm{grad}\,f = \nabla f$, $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$, $\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$
-- $\nabla^2 = \mathrm{div}\,\mathrm{grad}$, $\mathrm{rot}(\mathrm{grad}) = 0$, $\mathrm{div}(\mathrm{rot}) = 0$
+- <span class="tex2jax_process">$\nabla = (\partial_x, \partial_y, \partial_z)^T$</span> を定義し、勾配・発散・回転・ラプラシアンを導入した。
+- <span class="tex2jax_process">$\mathrm{grad}\,f = \nabla f$</span>, <span class="tex2jax_process">$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$</span>, <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$</span>
+- <span class="tex2jax_process">$\nabla^2 = \mathrm{div}\,\mathrm{grad}$</span>, <span class="tex2jax_process">$\mathrm{rot}(\mathrm{grad}) = 0$</span>, <span class="tex2jax_process">$\mathrm{div}(\mathrm{rot}) = 0$</span>
 - クロス積の外積行列表示と BAC-CAB 則。
-- ベクトル解析の難しさは公式の数もさることながら、すべてが同じ矢印に見えることにある。微分形式は測定器（$n$-form）の次数で区別する。第III部でこの二つの言語を繫ぐ。
+- ベクトル解析の難しさは公式の数もさることながら、すべてが同じ矢印に見えることにある。微分形式は測定器（<span class="tex2jax_process">$n$</span>-form）の次数で区別する。第III部でこの二つの言語を繫ぐ。
 </p></blockquote>
 <p>\newpage
 </p>
 <h1 id="第8章二つの言語--測定器の微分と場の微分">第8章：二つの言語 —— 測定器の微分と、場の微分</h1>
 <h3 id="80-本書のハイライト">§8.0 本書のハイライト</h3>
-<p>　ここまで長かった。第1章で $dx$ を行ベクトルと定義し、第2章で面積測定器と体積測定器を組み立て、第3章で積分を再構築し、第5章で外微分 $d$ を得て、第6章で計量 $g$ とホッジ・スター $\ast$ を手に入れ、そして第7章ではついに $\nabla$ を正面から定義してベクトル解析を一気に展開した。
+<p>　ここまで長かった。第1章で <span class="tex2jax_process">$dx$</span> を行ベクトルと定義し、第2章で面積測定器と体積測定器を組み立て、第3章で積分を再構築し、第5章で外微分 <span class="tex2jax_process">$d$</span> を得て、第6章で計量 <span class="tex2jax_process">$g$</span> とホッジ・スター <span class="tex2jax_process">$\ast$</span> を手に入れ、そして第7章ではついに <span class="tex2jax_process">$\nabla$</span> を正面から定義してベクトル解析を一気に展開した。
 </p>
-<p>ここから先は、もう遠慮しない。$d$ も $\ast$ も $\nabla$ も、すべての道具が揃った。ベクトル解析の用語を引き合いに出すのに、もはや「ベクトル解析を知っている読者へ」と断る必要もない。第7章で $\nabla$ は正式に本書の住人になったのだから。
+<p>ここから先は、もう遠慮しない。<span class="tex2jax_process">$d$</span> も <span class="tex2jax_process">$\ast$</span> も <span class="tex2jax_process">$\nabla$</span> も、すべての道具が揃った。ベクトル解析の用語を引き合いに出すのに、もはや「ベクトル解析を知っている読者へ」と断る必要もない。第7章で <span class="tex2jax_process">$\nabla$</span> は正式に本書の住人になったのだから。
 </p>
-<p>本章は、この本の<strong>ハイライト</strong>である。しかし、その実あっさりと、これまでのどの章よりも短くなる。そのために第1章から第7章までの入念な準備があった——行列、ウェッジ積、外微分、計量、ホッジ・スター、そしてベクトル解析。これらの道具がすべて揃っているからこそ、本章ではただ「翻訳する」だけで、二つの世界が一つの絵に収まる。我々は二つの言語を手に入れた——測定器の微分（$d$）と、場の微分（$\nabla$）。この二つは、やっていることが根本的に違う。しかし積分を通じて繋がるとき、まったく同じ結果を与える。その仕組みを、これから徹底的に掘り下げる。
+<p>本章は、この本の<strong>ハイライト</strong>である。しかし、その実あっさりと、これまでのどの章よりも短くなる。そのために第1章から第7章までの入念な準備があった——行列、ウェッジ積、外微分、計量、ホッジ・スター、そしてベクトル解析。これらの道具がすべて揃っているからこそ、本章ではただ「翻訳する」だけで、二つの世界が一つの絵に収まる。我々は二つの言語を手に入れた——測定器の微分（<span class="tex2jax_process">$d$</span>）と、場の微分（<span class="tex2jax_process">$\nabla$</span>）。この二つは、やっていることが根本的に違う。しかし積分を通じて繋がるとき、まったく同じ結果を与える。その仕組みを、これから徹底的に掘り下げる。
 </p>
 <hr />
 <h3 id="81-二つの微分二つの世界">§8.1 二つの微分、二つの世界</h3>
-<h4 id="811-測定器に微分を乗せる-の立場">8.1.1 測定器に微分を乗せる——$d$ の立場</h4>
-<p>第1章以来、我々は $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ を横ベクトルの測定器として扱ってきた。これらは縦ベクトル（変位）を食わせると、その方向の変位量をスカラーで返す。
+<h4 id="811-測定器に微分を乗せるspan-classtex2jaxprocessspan-の立場">8.1.1 測定器に微分を乗せる——<span class="tex2jax_process">$d$</span> の立場</h4>
+<p>第1章以来、我々は <span class="tex2jax_process">$dx = \begin{pmatrix}1&0&0\end{pmatrix}$</span>, <span class="tex2jax_process">$dy = \begin{pmatrix}0&1&0\end{pmatrix}$</span>, <span class="tex2jax_process">$dz = \begin{pmatrix}0&0&1\end{pmatrix}$</span> を横ベクトルの測定器として扱ってきた。これらは縦ベクトル（変位）を食わせると、その方向の変位量をスカラーで返す。
 </p>
-<p>外微分 $d$ は、この測定器に<strong>微分を乗せる</strong>操作である。
+<p>外微分 <span class="tex2jax_process">$d$</span> は、この測定器に<strong>微分を乗せる</strong>操作である。
 </p>
-<p>$f(x,y,z)$ がスカラー場のとき、$df$ は $f$ の変化を測る新しい測定器だ。各偏微分係数を成分として持つ横ベクトルになる。
+<span class="tex2jax_process">$f(x,y,z)$</span> がスカラー場のとき、<span class="tex2jax_process">$df$</span> は <span class="tex2jax_process">$f$</span> の変化を測る新しい測定器だ。各偏微分係数を成分として持つ横ベクトルになる。
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$</div>
+<span class="tex2jax_process">$\omega = P\,dx + Q\,dy + R\,dz$</span> が <span class="tex2jax_process">$1$</span>-form のとき、<span class="tex2jax_process">$d\omega$</span> は <span class="tex2jax_process">$\omega$</span> の局所的なズレを測る <span class="tex2jax_process">$2$</span>-form（反対称行列）になる。
+<div class="math-block tex2jax_process">$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$</div>
+<span class="tex2jax_process">$\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$</span> が <span class="tex2jax_process">$2$</span>-form のとき、<span class="tex2jax_process">$d\eta$</span> は <span class="tex2jax_process">$3$</span>-form（三階反対称テンソル）になる。
+<div class="math-block tex2jax_process">$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$</div>
+<p>このように、<span class="tex2jax_process">$d$</span> が作用するたびに測定器の次数が <span class="tex2jax_process">$0\to1\to2\to3$</span> と一つずつ上がっていく。核心は<strong>場はそのまま、測定器の側が変化する</strong>ことだ。<span class="tex2jax_process">$f$</span> はスカラー場のままだが、<span class="tex2jax_process">$d$</span> が作用するたびに新しい測定器——<span class="tex2jax_process">$df$</span>（<span class="tex2jax_process">$1$</span>-form）、<span class="tex2jax_process">$d\omega$</span>（<span class="tex2jax_process">$2$</span>-form）、<span class="tex2jax_process">$d\eta$</span>（<span class="tex2jax_process">$3$</span>-form）——が生み出される。
 </p>
-<p>$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+<h4 id="812-測定器はそのまま新たな場を考えるspan-classtex2jaxprocessspan-の立場">8.1.2 測定器はそのまま、新たな場を考える——<span class="tex2jax_process">$\nabla$</span> の立場</h4>
+<p>一方、第7章で導入した <span class="tex2jax_process">$\nabla = \begin{pmatrix} \frac{\partial}{\partial x} & \frac{\partial}{\partial y} & \frac{\partial}{\partial z} \end{pmatrix}^T$</span> の世界では、<strong>測定器（<span class="tex2jax_process">$\nabla$</span>）は変わらず、作用する相手に応じて新たな場が生まれる</strong>。<span class="tex2jax_process">$\nabla$</span> はつねに同じ演算子だが、スカラー場 <span class="tex2jax_process">$f$</span> に作用すればベクトル場 <span class="tex2jax_process">$\nabla f$</span> を、ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> に作用すればスカラー場 <span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> やベクトル場 <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> を返す。
 </p>
-<p>$\omega = P\,dx + Q\,dy + R\,dz$ が $1$-form のとき、$d\omega$ は $\omega$ の局所的なズレを測る $2$-form（反対称行列）になる。
+<p>スカラー場 <span class="tex2jax_process">$f(x,y,z)$</span> に <span class="tex2jax_process">$\nabla$</span> を作用させると、各方向の変化率を成分とする縦ベクトル場が得られる。
 </p>
-<p>$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$
+<div class="math-block tex2jax_process">$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$</div>
+<p>これは空間の各点に立つ矢印であり、もはや測定器ではない。<span class="tex2jax_process">$f$</span> が最も急に増加する方向とその強さを表す。
 </p>
-<p>$\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ が $2$-form のとき、$d\eta$ は $3$-form（三階反対称テンソル）になる。
+<p>ベクトル場 <span class="tex2jax_process">$\mathbf{F} = (F_x, F_y, F_z)^T$</span> に <span class="tex2jax_process">$\nabla\cdot$</span> を作用させると、スカラー場が得られる。
 </p>
-<p>$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
-</p>
-<p>このように、$d$ が作用するたびに測定器の次数が $0\to1\to2\to3$ と一つずつ上がっていく。核心は<strong>場はそのまま、測定器の側が変化する</strong>ことだ。$f$ はスカラー場のままだが、$d$ が作用するたびに新しい測定器——$df$（$1$-form）、$d\omega$（$2$-form）、$d\eta$（$3$-form）——が生み出される。
-</p>
-<h4 id="812-測定器はそのまま新たな場を考える-の立場">8.1.2 測定器はそのまま、新たな場を考える——$\nabla$ の立場</h4>
-<p>一方、第7章で導入した $\nabla = \begin{pmatrix} \frac{\partial}{\partial x} & \frac{\partial}{\partial y} & \frac{\partial}{\partial z} \end{pmatrix}^T$ の世界では、<strong>測定器（$\nabla$）は変わらず、作用する相手に応じて新たな場が生まれる</strong>。$\nabla$ はつねに同じ演算子だが、スカラー場 $f$ に作用すればベクトル場 $\nabla f$ を、ベクトル場 $\mathbf{F}$ に作用すればスカラー場 $\nabla\cdot\mathbf{F}$ やベクトル場 $\nabla\times\mathbf{F}$ を返す。
-</p>
-<p>スカラー場 $f(x,y,z)$ に $\nabla$ を作用させると、各方向の変化率を成分とする縦ベクトル場が得られる。
-</p>
-<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$
-</p>
-<p>これは空間の各点に立つ矢印であり、もはや測定器ではない。$f$ が最も急に増加する方向とその強さを表す。
-</p>
-<p>ベクトル場 $\mathbf{F} = (F_x, F_y, F_z)^T$ に $\nabla\cdot$ を作用させると、スカラー場が得られる。
-</p>
-<p>$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$</div>
 <p>各方向の変化率の和——湧き出しの強さ——を返す。
 </p>
-<p>同じ $\mathbf{F}$ に $\nabla\times$ を作用させると、再び縦ベクトル場が得られる。
+<p>同じ <span class="tex2jax_process">$\mathbf{F}$</span> に <span class="tex2jax_process">$\nabla\times$</span> を作用させると、再び縦ベクトル場が得られる。
 </p>
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$
-</p>
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$</div>
 <p>渦の軸方向と強さを表す。
 </p>
-<p>$\nabla$ の世界では、結果はつねに実空間の中の矢印かスカラーとして返される。$\nabla f$ も $\nabla\times\mathbf{F}$ も画面上では同じ「矢印」であり、型による区別はつかない。
-</p>
+<span class="tex2jax_process">$\nabla$</span> の世界では、結果はつねに実空間の中の矢印かスカラーとして返される。<span class="tex2jax_process">$\nabla f$</span> も <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> も画面上では同じ「矢印」であり、型による区別はつかない。
 <blockquote><p>**【ここまでのチェックポイント — §8.1】**</p>
-- $d$ の立場：場はそのまま、測定器の側が変化する。新しい測定器が生まれる。
-- $\nabla$ の立場：測定器（$\nabla$）はそのまま、新たな場が生まれる。
+- <span class="tex2jax_process">$d$</span> の立場：場はそのまま、測定器の側が変化する。新しい測定器が生まれる。
+- <span class="tex2jax_process">$\nabla$</span> の立場：測定器（<span class="tex2jax_process">$\nabla$</span>）はそのまま、新たな場が生まれる。
 </p></blockquote>
 <hr />
 <h3 id="82-翻訳辞書の完成">§8.2 翻訳辞書の完成</h3>
-<p>第6章 §5.5 で $\mathrm{grad}=d$, $\mathrm{rot}=\ast d$, $\mathrm{div}=\ast d\ast$ という対応を導入した。ここで、この辞書を $\nabla$ の言葉と突き合わせて、完全な形で整理する。
+<p>第6章 §5.5 で <span class="tex2jax_process">$\mathrm{grad}=d$</span>, <span class="tex2jax_process">$\mathrm{rot}=\ast d$</span>, <span class="tex2jax_process">$\mathrm{div}=\ast d\ast$</span> という対応を導入した。ここで、この辞書を <span class="tex2jax_process">$\nabla$</span> の言葉と突き合わせて、完全な形で整理する。
 </p>
-<p>以下、ベクトル場 $\mathbf{F} = (F_x, F_y, F_z)^T$ に対応する $1$-form を $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ と書く。
+<p>以下、ベクトル場 <span class="tex2jax_process">$\mathbf{F} = (F_x, F_y, F_z)^T$</span> に対応する <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$\omega = F_x\,dx + F_y\,dy + F_z\,dz$</span> と書く。
 </p>
 <h4 id="821-勾配">8.2.1 勾配</h4>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathrm{grad}\,f = \nabla f
 \quad\longleftrightarrow\quad
 df = \frac{\partial f}{\partial x}dx + \frac{\partial f}{\partial y}dy + \frac{\partial f}{\partial z}dz
-$$
-</p>
-<p>$\nabla f$ は<strong>縦ベクトル</strong>、$df$ は<strong>横ベクトル</strong>。転置の関係にある。本書の記法では、$\nabla f$ の各成分と $df$ の各成分は数値として同じだが、縦と横の区別が「場の見方」と「測定器の見方」の違いを反映している。
-</p>
+$$</div>
+<span class="tex2jax_process">$\nabla f$</span> は<strong>縦ベクトル</strong>、<span class="tex2jax_process">$df$</span> は<strong>横ベクトル</strong>。転置の関係にある。本書の記法では、<span class="tex2jax_process">$\nabla f$</span> の各成分と <span class="tex2jax_process">$df$</span> の各成分は数値として同じだが、縦と横の区別が「場の見方」と「測定器の見方」の違いを反映している。
 <h4 id="822-回転">8.2.2 回転</h4>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}
 \quad\longleftrightarrow\quad
 \ast d\omega
-$$
-</p>
-<p>$\nabla\times\mathbf{F}$ は<strong>縦ベクトル</strong>、$d\omega$ は<strong>$2$-form（反対称行列）</strong>、そして $\ast d\omega$ は<strong>$1$-form（横ベクトル）</strong>である。回転は「外微分で次数を上げてから、ホッジ・スターで次数を戻す」という二段階の操作だ。
-</p>
-<p>$\nabla\times\mathbf{F}$ の $x$ 成分 $\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}$ は、$\ast d\omega$ の $dx$ の係数と一致する。これは §5.5.2 で確認した通りである。
-</p>
+$$</div>
+<span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> は<strong>縦ベクトル</strong>、<span class="tex2jax_process">$d\omega$</span> は<strong><span class="tex2jax_process">$2$</span>-form（反対称行列）</strong>、そして <span class="tex2jax_process">$\ast d\omega$</span> は<strong><span class="tex2jax_process">$1$</span>-form（横ベクトル）</strong>である。回転は「外微分で次数を上げてから、ホッジ・スターで次数を戻す」という二段階の操作だ。
+<span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> の <span class="tex2jax_process">$x$</span> 成分 <span class="tex2jax_process">$\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}$</span> は、<span class="tex2jax_process">$\ast d\omega$</span> の <span class="tex2jax_process">$dx$</span> の係数と一致する。これは §5.5.2 で確認した通りである。
 <h4 id="823-発散">8.2.3 発散</h4>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}
 \quad\longleftrightarrow\quad
 \ast d \ast \omega
-$$
-</p>
-<p>$\nabla\cdot\mathbf{F}$ は<strong>スカラー場</strong>、$\ast d\ast\omega$ も<strong>$0$-form（スカラー場）</strong>である。発散は「ホッジ・スターで $2$-form に変え、外微分で $3$-form に上げ、再びホッジ・スターでスカラーに落とす」という三段階の操作だ。
-</p>
+$$</div>
+<span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> は<strong>スカラー場</strong>、<span class="tex2jax_process">$\ast d\ast\omega$</span> も<strong><span class="tex2jax_process">$0$</span>-form（スカラー場）</strong>である。発散は「ホッジ・スターで <span class="tex2jax_process">$2$</span>-form に変え、外微分で <span class="tex2jax_process">$3$</span>-form に上げ、再びホッジ・スターでスカラーに落とす」という三段階の操作だ。
 <h4 id="824-辞書の表">8.2.4 辞書の表</h4>
-<p>| 演算 | $\nabla$ 表記 | $d,\ast$ 表記 | 入力の次数 | 出力の次数 | $\ast$ の使用回数 |
+<p>| 演算 | <span class="tex2jax_process">$\nabla$</span> 表記 | <span class="tex2jax_process">$d,\ast$</span> 表記 | 入力の次数 | 出力の次数 | <span class="tex2jax_process">$\ast$</span> の使用回数 |
 |---|---|---|---|---|---|
-| 勾配 | $\nabla f$ | $df$ | $0$ | $1$ | $0$ |
-| 回転 | $\nabla\times\mathbf{F}$ | $\ast d\omega$ | $1$ | $1$ | $1$ |
-| 発散 | $\nabla\cdot\mathbf{F}$ | $\ast d\ast\omega$ | $1$ | $0$ | $2$ |
+| 勾配 | <span class="tex2jax_process">$\nabla f$</span> | <span class="tex2jax_process">$df$</span> | <span class="tex2jax_process">$0$</span> | <span class="tex2jax_process">$1$</span> | <span class="tex2jax_process">$0$</span> |
+| 回転 | <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> | <span class="tex2jax_process">$\ast d\omega$</span> | <span class="tex2jax_process">$1$</span> | <span class="tex2jax_process">$1$</span> | <span class="tex2jax_process">$1$</span> |
+| 発散 | <span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> | <span class="tex2jax_process">$\ast d\ast\omega$</span> | <span class="tex2jax_process">$1$</span> | <span class="tex2jax_process">$0$</span> | <span class="tex2jax_process">$2$</span> |
 </p>
-<p>$\ast$ の使用回数が増えるほど、$\nabla$ 表記と $d,\ast$ 表記の間の「翻訳コスト」が上がる。勾配は $\ast$ がゼロ回なので翻訳不要（$df$ と $\nabla f$ は転置の関係）、回転は $1$ 回、発散は $2$ 回である。この $\ast$ の往復が、第7章 §6.7 の注で「微分形式のほうが汚い」と感じた原因だった。
-</p>
+<span class="tex2jax_process">$\ast$</span> の使用回数が増えるほど、<span class="tex2jax_process">$\nabla$</span> 表記と <span class="tex2jax_process">$d,\ast$</span> 表記の間の「翻訳コスト」が上がる。勾配は <span class="tex2jax_process">$\ast$</span> がゼロ回なので翻訳不要（<span class="tex2jax_process">$df$</span> と <span class="tex2jax_process">$\nabla f$</span> は転置の関係）、回転は <span class="tex2jax_process">$1$</span> 回、発散は <span class="tex2jax_process">$2$</span> 回である。この <span class="tex2jax_process">$\ast$</span> の往復が、第7章 §6.7 の注で「微分形式のほうが汚い」と感じた原因だった。
 <blockquote><p>**【ここまでのチェックポイント — §8.2】**</p>
-- $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$。
-- $\ast$ の使用回数が勾配 $0$、回転 $1$、発散 $2$。この翻訳コストが「微分形式は汚い」という印象の正体。
+- <span class="tex2jax_process">$\nabla f \leftrightarrow df$</span>, <span class="tex2jax_process">$\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$</span>, <span class="tex2jax_process">$\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$</span>。
+- <span class="tex2jax_process">$\ast$</span> の使用回数が勾配 <span class="tex2jax_process">$0$</span>、回転 <span class="tex2jax_process">$1$</span>、発散 <span class="tex2jax_process">$2$</span>。この翻訳コストが「微分形式は汚い」という印象の正体。
 </p></blockquote>
 <hr />
 <h3 id="83-ストークスの定理を翻訳する">§8.3 ストークスの定理を翻訳する</h3>
-<p>第5章 §4.6 で、我々はすでに $\int_{\partial S}\omega = \int_S d\omega$ という形のストークスの定理を導いた。第7章 §6.8.1 では、同じ定理を $\nabla$ の言葉で $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ と書いた。この二つが同じものであることを、§8.2 の辞書を使って確認する。
+<p>第5章 §4.6 で、我々はすでに <span class="tex2jax_process">$\int_{\partial S}\omega = \int_S d\omega$</span> という形のストークスの定理を導いた。第7章 §6.8.1 では、同じ定理を <span class="tex2jax_process">$\nabla$</span> の言葉で <span class="tex2jax_process">$\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$</span> と書いた。この二つが同じものであることを、§8.2 の辞書を使って確認する。
 </p>
-<h4 id="831-から-へ">8.3.1 $\nabla$ から $d$ へ</h4>
-<p>$\nabla$ 表記のストークスの定理を出発点とする。
+<h4 id="831-span-classtex2jaxprocessspan-から-span-classtex2jaxprocessspan-へ">8.3.1 <span class="tex2jax_process">$\nabla$</span> から <span class="tex2jax_process">$d$</span> へ</h4>
+<span class="tex2jax_process">$\nabla$</span> 表記のストークスの定理を出発点とする。
+<div class="math-block tex2jax_process">$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$</div>
+<p>左辺の <span class="tex2jax_process">$\oint_C \mathbf{F}\cdot d\mathbf{r}$</span> は、ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> を曲線 <span class="tex2jax_process">$C$</span> に沿って線積分したものだ。<span class="tex2jax_process">$\mathbf{F}$</span> に対応する <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$\omega = F_x\,dx + F_y\,dy + F_z\,dz$</span> とすれば、第3章の定義によりこれは <span class="tex2jax_process">$\int_C \omega$</span> に等しい。
 </p>
-<p>$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+<div class="math-block tex2jax_process">$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \int_{\partial S} \omega$$</div>
+<p>右辺の <span class="tex2jax_process">$\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$</span> は、回転の法線成分の面積分である。辞書 <span class="tex2jax_process">$\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$</span> を使うと、<span class="tex2jax_process">$(\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$</span> は <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\ast(\ast d\omega) = d\omega$</span> の面積分に対応する（<span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> により <span class="tex2jax_process">$\ast$</span> が打ち消し合う）。
 </p>
-<p>左辺の $\oint_C \mathbf{F}\cdot d\mathbf{r}$ は、ベクトル場 $\mathbf{F}$ を曲線 $C$ に沿って線積分したものだ。$\mathbf{F}$ に対応する $1$-form を $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ とすれば、第3章の定義によりこれは $\int_C \omega$ に等しい。
-</p>
-<p>$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \int_{\partial S} \omega$$
-</p>
-<p>右辺の $\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ は、回転の法線成分の面積分である。辞書 $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$ を使うと、$(\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ は $2$-form $\ast(\ast d\omega) = d\omega$ の面積分に対応する（$\ast\ast = \mathrm{id}$ により $\ast$ が打ち消し合う）。
-</p>
-<p>$$\iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS = \int_S d\omega$$
-</p>
+<div class="math-block tex2jax_process">$$\iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS = \int_S d\omega$$</div>
 <p>したがって、
 </p>
-<p>$$\int_{\partial S} \omega = \int_S d\omega$$
-</p>
-<p>これは第5章 §4.6 で得た式そのものである。$\nabla$ の世界のストークスの定理は、辞書を通じて $d$ の言葉に翻訳すると、ただの $\int_{\partial M}\omega = \int_M d\omega$ になる。
+<div class="math-block tex2jax_process">$$\int_{\partial S} \omega = \int_S d\omega$$</div>
+<p>これは第5章 §4.6 で得た式そのものである。<span class="tex2jax_process">$\nabla$</span> の世界のストークスの定理は、辞書を通じて <span class="tex2jax_process">$d$</span> の言葉に翻訳すると、ただの <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> になる。
 </p>
 <h4 id="832-翻訳の往復どちらからでも行ける">8.3.2 翻訳の往復——どちらからでも行ける</h4>
-<p>逆方向もできる。$d$ の言葉で書かれた式に辞書を逆に当てれば、$\nabla$ の言葉に戻る。この双方向の翻訳が自由にできることこそ、第6章で $\ast$ を導入した最大の成果である。
+<p>逆方向もできる。<span class="tex2jax_process">$d$</span> の言葉で書かれた式に辞書を逆に当てれば、<span class="tex2jax_process">$\nabla$</span> の言葉に戻る。この双方向の翻訳が自由にできることこそ、第6章で <span class="tex2jax_process">$\ast$</span> を導入した最大の成果である。
 </p>
-<blockquote><p>**注** （どちらの言葉で考えるべきか）結論から言えば、問題による。境界の形状が単純で、場の対称性が高い問題では $\nabla$ 表記の方が見通しがよい。一方、座標系が歪んでいたり、場の「型」を明確に区別したい問題では $d,\ast$ 表記が有利である。重要なのは、両方の言語を使えることだ。</p>
+<blockquote><p>**注** （どちらの言葉で考えるべきか）結論から言えば、問題による。境界の形状が単純で、場の対称性が高い問題では <span class="tex2jax_process">$\nabla$</span> 表記の方が見通しがよい。一方、座標系が歪んでいたり、場の「型」を明確に区別したい問題では <span class="tex2jax_process">$d,\ast$</span> 表記が有利である。重要なのは、両方の言語を使えることだ。</p>
 </p></blockquote>
-<blockquote><p>**注**（筆者の本音）本文では「問題に応じて二つの言語を使い分ける」と書いた。これは読者のための建前である。筆者自身は、可能な限り $d,\ast$ の言葉で考える。なぜなら、$\nabla$ の記法は計算には便利だが、勾配・回転・発散の型の違いを同じ矢印やスカラーの中に押し込めてしまうからである。本書の目的は、ベクトル解析を禁止することではなく、その背後で暗黙に行われている型変換を見える場所に出すことにある。</p>
+<blockquote><p>**注**（筆者の本音）本文では「問題に応じて二つの言語を使い分ける」と書いた。これは読者のための建前である。筆者自身は、可能な限り <span class="tex2jax_process">$d,\ast$</span> の言葉で考える。なぜなら、<span class="tex2jax_process">$\nabla$</span> の記法は計算には便利だが、勾配・回転・発散の型の違いを同じ矢印やスカラーの中に押し込めてしまうからである。本書の目的は、ベクトル解析を禁止することではなく、その背後で暗黙に行われている型変換を見える場所に出すことにある。</p>
 </p></blockquote>
 <hr />
 <h3 id="84-ガウスの定理を翻訳する">§8.4 ガウスの定理を翻訳する</h3>
 <p>第7章 §6.8.2 のガウスの発散定理も、同様に翻訳できる。
 </p>
-<p>$$\oiint_{\partial V} \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+<div class="math-block tex2jax_process">$$\oiint_{\partial V} \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$</div>
+<p>左辺の面積分は、<span class="tex2jax_process">$\mathbf{F}$</span> に対応する <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\omega$</span> を使って <span class="tex2jax_process">$\int_{\partial V} \ast\omega$</span> と書ける（<span class="tex2jax_process">$\ast\omega$</span> は <span class="tex2jax_process">$2$</span>-form であり、閉曲面上の面積分の対象となる）。
 </p>
-<p>左辺の面積分は、$\mathbf{F}$ に対応する $1$-form $\omega$ を使って $\int_{\partial V} \ast\omega$ と書ける（$\ast\omega$ は $2$-form であり、閉曲面上の面積分の対象となる）。
-</p>
-<p>右辺の発散の体積分は、辞書 $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$ により $\int_V \ast d\ast\omega$ となる。ここで $\ast d\ast\omega$ は $0$-form（スカラー場）だから、体積分するには再び $\ast$ を掛けて $3$-form にする必要がある。すなわち $\int_V d\ast\omega$ である。
+<p>右辺の発散の体積分は、辞書 <span class="tex2jax_process">$\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$</span> により <span class="tex2jax_process">$\int_V \ast d\ast\omega$</span> となる。ここで <span class="tex2jax_process">$\ast d\ast\omega$</span> は <span class="tex2jax_process">$0$</span>-form（スカラー場）だから、体積分するには再び <span class="tex2jax_process">$\ast$</span> を掛けて <span class="tex2jax_process">$3$</span>-form にする必要がある。すなわち <span class="tex2jax_process">$\int_V d\ast\omega$</span> である。
 </p>
 <p>結局、ガウスの定理は次の形に翻訳される。
 </p>
-<p>$$\int_{\partial V} \ast\omega = \int_V d\ast\omega$$
+<div class="math-block tex2jax_process">$$\int_{\partial V} \ast\omega = \int_V d\ast\omega$$</div>
+<p>ここで <span class="tex2jax_process">$\eta = \ast\omega$</span>（<span class="tex2jax_process">$2$</span>-form）と置けば、
 </p>
-<p>ここで $\eta = \ast\omega$（$2$-form）と置けば、
-</p>
-<p>$$\int_{\partial V} \eta = \int_V d\eta$$
-</p>
-<p>これは第5章 §4.7 で得たガウスの定理の $d$-form 表現そのものだ。そしてこの式は、すでに §4.9.1 で $\int_{\partial M}\omega = \int_M d\omega$ の $k=2$ の場合として統合されている。
+<div class="math-block tex2jax_process">$$\int_{\partial V} \eta = \int_V d\eta$$</div>
+<p>これは第5章 §4.7 で得たガウスの定理の <span class="tex2jax_process">$d$</span>-form 表現そのものだ。そしてこの式は、すでに §4.9.1 で <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> の <span class="tex2jax_process">$k=2$</span> の場合として統合されている。
 </p>
 <h4 id="841-三つの定理一つの式">8.4.1 三つの定理、一つの式</h4>
-<p>第7章で別々の定理として並べた三つの積分定理——グリーン、ストークス、ガウス——は、$\nabla$ の言葉では確かに異なる顔をしていた。しかし $d$ の言葉に翻訳すれば、すべてが $\int_{\partial M}\omega = \int_M d\omega$ の $k$ の値が違うだけの同一の式になる。
+<p>第7章で別々の定理として並べた三つの積分定理——グリーン、ストークス、ガウス——は、<span class="tex2jax_process">$\nabla$</span> の言葉では確かに異なる顔をしていた。しかし <span class="tex2jax_process">$d$</span> の言葉に翻訳すれば、すべてが <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> の <span class="tex2jax_process">$k$</span> の値が違うだけの同一の式になる。
 </p>
-<p>| $k$ | $\partial M$ | $M$ | 定理 |
+<p>| <span class="tex2jax_process">$k$</span> | <span class="tex2jax_process">$\partial M$</span> | <span class="tex2jax_process">$M$</span> | 定理 |
 |---|---|---|---|
-| $0$ | $B-A$（二点） | 曲線 | 微積分学の基本定理 |
-| $1$ | 閉曲線 | 曲面 | ストークス（グリーンを含む） |
-| $2$ | 閉曲面 | 立体 | ガウス |
+| <span class="tex2jax_process">$0$</span> | <span class="tex2jax_process">$B-A$</span>（二点） | 曲線 | 微積分学の基本定理 |
+| <span class="tex2jax_process">$1$</span> | 閉曲線 | 曲面 | ストークス（グリーンを含む） |
+| <span class="tex2jax_process">$2$</span> | 閉曲面 | 立体 | ガウス |
 </p>
-<p>$k$ が違うだけだ。もはや三つの定理を別々に暗記する理由はない。$\int_{\partial M}\omega = \int_M d\omega$ 一つ覚えれば、あとは $M$ の次元に応じて適用するだけである。
-</p>
+<span class="tex2jax_process">$k$</span> が違うだけだ。もはや三つの定理を別々に暗記する理由はない。<span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> 一つ覚えれば、あとは <span class="tex2jax_process">$M$</span> の次元に応じて適用するだけである。
 <blockquote><p>**【ここまでのチェックポイント — §8.3–§8.4】**</p>
-- $\nabla$ 表記のストークスの定理は、辞書を当てると $\int_{\partial S}\omega = \int_S d\omega$ に還元される。
-- $\nabla$ 表記のガウスの定理は、辞書を当てると $\int_{\partial V}\eta = \int_V d\eta$ に還元される。
-- どちらも $\int_{\partial M}\omega = \int_M d\omega$ の $k$ が違うだけ。三定理は一つの式の異なる現れである。
+- <span class="tex2jax_process">$\nabla$</span> 表記のストークスの定理は、辞書を当てると <span class="tex2jax_process">$\int_{\partial S}\omega = \int_S d\omega$</span> に還元される。
+- <span class="tex2jax_process">$\nabla$</span> 表記のガウスの定理は、辞書を当てると <span class="tex2jax_process">$\int_{\partial V}\eta = \int_V d\eta$</span> に還元される。
+- どちらも <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> の <span class="tex2jax_process">$k$</span> が違うだけ。三定理は一つの式の異なる現れである。
 </p></blockquote>
 <hr />
 <h3 id="85-二つの方法論場はそのままか測定器はそのままか">§8.5 二つの方法論——場はそのままか、測定器はそのままか</h3>
 <p>第6章 §5.3.1 で、スカラーを得る二つの方法を導入した。本章の翻訳作業を経て、この二つの方法論の対比をより深く理解できる段階に来た。ここで改めて、二つの視点を突き合わせる。
 </p>
 <h4 id="851-方法dの方法場はそのまま測定器の側が変化する">8.5.1 方法①（dの方法）——場はそのまま、測定器の側が変化する</h4>
-<p>場そのものには手を触れない。$d$ が作用するたびに、<strong>新しい測定器が生み出される</strong>。
+<p>場そのものには手を触れない。<span class="tex2jax_process">$d$</span> が作用するたびに、<strong>新しい測定器が生み出される</strong>。
 </p>
 <ul>
-<li>スカラー場 $f$ の変化を測りたい → $df$ という $1$-form 測定器を作る</li>
+<li>スカラー場 <span class="tex2jax_process">$f$</span> の変化を測りたい → <span class="tex2jax_process">$df$</span> という <span class="tex2jax_process">$1$</span>-form 測定器を作る</li>
 </ol>
 <ul>
-<li>$1$-form 場 $\omega$ の循環を測りたい → $d\omega$ という $2$-form 面積測定器を作る</li>
+<li><span class="tex2jax_process">$1$</span>-form 場 <span class="tex2jax_process">$\omega$</span> の循環を測りたい → <span class="tex2jax_process">$d\omega$</span> という <span class="tex2jax_process">$2$</span>-form 面積測定器を作る</li>
 </ol>
 <ul>
-<li>$2$-form 場 $\eta$ の湧き出しを測りたい → $d\eta$ という $3$-form 体積測定器を作る</li>
+<li><span class="tex2jax_process">$2$</span>-form 場 <span class="tex2jax_process">$\eta$</span> の湧き出しを測りたい → <span class="tex2jax_process">$d\eta$</span> という <span class="tex2jax_process">$3$</span>-form 体積測定器を作る</li>
 </ol>
-<p>$d$ はつねに測定器の次数を $+1$ する。この立場では、<strong>場を測る手段そのものが変わる</strong>。$f$ を測る $df$ と $\omega$ を測る $d\omega$ は異なる種類の測定器であり、混同されることは原理的にない。
-</p>
-<p>積分は、作った測定器を領域に適用するだけである。そして $\int_{\partial M}\omega = \int_M d\omega$ が、測定器のすげ替えと積分の間の整合性を保証する。
+<span class="tex2jax_process">$d$</span> はつねに測定器の次数を <span class="tex2jax_process">$+1$</span> する。この立場では、<strong>場を測る手段そのものが変わる</strong>。<span class="tex2jax_process">$f$</span> を測る <span class="tex2jax_process">$df$</span> と <span class="tex2jax_process">$\omega$</span> を測る <span class="tex2jax_process">$d\omega$</span> は異なる種類の測定器であり、混同されることは原理的にない。
+<p>積分は、作った測定器を領域に適用するだけである。そして <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> が、測定器のすげ替えと積分の間の整合性を保証する。
 </p>
 <h4 id="852-方法の方法測定器はそのまま新たな場を考える">8.5.2 方法②（∇の方法）——測定器はそのまま、新たな場を考える</h4>
-<p>$\nabla$ という測定器はつねに同じ。作用する相手に応じて、<strong>異なる種類の場が結果として生まれる</strong>。
-</p>
+<span class="tex2jax_process">$\nabla$</span> という測定器はつねに同じ。作用する相手に応じて、<strong>異なる種類の場が結果として生まれる</strong>。
 <ul>
-<li>スカラー場 $f$ の変化 → $\nabla f$（縦ベクトル場）</li>
+<li>スカラー場 <span class="tex2jax_process">$f$</span> の変化 → <span class="tex2jax_process">$\nabla f$</span>（縦ベクトル場）</li>
 </ol>
 <ul>
-<li>ベクトル場 $\mathbf{F}$ の渦 → $\nabla\times\mathbf{F}$（縦ベクトル場）</li>
+<li>ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> の渦 → <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span>（縦ベクトル場）</li>
 </ol>
 <ul>
-<li>ベクトル場 $\mathbf{F}$ の湧き出し → $\nabla\cdot\mathbf{F}$（スカラー場）</li>
+<li>ベクトル場 <span class="tex2jax_process">$\mathbf{F}$</span> の湧き出し → <span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span>（スカラー場）</li>
 </ol>
-<p>この立場では、$\nabla f$ も $\nabla\times\mathbf{F}$ も画面上では同じ「矢印」である。勾配の矢印と回転の矢印は幾何的意味がまったく異なるのに、表示上は区別がつかない。第7章で指摘した「すべてが同じ矢印に見える」問題がここにある。
+<p>この立場では、<span class="tex2jax_process">$\nabla f$</span> も <span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> も画面上では同じ「矢印」である。勾配の矢印と回転の矢印は幾何的意味がまったく異なるのに、表示上は区別がつかない。第7章で指摘した「すべてが同じ矢印に見える」問題がここにある。
 </p>
 <h4 id="853-なぜ一致するのか">8.5.3 なぜ一致するのか</h4>
 <p>方法①と方法②は、やっていることが<strong>根本的に違う</strong>。一方は場をそのままに新しい測定器を生み出し、他方は測定器をそのままに新たな場を考える。操作方法も、出てくる対象の種類も異なる。
 </p>
-<p>なのに積分すると一致する。たとえばスカラー場 $f$ の変化を線積分するとき、$df$（横ベクトルの測定器）を使っても $\nabla f$（縦ベクトルの矢印）を使っても、結果はどちらも $f(B)-f(A)$ だ。
+<p>なのに積分すると一致する。たとえばスカラー場 <span class="tex2jax_process">$f$</span> の変化を線積分するとき、<span class="tex2jax_process">$df$</span>（横ベクトルの測定器）を使っても <span class="tex2jax_process">$\nabla f$</span>（縦ベクトルの矢印）を使っても、結果はどちらも <span class="tex2jax_process">$f(B)-f(A)$</span> だ。
 </p>
-<p>$$\int_C df = \int_C \nabla f \cdot d\mathbf{r} = f(B) - f(A)$$
+<div class="math-block tex2jax_process">$$\int_C df = \int_C \nabla f \cdot d\mathbf{r} = f(B) - f(A)$$</div>
+<p>なぜか。<span class="tex2jax_process">$\ast$</span> が両者を繫いでいるからだ。<span class="tex2jax_process">$\ast$</span> は、方法②の「矢印」を方法①の「測定器」に変換する（またはその逆）。この変換を経由することで、<span class="tex2jax_process">$\nabla f$</span> と <span class="tex2jax_process">$df$</span>、<span class="tex2jax_process">$\nabla\times\mathbf{F}$</span> と <span class="tex2jax_process">$\ast d\omega$</span>、<span class="tex2jax_process">$\nabla\cdot\mathbf{F}$</span> と <span class="tex2jax_process">$\ast d\ast\omega$</span> が、積分のレベルで同じ結果を与えることが保証される。
 </p>
-<p>なぜか。$\ast$ が両者を繫いでいるからだ。$\ast$ は、方法②の「矢印」を方法①の「測定器」に変換する（またはその逆）。この変換を経由することで、$\nabla f$ と $df$、$\nabla\times\mathbf{F}$ と $\ast d\omega$、$\nabla\cdot\mathbf{F}$ と $\ast d\ast\omega$ が、積分のレベルで同じ結果を与えることが保証される。
+<p>そして <span class="tex2jax_process">$\ast\ast = \mathrm{id}$</span> があるから、変換を何度往復しても情報は失われない。この往復の自由こそ、両方の言語を話せることの力である。
 </p>
-<p>そして $\ast\ast = \mathrm{id}$ があるから、変換を何度往復しても情報は失われない。この往復の自由こそ、両方の言語を話せることの力である。
-</p>
-<blockquote><p>**注**（二つの方法の使い分け——筆者の立場）筆者は、問題に応じて両方の方法を行き来する。対称性の高い系では $\nabla$ で見通しをつけ、座標系が歪んだり場の種類が入り組んだりする系では $d,\ast$ に翻訳して型の整合性を確認する。どちらか一方に固執する必要はない。重要なのは、翻訳の辞書を頭に入れておくことだ。</p>
+<blockquote><p>**注**（二つの方法の使い分け——筆者の立場）筆者は、問題に応じて両方の方法を行き来する。対称性の高い系では <span class="tex2jax_process">$\nabla$</span> で見通しをつけ、座標系が歪んだり場の種類が入り組んだりする系では <span class="tex2jax_process">$d,\ast$</span> に翻訳して型の整合性を確認する。どちらか一方に固執する必要はない。重要なのは、翻訳の辞書を頭に入れておくことだ。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント — §8.5】**</p>
 
@@ -4182,92 +3856,81 @@ $$
 |:---|:---|:---|
 | **対象** | 場はそのまま | 測定器はそのまま |
 | **変化** | 測定器の側が変化 | 新たな場を考える |
-| **操作** | 外微分 $d$ | ナブラ $\nabla$ |
+| **操作** | 外微分 <span class="tex2jax_process">$d$</span> | ナブラ <span class="tex2jax_process">$\nabla$</span> |
 | **結果** | 新しい測定器が生まれる | 異なる種類の場が生まれる |
 
-積分での一致を保証するのが $\ast$。$\ast\ast=\mathrm{id}$ により往復は自由。
+積分での一致を保証するのが <span class="tex2jax_process">$\ast$</span>。<span class="tex2jax_process">$\ast\ast=\mathrm{id}$</span> により往復は自由。
 </p></blockquote>
 <hr />
 <h3 id="86-曲線座標と二つの方法">§8.6 曲線座標と二つの方法</h3>
-<p>§8.2 の辞書はデカルト座標 $(x,y,z)$ で $\mathbf{g}=I$ を前提としていた。一般の座標系では計量 $g = J^T J$ が単位行列ではなくなり、$\ast$ の辞書も変わる。ここでは円柱座標を例に、辞書の変化を確認したあと、§8.5 で語った二つの方法論を目の前で回してみる。
+<p>§8.2 の辞書はデカルト座標 <span class="tex2jax_process">$(x,y,z)$</span> で <span class="tex2jax_process">$\mathbf{g}=I$</span> を前提としていた。一般の座標系では計量 <span class="tex2jax_process">$g = J^T J$</span> が単位行列ではなくなり、<span class="tex2jax_process">$\ast$</span> の辞書も変わる。ここでは円柱座標を例に、辞書の変化を確認したあと、§8.5 で語った二つの方法論を目の前で回してみる。
 </p>
 <h4 id="861-辞書は計量で変わる">8.6.1 辞書は計量で変わる</h4>
 <p>第6章 §5.1.3 で円柱座標の計量を導出した。
 </p>
-<p>$$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$$
+<div class="math-block tex2jax_process">$$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$$</div>
+<p>この <span class="tex2jax_process">$\mathbf{g} \neq I$</span> が <span class="tex2jax_process">$\ast$</span> の辞書にどう影響するか。デカルト座標では <span class="tex2jax_process">$\ast(dx) = dy \wedge dz$</span> だった。円柱座標の基底 <span class="tex2jax_process">$1$</span>-form を <span class="tex2jax_process">$(dr, d\theta, dz)$</span> とすると、<span class="tex2jax_process">$\ast$</span> の辞書は次のように変わる。
 </p>
-<p>この $\mathbf{g} \neq I$ が $\ast$ の辞書にどう影響するか。デカルト座標では $\ast(dx) = dy \wedge dz$ だった。円柱座標の基底 $1$-form を $(dr, d\theta, dz)$ とすると、$\ast$ の辞書は次のように変わる。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast(dr) &= r\,d\theta \wedge dz \\
 \ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
 \ast(dz) &= r\,dr \wedge d\theta
-\end{aligned}$$
-</p>
-<p>$r$ や $1/r$ という係数は $\mathbf{g} = J^T J$ の対角成分 $1, r^2, 1$ から決まる。$\ast$ の辞書は、その場所の計量を反映して場所ごとに異なる係数を持つ。
-</p>
+\end{aligned}$$</div>
+<span class="tex2jax_process">$r$</span> や <span class="tex2jax_process">$1/r$</span> という係数は <span class="tex2jax_process">$\mathbf{g} = J^T J$</span> の対角成分 <span class="tex2jax_process">$1, r^2, 1$</span> から決まる。<span class="tex2jax_process">$\ast$</span> の辞書は、その場所の計量を反映して場所ごとに異なる係数を持つ。
 <h4 id="862-二つの方法を回してみる">8.6.2 二つの方法を回してみる</h4>
 <p>辞書が変わるということは、§8.1 で対比した二つの方法の違いが具体的な計算に現れるということだ。ここで、同じ問題を二つの方法で実際に解いてみよう。題材は「二次元平面上のある点での発散を求める」である。
 </p>
-<blockquote><p>**注** （二次元で考える）第1章以来、二次元の問題を扱うときは $z=0$ と断ってきた。しかし本章まで読み進めた読者に、もはやそのような断りは不要だろう。以下では二次元平面 $(x,y)$ とその極座標 $(r,\theta)$ だけで話を進める。</p>
+<blockquote><p>**注** （二次元で考える）第1章以来、二次元の問題を扱うときは <span class="tex2jax_process">$z=0$</span> と断ってきた。しかし本章まで読み進めた読者に、もはやそのような断りは不要だろう。以下では二次元平面 <span class="tex2jax_process">$(x,y)$</span> とその極座標 <span class="tex2jax_process">$(r,\theta)$</span> だけで話を進める。</p>
 </p></blockquote>
 <strong>方法①——場はそのまま、測定器を変える。</strong>
-<p>パラメータ空間 $(r,\theta)$ と実空間 $(x,y)$、二枚のデカルト座標を用意する。パラメータ空間の用紙には、どこも同じ大きさの正方形グリッドが敷き詰められている。この正方形グリッドの上で、我々は測定を行う。
+<p>パラメータ空間 <span class="tex2jax_process">$(r,\theta)$</span> と実空間 <span class="tex2jax_process">$(x,y)$</span>、二枚のデカルト座標を用意する。パラメータ空間の用紙には、どこも同じ大きさの正方形グリッドが敷き詰められている。この正方形グリッドの上で、我々は測定を行う。
 </p>
-<p>ベクトル場 $\mathbf{F} = (F_x, F_y)^T$ は実空間に住んでいる。その測定器 $\omega = F_x\,dx + F_y\,dy$ を、パラメータ空間の用紙に<strong>引き戻す</strong>。引き戻し（pullback）とは、実空間の測定器をパラメータ空間の言葉に焼き直す操作だ。写像 $\phi: (r,\theta) \to (x,y)$ で実空間に送るのと逆向きに、測定器を戻してくる。$dx = \cos\theta\,dr - r\sin\theta\,d\theta$, $dy = \sin\theta\,dr + r\cos\theta\,d\theta$ を使って、
+<p>ベクトル場 <span class="tex2jax_process">$\mathbf{F} = (F_x, F_y)^T$</span> は実空間に住んでいる。その測定器 <span class="tex2jax_process">$\omega = F_x\,dx + F_y\,dy$</span> を、パラメータ空間の用紙に<strong>引き戻す</strong>。引き戻し（pullback）とは、実空間の測定器をパラメータ空間の言葉に焼き直す操作だ。写像 <span class="tex2jax_process">$\phi: (r,\theta) \to (x,y)$</span> で実空間に送るのと逆向きに、測定器を戻してくる。<span class="tex2jax_process">$dx = \cos\theta\,dr - r\sin\theta\,d\theta$</span>, <span class="tex2jax_process">$dy = \sin\theta\,dr + r\cos\theta\,d\theta$</span> を使って、
 </p>
-<p>$$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
-</p>
+<div class="math-block tex2jax_process">$$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$</div>
 <p>が得られる。
 </p>
-<blockquote><p>**注** （正規直交成分と form 係数）ベクトル解析では $\mathbf{F}$ を「長さ1の矢印」に対する成分 $(F_r, F_\theta)$ で表す。しかし微分形式の自然な基底は座標微分 $(dr, d\theta)$ であり、$d\theta$ 方向の目盛り間隔は場所によって $r$ 倍異なる。したがって $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$ と書いたときの form 係数 $\tilde{F}_\theta$ は $r F_\theta$ であり、ベクトル解析の成分 $F_\theta$ とは次元も値も異なる。この違いが、方法①と方法②の公式の見た目の差を生んでいる。</p>
+<blockquote><p>**注** （正規直交成分と form 係数）ベクトル解析では <span class="tex2jax_process">$\mathbf{F}$</span> を「長さ1の矢印」に対する成分 <span class="tex2jax_process">$(F_r, F_\theta)$</span> で表す。しかし微分形式の自然な基底は座標微分 <span class="tex2jax_process">$(dr, d\theta)$</span> であり、<span class="tex2jax_process">$d\theta$</span> 方向の目盛り間隔は場所によって <span class="tex2jax_process">$r$</span> 倍異なる。したがって <span class="tex2jax_process">$\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$</span> と書いたときの form 係数 <span class="tex2jax_process">$\tilde{F}_\theta$</span> は <span class="tex2jax_process">$r F_\theta$</span> であり、ベクトル解析の成分 <span class="tex2jax_process">$F_\theta$</span> とは次元も値も異なる。この違いが、方法①と方法②の公式の見た目の差を生んでいる。</p>
 </p></blockquote>
-<p>ここから先は $\ast d\ast$ の機械的な計算だ。極座標の計量 $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$ から $\ast$ の辞書は $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ となる（§8.6.1 の二次元版）。$d$ は偏微分の係数をそのまま拾うだけ——途中に $\frac{1}{r}$ などを挟み込む必要は一切ない。
+<p>ここから先は <span class="tex2jax_process">$\ast d\ast$</span> の機械的な計算だ。極座標の計量 <span class="tex2jax_process">$\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書は <span class="tex2jax_process">$\ast(dr) = r\,d\theta$</span>, <span class="tex2jax_process">$\ast(d\theta) = -\frac{1}{r}\,dr$</span> となる（§8.6.1 の二次元版）。<span class="tex2jax_process">$d$</span> は偏微分の係数をそのまま拾うだけ——途中に <span class="tex2jax_process">$\frac{1}{r}$</span> などを挟み込む必要は一切ない。
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
 d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
-\end{aligned}$$
-</p>
-<p>$\frac{1}{r}$ が現れたのは最後の $\ast(dr\wedge d\theta) = \frac{1}{r}$ の一箇所だけだ。途中の $r$ と $\frac{1}{r}$ は、$d\theta$ の係数に付いていた $r$ と $\ast(d\theta)$ の $\frac{1}{r}$ が打ち消し合った結果である。$\ast$ が計量の情報を一手に引き受け、$d$ は純粋に偏微分だけを担当する——この分業こそが方法①の最大の強みだ。
-</p>
-<p>測るのはつねに均一な正方形グリッド。場所ごとの換算係数の違いは pullback が織り込み、$\ast$ が整理する。グリッドは有限でよい——極限は最後の一手で十分だ。
+\end{aligned}$$</div>
+<span class="tex2jax_process">$\frac{1}{r}$</span> が現れたのは最後の <span class="tex2jax_process">$\ast(dr\wedge d\theta) = \frac{1}{r}$</span> の一箇所だけだ。途中の <span class="tex2jax_process">$r$</span> と <span class="tex2jax_process">$\frac{1}{r}$</span> は、<span class="tex2jax_process">$d\theta$</span> の係数に付いていた <span class="tex2jax_process">$r$</span> と <span class="tex2jax_process">$\ast(d\theta)$</span> の <span class="tex2jax_process">$\frac{1}{r}$</span> が打ち消し合った結果である。<span class="tex2jax_process">$\ast$</span> が計量の情報を一手に引き受け、<span class="tex2jax_process">$d$</span> は純粋に偏微分だけを担当する——この分業こそが方法①の最大の強みだ。
+<p>測るのはつねに均一な正方形グリッド。場所ごとの換算係数の違いは pullback が織り込み、<span class="tex2jax_process">$\ast$</span> が整理する。グリッドは有限でよい——極限は最後の一手で十分だ。
 </p>
 <strong>方法②——測定器はそのまま、新たな場を考える。</strong>
-<p>今度は実空間に一枚のグラフ用紙を使う。極座標 $(r,\theta)$ の上に、点 $(r,\theta)$ を中心とする小さな面積要素を直接描く。$r$ 方向に $\Delta r$、$\theta$ 方向に $\Delta\theta$ の幅を持った小片だ。ここでは<strong>$\Delta r, \Delta\theta$ は微小でなければならない</strong>——角度があるために、有限の $\Delta\theta$ では動径方向の辺が平行にならず、単純な四角形にならないからだ。
+<p>今度は実空間に一枚のグラフ用紙を使う。極座標 <span class="tex2jax_process">$(r,\theta)$</span> の上に、点 <span class="tex2jax_process">$(r,\theta)$</span> を中心とする小さな面積要素を直接描く。<span class="tex2jax_process">$r$</span> 方向に <span class="tex2jax_process">$\Delta r$</span>、<span class="tex2jax_process">$\theta$</span> 方向に <span class="tex2jax_process">$\Delta\theta$</span> の幅を持った小片だ。ここでは<strong><span class="tex2jax_process">$\Delta r, \Delta\theta$</span> は微小でなければならない</strong>——角度があるために、有限の <span class="tex2jax_process">$\Delta\theta$</span> では動径方向の辺が平行にならず、単純な四角形にならないからだ。
 </p>
-<p>この小片は扇形の一部である。$\theta$ 方向の内側の辺の長さは $r\Delta\theta$、外側の辺の長さは $(r+\Delta r)\Delta\theta$ で、$r$ が大きいほど辺が長い。ベクトル場 $\mathbf{F} = (F_r, F_\theta)^T$ がこの小片の四辺を通り抜ける流束を、一辺ずつ勘定する。
+<p>この小片は扇形の一部である。<span class="tex2jax_process">$\theta$</span> 方向の内側の辺の長さは <span class="tex2jax_process">$r\Delta\theta$</span>、外側の辺の長さは <span class="tex2jax_process">$(r+\Delta r)\Delta\theta$</span> で、<span class="tex2jax_process">$r$</span> が大きいほど辺が長い。ベクトル場 <span class="tex2jax_process">$\mathbf{F} = (F_r, F_\theta)^T$</span> がこの小片の四辺を通り抜ける流束を、一辺ずつ勘定する。
 </p>
-<p>$r$ 方向：内側の辺から $-F_r(r,\theta) \cdot r\Delta\theta$ が流入し、外側の辺から $+F_r(r+\Delta r,\theta) \cdot (r+\Delta r)\Delta\theta$ が流出する。差を $\Delta r$ で割り、さらに面積 $r\Delta r\Delta\theta$ で割って極限をとれば $\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$ が現れる。
-</p>
-<p>$\theta$ 方向：$\theta$ 側の辺から $-F_\theta(r,\theta) \cdot \Delta r$ が流入し、$\theta+\Delta\theta$ 側の辺から $+F_\theta(r,\theta+\Delta\theta) \cdot \Delta r$ が流出する。同様に処理すれば $\frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$ が現れる。
-</p>
-<p>$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}$$
-</p>
-<p>実空間に直接小片を描き、壁を通る流れを数え上げる——絵は直感的だ。しかし座標系が変わるたびに小片の形が変わり、毎回異なる勘定を強いられる。$\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$ の $\frac{1}{r}$ は扇形の面積 $r\Delta r\Delta\theta$ で割るために出てくるが、デカルト座標で同じ計算をしたときには現れなかった項だ。
+<span class="tex2jax_process">$r$</span> 方向：内側の辺から <span class="tex2jax_process">$-F_r(r,\theta) \cdot r\Delta\theta$</span> が流入し、外側の辺から <span class="tex2jax_process">$+F_r(r+\Delta r,\theta) \cdot (r+\Delta r)\Delta\theta$</span> が流出する。差を <span class="tex2jax_process">$\Delta r$</span> で割り、さらに面積 <span class="tex2jax_process">$r\Delta r\Delta\theta$</span> で割って極限をとれば <span class="tex2jax_process">$\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$</span> が現れる。
+<span class="tex2jax_process">$\theta$</span> 方向：<span class="tex2jax_process">$\theta$</span> 側の辺から <span class="tex2jax_process">$-F_\theta(r,\theta) \cdot \Delta r$</span> が流入し、<span class="tex2jax_process">$\theta+\Delta\theta$</span> 側の辺から <span class="tex2jax_process">$+F_\theta(r,\theta+\Delta\theta) \cdot \Delta r$</span> が流出する。同様に処理すれば <span class="tex2jax_process">$\frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$</span> が現れる。
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}$$</div>
+<p>実空間に直接小片を描き、壁を通る流れを数え上げる——絵は直感的だ。しかし座標系が変わるたびに小片の形が変わり、毎回異なる勘定を強いられる。<span class="tex2jax_process">$\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$</span> の <span class="tex2jax_process">$\frac{1}{r}$</span> は扇形の面積 <span class="tex2jax_process">$r\Delta r\Delta\theta$</span> で割るために出てくるが、デカルト座標で同じ計算をしたときには現れなかった項だ。
 </p>
 <strong>どちらが優れているというわけではない</strong>
-<p>方法①は均一な正方形グリッドで測り、方法②は扇形の小片を描いて流れを数える。やっていることはまったく違う。しかし出てくる答えは同じ $\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$ だ。そして、この一致は発散に限らない。勾配も回転もラプラシアンも、すべての微分演算がこの二つの方法で構成できる。単純な座標変換なら方法②のほうが早いこともあるが、座標系が歪んだり場の種類が入り組んだりしたら方法①に切り替えればよい。
+<p>方法①は均一な正方形グリッドで測り、方法②は扇形の小片を描いて流れを数える。やっていることはまったく違う。しかし出てくる答えは同じ <span class="tex2jax_process">$\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$</span> だ。そして、この一致は発散に限らない。勾配も回転もラプラシアンも、すべての微分演算がこの二つの方法で構成できる。単純な座標変換なら方法②のほうが早いこともあるが、座標系が歪んだり場の種類が入り組んだりしたら方法①に切り替えればよい。
 </p>
 <h4 id="863-曲線座標での発散と回転">8.6.3 曲線座標での発散と回転</h4>
-<p>§8.6.1 の辞書と §8.6.2 の方法①を組み合わせれば、円柱座標での発散と回転の公式が機械的に導出できる。結果だけを示す（$\mathbf{F} = (F_r, F_\theta, F_z)^T$）。
+<p>§8.6.1 の辞書と §8.6.2 の方法①を組み合わせれば、円柱座標での発散と回転の公式が機械的に導出できる。結果だけを示す（<span class="tex2jax_process">$\mathbf{F} = (F_r, F_\theta, F_z)^T$</span>）。
 </p>
-<p>$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$
-</p>
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$</div>
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
 \frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
 \frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
-\end{pmatrix}$$
-</p>
-<p>これらの公式を暗記するのは骨が折れる。しかし $\ast d\ast\omega$ という $d$ と $\ast$ の組み合わせで考えれば、$g = J^T J$ から $\ast$ の辞書をその場で導出し、機械的に計算できる。第9章では、この「辞書をその場で作る」技術を実践する。
+\end{pmatrix}$$</div>
+<p>これらの公式を暗記するのは骨が折れる。しかし <span class="tex2jax_process">$\ast d\ast\omega$</span> という <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の組み合わせで考えれば、<span class="tex2jax_process">$g = J^T J$</span> から <span class="tex2jax_process">$\ast$</span> の辞書をその場で導出し、機械的に計算できる。第9章では、この「辞書をその場で作る」技術を実践する。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — 第8章全体】**</p>
-- $d$ と $\nabla$ は根本的に異なる世界観に立つが、積分では一致する。$d$ は場をそのままに測定器を変え、$\nabla$ は測定器をそのままに新たな場を考える。
-- $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$ の辞書により、両者は自由に翻訳できる。
-- $\int_{\partial M}\omega = \int_M d\omega$ 一本で、微積分学の基本定理・ストークス・ガウスのすべてを統合できる。
-- $\ast$ の辞書は計量 $g = J^T J$ に依存し、曲線座標では $r$ や $1/r$ の係数が現れる。
+- <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\nabla$</span> は根本的に異なる世界観に立つが、積分では一致する。<span class="tex2jax_process">$d$</span> は場をそのままに測定器を変え、<span class="tex2jax_process">$\nabla$</span> は測定器をそのままに新たな場を考える。
+- <span class="tex2jax_process">$\nabla f \leftrightarrow df$</span>, <span class="tex2jax_process">$\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$</span>, <span class="tex2jax_process">$\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$</span> の辞書により、両者は自由に翻訳できる。
+- <span class="tex2jax_process">$\int_{\partial M}\omega = \int_M d\omega$</span> 一本で、微積分学の基本定理・ストークス・ガウスのすべてを統合できる。
+- <span class="tex2jax_process">$\ast$</span> の辞書は計量 <span class="tex2jax_process">$g = J^T J$</span> に依存し、曲線座標では <span class="tex2jax_process">$r$</span> や <span class="tex2jax_process">$1/r$</span> の係数が現れる。
 - 重要なのは、一つの言語に固執せず、問題に応じて二つの言語を使い分けること。そのための辞書は、もう手に入れた。
 </p></blockquote>
 <p>\newpage
@@ -4280,29 +3943,29 @@ d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial
 </p>
 <p>読者は、以下の計算を眺めるだけでよい。あるいは、自分の手で追ってみてもよい。いずれにせよ、ここで見るのは「公式を暗記しなくても、辞書さえあればすべて導出できる」という事実の実演だ。
 </p>
-<blockquote><p>**注** （ベクトル解析を学んだことがない読者へ）以下の計算のうち、grad, div, rot の導出はどれも数行で済んでいる。$\ast d\ast$ に辞書を代入し、偏微分を展開する——それだけだ。だから簡単そうに見える。しかし、これと同じ結果をベクトル解析の流儀で導出しようとすると、$\nabla$ に $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ や $\frac{1}{\rho^2\sin\theta}$ といった因子を手作業で管理しながら、数ページにわたる式変形を強いられる。簡単そうに見えるのは、次数の異なる測定器を $\ast$ が自動的に整理してくれるからだ。§9.4 のラプラシアンはさすがに手強いが、それでもやっていることは辞書を引いて偏微分を展開するだけ——要領は変わらない。この差こそ、本書が第1章から積み上げてきた「測定器」の枠組みの真価である。</p>
+<blockquote><p>**注** （ベクトル解析を学んだことがない読者へ）以下の計算のうち、grad, div, rot の導出はどれも数行で済んでいる。<span class="tex2jax_process">$\ast d\ast$</span> に辞書を代入し、偏微分を展開する——それだけだ。だから簡単そうに見える。しかし、これと同じ結果をベクトル解析の流儀で導出しようとすると、<span class="tex2jax_process">$\nabla$</span> に <span class="tex2jax_process">$\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$</span> や <span class="tex2jax_process">$\frac{1}{\rho^2\sin\theta}$</span> といった因子を手作業で管理しながら、数ページにわたる式変形を強いられる。簡単そうに見えるのは、次数の異なる測定器を <span class="tex2jax_process">$\ast$</span> が自動的に整理してくれるからだ。§9.4 のラプラシアンはさすがに手強いが、それでもやっていることは辞書を引いて偏微分を展開するだけ——要領は変わらない。この差こそ、本書が第1章から積み上げてきた「測定器」の枠組みの真価である。</p>
 </p></blockquote>
 <hr />
 <h3 id="91-辞書をその場で作る機械的手順">§9.1 辞書をその場で作る——機械的手順</h3>
-<p>任意の座標系で $\mathrm{grad}, \mathrm{div}, \mathrm{rot}$ の公式を導出する手順は、以下の3ステップに集約される。
+<p>任意の座標系で <span class="tex2jax_process">$\mathrm{grad}, \mathrm{div}, \mathrm{rot}$</span> の公式を導出する手順は、以下の3ステップに集約される。
 </p>
 <ol>
-<li>**ヤコビ行列 $J$ を書く**。座標変換 $x = x(q_1,q_2,q_3)$, $y = y(q_1,q_2,q_3)$, $z = z(q_1,q_2,q_3)$ から偏微分を並べる。$J$ の各列はパラメータ空間の各軸方向の一歩が実空間でどう動くかを表す。</li>
+<li>**ヤコビ行列 <span class="tex2jax_process">$J$</span> を書く**。座標変換 <span class="tex2jax_process">$x = x(q_1,q_2,q_3)$</span>, <span class="tex2jax_process">$y = y(q_1,q_2,q_3)$</span>, <span class="tex2jax_process">$z = z(q_1,q_2,q_3)$</span> から偏微分を並べる。<span class="tex2jax_process">$J$</span> の各列はパラメータ空間の各軸方向の一歩が実空間でどう動くかを表す。</li>
 </ol>
 <ol>
-<li>**計量 $\mathbf{g} = J^T J$ を計算する**。これは第6章 §5.1.3 以来の手順だ。$\mathbf{g}$ の対角成分が各軸方向の目盛りの二乗、非対角成分が軸どうしの直交度を表す。</li>
+<li>**計量 <span class="tex2jax_process">$\mathbf{g} = J^T J$</span> を計算する**。これは第6章 §5.1.3 以来の手順だ。<span class="tex2jax_process">$\mathbf{g}$</span> の対角成分が各軸方向の目盛りの二乗、非対角成分が軸どうしの直交度を表す。</li>
 </ol>
 <ol>
-<li>**$\mathbf{g}$ から $\ast$ の辞書を導き、$d$ と組み合わせる**。$\mathrm{grad} = \ast d\ast$？（いや、$\mathrm{grad}=d$）、$\mathrm{rot}=\ast d$、$\mathrm{div}=\ast d\ast$ の各公式に、その座標系での $\ast$ の辞書を代入すれば、求める公式が機械的に得られる。</li>
+<li>**<span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書を導き、<span class="tex2jax_process">$d$</span> と組み合わせる**。<span class="tex2jax_process">$\mathrm{grad} = \ast d\ast$</span>？（いや、<span class="tex2jax_process">$\mathrm{grad}=d$</span>）、<span class="tex2jax_process">$\mathrm{rot}=\ast d$</span>、<span class="tex2jax_process">$\mathrm{div}=\ast d\ast$</span> の各公式に、その座標系での <span class="tex2jax_process">$\ast$</span> の辞書を代入すれば、求める公式が機械的に得られる。</li>
 </ol>
 <p>以下、この手順を円柱座標と球座標で実演する。
 </p>
 <hr />
-<h3 id="92-円柱座標">§9.2 円柱座標 $(r,\theta,z)$</h3>
+<h3 id="92-円柱座標-span-classtex2jaxprocessspan">§9.2 円柱座標 <span class="tex2jax_process">$(r,\theta,z)$</span></h3>
 <h4 id="921-辞書の導出">9.2.1 辞書の導出</h4>
-<p>円柱座標への変換は $x = r\cos\theta$, $y = r\sin\theta$, $z = z$。
+<p>円柱座標への変換は <span class="tex2jax_process">$x = r\cos\theta$</span>, <span class="tex2jax_process">$y = r\sin\theta$</span>, <span class="tex2jax_process">$z = z$</span>。
 </p>
-<p>$$J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J = \begin{pmatrix}
 \cos\theta & -r\sin\theta & 0 \\
 \sin\theta & r\cos\theta & 0 \\
 0 & 0 & 1
@@ -4311,66 +3974,52 @@ d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial
 1 & 0 & 0 \\
 0 & r^2 & 0 \\
 0 & 0 & 1
-\end{pmatrix}$$
-</p>
-<p>$\mathbf{g}$ から $\ast$ の辞書を導く。第6章 §5.3.3 でデカルト座標の $\ast$ 辞書が $\mathbf{g}=I$ から決まったのと同じ原理で、$\mathbf{g}$ の対角成分の平方根が $\ast$ の係数に現れる。
-</p>
-<p>$$\begin{aligned}
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書を導く。第6章 §5.3.3 でデカルト座標の <span class="tex2jax_process">$\ast$</span> 辞書が <span class="tex2jax_process">$\mathbf{g}=I$</span> から決まったのと同じ原理で、<span class="tex2jax_process">$\mathbf{g}$</span> の対角成分の平方根が <span class="tex2jax_process">$\ast$</span> の係数に現れる。
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast(dr) &= r\,d\theta \wedge dz \\
 \ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
 \ast(dz) &= r\,dr \wedge d\theta
-\end{aligned}$$
-</p>
-<p>また $\ast(1) = r\,dr\wedge d\theta\wedge dz$, $\ast(dr\wedge d\theta\wedge dz) = 1/r$。
+\end{aligned}$$</div>
+<p>また <span class="tex2jax_process">$\ast(1) = r\,dr\wedge d\theta\wedge dz$</span>, <span class="tex2jax_process">$\ast(dr\wedge d\theta\wedge dz) = 1/r$</span>。
 </p>
 <h4 id="922-勾配">9.2.2 勾配</h4>
-<p>$\mathrm{grad}\,f = df$ は $\ast$ を使わない。単に偏微分係数を基底 $1$-form に載せるだけだ。
-</p>
-<p>$$df = \frac{\partial f}{\partial r}\,dr + \frac{\partial f}{\partial \theta}\,d\theta + \frac{\partial f}{\partial z}\,dz$$
-</p>
+<span class="tex2jax_process">$\mathrm{grad}\,f = df$</span> は <span class="tex2jax_process">$\ast$</span> を使わない。単に偏微分係数を基底 <span class="tex2jax_process">$1$</span>-form に載せるだけだ。
+<div class="math-block tex2jax_process">$$df = \frac{\partial f}{\partial r}\,dr + \frac{\partial f}{\partial \theta}\,d\theta + \frac{\partial f}{\partial z}\,dz$$</div>
 <p>ベクトル解析の表記（縦ベクトル）では、
 </p>
-<p>$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial r} & \frac{1}{r}\frac{\partial f}{\partial \theta} & \frac{\partial f}{\partial z} \end{pmatrix}^T$$
-</p>
-<p>$\theta$ 成分に $\frac{1}{r}$ がつくのは、$\nabla f$ が正規直交基底に対する成分だからだ。$df$ の $d\theta$ の係数 $\frac{\partial f}{\partial\theta}$ は「角度あたりの変化率」だが、$\nabla f$ の $\mathbf{e}_\theta$ 成分は「長さあたりの変化率」であり、$d\theta$ が弧長 $r\,d\theta$ に対応するための換算 $\frac{1}{r}$ が必要になる。
-</p>
+<div class="math-block tex2jax_process">$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial r} & \frac{1}{r}\frac{\partial f}{\partial \theta} & \frac{\partial f}{\partial z} \end{pmatrix}^T$$</div>
+<span class="tex2jax_process">$\theta$</span> 成分に <span class="tex2jax_process">$\frac{1}{r}$</span> がつくのは、<span class="tex2jax_process">$\nabla f$</span> が正規直交基底に対する成分だからだ。<span class="tex2jax_process">$df$</span> の <span class="tex2jax_process">$d\theta$</span> の係数 <span class="tex2jax_process">$\frac{\partial f}{\partial\theta}$</span> は「角度あたりの変化率」だが、<span class="tex2jax_process">$\nabla f$</span> の <span class="tex2jax_process">$\mathbf{e}_\theta$</span> 成分は「長さあたりの変化率」であり、<span class="tex2jax_process">$d\theta$</span> が弧長 <span class="tex2jax_process">$r\,d\theta$</span> に対応するための換算 <span class="tex2jax_process">$\frac{1}{r}$</span> が必要になる。
 <h4 id="923-発散">9.2.3 発散</h4>
-<p>$\mathbf{F} = (F_r, F_\theta, F_z)^T$ に対応する $1$-form は $\tilde{\omega} = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$ である（§7.6.2 で確認したように、$d\theta$ の係数は $rF_\theta$）。
-</p>
-<blockquote><p>**注** （$\tilde{\omega}$ のチルダについて）第8章 §7.6.2 で、正規直交成分 $F_\theta$ と form 係数 $rF_\theta$ を区別するために $\tilde{\omega}$ という記法を使った。しかし本来、数学ではこの二つをいちいち区別しないことも多い。文脈からどちらの $\omega$ を指しているか明らかだからだ。以下でもチルダを省く。どちらを指しているかは、係数に $r$ や $\rho$ が現れているかどうかで判断してほしい。</p>
+<span class="tex2jax_process">$\mathbf{F} = (F_r, F_\theta, F_z)^T$</span> に対応する <span class="tex2jax_process">$1$</span>-form は <span class="tex2jax_process">$\tilde{\omega} = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$</span> である（§7.6.2 で確認したように、<span class="tex2jax_process">$d\theta$</span> の係数は <span class="tex2jax_process">$rF_\theta$</span>）。
+<blockquote><p>**注** （<span class="tex2jax_process">$\tilde{\omega}$</span> のチルダについて）第8章 §7.6.2 で、正規直交成分 <span class="tex2jax_process">$F_\theta$</span> と form 係数 <span class="tex2jax_process">$rF_\theta$</span> を区別するために <span class="tex2jax_process">$\tilde{\omega}$</span> という記法を使った。しかし本来、数学ではこの二つをいちいち区別しないことも多い。文脈からどちらの <span class="tex2jax_process">$\omega$</span> を指しているか明らかだからだ。以下でもチルダを省く。どちらを指しているかは、係数に <span class="tex2jax_process">$r$</span> や <span class="tex2jax_process">$\rho$</span> が現れているかどうかで判断してほしい。</p>
 </p></blockquote>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast\omega &= F_r(r\,d\theta\wedge dz) + rF_\theta\!\left(\frac{1}{r}\,dz\wedge dr\right) + F_z(r\,dr\wedge d\theta) \\
 &= rF_r\,d\theta\wedge dz + F_\theta\,dz\wedge dr + rF_z\,dr\wedge d\theta \\[0.3em]
 d\ast\omega &= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta}{\partial\theta} + \frac{\partial}{\partial z}(rF_z)\right) dr\wedge d\theta\wedge dz \\[0.3em]
 \ast d\ast\omega &= \frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta} + \frac{\partial F_z}{\partial z}
-\end{aligned}$$
-</p>
+\end{aligned}$$</div>
 <p>これが円柱座標での発散の公式である。
 </p>
 <h4 id="924-回転">9.2.4 回転</h4>
-<p>回転は $\mathrm{rot}\,\mathbf{F} \leftrightarrow \ast d\omega$。
+<p>回転は <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{F} \leftrightarrow \ast d\omega$</span>。
 </p>
-<p>$$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right) dr\wedge d\theta + \left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right) d\theta\wedge dz + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz\wedge dr$$
-</p>
-<p>$$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! d\theta + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz$$
-</p>
-<p>$1$-form の $dr, d\theta, dz$ の係数を読み取り、正規直交成分に焼き直すと $d\theta$ 係数はさらに $\frac{1}{r}$ される。最終的に、
-</p>
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right) dr\wedge d\theta + \left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right) d\theta\wedge dz + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz\wedge dr$$</div>
+<div class="math-block tex2jax_process">$$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! d\theta + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz$$</div>
+<span class="tex2jax_process">$1$</span>-form の <span class="tex2jax_process">$dr, d\theta, dz$</span> の係数を読み取り、正規直交成分に焼き直すと <span class="tex2jax_process">$d\theta$</span> 係数はさらに <span class="tex2jax_process">$\frac{1}{r}$</span> される。最終的に、
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
 \frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
 \frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
-\end{pmatrix}$$
-</p>
-<p>$r$ が $\frac{\partial}{\partial r}$ の内側と外側に現れる構造は、§7.6.2 の方法②で扇形の面積要素を数えたときの $\frac{1}{r}$ とまったく同じ起源を持つ。
-</p>
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$r$</span> が <span class="tex2jax_process">$\frac{\partial}{\partial r}$</span> の内側と外側に現れる構造は、§7.6.2 の方法②で扇形の面積要素を数えたときの <span class="tex2jax_process">$\frac{1}{r}$</span> とまったく同じ起源を持つ。
 <hr />
-<h3 id="93-球座標">§9.3 球座標 $(\rho,\theta,\phi)$</h3>
+<h3 id="93-球座標-span-classtex2jaxprocessspan">§9.3 球座標 <span class="tex2jax_process">$(\rho,\theta,\phi)$</span></h3>
 <h4 id="931-辞書の導出">9.3.1 辞書の導出</h4>
-<p>球座標への変換は $x = \rho\sin\theta\cos\phi$, $y = \rho\sin\theta\sin\phi$, $z = \rho\cos\theta$（$\theta$ は $z$ 軸からの角度、$\phi$ は $xy$ 平面内の方位角）。
+<p>球座標への変換は <span class="tex2jax_process">$x = \rho\sin\theta\cos\phi$</span>, <span class="tex2jax_process">$y = \rho\sin\theta\sin\phi$</span>, <span class="tex2jax_process">$z = \rho\cos\theta$</span>（<span class="tex2jax_process">$\theta$</span> は <span class="tex2jax_process">$z$</span> 軸からの角度、<span class="tex2jax_process">$\phi$</span> は <span class="tex2jax_process">$xy$</span> 平面内の方位角）。
 </p>
-<p>$$J = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$J = \begin{pmatrix}
 \sin\theta\cos\phi & \rho\cos\theta\cos\phi & -\rho\sin\theta\sin\phi \\
 \sin\theta\sin\phi & \rho\cos\theta\sin\phi & \rho\sin\theta\cos\phi \\
 \cos\theta & -\rho\sin\theta & 0
@@ -4379,144 +4028,114 @@ d\ast\omega &= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta
 1 & 0 & 0 \\
 0 & \rho^2 & 0 \\
 0 & 0 & \rho^2\sin^2\theta
-\end{pmatrix}$$
-</p>
-<p>$\ast$ の辞書は対角成分 $\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$ すなわち $1, \rho, \rho\sin\theta$ から決まる。
-</p>
-<p>$$\begin{aligned}
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$\ast$</span> の辞書は対角成分 <span class="tex2jax_process">$\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$</span> すなわち <span class="tex2jax_process">$1, \rho, \rho\sin\theta$</span> から決まる。
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \ast(d\rho) &= \rho^2\sin\theta\; d\theta \wedge d\phi \\
 \ast(d\theta) &= \sin\theta\; d\phi \wedge d\rho \\
 \ast(d\phi) &= \frac{1}{\sin\theta}\; d\rho \wedge d\theta
-\end{aligned}$$
-</p>
+\end{aligned}$$</div>
 <h4 id="932-発散">9.3.2 発散</h4>
-<p>$\mathbf{F} = (F_\rho, F_\theta, F_\phi)^T$ の $1$-form への変換では、$d\rho$ の係数は $F_\rho$（$\rho$ はすでに長さ）、$d\theta$ の係数は $\rho F_\theta$、$d\phi$ の係数は $\rho\sin\theta\,F_\phi$ となる（それぞれ弧長 $\rho\,d\theta$, $\rho\sin\theta\,d\phi$ に対応）。
-</p>
-<p>$$\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$$
-</p>
-<p>$\ast d\ast\omega$ を計算する。
-</p>
-<p>$$\ast\omega = \rho^2\sin\theta\,F_\rho\,d\theta\wedge d\phi + \rho\sin\theta\,F_\theta\,d\phi\wedge d\rho + \rho\,F_\phi\,d\rho\wedge d\theta$$
-</p>
-<p>$$d\ast\omega = \left(\frac{\partial}{\partial\rho}(\rho^2\sin\theta\,F_\rho) + \frac{\partial}{\partial\theta}(\rho\sin\theta\,F_\theta) + \frac{\partial}{\partial\phi}(\rho\,F_\phi)\right) d\rho\wedge d\theta\wedge d\phi$$
-</p>
-<p>$\ast(d\rho\wedge d\theta\wedge d\phi) = 1/(\rho^2\sin\theta)$ より、
-</p>
-<p>$$\nabla \cdot \mathbf{F} = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
-</p>
+<span class="tex2jax_process">$\mathbf{F} = (F_\rho, F_\theta, F_\phi)^T$</span> の <span class="tex2jax_process">$1$</span>-form への変換では、<span class="tex2jax_process">$d\rho$</span> の係数は <span class="tex2jax_process">$F_\rho$</span>（<span class="tex2jax_process">$\rho$</span> はすでに長さ）、<span class="tex2jax_process">$d\theta$</span> の係数は <span class="tex2jax_process">$\rho F_\theta$</span>、<span class="tex2jax_process">$d\phi$</span> の係数は <span class="tex2jax_process">$\rho\sin\theta\,F_\phi$</span> となる（それぞれ弧長 <span class="tex2jax_process">$\rho\,d\theta$</span>, <span class="tex2jax_process">$\rho\sin\theta\,d\phi$</span> に対応）。
+<div class="math-block tex2jax_process">$$\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$$</div>
+<span class="tex2jax_process">$\ast d\ast\omega$</span> を計算する。
+<div class="math-block tex2jax_process">$$\ast\omega = \rho^2\sin\theta\,F_\rho\,d\theta\wedge d\phi + \rho\sin\theta\,F_\theta\,d\phi\wedge d\rho + \rho\,F_\phi\,d\rho\wedge d\theta$$</div>
+<div class="math-block tex2jax_process">$$d\ast\omega = \left(\frac{\partial}{\partial\rho}(\rho^2\sin\theta\,F_\rho) + \frac{\partial}{\partial\theta}(\rho\sin\theta\,F_\theta) + \frac{\partial}{\partial\phi}(\rho\,F_\phi)\right) d\rho\wedge d\theta\wedge d\phi$$</div>
+<span class="tex2jax_process">$\ast(d\rho\wedge d\theta\wedge d\phi) = 1/(\rho^2\sin\theta)$</span> より、
+<div class="math-block tex2jax_process">$$\nabla \cdot \mathbf{F} = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</div>
 <h4 id="933-回転">9.3.3 回転</h4>
-<p>同様に $\ast d\omega$ から、
+<p>同様に <span class="tex2jax_process">$\ast d\omega$</span> から、
 </p>
-<p>$$\nabla \times \mathbf{F} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
 \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
 \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <hr />
 <h3 id="94-微積分の難問球座標でのベクトルラプラシアン">§9.4 微積分の難問——球座標でのベクトルラプラシアン</h3>
-<p>ベクトルラプラシアン $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ は、ベクトル解析の公式集で最も長い式の一つとして知られる。ここでは全成分を辞書から導出する。
+<p>ベクトルラプラシアン <span class="tex2jax_process">$\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$</span> は、ベクトル解析の公式集で最も長い式の一つとして知られる。ここでは全成分を辞書から導出する。
 </p>
 <p>方針は第8章の辞書をそのまま使うだけだ。
 <ul>
-<li>$\nabla(\nabla\cdot\mathbf{F}) \leftrightarrow d(\ast d\ast\omega)$</li>
+<li><span class="tex2jax_process">$\nabla(\nabla\cdot\mathbf{F}) \leftrightarrow d(\ast d\ast\omega)$</span></li>
 </ol>
 <ul>
-<li>$\nabla\times(\nabla\times\mathbf{F}) \leftrightarrow \ast d(\ast d\omega)$</li>
+<li><span class="tex2jax_process">$\nabla\times(\nabla\times\mathbf{F}) \leftrightarrow \ast d(\ast d\omega)$</span></li>
 </ol>
 <p>したがって、
 </p>
-<p>$$\nabla^2\mathbf{F} \leftrightarrow d\ast d\ast\omega - \ast d\ast d\omega$$
-</p>
-<p>球座標で $\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$ から出発し、$d\ast d\ast\omega$ と $\ast d\ast d\omega$ を個別に計算して差をとる。
+<div class="math-block tex2jax_process">$$\nabla^2\mathbf{F} \leftrightarrow d\ast d\ast\omega - \ast d\ast d\omega$$</div>
+<p>球座標で <span class="tex2jax_process">$\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$</span> から出発し、<span class="tex2jax_process">$d\ast d\ast\omega$</span> と <span class="tex2jax_process">$\ast d\ast d\omega$</span> を個別に計算して差をとる。
 </p>
 <h4 id="941-第一項勾配の発散">9.4.1 第一項——勾配の発散</h4>
 <p>§9.3.2 より、発散は
 </p>
-<p>$$\ast d\ast\omega = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+<div class="math-block tex2jax_process">$$\ast d\ast\omega = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</div>
+<p>これを <span class="tex2jax_process">$S$</span> とおく。<span class="tex2jax_process">$S$</span> はスカラー場だから、その勾配は <span class="tex2jax_process">$dS = \frac{\partial S}{\partial\rho}\,d\rho + \frac{\partial S}{\partial\theta}\,d\theta + \frac{\partial S}{\partial\phi}\,d\phi$</span> である。正規直交成分に焼き直すと、
 </p>
-<p>これを $S$ とおく。$S$ はスカラー場だから、その勾配は $dS = \frac{\partial S}{\partial\rho}\,d\rho + \frac{\partial S}{\partial\theta}\,d\theta + \frac{\partial S}{\partial\phi}\,d\phi$ である。正規直交成分に焼き直すと、
-</p>
-<p>$$\nabla(\nabla\cdot\mathbf{F}) = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\nabla(\nabla\cdot\mathbf{F}) = \begin{pmatrix}
 \frac{\partial S}{\partial\rho} \\[0.5em]
 \frac{1}{\rho}\frac{\partial S}{\partial\theta} \\[0.5em]
 \frac{1}{\rho\sin\theta}\frac{\partial S}{\partial\phi}
-\end{pmatrix}$$
-</p>
+\end{pmatrix}$$</div>
 <h4 id="942-第二項回転の回転">9.4.2 第二項——回転の回転</h4>
-<p>§9.3.3 の回転の結果を $C_\rho, C_\theta, C_\phi$ とおく。
+<p>§9.3.3 の回転の結果を <span class="tex2jax_process">$C_\rho, C_\theta, C_\phi$</span> とおく。
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 C_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
 C_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
 C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
-\end{aligned}$$
-</p>
-<p>$\mathbf{C} = \nabla\times\mathbf{F}$ に再度 $\nabla\times$ を作用させるには、$C_\rho, C_\theta, C_\phi$ を §9.3.3 の公式の $F_\rho, F_\theta, F_\phi$ の位置に代入すればよい。
-</p>
-<p>$$\begin{aligned}
+\end{aligned}$$</div>
+<span class="tex2jax_process">$\mathbf{C} = \nabla\times\mathbf{F}$</span> に再度 <span class="tex2jax_process">$\nabla\times$</span> を作用させるには、<span class="tex2jax_process">$C_\rho, C_\theta, C_\phi$</span> を §9.3.3 の公式の <span class="tex2jax_process">$F_\rho, F_\theta, F_\phi$</span> の位置に代入すればよい。
+<div class="math-block tex2jax_process">$$\begin{aligned}
 (\nabla\times(\nabla\times\mathbf{F}))_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi} \\[0.5em]
 (\nabla\times(\nabla\times\mathbf{F}))_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial C_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\phi) \\[0.5em]
 (\nabla\times(\nabla\times\mathbf{F}))_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\theta) - \frac{1}{\rho}\frac{\partial C_\rho}{\partial\theta}
-\end{aligned}$$
-</p>
+\end{aligned}$$</div>
 <h4 id="943-差をとるベクトルラプラシアン">9.4.3 差をとる——ベクトルラプラシアン</h4>
-<p>$\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ だから、各成分は第一項から第二項を引けばよい。$\rho$ 成分を展開する。
+<span class="tex2jax_process">$\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$</span> だから、各成分は第一項から第二項を引けばよい。<span class="tex2jax_process">$\rho$</span> 成分を展開する。
+<div class="math-block tex2jax_process">$$(\nabla^2\mathbf{F})_\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$</div>
+<span class="tex2jax_process">$S$</span> と <span class="tex2jax_process">$C_\theta, C_\phi$</span> の表式を代入し、偏微分を展開して整理すると、
+<div class="math-block tex2jax_process">$$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$</div>
+<p>ここで <span class="tex2jax_process">$\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$</span> である。
 </p>
-<p>$$(\nabla^2\mathbf{F})_\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$
+<p>同様に <span class="tex2jax_process">$\theta$</span> 成分と <span class="tex2jax_process">$\phi$</span> 成分も、
 </p>
-<p>$S$ と $C_\theta, C_\phi$ の表式を代入し、偏微分を展開して整理すると、
-</p>
-<p>$$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
-</p>
-<p>ここで $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$ である。
-</p>
-<p>同様に $\theta$ 成分と $\phi$ 成分も、
-</p>
-<p>$$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$
-</p>
-<p>$$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$
-</p>
-<p>以上で全成分の導出が完了した。ベクトル解析の流儀で一から導出すれば1ページを優に超える計算量だが、辞書を経由すれば各ステップは偏微分と係数の掛け算の繰り返しに過ぎない。暗記する必要はどこにもない——$d\ast d\ast\omega - \ast d\ast d\omega$ の一本と、§9.3 の $\ast$ 辞書さえあれば、すべてその場で再構成できる。
+<div class="math-block tex2jax_process">$$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$</div>
+<div class="math-block tex2jax_process">$$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$</div>
+<p>以上で全成分の導出が完了した。ベクトル解析の流儀で一から導出すれば1ページを優に超える計算量だが、辞書を経由すれば各ステップは偏微分と係数の掛け算の繰り返しに過ぎない。暗記する必要はどこにもない——<span class="tex2jax_process">$d\ast d\ast\omega - \ast d\ast d\omega$</span> の一本と、§9.3 の <span class="tex2jax_process">$\ast$</span> 辞書さえあれば、すべてその場で再構成できる。
 </p>
 <h3 id="95-電磁気学の難問点電荷の電場と発散">§9.5 電磁気学の難問——点電荷の電場と発散</h3>
 <p>最後に、電磁気学からの例題を一つ。第10章への橋渡しでもある。
 </p>
-<blockquote><p>**注** （電磁気学が未習の読者へ）以下に出てくる「電場」や「点電荷」といった用語は、理解できなくても構わない。単に「$\frac{1}{\rho^2}$ に比例するベクトル場」の計算だと思って眺めてほしい。第10章でも、電磁気学そのものを深く掘り下げるわけではない。ただ、マクスウェル方程式を微分形式で書くと恐ろしく簡潔になること、そして「みんなここで美しいと言って終わるが、行列まで落とすとどうなるか」を実際に全部書き下す——それだけだ。</p>
+<blockquote><p>**注** （電磁気学が未習の読者へ）以下に出てくる「電場」や「点電荷」といった用語は、理解できなくても構わない。単に「<span class="tex2jax_process">$\frac{1}{\rho^2}$</span> に比例するベクトル場」の計算だと思って眺めてほしい。第10章でも、電磁気学そのものを深く掘り下げるわけではない。ただ、マクスウェル方程式を微分形式で書くと恐ろしく簡潔になること、そして「みんなここで美しいと言って終わるが、行列まで落とすとどうなるか」を実際に全部書き下す——それだけだ。</p>
 </p></blockquote>
-<p>点電荷 $q$ が原点にあるとき、電場は $\mathbf{E} = \frac{q}{4\pi\varepsilon_0}\frac{\hat{\boldsymbol{\rho}}}{\rho^2}$（$\hat{\boldsymbol{\rho}}$ は動径方向の単位ベクトル）。ベクトル解析では $\nabla\cdot\mathbf{E} = 0$（原点以外）を示すために球座標の発散公式に代入するが、電場に対応する $1$-form を直接扱う方が見通しがよい。
+<p>点電荷 <span class="tex2jax_process">$q$</span> が原点にあるとき、電場は <span class="tex2jax_process">$\mathbf{E} = \frac{q}{4\pi\varepsilon_0}\frac{\hat{\boldsymbol{\rho}}}{\rho^2}$</span>（<span class="tex2jax_process">$\hat{\boldsymbol{\rho}}$</span> は動径方向の単位ベクトル）。ベクトル解析では <span class="tex2jax_process">$\nabla\cdot\mathbf{E} = 0$</span>（原点以外）を示すために球座標の発散公式に代入するが、電場に対応する <span class="tex2jax_process">$1$</span>-form を直接扱う方が見通しがよい。
 </p>
-<p>$\mathbf{E}$ の $\rho$ 成分は $E_\rho = \frac{k}{\rho^2}$（$k = q/4\pi\varepsilon_0$）、$\theta,\phi$ 成分はゼロ。対応する $1$-form は
+<span class="tex2jax_process">$\mathbf{E}$</span> の <span class="tex2jax_process">$\rho$</span> 成分は <span class="tex2jax_process">$E_\rho = \frac{k}{\rho^2}$</span>（<span class="tex2jax_process">$k = q/4\pi\varepsilon_0$</span>）、<span class="tex2jax_process">$\theta,\phi$</span> 成分はゼロ。対応する <span class="tex2jax_process">$1$</span>-form は
+<div class="math-block tex2jax_process">$$\omega = \frac{k}{\rho^2}\,d\rho$$</div>
+<span class="tex2jax_process">$d\ast\omega$</span> を計算する。球座標では <span class="tex2jax_process">$\ast(d\rho) = \rho^2\sin\theta\,d\theta\wedge d\phi$</span>（§9.3.1）だから、
+<div class="math-block tex2jax_process">$$\ast\omega = \frac{k}{\rho^2} \cdot \rho^2\sin\theta\,d\theta\wedge d\phi = k\sin\theta\,d\theta\wedge d\phi$$</div>
+<div class="math-block tex2jax_process">$$d\ast\omega = \frac{\partial}{\partial\rho}(k\sin\theta)\,d\rho\wedge d\theta\wedge d\phi + \frac{\partial}{\partial\theta}(k\sin\theta)\,d\theta\wedge d\theta\wedge d\phi + \cdots$$</div>
+<p>第二項は <span class="tex2jax_process">$d\theta\wedge d\theta = 0$</span> で消える。第三項も同様。第一項は <span class="tex2jax_process">$\frac{\partial}{\partial\rho}(k\sin\theta) = 0$</span>（<span class="tex2jax_process">$\rho$</span> に依存しない）。よって
 </p>
-<p>$$\omega = \frac{k}{\rho^2}\,d\rho$$
-</p>
-<p>$d\ast\omega$ を計算する。球座標では $\ast(d\rho) = \rho^2\sin\theta\,d\theta\wedge d\phi$（§9.3.1）だから、
-</p>
-<p>$$\ast\omega = \frac{k}{\rho^2} \cdot \rho^2\sin\theta\,d\theta\wedge d\phi = k\sin\theta\,d\theta\wedge d\phi$$
-</p>
-<p>$$d\ast\omega = \frac{\partial}{\partial\rho}(k\sin\theta)\,d\rho\wedge d\theta\wedge d\phi + \frac{\partial}{\partial\theta}(k\sin\theta)\,d\theta\wedge d\theta\wedge d\phi + \cdots$$
-</p>
-<p>第二項は $d\theta\wedge d\theta = 0$ で消える。第三項も同様。第一項は $\frac{\partial}{\partial\rho}(k\sin\theta) = 0$（$\rho$ に依存しない）。よって
-</p>
-<p>$$d\ast\omega = 0 \quad (\rho \neq 0)$$
-</p>
-<p>$\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$ である。$\rho^2$ が $\ast(d\rho)$ の $\rho^2$ と打ち消し合い、残った $\sin\theta\,d\theta\wedge d\phi$ の外微分がゼロ——これだけの計算で、原点以外での発散ゼロが示された。
-</p>
-<blockquote><p>**注** （原点では？）$\rho = 0$ では $\omega$ が定義できない。原点を含む領域での積分には $\int_{\partial V} \ast\omega = \int_V d\ast\omega$（ガウスの定理）を使い、右辺に $\delta$ 関数が現れる。これは第10章で $\ast d\ast\omega = \rho/\varepsilon_0$ として正式に扱う。</p>
+<div class="math-block tex2jax_process">$$d\ast\omega = 0 \quad (\rho \neq 0)$$</div>
+<span class="tex2jax_process">$\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$</span> である。<span class="tex2jax_process">$\rho^2$</span> が <span class="tex2jax_process">$\ast(d\rho)$</span> の <span class="tex2jax_process">$\rho^2$</span> と打ち消し合い、残った <span class="tex2jax_process">$\sin\theta\,d\theta\wedge d\phi$</span> の外微分がゼロ——これだけの計算で、原点以外での発散ゼロが示された。
+<blockquote><p>**注** （原点では？）<span class="tex2jax_process">$\rho = 0$</span> では <span class="tex2jax_process">$\omega$</span> が定義できない。原点を含む領域での積分には <span class="tex2jax_process">$\int_{\partial V} \ast\omega = \int_V d\ast\omega$</span>（ガウスの定理）を使い、右辺に <span class="tex2jax_process">$\delta$</span> 関数が現れる。これは第10章で <span class="tex2jax_process">$\ast d\ast\omega = \rho/\varepsilon_0$</span> として正式に扱う。</p>
 </p></blockquote>
 <hr />
 <h3 id="96-辞書は終わり旅は続く">§9.6 辞書は終わり、旅は続く</h3>
 <p>本章では、第8章までに構築した辞書を使って、ベクトル解析の公式を機械的に導出し、微積分と電磁気学の難問を解いた。重要なのは、どの計算も「公式を思い出す」ではなく「辞書を引いて手順をなぞる」だけで済んだことだ。
 </p>
-<p>もはや、円柱座標や球座標の発散・回転の公式を暗記する必要はない。$J \to g = J^T J \to \ast$ 辞書 $\to \ast d\ast$——この一本道を覚えておけば、どんな座標系でもその場で公式を再構成できる。
+<p>もはや、円柱座標や球座標の発散・回転の公式を暗記する必要はない。<span class="tex2jax_process">$J \to g = J^T J \to \ast$</span> 辞書 <span class="tex2jax_process">$\to \ast d\ast$</span>——この一本道を覚えておけば、どんな座標系でもその場で公式を再構成できる。
 </p>
 <p>第10章では、この道具をマクスウェル方程式に適用する。ベクトル解析では4本の基礎方程式が、微分形式では2本に集約される。多くの教科書はここで「なんと美しい」と止まってしまうが、我々はさらに進む。微分形式のマクスウェル方程式の微分形式表現を全成分書き下すとどうなるか——それを実際にやってみせる。本章の計算練習を経ていれば、その翻訳はもはや難しくないはずだ。
 </p>
 <blockquote><p>**【ここまでのチェックポイント — 第9章全体】**</p>
-- 任意の座標系での公式導出は $J \to g = J^T J \to \ast$ 辞書 $\to \ast d\ast$ の3ステップ。
-- 円柱座標・球座標での $\ast$ 辞書、発散・回転の公式を導出した。
-- ベクトルラプラシアン $\nabla^2\mathbf{F}$ のような難問も、辞書と恒等式の組み合わせで機械的に解ける。
-- 点電荷の電場の発散ゼロは、$\ast(d\rho)$ と $E_\rho$ の $\rho^2$ が打ち消し合うだけの単純な計算で示せる。
+- 任意の座標系での公式導出は <span class="tex2jax_process">$J \to g = J^T J \to \ast$</span> 辞書 <span class="tex2jax_process">$\to \ast d\ast$</span> の3ステップ。
+- 円柱座標・球座標での <span class="tex2jax_process">$\ast$</span> 辞書、発散・回転の公式を導出した。
+- ベクトルラプラシアン <span class="tex2jax_process">$\nabla^2\mathbf{F}$</span> のような難問も、辞書と恒等式の組み合わせで機械的に解ける。
+- 点電荷の電場の発散ゼロは、<span class="tex2jax_process">$\ast(d\rho)$</span> と <span class="tex2jax_process">$E_\rho$</span> の <span class="tex2jax_process">$\rho^2$</span> が打ち消し合うだけの単純な計算で示せる。
 - 公式は暗記しなくてもよい。辞書さえあれば、そしてその辞書すらも、すべてその場で再構成できる。
 </p></blockquote>
 <p>\newpage
@@ -4525,9 +4144,9 @@ C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{
 <h3 id="100-お約束">§10.0 お約束</h3>
 <p>さて、いよいよ本書も終わりが近づいてきた。微分形式の物理数学の教科書というのは、最後にマクスウェル方程式を微分形式で書き直して締めるというのが、どうやらお約束らしい。筆者もこの慣習に倣うことにしよう。
 </p>
-<p>ただし、一言断っておく。本書は電磁気学の教科書ではない。以下の内容を理解するのに、電磁気学の予備知識は一切不要だ。電場や磁場が何か知らなくても構わない。ただ、$E_x, E_y, E_z, B_x, B_y, B_z$ という6つの関数が登場し、それらがとある反対称行列に収まり、$d$ と $\ast$ を作用させるとベクトル解析でおなじみの式が現れる——その流れを、純粋に代数的な操作として眺めてほしい。
+<p>ただし、一言断っておく。本書は電磁気学の教科書ではない。以下の内容を理解するのに、電磁気学の予備知識は一切不要だ。電場や磁場が何か知らなくても構わない。ただ、<span class="tex2jax_process">$E_x, E_y, E_z, B_x, B_y, B_z$</span> という6つの関数が登場し、それらがとある反対称行列に収まり、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> を作用させるとベクトル解析でおなじみの式が現れる——その流れを、純粋に代数的な操作として眺めてほしい。
 </p>
-<blockquote><p>**注** （電磁気学が未習の読者へ）本章に出てくる物理用語はすべて読み飛ばしてよい。必要なのは「6つの関数を4×4行列に並べ、$d$ と $\ast$ を作用させたら何が出るか」を見ることだけだ。電磁気学の知識がなくても、ここまでの章を読み通した読者なら、行列の成分を追うだけで十分に楽しめるはずである。</p>
+<blockquote><p>**注** （電磁気学が未習の読者へ）本章に出てくる物理用語はすべて読み飛ばしてよい。必要なのは「6つの関数を4×4行列に並べ、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> を作用させたら何が出るか」を見ることだけだ。電磁気学の知識がなくても、ここまでの章を読み通した読者なら、行列の成分を追うだけで十分に楽しめるはずである。</p>
 </p></blockquote>
 <blockquote><p>**注** （本章の立ち位置）本書の核心は第8章で完結している。本章は、いわばおまけ、あるいは蛇足に近い。あまり真面目に身構えず、気楽に読んでほしい。</p>
 </p></blockquote>
@@ -4535,342 +4154,300 @@ C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{
 <h3 id="101-マクスウェル方程式2本で書く">§10.1 マクスウェル方程式——2本で書く</h3>
 <p>電磁気学の基本法則は、SI単位系で次の4本の式として書かれる。
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \mathrm{div}\,\mathbf{E} &= \frac{\rho}{\varepsilon_0} &
 \mathrm{div}\,\mathbf{B} &= 0 \\[0.5em]
 \mathrm{rot}\,\mathbf{B} &= \mu_0\mathbf{J} + \frac{1}{c^2}\frac{\partial \mathbf{E}}{\partial t} &
 \mathrm{rot}\,\mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t}
-\end{aligned}$$
-</p>
-<p>このままでは、これから $4\times4$ 行列に押し込むための「型」が揃っていない。電場 $\mathbf{E}$（次元 $\mathrm{V/m}$）と磁束密度 $\mathbf{B}$（次元 $\mathrm{T}$）は単位が違い、さらに空間の微分（$\mathrm{rot}$ や $\mathrm{div}$）と時間 $t$ の微分も次元が異なる。
+\end{aligned}$$</div>
+<p>このままでは、これから <span class="tex2jax_process">$4\times4$</span> 行列に押し込むための「型」が揃っていない。電場 <span class="tex2jax_process">$\mathbf{E}$</span>（次元 <span class="tex2jax_process">$\mathrm{V/m}$</span>）と磁束密度 <span class="tex2jax_process">$\mathbf{B}$</span>（次元 <span class="tex2jax_process">$\mathrm{T}$</span>）は単位が違い、さらに空間の微分（<span class="tex2jax_process">$\mathrm{rot}$</span> や <span class="tex2jax_process">$\mathrm{div}$</span>）と時間 <span class="tex2jax_process">$t$</span> の微分も次元が異なる。
 </p>
 <p>そこで、すべてを「長さ」の次元に変換する。
 </p>
 <ol>
-<li>**時間の変換**：時間 $t$ に光速 $c$ を掛けて、長さの次元を持つ座標 $w = ct$ を導入する。時間微分は $\frac{\partial}{\partial t} = c\frac{\partial}{\partial w}$ となる。</li>
+<li>**時間の変換**：時間 <span class="tex2jax_process">$t$</span> に光速 <span class="tex2jax_process">$c$</span> を掛けて、長さの次元を持つ座標 <span class="tex2jax_process">$w = ct$</span> を導入する。時間微分は <span class="tex2jax_process">$\frac{\partial}{\partial t} = c\frac{\partial}{\partial w}$</span> となる。</li>
 </ol>
 <ol>
-<li>**磁場の変換**：磁束密度 $\mathbf{B}$ に $c$ を掛けて、電場と同じ $\mathrm{V/m}$ の次元を持つ $\mathbf{B}' = c\mathbf{B}$ を定義する。</li>
+<li>**磁場の変換**：磁束密度 <span class="tex2jax_process">$\mathbf{B}$</span> に <span class="tex2jax_process">$c$</span> を掛けて、電場と同じ <span class="tex2jax_process">$\mathrm{V/m}$</span> の次元を持つ <span class="tex2jax_process">$\mathbf{B}' = c\mathbf{B}$</span> を定義する。</li>
 </ol>
 <p>これらを上の4式に代入する。ファラデーの法則は、
 </p>
-<p>$$\mathrm{rot}\,\mathbf{E} = -\frac{\partial}{\partial t}\!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}\!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$
-</p>
+<div class="math-block tex2jax_process">$$\mathrm{rot}\,\mathbf{E} = -\frac{\partial}{\partial t}\!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}\!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$</div>
 <p>アンペールの法則も同様に整理すると、
 </p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \mathrm{div}\,\mathbf{E} &= \frac{\rho}{\varepsilon_0} &
 \mathrm{div}\,\mathbf{B}' &= 0 \\[0.5em]
 \mathrm{rot}\,\mathbf{B}' &= c\mu_0\mathbf{J} + \frac{\partial \mathbf{E}}{\partial w} &
 \mathrm{rot}\,\mathbf{E} &= -\frac{\partial \mathbf{B}'}{\partial w}
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>時間微分が <span class="tex2jax_process">$\frac{\partial}{\partial w}$</span> になり、空間微分（<span class="tex2jax_process">$\mathrm{rot}, \mathrm{div}$</span>）と分母の次元（長さ）が揃った。
 </p>
-<p>時間微分が $\frac{\partial}{\partial w}$ になり、空間微分（$\mathrm{rot}, \mathrm{div}$）と分母の次元（長さ）が揃った。
+<p>以降、<span class="tex2jax_process">$\mathbf{B}'$</span> のことを改めて <span class="tex2jax_process">$\mathbf{B}$</span> と呼び、<span class="tex2jax_process">$w$</span> を改めて <span class="tex2jax_process">$t$</span> と書く。つまり、これ以降の <span class="tex2jax_process">$\mathbf{B}$</span> は本来の磁束密度ではなく <span class="tex2jax_process">$c$</span> 倍された「次元を揃えた磁場」であり、<span class="tex2jax_process">$t$</span> は本来の時間ではなく <span class="tex2jax_process">$c$</span> 倍された「長さの次元を持つ時間座標」である。
 </p>
-<p>以降、$\mathbf{B}'$ のことを改めて $\mathbf{B}$ と呼び、$w$ を改めて $t$ と書く。つまり、これ以降の $\mathbf{B}$ は本来の磁束密度ではなく $c$ 倍された「次元を揃えた磁場」であり、$t$ は本来の時間ではなく $c$ 倍された「長さの次元を持つ時間座標」である。
+<p>これで準備が整った。<span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> は同じ次元を持ち、同じ行列に並べられる。電磁場をまとめた<span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$F$</span> と、電流・電荷をまとめた<span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\mathcal{J}$</span> を用意すれば、4本の式は<strong>2本</strong>になる。
 </p>
-<p>これで準備が整った。$\mathbf{E}$ と $\mathbf{B}$ は同じ次元を持ち、同じ行列に並べられる。電磁場をまとめた$2$-form $F$ と、電流・電荷をまとめた$1$-form $\mathcal{J}$ を用意すれば、4本の式は<strong>2本</strong>になる。
-</p>
-<p>$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
-</p>
+<div class="math-block tex2jax_process">$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$</div>
 <p>以上である。4本が2本に——この簡潔さをもって「美しい」と讃えるのが、微分形式の教科書の定番の幕引きだ。
 </p>
-<p>しかし、本書はここで終わらない。$F$ の中身は何なのか。$dF=0$ を成分で展開すると、本当に $\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ と $\mathrm{div}\,\mathbf{B} = 0$ が出てくるのか。それを、この章で全部書き下す。
+<p>しかし、本書はここで終わらない。<span class="tex2jax_process">$F$</span> の中身は何なのか。<span class="tex2jax_process">$dF=0$</span> を成分で展開すると、本当に <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$</span> と <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B} = 0$</span> が出てくるのか。それを、この章で全部書き下す。
 </p>
 <hr />
-<h3 id="102-の中身行列で全部書く">§10.2 $F$ の中身——行列で全部書く</h3>
-<p>電磁場 $F$ は $2$-form である。第2章以来、$2$-form は反対称行列で表示できることを知っている。$F$ も例外ではない——ただし、時間も含めた4次元時空で考えるため、$F$ は $4\times4$ の反対称行列になる。
+<h3 id="102-span-classtex2jaxprocessspan-の中身行列で全部書く">§10.2 <span class="tex2jax_process">$F$</span> の中身——行列で全部書く</h3>
+<p>電磁場 <span class="tex2jax_process">$F$</span> は <span class="tex2jax_process">$2$</span>-form である。第2章以来、<span class="tex2jax_process">$2$</span>-form は反対称行列で表示できることを知っている。<span class="tex2jax_process">$F$</span> も例外ではない——ただし、時間も含めた4次元時空で考えるため、<span class="tex2jax_process">$F$</span> は <span class="tex2jax_process">$4\times4$</span> の反対称行列になる。
 </p>
-<p>時間座標を $t$（ただしこれは §10.1 で変換した $w=ct$ を改名したものであり、元のSI単位系の $t$ ではない）、空間座標を $x,y,z$ とする。§10.1 の変換により、$F$ の成分は次のようになる。
+<p>時間座標を <span class="tex2jax_process">$t$</span>（ただしこれは §10.1 で変換した <span class="tex2jax_process">$w=ct$</span> を改名したものであり、元のSI単位系の <span class="tex2jax_process">$t$</span> ではない）、空間座標を <span class="tex2jax_process">$x,y,z$</span> とする。§10.1 の変換により、<span class="tex2jax_process">$F$</span> の成分は次のようになる。
 </p>
-<p>$$F = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$F = \begin{pmatrix}
 0 & -E_x & -E_y & -E_z \\
 E_x & 0 & B_z & -B_y \\
 E_y & -B_z & 0 & B_x \\
 E_z & B_y & -B_x & 0
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<p>行と列の順は <span class="tex2jax_process">$(t,x,y,z)$</span>。<span class="tex2jax_process">$E_x, E_y, E_z$</span> は電場（元のSI単位系の値）、<span class="tex2jax_process">$B_x, B_y, B_z$</span> は <span class="tex2jax_process">$c$</span> 倍された磁場である。両者は §10.1 の正規化により同一の次元 <span class="tex2jax_process">$\mathrm{V/m}$</span> を持ち、行列にそのまま並べられる。<span class="tex2jax_process">$F$</span> は反対称行列（<span class="tex2jax_process">$F^T = -F$</span>）であり、独立な成分はちょうど6個だ。
 </p>
-<p>行と列の順は $(t,x,y,z)$。$E_x, E_y, E_z$ は電場（元のSI単位系の値）、$B_x, B_y, B_z$ は $c$ 倍された磁場である。両者は §10.1 の正規化により同一の次元 $\mathrm{V/m}$ を持ち、行列にそのまま並べられる。$F$ は反対称行列（$F^T = -F$）であり、独立な成分はちょうど6個だ。
+<p>基底 <span class="tex2jax_process">$2$</span>-form で書けば、
 </p>
-<p>基底 $2$-form で書けば、
-</p>
-<p>$$F = E_x\,dt\wedge dx + E_y\,dt\wedge dy + E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$
-</p>
-<p>$dt\wedge dx$ の係数が $E_x$ そのものなのは、§10.1 で $\mathbf{E}$ と $\mathbf{B}$ の次元を $\mathrm{V/m}$ に揃えたことの直接の帰結である。同一の次元を持つ量は、同じ行列にそのまま並べられる。
-</p>
-<blockquote><p>**注** （符号の規約）上の行列表示は、4元ポテンシャル $A$ から作る</p>
-$$
+<div class="math-block tex2jax_process">$$F = E_x\,dt\wedge dx + E_y\,dt\wedge dy + E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$</div>
+<span class="tex2jax_process">$dt\wedge dx$</span> の係数が <span class="tex2jax_process">$E_x$</span> そのものなのは、§10.1 で <span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> の次元を <span class="tex2jax_process">$\mathrm{V/m}$</span> に揃えたことの直接の帰結である。同一の次元を持つ量は、同じ行列にそのまま並べられる。
+<blockquote><p>**注** （符号の規約）上の行列表示は、4元ポテンシャル <span class="tex2jax_process">$A$</span> から作る</p>
+
+</p></blockquote>
+<div class="math-block tex2jax_process">$$
 > F_{\mu\nu}
 > =
 > \frac{\partial A_\nu}{\partial x^\mu}
 > -
 > \frac{\partial A_\mu}{\partial x^\nu}
-> $$
-という反対称な成分の並べ方に対応する（§10.6 ではこれを $F=-dA$ として扱う）。ここで
-$$
+> $$</div>
+<blockquote><p>という反対称な成分の並べ方に対応する（§10.6 ではこれを <span class="tex2jax_process">$F=-dA$</span> として扱う）。ここで</p>
+
+</p></blockquote>
+<div class="math-block tex2jax_process">$$
 > (x^0,x^1,x^2,x^3)=(t,x,y,z)
-> $$
-である。通常は $\partial_\mu A_\nu-\partial_\nu A_\mu$ と略記されるが、本書では不要な略記法を避ける。符号が逆の流儀もあるが、本章ではこの規約に従う。
+> $$</div>
+<blockquote><p>である。通常は <span class="tex2jax_process">$\partial_\mu A_\nu-\partial_\nu A_\mu$</span> と略記されるが、本書では不要な略記法を避ける。符号が逆の流儀もあるが、本章ではこの規約に従う。</p>
 </p></blockquote>
 <hr />
-<h3 id="103-ミンコフスキー計量-から4次元へ">§10.3 ミンコフスキー計量——$\mathbb{R}^3$ から4次元へ</h3>
-<p>本書は一貫して $\mathbb{R}^3$ のデカルト座標 $(x,y,z)$ を舞台にしてきた。しかし $F$ を扱うには、時間 $t$ を加えた4次元時空 $(t,x,y,z)$ が必要になる。
+<h3 id="103-ミンコフスキー計量span-classtex2jaxprocessspan-から4次元へ">§10.3 ミンコフスキー計量——<span class="tex2jax_process">$\mathbb{R}^3$</span> から4次元へ</h3>
+<p>本書は一貫して <span class="tex2jax_process">$\mathbb{R}^3$</span> のデカルト座標 <span class="tex2jax_process">$(x,y,z)$</span> を舞台にしてきた。しかし <span class="tex2jax_process">$F$</span> を扱うには、時間 <span class="tex2jax_process">$t$</span> を加えた4次元時空 <span class="tex2jax_process">$(t,x,y,z)$</span> が必要になる。
 </p>
-<p>幸い、ここまでに積み上げた知識があれば、拡張は容易だ。第6章で $\mathbf{g} = J^T J$ を導出し、第9章で $\mathbf{g}$ から $\ast$ の辞書を作る手順を練習した。時空でも同じことをすればよい。計量は次のようになる（時間成分の符号が空間成分と異なる点が唯一の新しい要素だ）。
+<p>幸い、ここまでに積み上げた知識があれば、拡張は容易だ。第6章で <span class="tex2jax_process">$\mathbf{g} = J^T J$</span> を導出し、第9章で <span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書を作る手順を練習した。時空でも同じことをすればよい。計量は次のようになる（時間成分の符号が空間成分と異なる点が唯一の新しい要素だ）。
 </p>
-<p>$$\mathbf{g} = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\mathbf{g} = \begin{pmatrix}
 -1 & 0 & 0 & 0 \\
 0 & 1 & 0 & 0 \\
 0 & 0 & 1 & 0 \\
 0 & 0 & 0 & 1
-\end{pmatrix}$$
-</p>
-<blockquote><p>**注** （正定値性からの離脱）本書の計量はこれまでつねに正定値（$\mathbf{v}^T\mathbf{g}\,\mathbf{v} > 0$ for $\mathbf{v}\neq\mathbf{0}$）だった。ミンコフスキー計量は正定値ではなく、これまでの $\mathbf{g}=J^T J$ 型の計量とは異なる。ここでは「計量行列から $\ast$ の辞書を作る」という手順だけを引き継いでいる。この違いは $\ast$ の辞書に符号の変化として現れるが、計算手順そのものは変わらない。第11章でこの点に簡単に触れる。</p>
+\end{pmatrix}$$</div>
+<blockquote><p>**注** （正定値性からの離脱）本書の計量はこれまでつねに正定値（<span class="tex2jax_process">$\mathbf{v}^T\mathbf{g}\,\mathbf{v} > 0$</span> for <span class="tex2jax_process">$\mathbf{v}\neq\mathbf{0}$</span>）だった。ミンコフスキー計量は正定値ではなく、これまでの <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> 型の計量とは異なる。ここでは「計量行列から <span class="tex2jax_process">$\ast$</span> の辞書を作る」という手順だけを引き継いでいる。この違いは <span class="tex2jax_process">$\ast$</span> の辞書に符号の変化として現れるが、計算手順そのものは変わらない。第11章でこの点に簡単に触れる。</p>
 </p></blockquote>
-<p>行と列の順は $(t,x,y,z)$。空間部分（右下の$3\times3$）は単位行列であり、これまでの $\mathbb{R}^3$ の計量そのものだ。時間成分の $-1$ が $\ast$ の辞書に符号の変化をもたらすが、それは §10.5 で $\ast F$ の行列表示として結果を受け取れば十分である。
+<p>行と列の順は <span class="tex2jax_process">$(t,x,y,z)$</span>。空間部分（右下の<span class="tex2jax_process">$3\times3$</span>）は単位行列であり、これまでの <span class="tex2jax_process">$\mathbb{R}^3$</span> の計量そのものだ。時間成分の <span class="tex2jax_process">$-1$</span> が <span class="tex2jax_process">$\ast$</span> の辞書に符号の変化をもたらすが、それは §10.5 で <span class="tex2jax_process">$\ast F$</span> の行列表示として結果を受け取れば十分である。
 </p>
 <hr />
-<h3 id="104-を全部書き下す">§10.4 $dF=0$ を全部書き下す</h3>
-<p>$F$ は $2$-form だから、$dF$ は $3$-form になる。4次元空間での $3$-form の独立成分は4つ。$F$ の全6項について $d$ を作用させ、同じ基底 $3$-form の係数をまとめる。
+<h3 id="104-span-classtex2jaxprocessspan-を全部書き下す">§10.4 <span class="tex2jax_process">$dF=0$</span> を全部書き下す</h3>
+<span class="tex2jax_process">$F$</span> は <span class="tex2jax_process">$2$</span>-form だから、<span class="tex2jax_process">$dF$</span> は <span class="tex2jax_process">$3$</span>-form になる。4次元空間での <span class="tex2jax_process">$3$</span>-form の独立成分は4つ。<span class="tex2jax_process">$F$</span> の全6項について <span class="tex2jax_process">$d$</span> を作用させ、同じ基底 <span class="tex2jax_process">$3$</span>-form の係数をまとめる。
+<span class="tex2jax_process">$F$</span> の6項を形式で書く。
+<div class="math-block tex2jax_process">$$F = E_x\,dt\wedge dx + E_y\,dt\wedge dy + E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$</div>
+<p>各項に <span class="tex2jax_process">$d$</span> を作用させる。<span class="tex2jax_process">$E_x, E_y, E_z, B_x, B_y, B_z$</span> はすべて <span class="tex2jax_process">$(t,x,y,z)$</span> の関数である。
 </p>
-<p>$F$ の6項を形式で書く。
-</p>
-<p>$$F = E_x\,dt\wedge dx + E_y\,dt\wedge dy + E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$
-</p>
-<p>各項に $d$ を作用させる。$E_x, E_y, E_z, B_x, B_y, B_z$ はすべて $(t,x,y,z)$ の関数である。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d\!\left(E_x\,dt\wedge dx\right) &= \frac{\partial E_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial E_x}{\partial z}\,dz\wedge dt\wedge dx \\
 d\!\left(E_y\,dt\wedge dy\right) &= \frac{\partial E_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial E_y}{\partial z}\,dz\wedge dt\wedge dy \\
 d\!\left(E_z\,dt\wedge dz\right) &= \frac{\partial E_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial E_z}{\partial y}\,dy\wedge dt\wedge dz
-\end{aligned}$$
-</p>
-<p>$B$ の項は $t$ 微分も含む。
-</p>
-<p>$$\begin{aligned}
+\end{aligned}$$</div>
+<span class="tex2jax_process">$B$</span> の項は <span class="tex2jax_process">$t$</span> 微分も含む。
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d(B_x\,dy\wedge dz) &= \frac{\partial B_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial B_x}{\partial x}\,dx\wedge dy\wedge dz \\
 d(B_y\,dz\wedge dx) &= \frac{\partial B_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial B_y}{\partial y}\,dy\wedge dz\wedge dx \\
 d(B_z\,dx\wedge dy) &= \frac{\partial B_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial B_z}{\partial z}\,dz\wedge dx\wedge dy
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>これらをすべて足し合わせる。基底 <span class="tex2jax_process">$3$</span>-form の種類は <span class="tex2jax_process">$(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$</span> の4つ。ウェッジ積の反対称性を使って項を整理する（たとえば <span class="tex2jax_process">$dy\wedge dt\wedge dx = -dt\wedge dy\wedge dx = dt\wedge dx\wedge dy$</span>）。
 </p>
-<p>これらをすべて足し合わせる。基底 $3$-form の種類は $(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$ の4つ。ウェッジ積の反対称性を使って項を整理する（たとえば $dy\wedge dt\wedge dx = -dt\wedge dy\wedge dx = dt\wedge dx\wedge dy$）。
+<p>各基底 <span class="tex2jax_process">$3$</span>-form の係数をゼロとおくと、<span class="tex2jax_process">$dF=0$</span> は次と同値になる。
 </p>
-<p>各基底 $3$-form の係数をゼロとおくと、$dF=0$ は次と同値になる。
-</p>
-<p>$$dF = 0 \Longleftrightarrow \begin{cases}
+<div class="math-block tex2jax_process">$$dF = 0 \Longleftrightarrow \begin{cases}
 \displaystyle \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z} = 0 \\[1em]
 \displaystyle \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \frac{\partial B_x}{\partial t} = 0 \\[0.5em]
 \displaystyle \frac{\partial E_x}{\partial z} - \frac{\partial E_z}{\partial x} + \frac{\partial B_y}{\partial t} = 0 \\[0.5em]
 \displaystyle \frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t} = 0
-\end{cases}$$
-</p>
-<p>1行目は $\mathrm{div}\,\mathbf{B} = 0$、2〜4行目は $\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ の各成分にほかならない。
+\end{cases}$$</div>
+<p>1行目は <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B} = 0$</span>、2〜4行目は <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$</span> の各成分にほかならない。
 </p>
 <hr />
-<h3 id="105-と残りの2本">§10.5 $\ast F$ と残りの2本</h3>
-<p>もう一つの式 $d(\ast F) = \mu_0(\ast\mathcal{J})$ も、§10.4 と同じ手順で全部書き下す。
+<h3 id="105-span-classtex2jaxprocessspan-と残りの2本">§10.5 <span class="tex2jax_process">$\ast F$</span> と残りの2本</h3>
+<p>もう一つの式 <span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> も、§10.4 と同じ手順で全部書き下す。
 </p>
-<p>まず $\ast F$ を求める。$\ast$ は4次元時空の計量に依存するが、特殊相対論の平坦な時空（計量は時間成分だけ符号が異なる）では、$\ast F$ は §10.2 の $F$ で $\mathbf{E}$ と $\mathbf{B}$ を入れ替えた形になる。行列表示は次の通りだ。
+<p>まず <span class="tex2jax_process">$\ast F$</span> を求める。<span class="tex2jax_process">$\ast$</span> は4次元時空の計量に依存するが、特殊相対論の平坦な時空（計量は時間成分だけ符号が異なる）では、<span class="tex2jax_process">$\ast F$</span> は §10.2 の <span class="tex2jax_process">$F$</span> で <span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> を入れ替えた形になる。行列表示は次の通りだ。
 </p>
-<p>$$\ast F = \begin{pmatrix}
+<div class="math-block tex2jax_process">$$\ast F = \begin{pmatrix}
 0 & B_x & B_y & B_z \\
 -B_x & 0 & E_z & -E_y \\
 -B_y & -E_z & 0 & E_x \\
 -B_z & E_y & -E_x & 0
-\end{pmatrix}$$
+\end{pmatrix}$$</div>
+<span class="tex2jax_process">$F$</span> と見比べてほしい。<span class="tex2jax_process">$E$</span> と <span class="tex2jax_process">$B$</span> の位置が入れ替わっている。この規約と正規化のもとでは、<span class="tex2jax_process">$\ast$</span> はほとんど「<span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> を入れ替える装置」として働く。
+<p>基底 <span class="tex2jax_process">$2$</span>-form で書けば、§10.2 の <span class="tex2jax_process">$F$</span> と対応する形になる。
 </p>
-<p>$F$ と見比べてほしい。$E$ と $B$ の位置が入れ替わっている。この規約と正規化のもとでは、$\ast$ はほとんど「$\mathbf{E}$ と $\mathbf{B}$ を入れ替える装置」として働く。
+<div class="math-block tex2jax_process">$$\ast F = B_x\,dt\wedge dx + B_y\,dt\wedge dy + B_z\,dt\wedge dz + E_x\,dy\wedge dz + E_y\,dz\wedge dx + E_z\,dx\wedge dy$$</div>
+<p>次に、<span class="tex2jax_process">$d(\ast F)$</span> を展開する。<span class="tex2jax_process">$\ast F$</span> も <span class="tex2jax_process">$2$</span>-form だから、<span class="tex2jax_process">$d(\ast F)$</span> は <span class="tex2jax_process">$3$</span>-form だ。
 </p>
-<p>基底 $2$-form で書けば、§10.2 の $F$ と対応する形になる。
+<p>まず <span class="tex2jax_process">$B$</span> の項（<span class="tex2jax_process">$dt\wedge dx, dt\wedge dy, dt\wedge dz$</span>）に <span class="tex2jax_process">$d$</span> を作用させる。これらの時間微分は <span class="tex2jax_process">$dt\wedge dt = 0$</span> で消え、空間微分だけが残る。§10.4 の <span class="tex2jax_process">$E$</span> の項と同じ構造だ。
 </p>
-<p>$$\ast F = B_x\,dt\wedge dx + B_y\,dt\wedge dy + B_z\,dt\wedge dz + E_x\,dy\wedge dz + E_y\,dz\wedge dx + E_z\,dx\wedge dy$$
-</p>
-<p>次に、$d(\ast F)$ を展開する。$\ast F$ も $2$-form だから、$d(\ast F)$ は $3$-form だ。
-</p>
-<p>まず $B$ の項（$dt\wedge dx, dt\wedge dy, dt\wedge dz$）に $d$ を作用させる。これらの時間微分は $dt\wedge dt = 0$ で消え、空間微分だけが残る。§10.4 の $E$ の項と同じ構造だ。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d\!\left(B_x\,dt\wedge dx\right) &= \frac{\partial B_x}{\partial y}\,dy\wedge dt\wedge dx + \frac{\partial B_x}{\partial z}\,dz\wedge dt\wedge dx \\
 d\!\left(B_y\,dt\wedge dy\right) &= \frac{\partial B_y}{\partial x}\,dx\wedge dt\wedge dy + \frac{\partial B_y}{\partial z}\,dz\wedge dt\wedge dy \\
 d\!\left(B_z\,dt\wedge dz\right) &= \frac{\partial B_z}{\partial x}\,dx\wedge dt\wedge dz + \frac{\partial B_z}{\partial y}\,dy\wedge dt\wedge dz
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>次に <span class="tex2jax_process">$E$</span> の項（<span class="tex2jax_process">$dy\wedge dz, dz\wedge dx, dx\wedge dy$</span>）に <span class="tex2jax_process">$d$</span> を作用させる。こちらは時間微分も含む。§10.4 の <span class="tex2jax_process">$B$</span> の項と同じ構造だ。
 </p>
-<p>次に $E$ の項（$dy\wedge dz, dz\wedge dx, dx\wedge dy$）に $d$ を作用させる。こちらは時間微分も含む。§10.4 の $B$ の項と同じ構造だ。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d\!\left(E_x\,dy\wedge dz\right) &= \frac{\partial E_x}{\partial t}\,dt\wedge dy\wedge dz + \frac{\partial E_x}{\partial x}\,dx\wedge dy\wedge dz \\
 d\!\left(E_y\,dz\wedge dx\right) &= \frac{\partial E_y}{\partial t}\,dt\wedge dz\wedge dx + \frac{\partial E_y}{\partial y}\,dy\wedge dz\wedge dx \\
 d\!\left(E_z\,dx\wedge dy\right) &= \frac{\partial E_z}{\partial t}\,dt\wedge dx\wedge dy + \frac{\partial E_z}{\partial z}\,dz\wedge dx\wedge dy
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>これらをすべて足し合わせる。基底 <span class="tex2jax_process">$3$</span>-form の種類は §10.4 と同じ <span class="tex2jax_process">$(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$</span> の4つ。ウェッジ積の反対称性を使って項を整理する。
 </p>
-<p>これらをすべて足し合わせる。基底 $3$-form の種類は §10.4 と同じ $(dt\wedge dx\wedge dy,\; dt\wedge dy\wedge dz,\; dt\wedge dz\wedge dx,\; dx\wedge dy\wedge dz)$ の4つ。ウェッジ積の反対称性を使って項を整理する。
+<p>各基底 <span class="tex2jax_process">$3$</span>-form の係数をまとめると、<span class="tex2jax_process">$d(\ast F)$</span> は次になる。
 </p>
-<p>各基底 $3$-form の係数をまとめると、$d(\ast F)$ は次になる。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d(\ast F) = &\left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right) dt\wedge dx\wedge dy \\
 {+} &\left(\frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \frac{\partial E_x}{\partial t}\right) dt\wedge dy\wedge dz \\
 {+} &\left(\frac{\partial B_z}{\partial x} - \frac{\partial B_x}{\partial z} + \frac{\partial E_y}{\partial t}\right) dt\wedge dz\wedge dx \\
 {+} &\left(\frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}\right) dx\wedge dy\wedge dz
-\end{aligned}$$
+\end{aligned}$$</div>
+<span class="tex2jax_process">$dx\wedge dy\wedge dz$</span> の係数は <span class="tex2jax_process">$\mathrm{div}\,\mathbf{E}$</span> にほかならない。<span class="tex2jax_process">$dt\wedge dx\wedge dy$</span> の係数は <span class="tex2jax_process">$\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t} = -(\mathrm{rot}\,\mathbf{B})_z + \frac{\partial E_z}{\partial t}$</span> であり、2〜3行目も同様に <span class="tex2jax_process">$-(\mathrm{rot}\,\mathbf{B})_{x,y} + \frac{\partial E_{x,y}}{\partial t}$</span> の各成分だ。
+<p>一方、右辺の <span class="tex2jax_process">$\ast\mathcal{J}$</span> は電荷・電流を表す <span class="tex2jax_process">$3$</span>-form である。正規化された系では、次の形をとる。
 </p>
-<p>$dx\wedge dy\wedge dz$ の係数は $\mathrm{div}\,\mathbf{E}$ にほかならない。$dt\wedge dx\wedge dy$ の係数は $\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t} = -(\mathrm{rot}\,\mathbf{B})_z + \frac{\partial E_z}{\partial t}$ であり、2〜3行目も同様に $-(\mathrm{rot}\,\mathbf{B})_{x,y} + \frac{\partial E_{x,y}}{\partial t}$ の各成分だ。
+<div class="math-block tex2jax_process">$$\ast\mathcal{J} = \frac{\rho}{\varepsilon_0\mu_0}\,dx\wedge dy\wedge dz - cJ_x\,dt\wedge dy\wedge dz - cJ_y\,dt\wedge dz\wedge dx - cJ_z\,dt\wedge dx\wedge dy$$</div>
+<p>（<span class="tex2jax_process">$\rho$</span> は電荷密度、<span class="tex2jax_process">$J_x,J_y,J_z$</span> は電流密度。<span class="tex2jax_process">$\varepsilon_0\mu_0 = 1/c^2$</span> より、第1項の係数は <span class="tex2jax_process">$c^2\rho$</span> に等しい。）
 </p>
-<p>一方、右辺の $\ast\mathcal{J}$ は電荷・電流を表す $3$-form である。正規化された系では、次の形をとる。
-</p>
-<p>$$\ast\mathcal{J} = \frac{\rho}{\varepsilon_0\mu_0}\,dx\wedge dy\wedge dz - cJ_x\,dt\wedge dy\wedge dz - cJ_y\,dt\wedge dz\wedge dx - cJ_z\,dt\wedge dx\wedge dy$$
-</p>
-<p>（$\rho$ は電荷密度、$J_x,J_y,J_z$ は電流密度。$\varepsilon_0\mu_0 = 1/c^2$ より、第1項の係数は $c^2\rho$ に等しい。）
-</p>
-<blockquote><p>**注** （$\mathcal{J}$ の正規化）ここでの $\mathcal{J}$ は、§10.1 の $w=ct$ および $\mathbf{B}'=c\mathbf{B}$ に合わせて正規化された電流 $1$-form である。標準的な相対論的記法とは係数の置き方が異なる場合がある。本章では、§10.1 の4本のマクスウェル方程式を再現するように係数を選んでいる。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$\mathcal{J}$</span> の正規化）ここでの <span class="tex2jax_process">$\mathcal{J}$</span> は、§10.1 の <span class="tex2jax_process">$w=ct$</span> および <span class="tex2jax_process">$\mathbf{B}'=c\mathbf{B}$</span> に合わせて正規化された電流 <span class="tex2jax_process">$1$</span>-form である。標準的な相対論的記法とは係数の置き方が異なる場合がある。本章では、§10.1 の4本のマクスウェル方程式を再現するように係数を選んでいる。</p>
 </p></blockquote>
-<p>$d(\ast F) = \mu_0(\ast\mathcal{J})$ の両辺で基底 $3$-form の係数を比較する。
-</p>
-<p>$$\mu_0(\ast\mathcal{J}) = \frac{\rho}{\varepsilon_0}\,dx\wedge dy\wedge dz - c\mu_0J_x\,dt\wedge dy\wedge dz - c\mu_0J_y\,dt\wedge dz\wedge dx - c\mu_0J_z\,dt\wedge dx\wedge dy$$
-</p>
-<p>$dx\wedge dy\wedge dz$ の係数から $\mathrm{div}\,\mathbf{E} = \frac{\rho}{\varepsilon_0}$。$dt\wedge dy\wedge dz$ の係数から $-\frac{\partial B_z}{\partial y} + \frac{\partial B_y}{\partial z} + \frac{\partial E_x}{\partial t} = -c\mu_0J_x$、すなわち $(\mathrm{rot}\,\mathbf{B})_x - \frac{\partial E_x}{\partial t} = c\mu_0J_x$。整理すると $\mathrm{rot}\,\mathbf{B} = c\mu_0\mathbf{J} + \frac{\partial\mathbf{E}}{\partial t}$ を得る。
-</p>
-<p>以上で、$d(\ast F) = \mu_0(\ast\mathcal{J})$ を成分で完全に展開しきった。§10.4 の $dF=0$ と合わせて、マクスウェル方程式の4本が行列と偏微分の計算だけで再現されたことになる。
+<span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> の両辺で基底 <span class="tex2jax_process">$3$</span>-form の係数を比較する。
+<div class="math-block tex2jax_process">$$\mu_0(\ast\mathcal{J}) = \frac{\rho}{\varepsilon_0}\,dx\wedge dy\wedge dz - c\mu_0J_x\,dt\wedge dy\wedge dz - c\mu_0J_y\,dt\wedge dz\wedge dx - c\mu_0J_z\,dt\wedge dx\wedge dy$$</div>
+<span class="tex2jax_process">$dx\wedge dy\wedge dz$</span> の係数から <span class="tex2jax_process">$\mathrm{div}\,\mathbf{E} = \frac{\rho}{\varepsilon_0}$</span>。<span class="tex2jax_process">$dt\wedge dy\wedge dz$</span> の係数から <span class="tex2jax_process">$-\frac{\partial B_z}{\partial y} + \frac{\partial B_y}{\partial z} + \frac{\partial E_x}{\partial t} = -c\mu_0J_x$</span>、すなわち <span class="tex2jax_process">$(\mathrm{rot}\,\mathbf{B})_x - \frac{\partial E_x}{\partial t} = c\mu_0J_x$</span>。整理すると <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{B} = c\mu_0\mathbf{J} + \frac{\partial\mathbf{E}}{\partial t}$</span> を得る。
+<p>以上で、<span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> を成分で完全に展開しきった。§10.4 の <span class="tex2jax_process">$dF=0$</span> と合わせて、マクスウェル方程式の4本が行列と偏微分の計算だけで再現されたことになる。
 </p>
 <p>つまり、マクスウェル方程式の4本は、微分形式では
 </p>
-<p>$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
-</p>
+<div class="math-block tex2jax_process">$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$</div>
 <p>の2本に集約される。そして、この2本を実際に行列と偏微分で展開すれば、見慣れたベクトル解析の式がすべて再現される。美しさの裏に、ちゃんと泥臭い計算が息づいている——それを見届けたことが、本章の成果である。
 </p>
-<blockquote><p>**注** （なぜ2本なのか）鋭い読者ならこう思うかもしれない——「結局2本か。$dF=0$ と $d(\ast F)=\mu_0(\ast\mathcal{J})$ を、**1行**にまとめられないのか」と。できる。第12章では $\mathbf{E}$ と $\mathbf{B}$ をひとまとめにした複素ベクトルと、パウリ行列から作られるディラック演算子によって、マクスウェル方程式をたったの一撃に統合する。楽しみにしていてほしい。</p>
+<blockquote><p>**注** （なぜ2本なのか）鋭い読者ならこう思うかもしれない——「結局2本か。<span class="tex2jax_process">$dF=0$</span> と <span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span> を、**1行**にまとめられないのか」と。できる。第12章では <span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> をひとまとめにした複素ベクトルと、パウリ行列から作られるディラック演算子によって、マクスウェル方程式をたったの一撃に統合する。楽しみにしていてほしい。</p>
 </p></blockquote>
-<blockquote><p>**注** （なぜここで終わるのか）多くの教科書は $dF=0$ を示した時点で「かくしてマクスウェル方程式は幾何学である」と締める。しかし本書の流儀は違う。行列の成分を全部書き下し、$d$ と $\ast$ の辞書を通じてベクトル解析の式を再現する——その往復ができることこそ、第1章から積み上げてきた「測定器」の枠組みの到達点だ。</p>
+<blockquote><p>**注** （なぜここで終わるのか）多くの教科書は <span class="tex2jax_process">$dF=0$</span> を示した時点で「かくしてマクスウェル方程式は幾何学である」と締める。しかし本書の流儀は違う。行列の成分を全部書き下し、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の辞書を通じてベクトル解析の式を再現する——その往復ができることこそ、第1章から積み上げてきた「測定器」の枠組みの到達点だ。</p>
 </p></blockquote>
 <hr />
-<h3 id="106-ポテンシャル構成-から始める">§10.6 ポテンシャル構成——$F=-dA$ から始める</h3>
-<p>§10.2 では $F$ を「$\mathbf{E}$ と $\mathbf{B}$ の寄せ集め」として天下り的に定義した。しかし実は、$F$ はもっと根源的な量——<strong>4元ポテンシャル $A$</strong>——から機械的に導かれる。こちらが出発点として自然なのは、<strong>$dF=0$ が「$dd=0$」の一言で証明される</strong>からだ。
+<h3 id="106-ポテンシャル構成span-classtex2jaxprocessspan-から始める">§10.6 ポテンシャル構成——<span class="tex2jax_process">$F=-dA$</span> から始める</h3>
+<p>§10.2 では <span class="tex2jax_process">$F$</span> を「<span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> の寄せ集め」として天下り的に定義した。しかし実は、<span class="tex2jax_process">$F$</span> はもっと根源的な量——<strong>4元ポテンシャル <span class="tex2jax_process">$A$</span></strong>——から機械的に導かれる。こちらが出発点として自然なのは、<strong><span class="tex2jax_process">$dF=0$</span> が「<span class="tex2jax_process">$dd=0$</span>」の一言で証明される</strong>からだ。
 </p>
-<p>4元ポテンシャル $A$ は $1$-form である。電磁気学ではスカラーポテンシャル $\phi$ とベクトルポテンシャル $\mathbf{A} = (A_x, A_y, A_z)$ が組になる。時間成分の符号に注意して（§10.3 の計量の時間成分が $-1$ であることの反映）、
+<p>4元ポテンシャル <span class="tex2jax_process">$A$</span> は <span class="tex2jax_process">$1$</span>-form である。電磁気学ではスカラーポテンシャル <span class="tex2jax_process">$\phi$</span> とベクトルポテンシャル <span class="tex2jax_process">$\mathbf{A} = (A_x, A_y, A_z)$</span> が組になる。時間成分の符号に注意して（§10.3 の計量の時間成分が <span class="tex2jax_process">$-1$</span> であることの反映）、
 </p>
-<p>$$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$$
+<div class="math-block tex2jax_process">$$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$$</div>
+<p>と書く。<span class="tex2jax_process">$\phi, A_x, A_y, A_z$</span> はいずれも <span class="tex2jax_process">$(t,x,y,z)$</span> の関数である。
 </p>
-<p>と書く。$\phi, A_x, A_y, A_z$ はいずれも $(t,x,y,z)$ の関数である。
-</p>
-<p>$dA$ の計算は第5章以来の手順そのものだ。$A$ の4項それぞれに $d$ を作用させる。
-</p>
-<p>$$\begin{aligned}
+<span class="tex2jax_process">$dA$</span> の計算は第5章以来の手順そのものだ。<span class="tex2jax_process">$A$</span> の4項それぞれに <span class="tex2jax_process">$d$</span> を作用させる。
+<div class="math-block tex2jax_process">$$\begin{aligned}
 d(-\phi\,dt) &= -\frac{\partial\phi}{\partial x}\,dx\wedge dt - \frac{\partial\phi}{\partial y}\,dy\wedge dt - \frac{\partial\phi}{\partial z}\,dz\wedge dt \\
 d(A_x\,dx) &= \frac{\partial A_x}{\partial t}\,dt\wedge dx + \frac{\partial A_x}{\partial y}\,dy\wedge dx + \frac{\partial A_x}{\partial z}\,dz\wedge dx \\
 d(A_y\,dy) &= \frac{\partial A_y}{\partial t}\,dt\wedge dy + \frac{\partial A_y}{\partial x}\,dx\wedge dy + \frac{\partial A_y}{\partial z}\,dz\wedge dy \\
 d(A_z\,dz) &= \frac{\partial A_z}{\partial t}\,dt\wedge dz + \frac{\partial A_z}{\partial x}\,dx\wedge dz + \frac{\partial A_z}{\partial y}\,dy\wedge dz
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>（<span class="tex2jax_process">$\phi$</span> の時間微分は <span class="tex2jax_process">$dt\wedge dt = 0$</span> で消える。<span class="tex2jax_process">$A_x$</span> の <span class="tex2jax_process">$x$</span> 微分も <span class="tex2jax_process">$dx\wedge dx = 0$</span> で消える。以下同様。）
 </p>
-<p>（$\phi$ の時間微分は $dt\wedge dt = 0$ で消える。$A_x$ の $x$ 微分も $dx\wedge dx = 0$ で消える。以下同様。）
+<p>これらを足し合わせ、ウェッジ積の反対称性（<span class="tex2jax_process">$dx\wedge dt = -dt\wedge dx$</span> など）で基底 <span class="tex2jax_process">$2$</span>-form ごとに整理する。
 </p>
-<p>これらを足し合わせ、ウェッジ積の反対称性（$dx\wedge dt = -dt\wedge dx$ など）で基底 $2$-form ごとに整理する。
+<span class="tex2jax_process">$dt\wedge dx$</span> の係数を見よう。<span class="tex2jax_process">$d(-\phi\,dt)$</span> から <span class="tex2jax_process">$-\frac{\partial\phi}{\partial x}\,dx\wedge dt = \frac{\partial\phi}{\partial x}\,dt\wedge dx$</span>。<span class="tex2jax_process">$d(A_x\,dx)$</span> から <span class="tex2jax_process">$\frac{\partial A_x}{\partial t}\,dt\wedge dx$</span>。よって <span class="tex2jax_process">$dA$</span> の <span class="tex2jax_process">$dt\wedge dx$</span> 係数は <span class="tex2jax_process">$\displaystyle \frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}$</span>。
+<span class="tex2jax_process">$dy\wedge dz$</span> の係数は、<span class="tex2jax_process">$d(A_y\,dy)$</span> から <span class="tex2jax_process">$\frac{\partial A_y}{\partial z}\,dz\wedge dy = -\frac{\partial A_y}{\partial z}\,dy\wedge dz$</span>。<span class="tex2jax_process">$d(A_z\,dz)$</span> から <span class="tex2jax_process">$\frac{\partial A_z}{\partial y}\,dy\wedge dz$</span>。よって <span class="tex2jax_process">$dA$</span> の <span class="tex2jax_process">$dy\wedge dz$</span> 係数は <span class="tex2jax_process">$\displaystyle \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$</span>。
+<p>全6基底について同様に整理すると、<span class="tex2jax_process">$dA$</span> は次のようになる。
 </p>
-<p>$dt\wedge dx$ の係数を見よう。$d(-\phi\,dt)$ から $-\frac{\partial\phi}{\partial x}\,dx\wedge dt = \frac{\partial\phi}{\partial x}\,dt\wedge dx$。$d(A_x\,dx)$ から $\frac{\partial A_x}{\partial t}\,dt\wedge dx$。よって $dA$ の $dt\wedge dx$ 係数は $\displaystyle \frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}$。
-</p>
-<p>$dy\wedge dz$ の係数は、$d(A_y\,dy)$ から $\frac{\partial A_y}{\partial z}\,dz\wedge dy = -\frac{\partial A_y}{\partial z}\,dy\wedge dz$。$d(A_z\,dz)$ から $\frac{\partial A_z}{\partial y}\,dy\wedge dz$。よって $dA$ の $dy\wedge dz$ 係数は $\displaystyle \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$。
-</p>
-<p>全6基底について同様に整理すると、$dA$ は次のようになる。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 dA &= \left(\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}\right)dt\wedge dx + \left(\frac{\partial\phi}{\partial y} + \frac{\partial A_y}{\partial t}\right)dt\wedge dy + \left(\frac{\partial\phi}{\partial z} + \frac{\partial A_z}{\partial t}\right)dt\wedge dz \\
 &\quad+ \left(\frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial A_x}{\partial z} - \frac{\partial A_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial A_y}{\partial x} - \frac{\partial A_x}{\partial y}\right)dx\wedge dy
-\end{aligned}$$
+\end{aligned}$$</div>
+<p>ここで <span class="tex2jax_process">$dA$</span> の <span class="tex2jax_process">$dt\wedge dx$</span> 係数は <span class="tex2jax_process">$\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}$</span> だが、§10.2 の <span class="tex2jax_process">$F$</span> では同基底の係数は <span class="tex2jax_process">$E_x$</span>。両者の符号を見比べると、<span class="tex2jax_process">$E_x = -\frac{\partial\phi}{\partial x} - \frac{\partial A_x}{\partial t}$</span> とする必要がある。つまり、<span class="tex2jax_process">$F = -dA$</span> と置けばよい。まとめると、
 </p>
-<p>ここで $dA$ の $dt\wedge dx$ 係数は $\frac{\partial\phi}{\partial x} + \frac{\partial A_x}{\partial t}$ だが、§10.2 の $F$ では同基底の係数は $E_x$。両者の符号を見比べると、$E_x = -\frac{\partial\phi}{\partial x} - \frac{\partial A_x}{\partial t}$ とする必要がある。つまり、$F = -dA$ と置けばよい。まとめると、
+<div class="math-block tex2jax_process">$$F = -dA$$</div>
+<p>である。<span class="tex2jax_process">$\mathbf{E}$</span> の全成分と <span class="tex2jax_process">$\mathbf{B}$</span> の全成分を、ポテンシャルで書き下すと次のとおり。
 </p>
-<p>$$F = -dA$$
-</p>
-<p>である。$\mathbf{E}$ の全成分と $\mathbf{B}$ の全成分を、ポテンシャルで書き下すと次のとおり。
-</p>
-<p>$$\begin{aligned}
+<div class="math-block tex2jax_process">$$\begin{aligned}
 \mathbf{E} &= -\nabla\phi - \frac{\partial\mathbf{A}}{\partial t} \\[0.3em]
 \mathbf{B} &= -\left(\nabla\times\mathbf{A}\right)
-\end{aligned}$$
-</p>
-<p>$dt\wedge dx$ の係数 $E_x$ が $-\partial\phi/\partial x - \partial A_x/\partial t$、$dy\wedge dz$ の係数 $B_x$ が $-\frac{\partial A_z}{\partial y} + \frac{\partial A_y}{\partial z}$——電磁気学の教科書では $B_x = \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$ と書かれるが、ここでの負号は本章の規約（$F=-dA$）に由来する。この負号は $\mathbf{A}$ の符号を反転させれば吸収できる、形式的な違いにすぎない。
-</p>
-<blockquote><p>**注** （$F$ の符号規約）$F = -dA$ という定義は、§10.2 の $F$ の行列表示（$F_{tx}=-E_x$）と整合するように選んだものである。$F = +dA$、$A = +\phi\,dt + \cdots$ など、異なる符号の組み合わせを使う流儀も存在する。本章では、§10.2 の $F$ の行列と $\mathbf{E} = -\nabla\phi - \partial\mathbf{A}/\partial t$ が整合する規約として $F=-dA$ を採用している。</p>
+\end{aligned}$$</div>
+<span class="tex2jax_process">$dt\wedge dx$</span> の係数 <span class="tex2jax_process">$E_x$</span> が <span class="tex2jax_process">$-\partial\phi/\partial x - \partial A_x/\partial t$</span>、<span class="tex2jax_process">$dy\wedge dz$</span> の係数 <span class="tex2jax_process">$B_x$</span> が <span class="tex2jax_process">$-\frac{\partial A_z}{\partial y} + \frac{\partial A_y}{\partial z}$</span>——電磁気学の教科書では <span class="tex2jax_process">$B_x = \frac{\partial A_z}{\partial y} - \frac{\partial A_y}{\partial z}$</span> と書かれるが、ここでの負号は本章の規約（<span class="tex2jax_process">$F=-dA$</span>）に由来する。この負号は <span class="tex2jax_process">$\mathbf{A}$</span> の符号を反転させれば吸収できる、形式的な違いにすぎない。
+<blockquote><p>**注** （<span class="tex2jax_process">$F$</span> の符号規約）<span class="tex2jax_process">$F = -dA$</span> という定義は、§10.2 の <span class="tex2jax_process">$F$</span> の行列表示（<span class="tex2jax_process">$F_{tx}=-E_x$</span>）と整合するように選んだものである。<span class="tex2jax_process">$F = +dA$</span>、<span class="tex2jax_process">$A = +\phi\,dt + \cdots$</span> など、異なる符号の組み合わせを使う流儀も存在する。本章では、§10.2 の <span class="tex2jax_process">$F$</span> の行列と <span class="tex2jax_process">$\mathbf{E} = -\nabla\phi - \partial\mathbf{A}/\partial t$</span> が整合する規約として <span class="tex2jax_process">$F=-dA$</span> を採用している。</p>
 </p></blockquote>
-<h4 id="が-を証明する">$dd=0$ が $dF=0$ を証明する</h4>
-<p>§10.4 の主結果——$dF=0$ が $\mathrm{div}\,\mathbf{B}=0$ と $\mathrm{rot}\,\mathbf{E}=-\partial\mathbf{B}/\partial t$ に等しい——の証明は一瞬である。$F=-dA$ だから、
+<h4 id="span-classtex2jaxprocessspan-が-span-classtex2jaxprocessspan-を証明する"><span class="tex2jax_process">$dd=0$</span> が <span class="tex2jax_process">$dF=0$</span> を証明する</h4>
+<p>§10.4 の主結果——<span class="tex2jax_process">$dF=0$</span> が <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B}=0$</span> と <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{E}=-\partial\mathbf{B}/\partial t$</span> に等しい——の証明は一瞬である。<span class="tex2jax_process">$F=-dA$</span> だから、
 </p>
-<p>$$dF = d(-dA) = -d(dA) = 0$$
-</p>
-<p>$dd=0$ は第5章 §4.4 で証明した外微分の基本性質だ。$F$ が「何かの外微分」（定数倍を除いて）で書ける以上、その外微分は自動的にゼロになる。§10.4 で4つの基底 $3$-form の係数をゼロとおいて得た4本の式は、すべてこの一行に集約されている。
-</p>
-<p>$dd=0$ が物理法則を導く——この事実こそ、微分形式が電磁気学で「美しい」と言われる最大の理由である。
-</p>
-<blockquote><p>**注** （$\mathbf{B}$ と $\mathrm{div}\,\mathbf{B}=0$）ベクトル解析でも「$\mathbf{B}$ が何かの回転で書けるなら $\mathrm{div}\,\mathbf{B}=0$」は公式として知られている。$\mathrm{div}\,\mathrm{rot} \equiv 0$ である。これが $dd=0$ の $3$ 次元ベクトル解析版だ。</p>
+<div class="math-block tex2jax_process">$$dF = d(-dA) = -d(dA) = 0$$</div>
+<span class="tex2jax_process">$dd=0$</span> は第5章 §4.4 で証明した外微分の基本性質だ。<span class="tex2jax_process">$F$</span> が「何かの外微分」（定数倍を除いて）で書ける以上、その外微分は自動的にゼロになる。§10.4 で4つの基底 <span class="tex2jax_process">$3$</span>-form の係数をゼロとおいて得た4本の式は、すべてこの一行に集約されている。
+<span class="tex2jax_process">$dd=0$</span> が物理法則を導く——この事実こそ、微分形式が電磁気学で「美しい」と言われる最大の理由である。
+<blockquote><p>**注** （<span class="tex2jax_process">$\mathbf{B}$</span> と <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B}=0$</span>）ベクトル解析でも「<span class="tex2jax_process">$\mathbf{B}$</span> が何かの回転で書けるなら <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B}=0$</span>」は公式として知られている。<span class="tex2jax_process">$\mathrm{div}\,\mathrm{rot} \equiv 0$</span> である。これが <span class="tex2jax_process">$dd=0$</span> の <span class="tex2jax_process">$3$</span> 次元ベクトル解析版だ。</p>
 </p></blockquote>
 <h4 id="もう1本の式ポテンシャルで書く">もう1本の式——ポテンシャルで書く</h4>
-<p>$d(\ast F) = \mu_0(\ast\mathcal{J})$ の側も、$F=-dA$ を代入すればポテンシャル $A$ に対する方程式になる。
+<span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> の側も、<span class="tex2jax_process">$F=-dA$</span> を代入すればポテンシャル <span class="tex2jax_process">$A$</span> に対する方程式になる。
+<div class="math-block tex2jax_process">$$-d(\ast dA) = \mu_0(\ast\mathcal{J})$$</div>
+<p>これを §10.5 と同様に成分展開してもよいが、本書では第12章でディラック演算子を用いた統一的表現を扱うため、ここではこの形を提示するにとどめる。<span class="tex2jax_process">$\ast d\ast dA$</span> を展開すると、ローレンツゲージ <span class="tex2jax_process">$\frac{\partial A^0}{\partial t} + \frac{\partial A^1}{\partial x} + \frac{\partial A^2}{\partial y} + \frac{\partial A^3}{\partial z} = 0$</span> のもとで <span class="tex2jax_process">$\Box A = \mu_0\mathcal{J}$</span>（波動方程式）が現れる——が、その導出は電磁気学の教科書に譲ろう。
 </p>
-<p>$$-d(\ast dA) = \mu_0(\ast\mathcal{J})$$
-</p>
-<p>これを §10.5 と同様に成分展開してもよいが、本書では第12章でディラック演算子を用いた統一的表現を扱うため、ここではこの形を提示するにとどめる。$\ast d\ast dA$ を展開すると、ローレンツゲージ $\frac{\partial A^0}{\partial t} + \frac{\partial A^1}{\partial x} + \frac{\partial A^2}{\partial y} + \frac{\partial A^3}{\partial z} = 0$ のもとで $\Box A = \mu_0\mathcal{J}$（波動方程式）が現れる——が、その導出は電磁気学の教科書に譲ろう。
-</p>
-<blockquote><p>**注** （ゲージ自由度）$A' = A + d\chi$（$\chi$ は任意の $0$-form）と変換する。このとき $F' = -dA' = -dA - d(d\chi) = -dA = F$ となり、物理的な電磁場 $F$ は不変である。これがゲージ変換であり、$dd=0$ のもう一つの現れだ。電磁気学ではスカラーポテンシャル $\phi$ とベクトルポテンシャル $\mathbf{A}$ を同時に調整することで、$F$ を変えずに計算に都合のよいゲージを選ぶことができる。</p>
+<blockquote><p>**注** （ゲージ自由度）<span class="tex2jax_process">$A' = A + d\chi$</span>（<span class="tex2jax_process">$\chi$</span> は任意の <span class="tex2jax_process">$0$</span>-form）と変換する。このとき <span class="tex2jax_process">$F' = -dA' = -dA - d(d\chi) = -dA = F$</span> となり、物理的な電磁場 <span class="tex2jax_process">$F$</span> は不変である。これがゲージ変換であり、<span class="tex2jax_process">$dd=0$</span> のもう一つの現れだ。電磁気学ではスカラーポテンシャル <span class="tex2jax_process">$\phi$</span> とベクトルポテンシャル <span class="tex2jax_process">$\mathbf{A}$</span> を同時に調整することで、<span class="tex2jax_process">$F$</span> を変えずに計算に都合のよいゲージを選ぶことができる。</p>
 </p></blockquote>
 <blockquote><p>**【ここまでのチェックポイント — 第10章全体】**</p>
-- 電磁場 $F$ は $4\times4$ 反対称行列。6つの独立成分に $E_x,E_y,E_z,B_x,B_y,B_z$ が収まる。
-- $dF=0$ を成分展開すると $\mathrm{div}\,\mathbf{B}=0$ と $\mathrm{rot}\,\mathbf{E}=-\partial\mathbf{B}/\partial t$ が現れる。
-- $\ast F$ は $E$ と $B$ を入れ替える。$d(\ast F)=\mu_0(\ast\mathcal{J})$ から残りの2本が出る。
-- **ポテンシャル構成**：$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$ から $F=-dA$（§10.2 の行列規約と整合）。$dF=0$ は $dd=0$ より自動的。$\mathbf{E}=-\nabla\phi-\partial\mathbf{A}/\partial t$ が自然に出る。
+- 電磁場 <span class="tex2jax_process">$F$</span> は <span class="tex2jax_process">$4\times4$</span> 反対称行列。6つの独立成分に <span class="tex2jax_process">$E_x,E_y,E_z,B_x,B_y,B_z$</span> が収まる。
+- <span class="tex2jax_process">$dF=0$</span> を成分展開すると <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B}=0$</span> と <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{E}=-\partial\mathbf{B}/\partial t$</span> が現れる。
+- <span class="tex2jax_process">$\ast F$</span> は <span class="tex2jax_process">$E$</span> と <span class="tex2jax_process">$B$</span> を入れ替える。<span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span> から残りの2本が出る。
+- **ポテンシャル構成**：<span class="tex2jax_process">$A = -\phi\,dt + A_x\,dx + A_y\,dy + A_z\,dz$</span> から <span class="tex2jax_process">$F=-dA$</span>（§10.2 の行列規約と整合）。<span class="tex2jax_process">$dF=0$</span> は <span class="tex2jax_process">$dd=0$</span> より自動的。<span class="tex2jax_process">$\mathbf{E}=-\nabla\phi-\partial\mathbf{A}/\partial t$</span> が自然に出る。
 </p></blockquote>
 <hr />
-<h2 id="付録E-と-のスライス行列表示--配列で見るマクスウェル方程式">付録E：$dF$ と $d(\ast F)$ のスライス行列表示 —— $4\times4\times4$ 配列で見るマクスウェル方程式</h2>
-<p>§10.4・§10.5 では $dF$ と $d(\ast F)$ を基底 $3$-form の係数として展開した。付録Eでは、同じ計算を <strong>$4\times4$ スライス行列の束</strong>——実質的には $4\times4\times4$ の3階テンソル——で可視化する。付録Aの延長線上にあり、本書の「全部行列に載せる」流儀の到達点でもある。
+<h2 id="付録Espan-classtex2jaxprocessspan-と-span-classtex2jaxprocessspan-のスライス行列表示--span-classtex2jaxprocessspan-配列で見るマクスウェル方程式">付録E：<span class="tex2jax_process">$dF$</span> と <span class="tex2jax_process">$d(\ast F)$</span> のスライス行列表示 —— <span class="tex2jax_process">$4\times4\times4$</span> 配列で見るマクスウェル方程式</h2>
+<p>§10.4・§10.5 では <span class="tex2jax_process">$dF$</span> と <span class="tex2jax_process">$d(\ast F)$</span> を基底 <span class="tex2jax_process">$3$</span>-form の係数として展開した。付録Eでは、同じ計算を <strong><span class="tex2jax_process">$4\times4$</span> スライス行列の束</strong>——実質的には <span class="tex2jax_process">$4\times4\times4$</span> の3階テンソル——で可視化する。付録Aの延長線上にあり、本書の「全部行列に載せる」流儀の到達点でもある。
 </p>
-<h3 id="E1-基底-form-とそのスライス行列--全16枚">E.1 基底 $3$-form とそのスライス行列 —— 全16枚</h3>
-<p>4次元の基底 $3$-form は次の4つである（§10.4 の並びと比べると、$\omega_2$ と $\omega_3$ の符号・順序が異なるが、内容は同じ4つである）。
+<h3 id="E1-基底-span-classtex2jaxprocessspan-form-とそのスライス行列--全16枚">E.1 基底 <span class="tex2jax_process">$3$</span>-form とそのスライス行列 —— 全16枚</h3>
+<p>4次元の基底 <span class="tex2jax_process">$3$</span>-form は次の4つである（§10.4 の並びと比べると、<span class="tex2jax_process">$\omega_2$</span> と <span class="tex2jax_process">$\omega_3$</span> の符号・順序が異なるが、内容は同じ4つである）。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \omega_1 = dt\wedge dx\wedge dy,\qquad
 \omega_2 = dt\wedge dx\wedge dz,\qquad
 \omega_3 = dt\wedge dy\wedge dz,\qquad
 \omega_4 = dx\wedge dy\wedge dz
-$$
+$$</div>
+<p>各 <span class="tex2jax_process">$\omega_i$</span> について、座標方向 <span class="tex2jax_process">$t,x,y,z$</span> の<strong>スライス行列</strong> <span class="tex2jax_process">$\mathbf{S}_{t}^{(\omega_i)}, \mathbf{S}_{x}^{(\omega_i)}, \mathbf{S}_{y}^{(\omega_i)}, \mathbf{S}_{z}^{(\omega_i)}$</span> を定義する。スライス行列とは「その方向の座標を除いた残りの <span class="tex2jax_process">$3$</span> 方向が作る <span class="tex2jax_process">$3$</span>-form」を <span class="tex2jax_process">$4\times4$</span> 反対称行列に焼き直したものである。行・列の順は <span class="tex2jax_process">$(t,x,y,z)$</span>。非ゼロ成分には <span class="tex2jax_process">$\pm1$</span> が入る。<span class="tex2jax_process">$4$</span> 基底 <span class="tex2jax_process">$\times 4$</span> スライス <span class="tex2jax_process">$=$</span> 全 <span class="tex2jax_process">$16$</span> 枚。
 </p>
-<p>各 $\omega_i$ について、座標方向 $t,x,y,z$ の<strong>スライス行列</strong> $\mathbf{S}_{t}^{(\omega_i)}, \mathbf{S}_{x}^{(\omega_i)}, \mathbf{S}_{y}^{(\omega_i)}, \mathbf{S}_{z}^{(\omega_i)}$ を定義する。スライス行列とは「その方向の座標を除いた残りの $3$ 方向が作る $3$-form」を $4\times4$ 反対称行列に焼き直したものである。行・列の順は $(t,x,y,z)$。非ゼロ成分には $\pm1$ が入る。$4$ 基底 $\times 4$ スライス $=$ 全 $16$ 枚。
-</p>
-<strong>（1）</strong> $\omega_1 = dt\wedge dx\wedge dy$ のスライス：
-<p>$$
+<strong>（1）</strong> <span class="tex2jax_process">$\omega_1 = dt\wedge dx\wedge dy$</span> のスライス：
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(\omega_1)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&1&0\\[2pt]0&-1&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{x}^{(\omega_1)}=\begin{pmatrix}0&0&-1&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{y}^{(\omega_1)}=\begin{pmatrix}0&1&0&0\\[2pt]-1&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{z}^{(\omega_1)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
-$$
-</p>
-<strong>（2）</strong> $\omega_2 = dt\wedge dx\wedge dz$ のスライス：
-<p>$$
+$$</div>
+<strong>（2）</strong> <span class="tex2jax_process">$\omega_2 = dt\wedge dx\wedge dz$</span> のスライス：
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(\omega_2)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&0&0\\[2pt]0&-1&0&0\end{pmatrix},\;
 \mathbf{S}_{x}^{(\omega_2)}=\begin{pmatrix}0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\end{pmatrix},\;
 \mathbf{S}_{y}^{(\omega_2)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{z}^{(\omega_2)}=\begin{pmatrix}0&1&0&0\\[2pt]-1&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
-$$
-</p>
-<strong>（3）</strong> $\omega_3 = dt\wedge dy\wedge dz$ のスライス：
-<p>$$
+$$</div>
+<strong>（3）</strong> <span class="tex2jax_process">$\omega_3 = dt\wedge dy\wedge dz$</span> のスライス：
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(\omega_3)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix},\;
 \mathbf{S}_{x}^{(\omega_3)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{y}^{(\omega_3)}=\begin{pmatrix}0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\end{pmatrix},\;
 \mathbf{S}_{z}^{(\omega_3)}=\begin{pmatrix}0&0&-1&0\\[2pt]0&0&0&0\\[2pt]1&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
-$$
-</p>
-<strong>（4）</strong> $\omega_4 = dx\wedge dy\wedge dz$ のスライス：
-<p>$$
+$$</div>
+<strong>（4）</strong> <span class="tex2jax_process">$\omega_4 = dx\wedge dy\wedge dz$</span> のスライス：
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix},\;
 \mathbf{S}_{x}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&1\\[2pt]0&0&-1&0\end{pmatrix},\;
 \mathbf{S}_{y}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&0&-1\\[2pt]0&0&0&0\\[2pt]0&1&0&0\end{pmatrix},\;
 \mathbf{S}_{z}^{(\omega_4)}=\begin{pmatrix}0&0&0&0\\[2pt]0&0&-1&0\\[2pt]0&1&0&0\\[2pt]0&0&0&0\end{pmatrix}
-$$
+$$</div>
+<p>16枚のうち、<span class="tex2jax_process">$\mathbf{S}_{z}^{(\omega_1)}, \mathbf{S}_{y}^{(\omega_2)}, \mathbf{S}_{x}^{(\omega_3)}, \mathbf{S}_{t}^{(\omega_4)}$</span> の4枚はゼロ行列である。残る12枚に <span class="tex2jax_process">$\pm1$</span> が一つずつ（と反対称のペアが一つずつ）入っている。これが <span class="tex2jax_process">$4\times4\times4$</span> テンソルの正体だ。
 </p>
-<p>16枚のうち、$\mathbf{S}_{z}^{(\omega_1)}, \mathbf{S}_{y}^{(\omega_2)}, \mathbf{S}_{x}^{(\omega_3)}, \mathbf{S}_{t}^{(\omega_4)}$ の4枚はゼロ行列である。残る12枚に $\pm1$ が一つずつ（と反対称のペアが一つずつ）入っている。これが $4\times4\times4$ テンソルの正体だ。
+<h3 id="E2-span-classtex2jaxprocessspan-をスライス行列で書く">E.2 <span class="tex2jax_process">$dF$</span> をスライス行列で書く</h3>
+<p>§10.4 の展開により、<span class="tex2jax_process">$dF$</span> の各基底係数は次で与えられる（<span class="tex2jax_process">$c$</span> を含まない正規化された系）。
 </p>
-<h3 id="E2-をスライス行列で書く">E.2 $dF$ をスライス行列で書く</h3>
-<p>§10.4 の展開により、$dF$ の各基底係数は次で与えられる（$c$ を含まない正規化された系）。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 A_{txy} &= \frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}
 \quad (\omega_1 = dt\wedge dx\wedge dy\text{ の係数}) \\[6pt]
@@ -4881,20 +4458,17 @@ A_{tyz} &= \frac{\partial E_z}{\partial y} - \frac{\partial E_y}{\partial z} + \
 A_{xyz} &= \frac{\partial B_x}{\partial x} + \frac{\partial B_y}{\partial y} + \frac{\partial B_z}{\partial z}
 \quad (\omega_4 = dx\wedge dy\wedge dz\text{ の係数})
 \end{aligned}
-$$
-</p>
-<p>$dF$ の各スライスは、4つの基底スライス行列を係数 $A_{\cdots}$ で線形結合したものである。たとえば $t$-スライスは
-</p>
-<p>$$
+$$</div>
+<span class="tex2jax_process">$dF$</span> の各スライスは、4つの基底スライス行列を係数 <span class="tex2jax_process">$A_{\cdots}$</span> で線形結合したものである。たとえば <span class="tex2jax_process">$t$</span>-スライスは
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(dF)} = A_{txy}\,\mathbf{S}_{t}^{(\omega_1)}
 {+} A_{txz}\,\mathbf{S}_{t}^{(\omega_2)}
 {+} A_{tyz}\,\mathbf{S}_{t}^{(\omega_3)}
 {+} A_{xyz}\,\mathbf{S}_{t}^{(\omega_4)}
-$$
+$$</div>
+<p>となる。各 <span class="tex2jax_process">$A_{\cdots}$</span> を偏微分に展開し、それぞれの基底スライス行列に係数として掛けて並べると次のようになる。
 </p>
-<p>となる。各 $A_{\cdots}$ を偏微分に展開し、それぞれの基底スライス行列に係数として掛けて並べると次のようになる。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \mathbf{S}_{t}^{(dF)}
 &= \left(\frac{\partial E_y}{\partial x} - \frac{\partial E_x}{\partial y} + \frac{\partial B_z}{\partial t}\right)
@@ -4906,11 +4480,10 @@ $$
 {+} A_{xyz}
 \begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 \end{aligned}
-$$
+$$</div>
+<p>同じ位置の成分を<strong>一枚の行列に足し合わせる</strong>と、<span class="tex2jax_process">$t$</span>-スライスは <span class="tex2jax_process">$16$</span> 成分すべてが明示された単一の <span class="tex2jax_process">$4\times4$</span> 反対称行列にまとまる。
 </p>
-<p>同じ位置の成分を<strong>一枚の行列に足し合わせる</strong>と、$t$-スライスは $16$ 成分すべてが明示された単一の $4\times4$ 反対称行列にまとまる。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(dF)}
 {=}
 \left(\begin{array}{c|cccc}
@@ -4928,57 +4501,50 @@ z & 0 &
 \displaystyle{-}\frac{\partial E_z}{\partial y} {+} \frac{\partial E_y}{\partial z} {-} \frac{\partial B_x}{\partial t} &
 0
 \end{array}\right)
-$$
-</p>
-<p>$x,y,z$ のスライス $\mathbf{S}_{x}^{(dF)}, \mathbf{S}_{y}^{(dF)}, \mathbf{S}_{z}^{(dF)}$ も同様に4項の線形結合から得られる。$dF$ 全体は、これら4枚のスライス行列の束である。
-</p>
+$$</div>
+<span class="tex2jax_process">$x,y,z$</span> のスライス <span class="tex2jax_process">$\mathbf{S}_{x}^{(dF)}, \mathbf{S}_{y}^{(dF)}, \mathbf{S}_{z}^{(dF)}$</span> も同様に4項の線形結合から得られる。<span class="tex2jax_process">$dF$</span> 全体は、これら4枚のスライス行列の束である。
 <h3 id="E3-フロベニウス積で係数を抜き出す">E.3 フロベニウス積で係数を抜き出す</h3>
-<p>第6章付録D で導入したフロベニウス積は、$4\times4$ 行列にもそのまま拡張できる。
+<p>第6章付録D で導入したフロベニウス積は、<span class="tex2jax_process">$4\times4$</span> 行列にもそのまま拡張できる。
 </p>
-<blockquote><p>**注** （計量由来の内積ではない）ここでのフロベニウス積は、ミンコフスキー計量に由来する時空の内積ではない。反対称行列表示から係数を抜き出すための、配列上のペアリングである。基底スライス行列との係数抽出演算として使っており、$\frac{1}{2}\operatorname{tr}(A^T B)$ はそのための計算手段だ。</p>
+<blockquote><p>**注** （計量由来の内積ではない）ここでのフロベニウス積は、ミンコフスキー計量に由来する時空の内積ではない。反対称行列表示から係数を抜き出すための、配列上のペアリングである。基底スライス行列との係数抽出演算として使っており、<span class="tex2jax_process">$\frac{1}{2}\operatorname{tr}(A^T B)$</span> はそのための計算手段だ。</p>
 </p></blockquote>
-<p>$$
+<div class="math-block tex2jax_process">$$
 A \cdot B = \frac{1}{2}\operatorname{tr}(A^T B) = \frac{1}{2}\sum_{i=1}^{4}\sum_{j=1}^{4} A_{ij}B_{ij}
-$$
+$$</div>
+<p>この内積を使うと、各スライスから係数を<strong>一行で抽出</strong>できる。たとえば <span class="tex2jax_process">$A_{txy}$</span> は
 </p>
-<p>この内積を使うと、各スライスから係数を<strong>一行で抽出</strong>できる。たとえば $A_{txy}$ は
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 A_{txy} = \mathbf{S}_{t}^{(\omega_1)} \cdot \mathbf{S}_{t}^{(dF)}
-$$
+$$</div>
+<p>である。<span class="tex2jax_process">$\mathbf{S}_{t}^{(\omega_1)}$</span> の非ゼロ成分は <span class="tex2jax_process">$(x,y)=+1, (y,x)=-1$</span> だけなので、フロベニウス積は <span class="tex2jax_process">$(1 \cdot S_{xy} + (-1) \cdot S_{yx})/2 = (S_{xy} - S_{yx})/2 = S_{xy}$</span>（<span class="tex2jax_process">$\mathbf{S}_{t}^{(dF)}$</span> が反対称だから <span class="tex2jax_process">$S_{yx}=-S_{xy}$</span>）。一発で係数が抜ける。
 </p>
-<p>である。$\mathbf{S}_{t}^{(\omega_1)}$ の非ゼロ成分は $(x,y)=+1, (y,x)=-1$ だけなので、フロベニウス積は $(1 \cdot S_{xy} + (-1) \cdot S_{yx})/2 = (S_{xy} - S_{yx})/2 = S_{xy}$（$\mathbf{S}_{t}^{(dF)}$ が反対称だから $S_{yx}=-S_{xy}$）。一発で係数が抜ける。
+<p>同様に、<strong>すべての係数は対応する基底スライスとのフロベニウス積で得られる</strong>。この構造は、第6章付録D で <span class="tex2jax_process">$\ast_{2\to1}(\mathbf{M}) = (E_1\!\cdot\!\mathbf{M},\;E_2\!\cdot\!\mathbf{M},\;E_3\!\cdot\!\mathbf{M})$</span> が <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$\mathbf{M}$</span> の各成分を抽出したのと完全に相似である。次数が <span class="tex2jax_process">$1\to2$</span> から <span class="tex2jax_process">$2\to3$</span> に上がり、内積をとる相手が縦ベクトルから <span class="tex2jax_process">$4\times4$</span> 行列の束に変わっただけだ。
 </p>
-<p>同様に、<strong>すべての係数は対応する基底スライスとのフロベニウス積で得られる</strong>。この構造は、第6章付録D で $\ast_{2\to1}(\mathbf{M}) = (E_1\!\cdot\!\mathbf{M},\;E_2\!\cdot\!\mathbf{M},\;E_3\!\cdot\!\mathbf{M})$ が $2$-form $\mathbf{M}$ の各成分を抽出したのと完全に相似である。次数が $1\to2$ から $2\to3$ に上がり、内積をとる相手が縦ベクトルから $4\times4$ 行列の束に変わっただけだ。
-</p>
-<h3 id="E4-をスライスで読む">E.4 $dF=0$ をスライスで読む</h3>
-<p>$dF=0$ とは、4枚のスライス行列すべてがゼロ行列になることである。
-</p>
-<p>$$
+<h3 id="E4-span-classtex2jaxprocessspan-をスライスで読む">E.4 <span class="tex2jax_process">$dF=0$</span> をスライスで読む</h3>
+<span class="tex2jax_process">$dF=0$</span> とは、4枚のスライス行列すべてがゼロ行列になることである。
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(dF)} = \mathbf{0},\quad
 \mathbf{S}_{x}^{(dF)} = \mathbf{0},\quad
 \mathbf{S}_{y}^{(dF)} = \mathbf{0},\quad
 \mathbf{S}_{z}^{(dF)} = \mathbf{0}
-$$
-</p>
-<p>$t$-スライス（上記）の非ゼロ成分を読めば、
+$$</div>
+<span class="tex2jax_process">$t$</span>-スライス（上記）の非ゼロ成分を読めば、
 <ul>
-<li>$(x,y)$ 成分 $=0$ から $\mathrm{rot}_z\,\mathbf{E} + \partial B_z/\partial t = 0$</li>
+<li><span class="tex2jax_process">$(x,y)$</span> 成分 <span class="tex2jax_process">$=0$</span> から <span class="tex2jax_process">$\mathrm{rot}_z\,\mathbf{E} + \partial B_z/\partial t = 0$</span></li>
 </ol>
 <ul>
-<li>$(x,z)$ 成分 $=0$ から $-\mathrm{rot}_y\,\mathbf{E} - \partial B_y/\partial t = 0$</li>
+<li><span class="tex2jax_process">$(x,z)$</span> 成分 <span class="tex2jax_process">$=0$</span> から <span class="tex2jax_process">$-\mathrm{rot}_y\,\mathbf{E} - \partial B_y/\partial t = 0$</span></li>
 </ol>
 <ul>
-<li>$(y,z)$ 成分 $=0$ から $\mathrm{rot}_x\,\mathbf{E} + \partial B_x/\partial t = 0$</li>
+<li><span class="tex2jax_process">$(y,z)$</span> 成分 <span class="tex2jax_process">$=0$</span> から <span class="tex2jax_process">$\mathrm{rot}_x\,\mathbf{E} + \partial B_x/\partial t = 0$</span></li>
 </ol>
-<p>これら3つは $\mathrm{rot}\,\mathbf{E} = -\partial\mathbf{B}/\partial t$ にほかならない。$z$-スライス（$\mathbf{S}_{z}^{(\omega_4)}$ 由来）の非ゼロ成分からは $\mathrm{div}\,\mathbf{B} = 0$ が現れる。見かけは巨大だが、中身は §10.4 の4本の係数比較式の繰り返しにすぎない。
+<p>これら3つは <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{E} = -\partial\mathbf{B}/\partial t$</span> にほかならない。<span class="tex2jax_process">$z$</span>-スライス（<span class="tex2jax_process">$\mathbf{S}_{z}^{(\omega_4)}$</span> 由来）の非ゼロ成分からは <span class="tex2jax_process">$\mathrm{div}\,\mathbf{B} = 0$</span> が現れる。見かけは巨大だが、中身は §10.4 の4本の係数比較式の繰り返しにすぎない。
 </p>
-<h3 id="E5-のスライス表示">E.5 $d(\ast F) = \mu_0(\ast\mathcal{J})$ のスライス表示</h3>
-<p>有源側も同型の構造を持つ。$\ast F$ と $\ast\mathcal{J}$ は §10.5 で展開済みであり、$d(\ast F)$ は $dF$ と同型のスライス行列になる——$\mathbf{E}$ と $\mathbf{B}$ の係数位置が入れ替わるだけだ。
+<h3 id="E5-span-classtex2jaxprocessspan-のスライス表示">E.5 <span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> のスライス表示</h3>
+<p>有源側も同型の構造を持つ。<span class="tex2jax_process">$\ast F$</span> と <span class="tex2jax_process">$\ast\mathcal{J}$</span> は §10.5 で展開済みであり、<span class="tex2jax_process">$d(\ast F)$</span> は <span class="tex2jax_process">$dF$</span> と同型のスライス行列になる——<span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> の係数位置が入れ替わるだけだ。
 </p>
-<p>$d(\ast F)$ の $\omega_1\sim\omega_4$ 係数を $B_{txy}, B_{txz}, B_{tyz}, B_{xyz}$ と書く。
-</p>
-<p>$$
+<span class="tex2jax_process">$d(\ast F)$</span> の <span class="tex2jax_process">$\omega_1\sim\omega_4$</span> 係数を <span class="tex2jax_process">$B_{txy}, B_{txz}, B_{tyz}, B_{xyz}$</span> と書く。
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 B_{txy} &= \frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}
 \quad (\text{§10.5 の } dt\wedge dx\wedge dy \text{ 係数}) \\[6pt]
@@ -4987,11 +4553,9 @@ B_{tyz} &= \frac{\partial B_y}{\partial z} - \frac{\partial B_z}{\partial y} + \
 B_{xyz} &= \frac{\partial E_x}{\partial x} + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}
 \quad (= \mathrm{div}\,\mathbf{E})
 \end{aligned}
-$$
-</p>
-<p>$d(\ast F)$ の各スライスも $dF$ と同様に、4つの係数 $B_{\cdots}$ で基底スライス行列を線形結合すればよい。$t$-スライスを項別に書く。
-</p>
-<p>$$
+$$</div>
+<span class="tex2jax_process">$d(\ast F)$</span> の各スライスも <span class="tex2jax_process">$dF$</span> と同様に、4つの係数 <span class="tex2jax_process">$B_{\cdots}$</span> で基底スライス行列を線形結合すればよい。<span class="tex2jax_process">$t$</span>-スライスを項別に書く。
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \mathbf{S}_{t}^{(d(\ast F))}
 &= \left(\frac{\partial B_x}{\partial y} - \frac{\partial B_y}{\partial x} + \frac{\partial E_z}{\partial t}\right)
@@ -5003,11 +4567,10 @@ $$
 {+} B_{xyz}
 \begin{pmatrix}0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\\[2pt]0&0&0&0\end{pmatrix}
 \end{aligned}
-$$
+$$</div>
+<p>同じ位置の成分を一枚の行列に足し合わせる。<span class="tex2jax_process">$dF$</span> の <span class="tex2jax_process">$t$</span>-スライスと見比べてほしい——<span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span>（および添字の巡回）がきれいに入れ替わっている。
 </p>
-<p>同じ位置の成分を一枚の行列に足し合わせる。$dF$ の $t$-スライスと見比べてほしい——$\mathbf{E}$ と $\mathbf{B}$（および添字の巡回）がきれいに入れ替わっている。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(d(\ast F))}
 {=}
 \left(\begin{array}{c|cccc}
@@ -5025,29 +4588,26 @@ z & 0 &
 \displaystyle{-}\frac{\partial B_y}{\partial z} {+} \frac{\partial B_z}{\partial y} {-} \frac{\partial E_x}{\partial t} &
 0
 \end{array}\right)
-$$
+$$</div>
+<p>右辺 <span class="tex2jax_process">$\mu_0(\ast\mathcal{J})$</span> も同じ4枚のスライス行列の線形結合で書ける。<span class="tex2jax_process">$\ast\mathcal{J}$</span> を本付録の基底順に展開し直すと（§10.5 参照）、<span class="tex2jax_process">$\omega_1\!\sim\!\omega_4$</span> の係数は順に <span class="tex2jax_process">$-\mu_0 c J_z,\; +\mu_0 c J_y,\; -\mu_0 c J_x,\; \rho/\varepsilon_0$</span> となる。すなわち
 </p>
-<p>右辺 $\mu_0(\ast\mathcal{J})$ も同じ4枚のスライス行列の線形結合で書ける。$\ast\mathcal{J}$ を本付録の基底順に展開し直すと（§10.5 参照）、$\omega_1\!\sim\!\omega_4$ の係数は順に $-\mu_0 c J_z,\; +\mu_0 c J_y,\; -\mu_0 c J_x,\; \rho/\varepsilon_0$ となる。すなわち
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \mathbf{S}_{t}^{(d(\ast F))} = \mathbf{S}_{t}^{(\mu_0\ast\mathcal{J})},\quad
 \mathbf{S}_{x}^{(d(\ast F))} = \mathbf{S}_{x}^{(\mu_0\ast\mathcal{J})},\quad
 \mathbf{S}_{y}^{(d(\ast F))} = \mathbf{S}_{y}^{(\mu_0\ast\mathcal{J})},\quad
 \mathbf{S}_{z}^{(d(\ast F))} = \mathbf{S}_{z}^{(\mu_0\ast\mathcal{J})}
-$$
-</p>
-<p>$t$-スライスの非ゼロ成分を読めば $-\mathrm{rot}\,\mathbf{B} + \partial\mathbf{E}/\partial t = -c\mu_0\mathbf{J}$、すなわち $\mathrm{rot}\,\mathbf{B} = c\mu_0\mathbf{J} + \partial\mathbf{E}/\partial t$ の各成分。$z$-スライスの $(x,y)$ 成分からは $\mathrm{div}\,\mathbf{E} = \rho/\varepsilon_0$ が現れる。
-</p>
+$$</div>
+<span class="tex2jax_process">$t$</span>-スライスの非ゼロ成分を読めば <span class="tex2jax_process">$-\mathrm{rot}\,\mathbf{B} + \partial\mathbf{E}/\partial t = -c\mu_0\mathbf{J}$</span>、すなわち <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{B} = c\mu_0\mathbf{J} + \partial\mathbf{E}/\partial t$</span> の各成分。<span class="tex2jax_process">$z$</span>-スライスの <span class="tex2jax_process">$(x,y)$</span> 成分からは <span class="tex2jax_process">$\mathrm{div}\,\mathbf{E} = \rho/\varepsilon_0$</span> が現れる。
 <hr />
-<p>以上で、マクスウェル方程式の全容が $4\times4\times4$ のスライス行列の束として可視化された。この「巨大配列」の各マス目に書かれているのは偏微分の組み合わせにすぎず、外微分 $d$ とホッジ・スター $\ast$ という二つの代数操作が、いかに整然とした行列の文法で物理法則を記述しているか——それを見届けたことが、本付録の成果である。
+<p>以上で、マクスウェル方程式の全容が <span class="tex2jax_process">$4\times4\times4$</span> のスライス行列の束として可視化された。この「巨大配列」の各マス目に書かれているのは偏微分の組み合わせにすぎず、外微分 <span class="tex2jax_process">$d$</span> とホッジ・スター <span class="tex2jax_process">$\ast$</span> という二つの代数操作が、いかに整然とした行列の文法で物理法則を記述しているか——それを見届けたことが、本付録の成果である。
 </p>
 <p>\newpage
 </p>
 <h1 id="第11章曲がった空間へ--本書の先にあるもの">第11章：曲がった空間へ —— 本書の先にあるもの</h1>
 <h3 id="110-この章の立ち位置--さらに先を見たい読者のための道標">§11.0 この章の立ち位置 —— さらに先を見たい読者のための道標</h3>
-<p>　本書『ナブラ解体新書』の目的は、$\nabla$ を $d$ と $\ast$ に解体し、ベクトル解析の公式群を見通しよく再構築することだった。第8章・第9章でその目的は達成されている。第10章は「おまけ」として、この枠組みがマクスウェル方程式をいかに簡潔に記述するかを見た。
+<p>　本書『ナブラ解体新書』の目的は、<span class="tex2jax_process">$\nabla$</span> を <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> に解体し、ベクトル解析の公式群を見通しよく再構築することだった。第8章・第9章でその目的は達成されている。第10章は「おまけ」として、この枠組みがマクスウェル方程式をいかに簡潔に記述するかを見た。
 </p>
-<p>本章は、そのさらに先——本書を読み終えて「この $d$ と $\ast$ という道具は、もっと広い世界でどう使えるのか」と興味を持った読者のための<strong>道標</strong>である。完結した説明はしない。専門書への橋渡しとして、何がどう変わり、何が変わらないかの見取り図だけを示す。それからもう一つ——本章では、これまで筆者が意図的に避けてきた数学書的な言い回しを、特に読者に配慮せず、定義もせずに遠慮なく使う。まだまだ世界は広いのだ、ということを感じてほしい。
+<p>本章は、そのさらに先——本書を読み終えて「この <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> という道具は、もっと広い世界でどう使えるのか」と興味を持った読者のための<strong>道標</strong>である。完結した説明はしない。専門書への橋渡しとして、何がどう変わり、何が変わらないかの見取り図だけを示す。それからもう一つ——本章では、これまで筆者が意図的に避けてきた数学書的な言い回しを、特に読者に配慮せず、定義もせずに遠慮なく使う。まだまだ世界は広いのだ、ということを感じてほしい。
 </p>
 <blockquote><p>**注** （建前と本音）</p>
 「さらに先を見たい読者のための道標」というのは、一応の建前である。
@@ -5062,224 +4622,208 @@ $$
 ——ブルバキスタイルの論理的堅牢さに、まったくもって敬意を表する。
 </p></blockquote>
 <blockquote><p>**注** （本書の意外な帰結）</p>
-本書の直接的な目的は、ベクトル解析を行列形式で書き直し、$d$ と $\ast$ の辞書によって見通しよく再構築することだった。
+本書の直接的な目的は、ベクトル解析を行列形式で書き直し、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の辞書によって見通しよく再構築することだった。
 しかし振り返ってみると、本書は実質的に「成分を直接扱う」という点で、副次的にテンソル解析を行っていたのかもしれない。
-テンソル解析の弱点は、計算の過程で $k$-form としての幾何学的な「型」の直感が失われがちなことにある。
+テンソル解析の弱点は、計算の過程で <span class="tex2jax_process">$k$</span>-form としての幾何学的な「型」の直感が失われがちなことにある。
 本書が行列表示を採用したのは、逆にその型——次数、反対称性、横ベクトルと縦ベクトルの区別——を視覚的に保ちながら、成分計算を可能にするためだった。
 つまり本書は、「微分形式の幾何学的直感」と「テンソル解析の計算力」の両方を手に入れるための、中間的なアプローチだったのだ。
 ——ただし、どちらの伝統から見ても中途半端な側面は否めない。
 </p></blockquote>
-<h3 id="111-多様体--から始める">§11.1 多様体 —— $\mathbf{g}(x)$ から始める</h3>
-<p>本書では第6章で計量 $\mathbf{g}$ を導入し、第9章で $\mathbf{g}$ から $\ast$ の辞書を作る手順を練習した。いずれも $\mathbf{g}$ は場所に依存しない定数行列だった。では、計量が場所ごとに異なる行列 $\mathbf{g}(x,y,z)$ になったら何が起きるか。
+<h3 id="111-多様体--span-classtex2jaxprocessspan-から始める">§11.1 多様体 —— <span class="tex2jax_process">$\mathbf{g}(x)$</span> から始める</h3>
+<p>本書では第6章で計量 <span class="tex2jax_process">$\mathbf{g}$</span> を導入し、第9章で <span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書を作る手順を練習した。いずれも <span class="tex2jax_process">$\mathbf{g}$</span> は場所に依存しない定数行列だった。では、計量が場所ごとに異なる行列 <span class="tex2jax_process">$\mathbf{g}(x,y,z)$</span> になったら何が起きるか。
 </p>
-<p>$\ast$ の辞書は $\mathbf{g}$ から作られる。$\mathbf{g}$ が場所ごとに変われば、$\ast$ の辞書も場所ごとに変わる。$dx \mapsto \ast(dx) = \cdots\,dy\wedge dz$ という対応表が、空間の各点で異なる係数を持つようになるのだ。
+<span class="tex2jax_process">$\ast$</span> の辞書は <span class="tex2jax_process">$\mathbf{g}$</span> から作られる。<span class="tex2jax_process">$\mathbf{g}$</span> が場所ごとに変われば、<span class="tex2jax_process">$\ast$</span> の辞書も場所ごとに変わる。<span class="tex2jax_process">$dx \mapsto \ast(dx) = \cdots\,dy\wedge dz$</span> という対応表が、空間の各点で異なる係数を持つようになるのだ。
+<p>この「各点で計量 <span class="tex2jax_process">$\mathbf{g}(p)$</span> を持ち、その計量から各点の <span class="tex2jax_process">$\ast$</span> を作る」という見方は、リーマン多様体へ進むための最初の模型である。平たい <span class="tex2jax_process">$\mathbb{R}^3$</span> では <span class="tex2jax_process">$\mathbf{g}$</span> が単位行列だったから <span class="tex2jax_process">$\ast$</span> の辞書は至って単純だった。一般の座標表示では、<span class="tex2jax_process">$\mathbf{g}$</span> はもはや単位行列とは限らず、場所の関数として現れる。それでも <span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\ast$</span> の辞書を書き下す手順そのものは、第9章でやったのと同じだ——ただ毎回、各点で辞書を引き直す必要があるだけである。
 </p>
-<p>この「各点で計量 $\mathbf{g}(p)$ を持ち、その計量から各点の $\ast$ を作る」という見方は、リーマン多様体へ進むための最初の模型である。平たい $\mathbb{R}^3$ では $\mathbf{g}$ が単位行列だったから $\ast$ の辞書は至って単純だった。一般の座標表示では、$\mathbf{g}$ はもはや単位行列とは限らず、場所の関数として現れる。それでも $\mathbf{g}$ から $\ast$ の辞書を書き下す手順そのものは、第9章でやったのと同じだ——ただ毎回、各点で辞書を引き直す必要があるだけである。
-</p>
-<blockquote><p>**注** （計量の場所依存と曲率の関係）計量成分 $g_{ij}(x)$ が場所に依存すること自体は、ただちに空間が曲がっていることを意味しない。ユークリッド空間を曲線座標（極座標・球座標など）で書けば、平坦な空間でも $g_{ij}(x)$ は場所に依存する。曲がっているかどうかは、計量成分そのものや特定の座標での接続係数 $\Gamma^i_{jk}$ の見た目ではなく、そこから構成される曲率テンソル $R^i{}_{mjk}$ が消えるかどうかで判定される。</p>
+<blockquote><p>**注** （計量の場所依存と曲率の関係）計量成分 <span class="tex2jax_process">$g_{ij}(x)$</span> が場所に依存すること自体は、ただちに空間が曲がっていることを意味しない。ユークリッド空間を曲線座標（極座標・球座標など）で書けば、平坦な空間でも <span class="tex2jax_process">$g_{ij}(x)$</span> は場所に依存する。曲がっているかどうかは、計量成分そのものや特定の座標での接続係数 <span class="tex2jax_process">$\Gamma^i_{jk}$</span> の見た目ではなく、そこから構成される曲率テンソル <span class="tex2jax_process">$R^i{}_{mjk}$</span> が消えるかどうかで判定される。</p>
 </p></blockquote>
-<blockquote><p>**注** （計量遅延の果てに）本書は第6章まで計量の形式的定義を意図的に後回しにしてきた。これは物理学者 W. L. Burke の "put the metric later and later into the course" という教育哲学に倣ったものである。計量を遅延させたからこそ、$d$（計量不要）と $\ast$（計量依存）の役割分担がくっきりと見える——この章は、その分離の果てに広がる風景を眺める場所だ。</p>
+<blockquote><p>**注** （計量遅延の果てに）本書は第6章まで計量の形式的定義を意図的に後回しにしてきた。これは物理学者 W. L. Burke の "put the metric later and later into the course" という教育哲学に倣ったものである。計量を遅延させたからこそ、<span class="tex2jax_process">$d$</span>（計量不要）と <span class="tex2jax_process">$\ast$</span>（計量依存）の役割分担がくっきりと見える——この章は、その分離の果てに広がる風景を眺める場所だ。</p>
 </p></blockquote>
-<p>この「場所ごとに座標や計量を扱う」世界を数学的に整理する枠組みが<strong>多様体（manifold）</strong>である。多様体そのものは、まず局所的に $\mathbb{R}^n$ と見なせる滑らかな空間として定義される。その上に、各点の接空間に非退化な対称双線形形式 $g_p$ を滑らかに与えたものが<strong>計量付き多様体</strong>であり、特に $g_p$ が正定値なら<strong>リーマン多様体</strong>、ローレンツ符号なら<strong>ローレンツ多様体</strong>になる。
+<p>この「場所ごとに座標や計量を扱う」世界を数学的に整理する枠組みが<strong>多様体（manifold）</strong>である。多様体そのものは、まず局所的に <span class="tex2jax_process">$\mathbb{R}^n$</span> と見なせる滑らかな空間として定義される。その上に、各点の接空間に非退化な対称双線形形式 <span class="tex2jax_process">$g_p$</span> を滑らかに与えたものが<strong>計量付き多様体</strong>であり、特に <span class="tex2jax_process">$g_p$</span> が正定値なら<strong>リーマン多様体</strong>、ローレンツ符号なら<strong>ローレンツ多様体</strong>になる。
 </p>
 <blockquote><p>**注** （「曲がった時空」という言葉について）一般相対性理論の解説では「時空が曲がる」と表現される。個人的なこだわりではあるが、筆者はこの言い回しが好きではない。というのも、任意の一点では局所慣性系を選んで計量をミンコフスキー計量にし、接続係数を消すことができるが、曲率は一般には消えず、有限の近傍全体が平坦になるわけではない。曲率は、まさにその局所慣性系を二階以上で貼り合わせるときのずれとして現れるからだ。つまり、単体の「曲がったゴム膜」のようなお絵かきでは不十分で、むしろ「計量と接続を通じて、異なる点の接空間をどう比べるかが問題になる」と捉えたほうが正確だと感じている。とはいえこれは筆者が偏屈なのであり、事実として「曲がっている」と考えたほうが直感的だろう。</p>
 </p></blockquote>
 <h4 id="1111-定義--チャートとアトラス">11.1.1 定義 —— チャートとアトラス</h4>
-<p>$n$ 次元<strong>位相多様体</strong> $M$ とは、ハウスドルフかつ第二可算公理を満たす位相空間であって、任意の点 $p \in M$ に対し、$p$ を含む開集合 $U \subset M$ と、$U$ から $\mathbb{R}^n$ の開集合への同相写像 $\varphi: U \to \varphi(U) \subset \mathbb{R}^n$ が存在するものである。この組 $(U, \varphi)$ を<strong>チャート</strong>（座標近傍）と呼ぶ。$\varphi(p) = (x^1(p), \dots, x^n(p))$ と書いたとき、$x^i$ を<strong>局所座標</strong>という。
+<span class="tex2jax_process">$n$</span> 次元<strong>位相多様体</strong> <span class="tex2jax_process">$M$</span> とは、ハウスドルフかつ第二可算公理を満たす位相空間であって、任意の点 <span class="tex2jax_process">$p \in M$</span> に対し、<span class="tex2jax_process">$p$</span> を含む開集合 <span class="tex2jax_process">$U \subset M$</span> と、<span class="tex2jax_process">$U$</span> から <span class="tex2jax_process">$\mathbb{R}^n$</span> の開集合への同相写像 <span class="tex2jax_process">$\varphi: U \to \varphi(U) \subset \mathbb{R}^n$</span> が存在するものである。この組 <span class="tex2jax_process">$(U, \varphi)$</span> を<strong>チャート</strong>（座標近傍）と呼ぶ。<span class="tex2jax_process">$\varphi(p) = (x^1(p), \dots, x^n(p))$</span> と書いたとき、<span class="tex2jax_process">$x^i$</span> を<strong>局所座標</strong>という。
+<span class="tex2jax_process">$M$</span> を覆うチャートの族 <span class="tex2jax_process">$\{(U_\alpha, \varphi_\alpha)\}$</span> であって、任意の重なるチャート対に対して<strong>座標変換</strong>
+<div class="math-block tex2jax_process">$$\varphi_\beta \circ \varphi_\alpha^{-1}: \varphi_\alpha(U_\alpha \cap U_\beta) \to \varphi_\beta(U_\alpha \cap U_\beta)$$</div>
+<p>が <span class="tex2jax_process">$C^\infty$</span> 級であるとき、これを<strong>滑らかなアトラス</strong>と呼び、<span class="tex2jax_process">$M$</span> は<strong>滑らかな多様体（<span class="tex2jax_process">$C^\infty$</span> 多様体）</strong> になる。座標変換が滑らかであること——この一点が、多様体上で微積分を可能にする根幹である。
 </p>
-<p>$M$ を覆うチャートの族 $\{(U_\alpha, \varphi_\alpha)\}$ であって、任意の重なるチャート対に対して<strong>座標変換</strong>
+<p>本書がこれまで舞台としてきた <span class="tex2jax_process">$\mathbb{R}^3$</span> は、恒等写像 <span class="tex2jax_process">$\mathrm{id}: \mathbb{R}^3 \to \mathbb{R}^3$</span> という一枚のチャートで全体を覆える、最も自明な多様体の例だ。
 </p>
-<p>$$\varphi_\beta \circ \varphi_\alpha^{-1}: \varphi_\alpha(U_\alpha \cap U_\beta) \to \varphi_\beta(U_\alpha \cap U_\beta)$$
-</p>
-<p>が $C^\infty$ 級であるとき、これを<strong>滑らかなアトラス</strong>と呼び、$M$ は<strong>滑らかな多様体（$C^\infty$ 多様体）</strong> になる。座標変換が滑らかであること——この一点が、多様体上で微積分を可能にする根幹である。
-</p>
-<p>本書がこれまで舞台としてきた $\mathbb{R}^3$ は、恒等写像 $\mathrm{id}: \mathbb{R}^3 \to \mathbb{R}^3$ という一枚のチャートで全体を覆える、最も自明な多様体の例だ。
-</p>
-<p>よく知られた別の例として、$n$ 次元球面 $S^n = \{x \in \mathbb{R}^{n+1} \mid \|x\| = 1\}$ がある。$S^n$ は一枚のチャートでは覆えないが、北極と南極を除いた二枚のチャート（立体射影）でアトラスが構成できる。一般相対性理論の時空はローレンツ多様体——計量の符号が $(-,+,+,+)$ である4次元多様体——として定式化される。
+<p>よく知られた別の例として、<span class="tex2jax_process">$n$</span> 次元球面 <span class="tex2jax_process">$S^n = \{x \in \mathbb{R}^{n+1} \mid \|x\| = 1\}$</span> がある。<span class="tex2jax_process">$S^n$</span> は一枚のチャートでは覆えないが、北極と南極を除いた二枚のチャート（立体射影）でアトラスが構成できる。一般相対性理論の時空はローレンツ多様体——計量の符号が <span class="tex2jax_process">$(-,+,+,+)$</span> である4次元多様体——として定式化される。
 </p>
 <h4 id="1112-接空間--曲がった空間での微分の定義">11.1.2 接空間 —— 「曲がった空間での微分」の定義</h4>
-<p>$\mathbb{R}^n$ では「ベクトル」を「原点から伸びる矢印」として素朴に定義できた。多様体上ではそうはいかない。球面の表面に矢印を描こうとしても、矢印は曲面からはみ出してしまう。
-</p>
+<span class="tex2jax_process">$\mathbb{R}^n$</span> では「ベクトル」を「原点から伸びる矢印」として素朴に定義できた。多様体上ではそうはいかない。球面の表面に矢印を描こうとしても、矢印は曲面からはみ出してしまう。
 <p>接空間の構成には二つの同値な方法がある。
 </p>
-<strong>曲線の同値類による定義。</strong> $p$ を通る滑らかな曲線 $\gamma: (-\varepsilon, \varepsilon) \to M$（$\gamma(0)=p$）に対し、チャート $(U, \varphi)$ を一つ選び、$\mathbb{R}^n$ における速度ベクトル $(\varphi \circ \gamma)'(0)$ を計算する。別のチャート $(V, \psi)$ を選んでも、$(\psi \circ \gamma)'(0) = D(\psi \circ \varphi^{-1})_{\varphi(p)} \cdot (\varphi \circ \gamma)'(0)$ とヤコビ行列で変換されるから、ある一つのチャートで速度ベクトルが一致すれば、座標変換の微分により任意のチャートでも一致する。したがって、この一致関係はチャートの選び方に依存せず、接ベクトルの同値類を定める。この同値類 $[\gamma]$ が $p$ における<strong>接ベクトル</strong>である。
-<strong>方向微分（derivation）による定義。</strong> 接ベクトル $v \in T_p M$ を、$p$ の近傍の滑らかな関数 $f$ に実数 $v(f)$ を対応させる線形写像であって、ライプニッツ則 $v(fg) = v(f)\,g(p) + f(p)\,v(g)$ を満たすものとして定義する。この定義はチャートに依存しない内在的なものであり、代数幾何などへの一般化にも耐える。チャート $(U, \varphi)$ と局所座標 $x^i$ が与えられれば、
-<p>$$\left.\frac{\partial}{\partial x^i}\right|_p (f) = \left.\frac{\partial (f \circ \varphi^{-1})}{\partial x^i}\right|_{\varphi(p)}$$
+<strong>曲線の同値類による定義。</strong> <span class="tex2jax_process">$p$</span> を通る滑らかな曲線 <span class="tex2jax_process">$\gamma: (-\varepsilon, \varepsilon) \to M$</span>（<span class="tex2jax_process">$\gamma(0)=p$</span>）に対し、チャート <span class="tex2jax_process">$(U, \varphi)$</span> を一つ選び、<span class="tex2jax_process">$\mathbb{R}^n$</span> における速度ベクトル <span class="tex2jax_process">$(\varphi \circ \gamma)'(0)$</span> を計算する。別のチャート <span class="tex2jax_process">$(V, \psi)$</span> を選んでも、<span class="tex2jax_process">$(\psi \circ \gamma)'(0) = D(\psi \circ \varphi^{-1})_{\varphi(p)} \cdot (\varphi \circ \gamma)'(0)$</span> とヤコビ行列で変換されるから、ある一つのチャートで速度ベクトルが一致すれば、座標変換の微分により任意のチャートでも一致する。したがって、この一致関係はチャートの選び方に依存せず、接ベクトルの同値類を定める。この同値類 <span class="tex2jax_process">$[\gamma]$</span> が <span class="tex2jax_process">$p$</span> における<strong>接ベクトル</strong>である。
+<strong>方向微分（derivation）による定義。</strong> 接ベクトル <span class="tex2jax_process">$v \in T_p M$</span> を、<span class="tex2jax_process">$p$</span> の近傍の滑らかな関数 <span class="tex2jax_process">$f$</span> に実数 <span class="tex2jax_process">$v(f)$</span> を対応させる線形写像であって、ライプニッツ則 <span class="tex2jax_process">$v(fg) = v(f)\,g(p) + f(p)\,v(g)$</span> を満たすものとして定義する。この定義はチャートに依存しない内在的なものであり、代数幾何などへの一般化にも耐える。チャート <span class="tex2jax_process">$(U, \varphi)$</span> と局所座標 <span class="tex2jax_process">$x^i$</span> が与えられれば、
+<div class="math-block tex2jax_process">$$\left.\frac{\partial}{\partial x^i}\right|_p (f) = \left.\frac{\partial (f \circ \varphi^{-1})}{\partial x^i}\right|_{\varphi(p)}$$</div>
+<p>が <span class="tex2jax_process">$T_p M$</span> の基底をなす。<span class="tex2jax_process">$\dim T_p M = \dim M = n$</span> である。
 </p>
-<p>が $T_p M$ の基底をなす。$\dim T_p M = \dim M = n$ である。
+<p>二つのベクトル場 <span class="tex2jax_process">$X, Y$</span> が与えられたとき、その<strong>リー括弧（Lie bracket）</strong> <span class="tex2jax_process">$[X, Y] = XY - YX$</span> は再びベクトル場になる。<span class="tex2jax_process">$[X,Y]^i = \sum_j (X^j \partial_j Y^i - Y^j \partial_j X^i)$</span> であり、本書では陽に扱わなかったが、フロベニウスの定理（分布の積分可能性）やリー群論の根幹をなす演算である。
 </p>
-<p>二つのベクトル場 $X, Y$ が与えられたとき、その<strong>リー括弧（Lie bracket）</strong> $[X, Y] = XY - YX$ は再びベクトル場になる。$[X,Y]^i = \sum_j (X^j \partial_j Y^i - Y^j \partial_j X^i)$ であり、本書では陽に扱わなかったが、フロベニウスの定理（分布の積分可能性）やリー群論の根幹をなす演算である。
+<p>すべての点における接空間の非交和が<strong>接束</strong> <span class="tex2jax_process">$TM = \bigsqcup_{p \in M} T_p M$</span> である。<span class="tex2jax_process">$TM$</span> 自身も <span class="tex2jax_process">$2n$</span> 次元の多様体になる。<span class="tex2jax_process">$M$</span> 上の<strong>ベクトル場</strong> <span class="tex2jax_process">$X$</span> とは、各点 <span class="tex2jax_process">$p \in M$</span> に接ベクトル <span class="tex2jax_process">$X_p \in T_p M$</span> を滑らかに割り当てる写像、すなわち接束の<strong>切断</strong> <span class="tex2jax_process">$X: M \to TM$</span> にほかならない。
 </p>
-<p>すべての点における接空間の非交和が<strong>接束</strong> $TM = \bigsqcup_{p \in M} T_p M$ である。$TM$ 自身も $2n$ 次元の多様体になる。$M$ 上の<strong>ベクトル場</strong> $X$ とは、各点 $p \in M$ に接ベクトル $X_p \in T_p M$ を滑らかに割り当てる写像、すなわち接束の<strong>切断</strong> $X: M \to TM$ にほかならない。
+<p>座標変換と基底の変換則にも触れておく。二つのチャート <span class="tex2jax_process">$(U, x^i)$</span> と <span class="tex2jax_process">$(V, y^j)$</span> が重なっているとき、接空間の基底は
 </p>
-<p>座標変換と基底の変換則にも触れておく。二つのチャート $(U, x^i)$ と $(V, y^j)$ が重なっているとき、接空間の基底は
-</p>
-<p>$$\frac{\partial}{\partial y^j} = \sum_i \frac{\partial x^i}{\partial y^j}\,\frac{\partial}{\partial x^i}$$
-</p>
-<p>と変換される。この変換行列 $\partial x^i/\partial y^j$ は、本書第3章で座標変換のヤコビ行列として繰り返し登場したものだ。接ベクトルの成分はこのヤコビ行列の逆行列で変換される（反変ベクトル）。これに対し、1-form の成分はヤコビ行列そのもので変換される（共変ベクトル）。この「反変」と「共変」の区別——本書ではベクトルが「縦」、1-form が「横」として視覚化されてきた——が、多様体論におけるテンソル解析の出発点である。
+<div class="math-block tex2jax_process">$$\frac{\partial}{\partial y^j} = \sum_i \frac{\partial x^i}{\partial y^j}\,\frac{\partial}{\partial x^i}$$</div>
+<p>と変換される。この変換行列 <span class="tex2jax_process">$\partial x^i/\partial y^j$</span> は、本書第3章で座標変換のヤコビ行列として繰り返し登場したものだ。接ベクトルの成分はこのヤコビ行列の逆行列で変換される（反変ベクトル）。これに対し、1-form の成分はヤコビ行列そのもので変換される（共変ベクトル）。この「反変」と「共変」の区別——本書ではベクトルが「縦」、1-form が「横」として視覚化されてきた——が、多様体論におけるテンソル解析の出発点である。
 </p>
 <h4 id="1113-微分形式--余接束とテンソル場">11.1.3 微分形式 —— 余接束とテンソル場</h4>
-<p>接空間 $T_p M$ の双対空間を<strong>余接空間</strong> $T_p^* M$ と呼ぶ。$\omega_p \in T_p^* M$ は接ベクトルを食べて実数を返す線形写像 $\omega_p: T_p M \to \mathbb{R}$、すなわち<strong>1-form</strong>である。本書第1章で $dx$ を「変位ベクトルから $x$ 成分を抽出する横ベクトル」と定義したのは、まさにこの双対性の具現化だった。
+<p>接空間 <span class="tex2jax_process">$T_p M$</span> の双対空間を<strong>余接空間</strong> <span class="tex2jax_process">$T_p^* M$</span> と呼ぶ。<span class="tex2jax_process">$\omega_p \in T_p^* M$</span> は接ベクトルを食べて実数を返す線形写像 <span class="tex2jax_process">$\omega_p: T_p M \to \mathbb{R}$</span>、すなわち<strong>1-form</strong>である。本書第1章で <span class="tex2jax_process">$dx$</span> を「変位ベクトルから <span class="tex2jax_process">$x$</span> 成分を抽出する横ベクトル」と定義したのは、まさにこの双対性の具現化だった。
 </p>
-<blockquote><p>**注**（本編との対応）  これは、第1章で $dx=\begin{pmatrix}1&0&0\end{pmatrix}$ と書いた約束を、標準デカルト座標における余接基底 $dx^1|_p$ の成分表示として言い直したものである。第1章では点 $p$ への依存を抑えて書いたが、多様体論では各点の余接空間 $T_p^* M$ に属する対象として扱う。</p>
+<blockquote><p>**注**（本編との対応）  これは、第1章で <span class="tex2jax_process">$dx=\begin{pmatrix}1&0&0\end{pmatrix}$</span> と書いた約束を、標準デカルト座標における余接基底 <span class="tex2jax_process">$dx^1|_p$</span> の成分表示として言い直したものである。第1章では点 <span class="tex2jax_process">$p$</span> への依存を抑えて書いたが、多様体論では各点の余接空間 <span class="tex2jax_process">$T_p^* M$</span> に属する対象として扱う。</p>
 </p></blockquote>
-<p>局所座標 $x^i$ に対し、$dx^i|_p \in T_p^* M$ を $dx^i|_p(\partial/\partial x^j|_p) = \delta^i_j$ で定めると、$\{dx^i|_p\}$ は $T_p^* M$ の $\{\partial/\partial x^i|_p\}$ に対する双対基底になる。任意の1-form $\omega$ は局所的に $\omega = \sum_i \omega_i\,dx^i$ と展開できる。
+<p>局所座標 <span class="tex2jax_process">$x^i$</span> に対し、<span class="tex2jax_process">$dx^i|_p \in T_p^* M$</span> を <span class="tex2jax_process">$dx^i|_p(\partial/\partial x^j|_p) = \delta^i_j$</span> で定めると、<span class="tex2jax_process">$\{dx^i|_p\}$</span> は <span class="tex2jax_process">$T_p^* M$</span> の <span class="tex2jax_process">$\{\partial/\partial x^i|_p\}$</span> に対する双対基底になる。任意の1-form <span class="tex2jax_process">$\omega$</span> は局所的に <span class="tex2jax_process">$\omega = \sum_i \omega_i\,dx^i$</span> と展開できる。
 </p>
-<p>これを $k$ 重に拡張したものが <strong>$k$-form</strong> である。多様体上の $k$-form とは、各点 $p$ に $\Lambda^k T_p^* M$ の元を滑らかに割り当てる切断である。つまり、各点では $k$ 個の接ベクトルを引数にとる交代多重線形写像
+<p>これを <span class="tex2jax_process">$k$</span> 重に拡張したものが <strong><span class="tex2jax_process">$k$</span>-form</strong> である。多様体上の <span class="tex2jax_process">$k$</span>-form とは、各点 <span class="tex2jax_process">$p$</span> に <span class="tex2jax_process">$\Lambda^k T_p^* M$</span> の元を滑らかに割り当てる切断である。つまり、各点では <span class="tex2jax_process">$k$</span> 個の接ベクトルを引数にとる交代多重線形写像
 </p>
-<p>$$\omega_p: \underbrace{T_p M \times \cdots \times T_p M}_{k\ \text{個}} \to \mathbb{R}$$
+<div class="math-block tex2jax_process">$$\omega_p: \underbrace{T_p M \times \cdots \times T_p M}_{k\ \text{個}} \to \mathbb{R}$$</div>
+<p>であり、その成分が局所座標で滑らかに変化するものをいう。ウェッジ積 <span class="tex2jax_process">$\wedge$</span> は、二つの形式の引数を「すべての順列にわたって符号付きで和をとる」操作として定義される。本書第2章で反対称行列の成分計算として導入したウェッジ積が、この抽象的な定義のもとで自然に再現される。
 </p>
-<p>であり、その成分が局所座標で滑らかに変化するものをいう。ウェッジ積 $\wedge$ は、二つの形式の引数を「すべての順列にわたって符号付きで和をとる」操作として定義される。本書第2章で反対称行列の成分計算として導入したウェッジ積が、この抽象的な定義のもとで自然に再現される。
+<strong>引き戻し（pullback）</strong>も多様体間の写像へと一般化される。滑らかな写像 <span class="tex2jax_process">$f: M \to N$</span> に対し、<span class="tex2jax_process">$N$</span> 上の <span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> の引き戻し <span class="tex2jax_process">$f^*\omega$</span> は <span class="tex2jax_process">$M$</span> 上の <span class="tex2jax_process">$k$</span>-form であり、
+<div class="math-block tex2jax_process">$$(f^*\omega)_p(v_1, \dots, v_k) = \omega_{f(p)}(df_p(v_1), \dots, df_p(v_k))$$</div>
+<p>で定義される。<span class="tex2jax_process">$df_p: T_p M \to T_{f(p)} N$</span> は <span class="tex2jax_process">$f$</span> の微分（接写像）である。本書第3章で座標変換のヤコビアンとして計算した引き戻しは、この一般公式において <span class="tex2jax_process">$f$</span> をチャート間の座標変換とし、局所座標で成分表示したものに一致する。
 </p>
-<strong>引き戻し（pullback）</strong>も多様体間の写像へと一般化される。滑らかな写像 $f: M \to N$ に対し、$N$ 上の $k$-form $\omega$ の引き戻し $f^*\omega$ は $M$ 上の $k$-form であり、
-<p>$$(f^*\omega)_p(v_1, \dots, v_k) = \omega_{f(p)}(df_p(v_1), \dots, df_p(v_k))$$
+<p>本書が一貫して使ってきた「<span class="tex2jax_process">$dx$</span> は横ベクトル」という記法は、実は多様体論の標準言語では <span class="tex2jax_process">$dx^i$</span> たちが余接空間の基底であるという事実にほかならない。<span class="tex2jax_process">$\omega = \sum_i \omega_i\,dx^i$</span> と書いたとき、係数 <span class="tex2jax_process">$\omega_i$</span> は本書の言葉では「横ベクトルの第 <span class="tex2jax_process">$i$</span> 成分」であり、多様体論の言葉では「1-form の局所座標に関する成分」である。<span class="tex2jax_process">$\omega(v) = \sum_i \omega_i\,dx^i(v) = \sum_i \omega_i v^i$</span> という計算は、本書第1章の行列の積 <span class="tex2jax_process">$\begin{pmatrix}\omega_1&\omega_2&\omega_3\end{pmatrix}\begin{pmatrix}v^1\\v^2\\v^3\end{pmatrix}$</span> に完全に対応する。
 </p>
-<p>で定義される。$df_p: T_p M \to T_{f(p)} N$ は $f$ の微分（接写像）である。本書第3章で座標変換のヤコビアンとして計算した引き戻しは、この一般公式において $f$ をチャート間の座標変換とし、局所座標で成分表示したものに一致する。
+<p>この双対性は高次の形式にも拡張される。本書第2章で <span class="tex2jax_process">$k$</span>-form を行列（<span class="tex2jax_process">$k=1$</span> では横ベクトル、<span class="tex2jax_process">$k=2$</span> では反対称行列、<span class="tex2jax_process">$k=3$</span> では反対称3階テンソル）で表示したのは、交代多重線形写像としての <span class="tex2jax_process">$k$</span>-form の成分表示にほかならない。付録Eで <span class="tex2jax_process">$4\times4\times4$</span> のスライス行列を扱ったとき、我々はすでに多様体上の3-form の成分計算を実践していたのだ。
 </p>
-<p>本書が一貫して使ってきた「$dx$ は横ベクトル」という記法は、実は多様体論の標準言語では $dx^i$ たちが余接空間の基底であるという事実にほかならない。$\omega = \sum_i \omega_i\,dx^i$ と書いたとき、係数 $\omega_i$ は本書の言葉では「横ベクトルの第 $i$ 成分」であり、多様体論の言葉では「1-form の局所座標に関する成分」である。$\omega(v) = \sum_i \omega_i\,dx^i(v) = \sum_i \omega_i v^i$ という計算は、本書第1章の行列の積 $\begin{pmatrix}\omega_1&\omega_2&\omega_3\end{pmatrix}\begin{pmatrix}v^1\\v^2\\v^3\end{pmatrix}$ に完全に対応する。
+<h4 id="1114-外微分-span-classtex2jaxprocessspan--多様体上で変わらないもの">11.1.4 外微分 <span class="tex2jax_process">$d$</span> —— 多様体上で変わらないもの</h4>
+<p>外微分 <span class="tex2jax_process">$d$</span> は、多様体上で<strong>計量を一切使わずに</strong>定義できる数少ない微分演算子の一つである。<span class="tex2jax_process">$k$</span>-form <span class="tex2jax_process">$\omega$</span> に対し、<span class="tex2jax_process">$d\omega$</span> は <span class="tex2jax_process">$(k+1)$</span>-form であり、その定義は本書第5章で偏微分とウェッジ積の組み合わせとして学んだものと完全に一致する。
 </p>
-<p>この双対性は高次の形式にも拡張される。本書第2章で $k$-form を行列（$k=1$ では横ベクトル、$k=2$ では反対称行列、$k=3$ では反対称3階テンソル）で表示したのは、交代多重線形写像としての $k$-form の成分表示にほかならない。付録Eで $4\times4\times4$ のスライス行列を扱ったとき、我々はすでに多様体上の3-form の成分計算を実践していたのだ。
-</p>
-<h4 id="1114-外微分--多様体上で変わらないもの">11.1.4 外微分 $d$ —— 多様体上で変わらないもの</h4>
-<p>外微分 $d$ は、多様体上で<strong>計量を一切使わずに</strong>定義できる数少ない微分演算子の一つである。$k$-form $\omega$ に対し、$d\omega$ は $(k+1)$-form であり、その定義は本書第5章で偏微分とウェッジ積の組み合わせとして学んだものと完全に一致する。
-</p>
-<p>外微分 $d$ は、$\Omega^k(M)$ から $\Omega^{k+1}(M)$ への線形作用素であり、関数に対して通常の全微分を与え、次数付きライプニッツ則を満たし、局所座標では偏微分とウェッジ積によって与えられる。この作用素について $d^2 = 0$ が成り立つ。計量はどこにも登場しない。曲がっていようがいまいが、$d$ は本書で慣れ親しんだ計算規則をそのまま使える。
+<p>外微分 <span class="tex2jax_process">$d$</span> は、<span class="tex2jax_process">$\Omega^k(M)$</span> から <span class="tex2jax_process">$\Omega^{k+1}(M)$</span> への線形作用素であり、関数に対して通常の全微分を与え、次数付きライプニッツ則を満たし、局所座標では偏微分とウェッジ積によって与えられる。この作用素について <span class="tex2jax_process">$d^2 = 0$</span> が成り立つ。計量はどこにも登場しない。曲がっていようがいまいが、<span class="tex2jax_process">$d$</span> は本書で慣れ親しんだ計算規則をそのまま使える。
 </p>
 <p>この普遍性こそが微分形式の最大の武器であり、<strong>ストークスの定理</strong>
 </p>
-<p>$$\int_M d\omega = \int_{\partial M} \omega$$
-</p>
-<p>が向き付けられた $n$ 次元多様体 $M$ と、適切な滑らかさ・台条件を満たす $(n-1)$-form に対して成立する根拠でもある。本書第8章で「統一ストークスの定理」として出会ったものは、この一般公式の特別な場合（$M \subset \mathbb{R}^3$, $n \le 3$）だった。
+<div class="math-block tex2jax_process">$$\int_M d\omega = \int_{\partial M} \omega$$</div>
+<p>が向き付けられた <span class="tex2jax_process">$n$</span> 次元多様体 <span class="tex2jax_process">$M$</span> と、適切な滑らかさ・台条件を満たす <span class="tex2jax_process">$(n-1)$</span>-form に対して成立する根拠でもある。本書第8章で「統一ストークスの定理」として出会ったものは、この一般公式の特別な場合（<span class="tex2jax_process">$M \subset \mathbb{R}^3$</span>, <span class="tex2jax_process">$n \le 3$</span>）だった。
 </p>
 <h4 id="1115-計量とホッジ・スター--場所ごとに変わるもの">11.1.5 計量とホッジ・スター —— 場所ごとに変わるもの</h4>
-<p>$d$ が普遍的であるのに対し、$\ast$ はそうではない。<strong>リーマン計量</strong> $g$ とは、各点 $p \in M$ において接空間 $T_p M$ 上の正定値内積 $g_p: T_p M \times T_p M \to \mathbb{R}$ を滑らかに与える2階の共変テンソル場である。局所座標では
+<span class="tex2jax_process">$d$</span> が普遍的であるのに対し、<span class="tex2jax_process">$\ast$</span> はそうではない。<strong>リーマン計量</strong> <span class="tex2jax_process">$g$</span> とは、各点 <span class="tex2jax_process">$p \in M$</span> において接空間 <span class="tex2jax_process">$T_p M$</span> 上の正定値内積 <span class="tex2jax_process">$g_p: T_p M \times T_p M \to \mathbb{R}$</span> を滑らかに与える2階の共変テンソル場である。局所座標では
+<div class="math-block tex2jax_process">$$g = \sum_i\sum_j g_{ij}(x)\,dx^i \otimes dx^j$$</div>
+<p>と書け、<span class="tex2jax_process">$g_{ij}(x)$</span> は場所の関数である。本書では <span class="tex2jax_process">$g_{ij}$</span> を成分とする行列を <span class="tex2jax_process">$\mathbf{g}$</span> と書いてきた。<span class="tex2jax_process">$\mathbb{R}^3$</span> のデカルト座標では <span class="tex2jax_process">$\mathbf{g}$</span> は単位行列、ミンコフスキー時空では対角成分が <span class="tex2jax_process">$(-1,1,1,1)$</span> の定数行列だが、一般の多様体では <span class="tex2jax_process">$\mathbf{g}(x)$</span> は場所ごとに異なる。
 </p>
-<p>$$g = \sum_i\sum_j g_{ij}(x)\,dx^i \otimes dx^j$$
+<p>向き付けられたリーマン多様体では、計量から<strong>体積形式</strong> <span class="tex2jax_process">$\mathrm{vol}_g = \sqrt{\det g}\;dx^1 \wedge \cdots \wedge dx^n$</span>（擬リーマン計量では規約に応じて <span class="tex2jax_process">$\sqrt{|\det g|}$</span> が現れる）が定まり、これを用いて<strong>ホッジ・スター作用素</strong>
 </p>
-<p>と書け、$g_{ij}(x)$ は場所の関数である。本書では $g_{ij}$ を成分とする行列を $\mathbf{g}$ と書いてきた。$\mathbb{R}^3$ のデカルト座標では $\mathbf{g}$ は単位行列、ミンコフスキー時空では対角成分が $(-1,1,1,1)$ の定数行列だが、一般の多様体では $\mathbf{g}(x)$ は場所ごとに異なる。
+<div class="math-block tex2jax_process">$$\ast: \Omega^k(M) \to \Omega^{n-k}(M)$$</div>
+<p>が定義される。<span class="tex2jax_process">$\ast$</span> の定義式 <span class="tex2jax_process">$\omega \wedge \ast\eta = \langle\omega,\eta\rangle_g\,\mathrm{vol}_g$</span> には明示的に <span class="tex2jax_process">$g$</span> が入っている。<span class="tex2jax_process">$\mathbf{g}(x)$</span> が場所の関数なら、<span class="tex2jax_process">$\ast$</span> の辞書も場所ごとに異なる——本書第9章で練習した「<span class="tex2jax_process">$\mathbf{g} \to \ast$</span> 辞書」の手順を、各点で繰り返す必要がある。擬リーマン計量の場合も同様の構成は可能だが、符号規約に注意が必要である。
 </p>
-<p>向き付けられたリーマン多様体では、計量から<strong>体積形式</strong> $\mathrm{vol}_g = \sqrt{\det g}\;dx^1 \wedge \cdots \wedge dx^n$（擬リーマン計量では規約に応じて $\sqrt{|\det g|}$ が現れる）が定まり、これを用いて<strong>ホッジ・スター作用素</strong>
-</p>
-<p>$$\ast: \Omega^k(M) \to \Omega^{n-k}(M)$$
-</p>
-<p>が定義される。$\ast$ の定義式 $\omega \wedge \ast\eta = \langle\omega,\eta\rangle_g\,\mathrm{vol}_g$ には明示的に $g$ が入っている。$\mathbf{g}(x)$ が場所の関数なら、$\ast$ の辞書も場所ごとに異なる——本書第9章で練習した「$\mathbf{g} \to \ast$ 辞書」の手順を、各点で繰り返す必要がある。擬リーマン計量の場合も同様の構成は可能だが、符号規約に注意が必要である。
-</p>
-<p>この $d$ と $\ast$ の非対称性——$d$ は普遍的、$\ast$ は計量依存——こそが、Burke の「計量遅延」が最終的に照射する構造である。一般相対性理論では、計量 $g$ そのものがアインシュタイン方程式の解として動的に決まる。電磁場の方程式 $dF = 0$, $d(\ast F) = \mu_0(\ast\mathcal{J})$ は、時空計量から定まる $\ast$ と適切な電流形式を用いれば、曲がった時空上でも同じ形で書ける。
+<p>この <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の非対称性——<span class="tex2jax_process">$d$</span> は普遍的、<span class="tex2jax_process">$\ast$</span> は計量依存——こそが、Burke の「計量遅延」が最終的に照射する構造である。一般相対性理論では、計量 <span class="tex2jax_process">$g$</span> そのものがアインシュタイン方程式の解として動的に決まる。電磁場の方程式 <span class="tex2jax_process">$dF = 0$</span>, <span class="tex2jax_process">$d(\ast F) = \mu_0(\ast\mathcal{J})$</span> は、時空計量から定まる <span class="tex2jax_process">$\ast$</span> と適切な電流形式を用いれば、曲がった時空上でも同じ形で書ける。
 </p>
 <h4 id="1116-積分--1の分割と向き付け可能性">11.1.6 積分 —— 1の分割と向き付け可能性</h4>
-<p>多様体上の積分もまた、本書のリーマン和の延長線上にある。$\mathbb{R}^n$ では、$n$-form $\omega = f\,dx^1 \wedge \cdots \wedge dx^n$ の積分を素朴に $\int f\,dx^1 \cdots dx^n$ と定義できた。多様体上で $n$-form を積分するには、チャートごとに局所積分を計算し、それらを貼り合わせる必要がある。この貼り合わせを可能にするのが<strong>1の分割（partition of unity）</strong>——多様体を被覆するチャート族に付随する、足して1になる滑らかな関数の族——である。
+<p>多様体上の積分もまた、本書のリーマン和の延長線上にある。<span class="tex2jax_process">$\mathbb{R}^n$</span> では、<span class="tex2jax_process">$n$</span>-form <span class="tex2jax_process">$\omega = f\,dx^1 \wedge \cdots \wedge dx^n$</span> の積分を素朴に <span class="tex2jax_process">$\int f\,dx^1 \cdots dx^n$</span> と定義できた。多様体上で <span class="tex2jax_process">$n$</span>-form を積分するには、チャートごとに局所積分を計算し、それらを貼り合わせる必要がある。この貼り合わせを可能にするのが<strong>1の分割（partition of unity）</strong>——多様体を被覆するチャート族に付随する、足して1になる滑らかな関数の族——である。
 </p>
-<p>また、多様体上で $n$-form の積分が座標の取り方に依存しないためには、多様体が<strong>向き付け可能（orientable）</strong>でなければならない。本書で一貫して右手系 $(x,y,z)$ を仮定してきたのは、$\mathbb{R}^3$ に向きを固定していたことに相当する。メビウスの帯のように向き付け不能な多様体では、大域的な体積形式が定義できない。
+<p>また、多様体上で <span class="tex2jax_process">$n$</span>-form の積分が座標の取り方に依存しないためには、多様体が<strong>向き付け可能（orientable）</strong>でなければならない。本書で一貫して右手系 <span class="tex2jax_process">$(x,y,z)$</span> を仮定してきたのは、<span class="tex2jax_process">$\mathbb{R}^3$</span> に向きを固定していたことに相当する。メビウスの帯のように向き付け不能な多様体では、大域的な体積形式が定義できない。
 </p>
-<p>こうして多様体上の積分論が整備されると、適切な滑らかさ・台条件のもとで、ストークスの定理 $\int_M d\omega = \int_{\partial M} \omega$ は向き付けられた $n$ 次元多様体とその上の $(n-1)$-form に対して成立する。本書の旅が到達した統一ストークスの定理は、この一般的枠組みの $n \le 3$ への適用だったのだ。
+<p>こうして多様体上の積分論が整備されると、適切な滑らかさ・台条件のもとで、ストークスの定理 <span class="tex2jax_process">$\int_M d\omega = \int_{\partial M} \omega$</span> は向き付けられた <span class="tex2jax_process">$n$</span> 次元多様体とその上の <span class="tex2jax_process">$(n-1)$</span>-form に対して成立する。本書の旅が到達した統一ストークスの定理は、この一般的枠組みの <span class="tex2jax_process">$n \le 3$</span> への適用だったのだ。
 </p>
 <h4 id="1117-接続と曲率--一言だけ">11.1.7 接続と曲率 —— 一言だけ</h4>
-<p>多様体上でベクトル場を「平行移動」するための追加構造が<strong>接続（connection）</strong>、あるいは<strong>共変微分</strong> $\nabla$ である。接続が与えられると、曲がり具合を測る<strong>曲率テンソル</strong> $R$ が定義される。一般相対性理論では、レヴィ＝チヴィタ接続（計量と整合的で捩れのない唯一の接続）から得られる曲率が、時空の重力を記述する。
+<p>多様体上でベクトル場を「平行移動」するための追加構造が<strong>接続（connection）</strong>、あるいは<strong>共変微分</strong> <span class="tex2jax_process">$\nabla$</span> である。接続が与えられると、曲がり具合を測る<strong>曲率テンソル</strong> <span class="tex2jax_process">$R$</span> が定義される。一般相対性理論では、レヴィ＝チヴィタ接続（計量と整合的で捩れのない唯一の接続）から得られる曲率が、時空の重力を記述する。
 </p>
-<p>微分形式の言葉では、曲率は<strong>曲率2-form</strong> $\Omega$ として表され、ビアンキ恒等式 $D\Omega = 0$（外共変微分で $\Omega$ が閉じている）といった構造が現れる。この先は、Flanders や Burke の専門書に譲る。
+<p>微分形式の言葉では、曲率は<strong>曲率2-form</strong> <span class="tex2jax_process">$\Omega$</span> として表され、ビアンキ恒等式 <span class="tex2jax_process">$D\Omega = 0$</span>（外共変微分で <span class="tex2jax_process">$\Omega$</span> が閉じている）といった構造が現れる。この先は、Flanders や Burke の専門書に譲る。
 </p>
 <h4 id="1118-本書との対応">11.1.8 本書との対応</h4>
 <p>本書の概念が多様体論のどこに対応するかを一覧にしておく。
 </p>
 <p>| 本書 | 多様体論 |
 |------|---------|
-| $dx$ は横ベクトル（第1章） | $dx^i$ は余接空間 $T_p^*M$ の基底 |
-| $dx(v) = v_x$（第1章） | 1-form と接ベクトルの双対ペアリング $\langle\omega, v\rangle$ |
-| ウェッジ積の反対称行列表示（第2章） | 交代多重線形写像としての $k$-form の成分表示 |
-| 引き戻し＝ヤコビ行列（第3章） | 滑らかな写像による $k$-form の引き戻し $f^*\omega$ |
-| $d$ の偏微分＋ウェッジ積（第5章） | 外微分 $d$（多様体上で計量不要） |
-| $\mathbf{g} = J^T J$（第6章） | ユークリッド空間内の座標変換・埋め込みから誘導される計量の具体例 |
-| $\ast$ の辞書（第6章、第9章） | ホッジ・スター $\ast: \Omega^k(M) \to \Omega^{n-k}(M)$（計量依存） |
-| 統一ストークスの定理（第8章） | $\int_M d\omega = \int_{\partial M} \omega$（一般次元） |
-| $dF=0$, $d(\ast F)=\mu_0(\ast\mathcal{J})$（第10章） | 曲がった時空上でも、時空計量から定まる $\ast$ と適切な電流形式を用いれば同じ形で書ける |
-| 付録Eの $4\times4\times4$ スライス | 4次元多様体上の3-form の成分計算 |
+| <span class="tex2jax_process">$dx$</span> は横ベクトル（第1章） | <span class="tex2jax_process">$dx^i$</span> は余接空間 <span class="tex2jax_process">$T_p^*M$</span> の基底 |
+| <span class="tex2jax_process">$dx(v) = v_x$</span>（第1章） | 1-form と接ベクトルの双対ペアリング <span class="tex2jax_process">$\langle\omega, v\rangle$</span> |
+| ウェッジ積の反対称行列表示（第2章） | 交代多重線形写像としての <span class="tex2jax_process">$k$</span>-form の成分表示 |
+| 引き戻し＝ヤコビ行列（第3章） | 滑らかな写像による <span class="tex2jax_process">$k$</span>-form の引き戻し <span class="tex2jax_process">$f^*\omega$</span> |
+| <span class="tex2jax_process">$d$</span> の偏微分＋ウェッジ積（第5章） | 外微分 <span class="tex2jax_process">$d$</span>（多様体上で計量不要） |
+| <span class="tex2jax_process">$\mathbf{g} = J^T J$</span>（第6章） | ユークリッド空間内の座標変換・埋め込みから誘導される計量の具体例 |
+| <span class="tex2jax_process">$\ast$</span> の辞書（第6章、第9章） | ホッジ・スター <span class="tex2jax_process">$\ast: \Omega^k(M) \to \Omega^{n-k}(M)$</span>（計量依存） |
+| 統一ストークスの定理（第8章） | <span class="tex2jax_process">$\int_M d\omega = \int_{\partial M} \omega$</span>（一般次元） |
+| <span class="tex2jax_process">$dF=0$</span>, <span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span>（第10章） | 曲がった時空上でも、時空計量から定まる <span class="tex2jax_process">$\ast$</span> と適切な電流形式を用いれば同じ形で書ける |
+| 付録Eの <span class="tex2jax_process">$4\times4\times4$</span> スライス | 4次元多様体上の3-form の成分計算 |
 </p>
 <h3 id="112-リーマン幾何学--テンソル解析のスタイル">§11.2 リーマン幾何学 —— テンソル解析のスタイル</h3>
 <p>多様体論が「幾何学的対象を座標に依存せずに定義する」ことを目指すのに対し、古典的なリーマン幾何学——アインシュタインの一般相対性理論で使われるテンソル解析——は「座標を選び、成分の変換則を正面から扱う」スタイルをとる。本書が行列の成分を明示してきた流儀に近いのは、むしろこちらである。
 </p>
 <h4 id="1121-テンソル--変換則による定義">11.2.1 テンソル —— 変換則による定義</h4>
-<p>古典的なテンソル解析では、テンソルを「座標変換に対する変換規則」で定義する。座標 $x^i$ から $\bar{x}^i$ への変換に対して、
+<p>古典的なテンソル解析では、テンソルを「座標変換に対する変換規則」で定義する。座標 <span class="tex2jax_process">$x^i$</span> から <span class="tex2jax_process">$\bar{x}^i$</span> への変換に対して、
 </p>
-<strong>反変ベクトル</strong> $V^i$ は $\bar{V}^i = \sum_j \frac{\partial \bar{x}^i}{\partial x^j} V^j$ と変換され、
-<strong>共変ベクトル</strong> $\omega_i$ は $\bar{\omega}_i = \sum_j \frac{\partial x^j}{\partial \bar{x}^i} \omega_j$ と変換される。
-<p>この区別は本書第3章で既に出会っている。変位ベクトル $\mathbf{v}$ の成分 $v^i$ は反変（ヤコビ行列の逆行列で変換）、1-form $\omega$ の係数 $\omega_i$ は共変（ヤコビ行列で変換）だった。一般の $(r,s)$-テンソル $T^{i_1\cdots i_r}_{j_1\cdots j_s}$ は、$r$ 個の反変添字と $s$ 個の共変添字を持ち、添字ごとに上記の変換則を適用する。
+<strong>反変ベクトル</strong> <span class="tex2jax_process">$V^i$</span> は <span class="tex2jax_process">$\bar{V}^i = \sum_j \frac{\partial \bar{x}^i}{\partial x^j} V^j$</span> と変換され、
+<strong>共変ベクトル</strong> <span class="tex2jax_process">$\omega_i$</span> は <span class="tex2jax_process">$\bar{\omega}_i = \sum_j \frac{\partial x^j}{\partial \bar{x}^i} \omega_j$</span> と変換される。
+<p>この区別は本書第3章で既に出会っている。変位ベクトル <span class="tex2jax_process">$\mathbf{v}$</span> の成分 <span class="tex2jax_process">$v^i$</span> は反変（ヤコビ行列の逆行列で変換）、1-form <span class="tex2jax_process">$\omega$</span> の係数 <span class="tex2jax_process">$\omega_i$</span> は共変（ヤコビ行列で変換）だった。一般の <span class="tex2jax_process">$(r,s)$</span>-テンソル <span class="tex2jax_process">$T^{i_1\cdots i_r}_{j_1\cdots j_s}$</span> は、<span class="tex2jax_process">$r$</span> 個の反変添字と <span class="tex2jax_process">$s$</span> 個の共変添字を持ち、添字ごとに上記の変換則を適用する。
 </p>
-<p>本書で計量を表す行列 $\mathbf{g}$ の成分 $g_{ij}$ は $(0,2)$-テンソル（二階共変テンソル）である。座標変換に対して $g_{ij}$ は
+<p>本書で計量を表す行列 <span class="tex2jax_process">$\mathbf{g}$</span> の成分 <span class="tex2jax_process">$g_{ij}$</span> は <span class="tex2jax_process">$(0,2)$</span>-テンソル（二階共変テンソル）である。座標変換に対して <span class="tex2jax_process">$g_{ij}$</span> は
 </p>
-<p>$$\bar{g}_{ij} = \sum_{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$
-</p>
-<p>と変換される。本書第6章で導出した $\mathbf{g} = J^T J$ という関係式は、デカルト座標で $g_{ij} = \delta_{ij}$ であるときに曲線座標での $\bar{g}_{ij}$ を計算する公式にほかならない。一般のリーマン計量は、必ずしも一つの座標変換のヤコビ行列 $J$ から $J^T J$ として得られるわけではない。第6章の $J^T J$ は、あくまでユークリッド空間内で誘導計量を計算する最も具体的な例である。
+<div class="math-block tex2jax_process">$$\bar{g}_{ij} = \sum_{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$</div>
+<p>と変換される。本書第6章で導出した <span class="tex2jax_process">$\mathbf{g} = J^T J$</span> という関係式は、デカルト座標で <span class="tex2jax_process">$g_{ij} = \delta_{ij}$</span> であるときに曲線座標での <span class="tex2jax_process">$\bar{g}_{ij}$</span> を計算する公式にほかならない。一般のリーマン計量は、必ずしも一つの座標変換のヤコビ行列 <span class="tex2jax_process">$J$</span> から <span class="tex2jax_process">$J^T J$</span> として得られるわけではない。第6章の <span class="tex2jax_process">$J^T J$</span> は、あくまでユークリッド空間内で誘導計量を計算する最も具体的な例である。
 </p>
 <h4 id="1122-クリストッフェル記号--微分がテンソルでなくなる問題">11.2.2 クリストッフェル記号 —— 微分がテンソルでなくなる問題</h4>
-<p>ベクトル場 $V^i$ の偏微分 $\partial_j V^i$ は、そのままではテンソルとして振る舞わない。座標変換すると余分な項が現れてしまう。計量 $g$ と整合的で捩れのないレヴィ＝チヴィタ接続を選ぶと、その接続係数、すなわち<strong>クリストッフェル記号（Christoffel symbols）</strong>は
+<p>ベクトル場 <span class="tex2jax_process">$V^i$</span> の偏微分 <span class="tex2jax_process">$\partial_j V^i$</span> は、そのままではテンソルとして振る舞わない。座標変換すると余分な項が現れてしまう。計量 <span class="tex2jax_process">$g$</span> と整合的で捩れのないレヴィ＝チヴィタ接続を選ぶと、その接続係数、すなわち<strong>クリストッフェル記号（Christoffel symbols）</strong>は
 </p>
-<p>$$\Gamma^i_{jk} = \frac{1}{2}\sum_m g^{im}(\partial_j g_{km} + \partial_k g_{jm} - \partial_m g_{jk})$$
-</p>
-<p>で与えられる。ここで $g^{im}$ は $g_{ij}$ の逆行列の成分である。本書の用語では、$\Gamma^i_{jk}$ は「その座標表示において、基底の変化や計量の変化を補正する係数」であり、一般には $g_{ij}$ の一階微分を含む。
+<div class="math-block tex2jax_process">$$\Gamma^i_{jk} = \frac{1}{2}\sum_m g^{im}(\partial_j g_{km} + \partial_k g_{jm} - \partial_m g_{jk})$$</div>
+<p>で与えられる。ここで <span class="tex2jax_process">$g^{im}$</span> は <span class="tex2jax_process">$g_{ij}$</span> の逆行列の成分である。本書の用語では、<span class="tex2jax_process">$\Gamma^i_{jk}$</span> は「その座標表示において、基底の変化や計量の変化を補正する係数」であり、一般には <span class="tex2jax_process">$g_{ij}$</span> の一階微分を含む。
 </p>
 <p>クリストッフェル記号を用いて<strong>共変微分</strong>
 </p>
-<p>$$\nabla_j V^i = \partial_j V^i + \sum_k \Gamma^i_{jk} V^k$$
+<div class="math-block tex2jax_process">$$\nabla_j V^i = \partial_j V^i + \sum_k \Gamma^i_{jk} V^k$$</div>
+<p>を定義すると、<span class="tex2jax_process">$\nabla_j V^i$</span> は <span class="tex2jax_process">$(1,1)$</span>-テンソルとして正しく変換される。共変微分こそが、曲がった空間における「まっすぐ」を定義する道具である。接続の概念（§11.1.7）の成分表示が <span class="tex2jax_process">$\Gamma^i_{jk}$</span> にほかならない。
 </p>
-<p>を定義すると、$\nabla_j V^i$ は $(1,1)$-テンソルとして正しく変換される。共変微分こそが、曲がった空間における「まっすぐ」を定義する道具である。接続の概念（§11.1.7）の成分表示が $\Gamma^i_{jk}$ にほかならない。
-</p>
-<p>本書の経験で言い換えよう。第9章では、円柱座標や球座標の $\mathbf{g}$ から $\mathrm{div}$ や $\mathrm{rot}$ の公式を導出した。第9章の $\ast$ 辞書による導出は、クリストッフェル記号を明示的に計算する方法とは異なる。むしろ、$d$ と $\ast$ を使うことで、$\Gamma^i_{jk}$ を表に出さずに同じ座標公式へ到達していた、と言うべきである。テンソル解析で同じ公式を導けば、そこには共変微分とクリストッフェル記号が現れる。リーマン幾何学を学ぶとは、同じ座標公式を、接続係数 $\Gamma^i_{jk}$ と曲率テンソル $R^i_{\,mjk}$ の側から見直すことである。
+<p>本書の経験で言い換えよう。第9章では、円柱座標や球座標の <span class="tex2jax_process">$\mathbf{g}$</span> から <span class="tex2jax_process">$\mathrm{div}$</span> や <span class="tex2jax_process">$\mathrm{rot}$</span> の公式を導出した。第9章の <span class="tex2jax_process">$\ast$</span> 辞書による導出は、クリストッフェル記号を明示的に計算する方法とは異なる。むしろ、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> を使うことで、<span class="tex2jax_process">$\Gamma^i_{jk}$</span> を表に出さずに同じ座標公式へ到達していた、と言うべきである。テンソル解析で同じ公式を導けば、そこには共変微分とクリストッフェル記号が現れる。リーマン幾何学を学ぶとは、同じ座標公式を、接続係数 <span class="tex2jax_process">$\Gamma^i_{jk}$</span> と曲率テンソル <span class="tex2jax_process">$R^i_{\,mjk}$</span> の側から見直すことである。
 </p>
 <h4 id="1123-リーマン曲率テンソル">11.2.3 リーマン曲率テンソル</h4>
-<p>共変微分の非可換性が、空間の曲がり具合を定量化する。ベクトル場 $V^i$ に対して
+<p>共変微分の非可換性が、空間の曲がり具合を定量化する。ベクトル場 <span class="tex2jax_process">$V^i$</span> に対して
 </p>
-<p>$$(\nabla_j \nabla_k - \nabla_k \nabla_j) V^i = \sum_m R^i_{\,mjk} V^m$$
+<div class="math-block tex2jax_process">$$(\nabla_j \nabla_k - \nabla_k \nabla_j) V^i = \sum_m R^i_{\,mjk} V^m$$</div>
+<p>と書いたとき、<span class="tex2jax_process">$R^i_{\,mjk}$</span> が<strong>リーマン曲率テンソル</strong>である。クリストッフェル記号で明示的に書けば
 </p>
-<p>と書いたとき、$R^i_{\,mjk}$ が<strong>リーマン曲率テンソル</strong>である。クリストッフェル記号で明示的に書けば
+<div class="math-block tex2jax_process">$$R^i_{\,mjk} = \partial_j \Gamma^i_{mk} - \partial_k \Gamma^i_{mj} + \sum_p (\Gamma^i_{jp} \Gamma^p_{mk} - \Gamma^i_{kp} \Gamma^p_{mj})$$</div>
+<p>となる。<span class="tex2jax_process">$\mathbf{g}$</span> が定数行列なら <span class="tex2jax_process">$\Gamma$</span> はすべてゼロであり、<span class="tex2jax_process">$R^i_{\,mjk} = 0$</span> ——空間は平坦である。
 </p>
-<p>$$R^i_{\,mjk} = \partial_j \Gamma^i_{mk} - \partial_k \Gamma^i_{mj} + \sum_p (\Gamma^i_{jp} \Gamma^p_{mk} - \Gamma^i_{kp} \Gamma^p_{mj})$$
-</p>
-<p>となる。$\mathbf{g}$ が定数行列なら $\Gamma$ はすべてゼロであり、$R^i_{\,mjk} = 0$ ——空間は平坦である。
-</p>
-<blockquote><p>**注** （座標依存計量と曲率）$\mathbf{g}(x)$ が場所に依存すること自体は、曲率が非ゼロであることを意味しない。ユークリッド空間を曲線座標（極座標・球座標など）で書けば、$g_{ij}(x)$ は場所に依存しても曲率はゼロである。曲率が非ゼロになるのは、$\Gamma$ とその微分から構成される $R^i_{\,mjk}$ が消えない場合である。</p>
+<blockquote><p>**注** （座標依存計量と曲率）<span class="tex2jax_process">$\mathbf{g}(x)$</span> が場所に依存すること自体は、曲率が非ゼロであることを意味しない。ユークリッド空間を曲線座標（極座標・球座標など）で書けば、<span class="tex2jax_process">$g_{ij}(x)$</span> は場所に依存しても曲率はゼロである。曲率が非ゼロになるのは、<span class="tex2jax_process">$\Gamma$</span> とその微分から構成される <span class="tex2jax_process">$R^i_{\,mjk}$</span> が消えない場合である。</p>
 </p></blockquote>
-<p>曲率テンソルは $n^4$ 個の成分を持つが、多数の対称性により独立な成分ははるかに少ない。全共変曲率テンソルを $R_{abcd}$ と書くと、代表的な規約では
-$$R_{abcd}=-R_{bacd},\qquad R_{abcd}=-R_{abdc},\qquad R_{abcd}=R_{cdab}$$
-といった対称性を持つ。さらに第一ビアンキ恒等式も成り立つ。これにより、4次元では独立成分は20個になる。
+<p>曲率テンソルは <span class="tex2jax_process">$n^4$</span> 個の成分を持つが、多数の対称性により独立な成分ははるかに少ない。全共変曲率テンソルを <span class="tex2jax_process">$R_{abcd}$</span> と書くと、代表的な規約では
+</p>
+<div class="math-block tex2jax_process">$$R_{abcd}=-R_{bacd},\qquad R_{abcd}=-R_{abdc},\qquad R_{abcd}=R_{cdab}$$</div>
+<p>といった対称性を持つ。さらに第一ビアンキ恒等式も成り立つ。これにより、4次元では独立成分は20個になる。
 </p>
 <blockquote><p>**注**（曲率テンソルの符号と添字順序）</p>
 曲率テンソルの符号と添字順序には複数の規約がある。本項では一つの代表的な規約を示したが、他の文献では添字の順序や符号が異なる場合がある。
 
-$$
-> \nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
-> $$
 
-この恒等式は、外微分の $d^2=0$ と同じ「二度境界を取ると消える」型の構造を思わせるが、厳密には接続を含む外共変微分 $D$ に関する恒等式であり、単なる $d^2=0$ ではない。
 </p></blockquote>
-<p>リッチテンソルは曲率テンソルの一組の添字を縮約して得られる。縮約の具体的な位置や符号は曲率テンソルの規約に依存する。ここでは詳細な規約の固定には立ち入らない。これと<strong>スカラー曲率</strong> $R = \sum_i\sum_j g^{ij} \mathrm{Ric}_{ij}$ が、アインシュタイン方程式の左辺を構成する。方程式は
-</p>
-<p>$$R_{ij} - \frac{1}{2}R\,g_{ij} = \frac{8\pi G}{c^4}\,T_{ij}$$
-</p>
-<p>である。左辺が時空の幾何（曲率）、右辺が物質のエネルギー運動量テンソル $T_{ij}$ を表す。
-</p>
-<blockquote><p>**注** （アインシュタイン方程式の符号規約と宇宙項）この式は一つの符号規約と宇宙項 $\Lambda = 0$ を選んだ結果である。符号規約（計量の符号、座標系、曲率テンソルの定義）によって式の形は変わり、宇宙項を含む拡張もある。本書では導出も証明もしないが、読者が他の文献を読むときの注意喚起として記す。</p>
+<div class="math-block tex2jax_process">$$
+> \nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
+> $$</div>
+<blockquote><p></p>
+この恒等式は、外微分の <span class="tex2jax_process">$d^2=0$</span> と同じ「二度境界を取ると消える」型の構造を思わせるが、厳密には接続を含む外共変微分 <span class="tex2jax_process">$D$</span> に関する恒等式であり、単なる <span class="tex2jax_process">$d^2=0$</span> ではない。
 </p></blockquote>
-<p>本書はこの式を導出しないし、読者に理解を求めもしない。ただ、この式の背後にある土台——多様体、計量、共変微分、曲率——は、本書で扱った $d$ と $\ast$ だけでは尽くせない。むしろ、第11章で初めて現れた接続 $\nabla$ が不可欠である。それでも、微分形式による見方は、これらの構造へ進むための有力な入口になる。
+<p>リッチテンソルは曲率テンソルの一組の添字を縮約して得られる。縮約の具体的な位置や符号は曲率テンソルの規約に依存する。ここでは詳細な規約の固定には立ち入らない。これと<strong>スカラー曲率</strong> <span class="tex2jax_process">$R = \sum_i\sum_j g^{ij} \mathrm{Ric}_{ij}$</span> が、アインシュタイン方程式の左辺を構成する。方程式は
+</p>
+<div class="math-block tex2jax_process">$$R_{ij} - \frac{1}{2}R\,g_{ij} = \frac{8\pi G}{c^4}\,T_{ij}$$</div>
+<p>である。左辺が時空の幾何（曲率）、右辺が物質のエネルギー運動量テンソル <span class="tex2jax_process">$T_{ij}$</span> を表す。
+</p>
+<blockquote><p>**注** （アインシュタイン方程式の符号規約と宇宙項）この式は一つの符号規約と宇宙項 <span class="tex2jax_process">$\Lambda = 0$</span> を選んだ結果である。符号規約（計量の符号、座標系、曲率テンソルの定義）によって式の形は変わり、宇宙項を含む拡張もある。本書では導出も証明もしないが、読者が他の文献を読むときの注意喚起として記す。</p>
+</p></blockquote>
+<p>本書はこの式を導出しないし、読者に理解を求めもしない。ただ、この式の背後にある土台——多様体、計量、共変微分、曲率——は、本書で扱った <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> だけでは尽くせない。むしろ、第11章で初めて現れた接続 <span class="tex2jax_process">$\nabla$</span> が不可欠である。それでも、微分形式による見方は、これらの構造へ進むための有力な入口になる。
 </p>
 <h4 id="1124-二つのスタイル--本書との関係">11.2.4 二つのスタイル —— 本書との関係</h4>
 <p>微分形式による記述と、添字を用いたテンソル解析による記述は、どちらもテンソル場を扱うための言語である。前者は反対称テンソルと外微分を前面に出し、後者は成分と変換則を前面に出す。
 </p>
-<p>本書は一貫して成分を明示するスタイル——行列、添字なしの偏微分、ウェッジ積の展開——をとってきた。この意味で、本書の自然な延長は微分形式の抽象論よりもむしろ、テンソル解析の具体的計算にある。すでに第9章で曲線座標の $\ast$ 辞書を引いたとき、我々は $\Gamma^i_{jk}$ を明示せずに $\mathrm{rot}$ や $\mathrm{div}$ の座標公式へ到達した。テンソル解析で同じ公式を導くなら、その背後には $g_{ij}$、接続係数 $\Gamma^i_{jk}$、共変微分の世界が現れる。その先にリーマン幾何学の全容がある。
+<p>本書は一貫して成分を明示するスタイル——行列、添字なしの偏微分、ウェッジ積の展開——をとってきた。この意味で、本書の自然な延長は微分形式の抽象論よりもむしろ、テンソル解析の具体的計算にある。すでに第9章で曲線座標の <span class="tex2jax_process">$\ast$</span> 辞書を引いたとき、我々は <span class="tex2jax_process">$\Gamma^i_{jk}$</span> を明示せずに <span class="tex2jax_process">$\mathrm{rot}$</span> や <span class="tex2jax_process">$\mathrm{div}$</span> の座標公式へ到達した。テンソル解析で同じ公式を導くなら、その背後には <span class="tex2jax_process">$g_{ij}$</span>、接続係数 <span class="tex2jax_process">$\Gamma^i_{jk}$</span>、共変微分の世界が現れる。その先にリーマン幾何学の全容がある。
 </p>
 <h3 id="113-その先へ">§11.3 その先へ</h3>
-<p>本書はここで終わりである。第1章から積み上げてきた $d$ と $\ast$ の枠組みは、ベクトル解析の解体という当初の目的を果たした。
+<p>本書はここで終わりである。第1章から積み上げてきた <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> の枠組みは、ベクトル解析の解体という当初の目的を果たした。
 </p>
 <p>ただ、ここまで来ると趣味の領域だが——別の流派の姿を少しだけ覗いてみよう。
 </p>
-<p>現代数理物理には、我々が苦労して分離した外積（$\wedge$）と内積（計量）を、最初から「幾何積」として一つの代数に統合する<strong>幾何代数（Geometric Algebra）</strong> という世界がある。$d$ と $\ast$ という二つの道具も、そこではより根源的な演算子に吸収される。分離の苦しみを知った者だけが、統合の凄みを味わえる——それだけを伝えて、本書を閉じることにする。
+<p>現代数理物理には、我々が苦労して分離した外積（<span class="tex2jax_process">$\wedge$</span>）と内積（計量）を、最初から「幾何積」として一つの代数に統合する<strong>幾何代数（Geometric Algebra）</strong> という世界がある。<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> という二つの道具も、そこではより根源的な演算子に吸収される。分離の苦しみを知った者だけが、統合の凄みを味わえる——それだけを伝えて、本書を閉じることにする。
 </p>
 <p>\newpage
 </p>
 <h1 id="第12章真のナブラ--クリフォード・パウリ・ディラック・ハミルトン">第12章：真のナブラ —— クリフォード・パウリ・ディラック・ハミルトン</h1>
 <h3 id="120-2本を1本に">§12.0 2本を1本に</h3>
-<p>　第10章の注釈内で、実はこんなことを書いていた——「なぜ2本なのか。$dF=0$ と $d(\ast F)=\mu_0(\ast\mathcal{J})$ を1本にまとめられないのか」と。
+<p>　第10章の注釈内で、実はこんなことを書いていた——「なぜ2本なのか。<span class="tex2jax_process">$dF=0$</span> と <span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span> を1本にまとめられないのか」と。
 </p>
-<p>できるのだ。それも、あっさりと。虚数単位 $i$ を持ち出せば、たったの一行で済む。本章ではまずその「トリック」を見てから、その先にあるもっと深い統合——パウリ行列とディラック演算子——へと進む。
+<p>できるのだ。それも、あっさりと。虚数単位 <span class="tex2jax_process">$i$</span> を持ち出せば、たったの一行で済む。本章ではまずその「トリック」を見てから、その先にあるもっと深い統合——パウリ行列とディラック演算子——へと進む。
 </p>
 <blockquote><p>**注** （本章の立ち位置）本章は完全なおまけであり、本書の本線からは外れている。第8章でベクトル解析の書き換えは完了し、第10章でマクスウェル方程式の行列展開も終えた。本章では、厳密な幾何代数（クリフォード代数）の教科書を書くつもりはない。目的は、本書で解体してきた grad・rot・div が、パウリ行列とディラック演算子の中で再び一つの演算へ統合される様子を、計算として見ることである。</p>
 </p></blockquote>
@@ -5287,28 +4831,22 @@ $$
 <h3 id="121-虚数で一本に--マクスウェル方程式の統合">§12.1 虚数で一本に —— マクスウェル方程式の統合</h3>
 <p>第10章で我々は、マクスウェル方程式を
 </p>
-<p>$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
+<div class="math-block tex2jax_process">$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$</div>
+<p>の2本に集約した。ここで <span class="tex2jax_process">$F$</span> も <span class="tex2jax_process">$\ast F$</span> も <span class="tex2jax_process">$2$</span>-form であることに注目しよう。4次元時空では、ホッジ・スター <span class="tex2jax_process">$\ast$</span> は <span class="tex2jax_process">$2$</span>-form を <span class="tex2jax_process">$2$</span>-form に写す。だから <span class="tex2jax_process">$F$</span> と <span class="tex2jax_process">$\ast F$</span> は同じ次数の形式だ。
 </p>
-<p>の2本に集約した。ここで $F$ も $\ast F$ も $2$-form であることに注目しよう。4次元時空では、ホッジ・スター $\ast$ は $2$-form を $2$-form に写す。だから $F$ と $\ast F$ は同じ次数の形式だ。
+<p>同じ次数なら、足し算に支障はない。虚数単位 <span class="tex2jax_process">$i$</span> を使って一つの複素 <span class="tex2jax_process">$2$</span>-form を作る。
 </p>
-<p>同じ次数なら、足し算に支障はない。虚数単位 $i$ を使って一つの複素 $2$-form を作る。
-</p>
-<p>$$G = F + i\ast F$$
-</p>
-<p>$G$ に外微分 $d$ を作用させる。$d$ は実数の微分演算子だから、$d(i\ast F) = i\,d(\ast F)$ である。
-</p>
-<p>$$dG = dF + i\,d(\ast F) = 0 + i\mu_0(\ast\mathcal{J})$$
-</p>
+<div class="math-block tex2jax_process">$$G = F + i\ast F$$</div>
+<span class="tex2jax_process">$G$</span> に外微分 <span class="tex2jax_process">$d$</span> を作用させる。<span class="tex2jax_process">$d$</span> は実数の微分演算子だから、<span class="tex2jax_process">$d(i\ast F) = i\,d(\ast F)$</span> である。
+<div class="math-block tex2jax_process">$$dG = dF + i\,d(\ast F) = 0 + i\mu_0(\ast\mathcal{J})$$</div>
 <p>すなわち
 </p>
-<p>$$d(F + i\ast F) = i\mu_0(\ast\mathcal{J})$$
+<div class="math-block tex2jax_process">$$d(F + i\ast F) = i\mu_0(\ast\mathcal{J})$$</div>
+<p>これだけだ。<span class="tex2jax_process">$dF=0$</span> と <span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span> の2本が、たった一本の複素方程式に統合された。<span class="tex2jax_process">$F$</span> と <span class="tex2jax_process">$\ast F$</span> という実部と虚部が、それぞれ無源側と有源側のマクスウェル方程式を分担している。
 </p>
-<p>これだけだ。$dF=0$ と $d(\ast F)=\mu_0(\ast\mathcal{J})$ の2本が、たった一本の複素方程式に統合された。$F$ と $\ast F$ という実部と虚部が、それぞれ無源側と有源側のマクスウェル方程式を分担している。
+<p>しかし、ここで立ち止まって考えてほしい。このトリックが成り立つのは、<strong>たまたま</strong> 4次元で <span class="tex2jax_process">$\ast$</span> が <span class="tex2jax_process">$2$</span>-form を <span class="tex2jax_process">$2$</span>-form に写すからだ。一般の <span class="tex2jax_process">$n$</span> 次元では <span class="tex2jax_process">$\ast$</span> は <span class="tex2jax_process">$k$</span>-form を <span class="tex2jax_process">$(n-k)$</span>-form に写す。<span class="tex2jax_process">$2$</span>-form と <span class="tex2jax_process">$2$</span>-form を足せるのは <span class="tex2jax_process">$n=4$</span> の特権であり、ましてや <span class="tex2jax_process">$1$</span>-form と <span class="tex2jax_process">$2$</span>-form を直接足すことは、通常の微分形式の枠組みでは許されていない。
 </p>
-<p>しかし、ここで立ち止まって考えてほしい。このトリックが成り立つのは、<strong>たまたま</strong> 4次元で $\ast$ が $2$-form を $2$-form に写すからだ。一般の $n$ 次元では $\ast$ は $k$-form を $(n-k)$-form に写す。$2$-form と $2$-form を足せるのは $n=4$ の特権であり、ましてや $1$-form と $2$-form を直接足すことは、通常の微分形式の枠組みでは許されていない。
-</p>
-<p>$d$ と $\ast$ を組み合わせたとき、grad（$0\to1$）、rot（$1\to1$）、div（$1\to0$）といった異なる次数の間の変換が現れる。これらの元を一つの代数の中でまとめて扱うことができれば、$\nabla$ の解体ではなく、$\nabla$ の<strong>統合</strong>ができるはずだ。
-</p>
+<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> を組み合わせたとき、grad（<span class="tex2jax_process">$0\to1$</span>）、rot（<span class="tex2jax_process">$1\to1$</span>）、div（<span class="tex2jax_process">$1\to0$</span>）といった異なる次数の間の変換が現れる。これらの元を一つの代数の中でまとめて扱うことができれば、<span class="tex2jax_process">$\nabla$</span> の解体ではなく、<span class="tex2jax_process">$\nabla$</span> の<strong>統合</strong>ができるはずだ。
 <p>異なる次数の形式を足し合わせる——そんな「魔法の箱」はないものだろうか。
 </p>
 <hr />
@@ -5316,230 +4854,199 @@ $$
 <p>実はある。物理学者たちが量子力学のために発見した道具が、そのままこの魔法の箱として使える。<strong>パウリ行列</strong>だ。
 </p>
 <h4 id="1221-パウリ行列の定義と掛け算">12.2.1 パウリ行列の定義と掛け算</h4>
-<p>パウリ行列 $\sigma_1, \sigma_2, \sigma_3$ は次の $2\times2$ 行列である。
+<p>パウリ行列 <span class="tex2jax_process">$\sigma_1, \sigma_2, \sigma_3$</span> は次の <span class="tex2jax_process">$2\times2$</span> 行列である。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \sigma_1 = \begin{pmatrix}0 & 1 \\ 1 & 0\end{pmatrix},\quad
 \sigma_2 = \begin{pmatrix}0 & -i \\ i & 0\end{pmatrix},\quad
 \sigma_3 = \begin{pmatrix}1 & 0 \\ 0 & -1\end{pmatrix}
-$$
+$$</div>
+<p>これらの掛け算規則を調べてみよう。単独では <span class="tex2jax_process">$\sigma_1^2 = \sigma_2^2 = \sigma_3^2 = I$</span>（単位行列）であり、異なるもの同士では <span class="tex2jax_process">$\sigma_1\sigma_2 = -\sigma_2\sigma_1$</span> という<strong>反可換性</strong>が成り立つ。積は全部で9通りある。
 </p>
-<p>これらの掛け算規則を調べてみよう。単独では $\sigma_1^2 = \sigma_2^2 = \sigma_3^2 = I$（単位行列）であり、異なるもの同士では $\sigma_1\sigma_2 = -\sigma_2\sigma_1$ という<strong>反可換性</strong>が成り立つ。積は全部で9通りある。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \sigma_1\sigma_1 = I,\quad &\sigma_1\sigma_2 = i\sigma_3,\quad &\sigma_1\sigma_3 = -i\sigma_2 \\
 \sigma_2\sigma_1 = -i\sigma_3,\quad &\sigma_2\sigma_2 = I,\quad &\sigma_2\sigma_3 = i\sigma_1 \\
 \sigma_3\sigma_1 = i\sigma_2,\quad &\sigma_3\sigma_2 = -i\sigma_1,\quad &\sigma_3\sigma_3 = I
 \end{aligned}
-$$
+$$</div>
+<p>この9通りの積を、対称部分と反対称部分に分解してみよう。第2章でウェッジ積 <span class="tex2jax_process">$\wedge$</span> を反対称化によって導入したのと同じ発想である。
 </p>
-<p>この9通りの積を、対称部分と反対称部分に分解してみよう。第2章でウェッジ積 $\wedge$ を反対称化によって導入したのと同じ発想である。
+<p>同じ添字どうし（<span class="tex2jax_process">$\sigma_1\sigma_1$</span>, <span class="tex2jax_process">$\sigma_2\sigma_2$</span>, <span class="tex2jax_process">$\sigma_3\sigma_3$</span>）の対称部分は <span class="tex2jax_process">$I$</span>、反対称部分は <span class="tex2jax_process">$0$</span> だ。異なる添字の場合は、たとえば <span class="tex2jax_process">$\sigma_1\sigma_2 = i\sigma_3$</span> について、
 </p>
-<p>同じ添字どうし（$\sigma_1\sigma_1$, $\sigma_2\sigma_2$, $\sigma_3\sigma_3$）の対称部分は $I$、反対称部分は $0$ だ。異なる添字の場合は、たとえば $\sigma_1\sigma_2 = i\sigma_3$ について、
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \frac{1}{2}(\sigma_1\sigma_2 + \sigma_2\sigma_1) = \frac{i\sigma_3 + (-i\sigma_3)}{2} = 0,\qquad
 \frac{1}{2}(\sigma_1\sigma_2 - \sigma_2\sigma_1) = \frac{i\sigma_3 - (-i\sigma_3)}{2} = i\sigma_3
-$$
+$$</div>
+<p>という具合に、異なる添字の積は純粋に反対称である。対称部分は添字が同じときだけ <span class="tex2jax_process">$I$</span>、それ以外は <span class="tex2jax_process">$0$</span>——これは第6章で導入した計量（デカルト座標では単位行列）が、パウリ行列の積の対称部分として姿を現したことにほかならない。反対称部分は添字を入れ替えると符号が反転する——第2章のウェッジ積 <span class="tex2jax_process">$dx\wedge dy = -dy\wedge dx$</span> とまったく同じ構造だ。
 </p>
-<p>という具合に、異なる添字の積は純粋に反対称である。対称部分は添字が同じときだけ $I$、それ以外は $0$——これは第6章で導入した計量（デカルト座標では単位行列）が、パウリ行列の積の対称部分として姿を現したことにほかならない。反対称部分は添字を入れ替えると符号が反転する——第2章のウェッジ積 $dx\wedge dy = -dy\wedge dx$ とまったく同じ構造だ。
-</p>
-<p>パウリ行列の積は、つねに「内積（対称部分）$+$ ウェッジ積（反対称部分）」に分解される。この一点が、パウリ行列のすべての魔法の源である。
+<p>パウリ行列の積は、つねに「内積（対称部分）<span class="tex2jax_process">$+$</span> ウェッジ積（反対称部分）」に分解される。この一点が、パウリ行列のすべての魔法の源である。
 </p>
 <h4 id="1222-ベクトルをパウリ行列で書く">12.2.2 ベクトルをパウリ行列で書く</h4>
-<p>3次元ベクトル $\mathbf{v} = (v_1, v_2, v_3)$ をパウリ行列で表してみよう。
+<p>3次元ベクトル <span class="tex2jax_process">$\mathbf{v} = (v_1, v_2, v_3)$</span> をパウリ行列で表してみよう。
 </p>
-<p>$$V = v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3 = \mathbf{v}\!\cdot\!\bm{\sigma}$$
+<div class="math-block tex2jax_process">$$V = v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3 = \mathbf{v}\!\cdot\!\bm{\sigma}$$</div>
+<p>二つのベクトル <span class="tex2jax_process">$\mathbf{v}, \mathbf{w}$</span> に対応するパウリ行列 <span class="tex2jax_process">$V = \mathbf{v}\!\cdot\!\bm{\sigma}$</span>, <span class="tex2jax_process">$W = \mathbf{w}\!\cdot\!\bm{\sigma}$</span> の積を計算する。
 </p>
-<p>二つのベクトル $\mathbf{v}, \mathbf{w}$ に対応するパウリ行列 $V = \mathbf{v}\!\cdot\!\bm{\sigma}$, $W = \mathbf{w}\!\cdot\!\bm{\sigma}$ の積を計算する。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 VW &= (v_1\sigma_1 + v_2\sigma_2 + v_3\sigma_3)(w_1\sigma_1 + w_2\sigma_2 + w_3\sigma_3) \\[4pt]
 &= v_1w_1\sigma_1\sigma_1 + v_1w_2\sigma_1\sigma_2 + v_1w_3\sigma_1\sigma_3 \\
 &\quad + v_2w_1\sigma_2\sigma_1 + v_2w_2\sigma_2\sigma_2 + v_2w_3\sigma_2\sigma_3 \\
 &\quad + v_3w_1\sigma_3\sigma_1 + v_3w_2\sigma_3\sigma_2 + v_3w_3\sigma_3\sigma_3
 \end{aligned}
-$$
-</p>
+$$</div>
 <p>上記の9通りの積を各項に適用する。非ゼロの置き換えだけ書けば
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \sigma_1\sigma_1 = I,\quad \sigma_2\sigma_2 = I,\quad \sigma_3\sigma_3 = I,\quad
 \sigma_1\sigma_2 = i\sigma_3,\quad \sigma_2\sigma_3 = i\sigma_1,\quad \sigma_3\sigma_1 = i\sigma_2
-$$
+$$</div>
+<p>と、これらの添字を逆順にした <span class="tex2jax_process">$\sigma_2\sigma_1 = -i\sigma_3$</span>, <span class="tex2jax_process">$\sigma_3\sigma_2 = -i\sigma_1$</span>, <span class="tex2jax_process">$\sigma_1\sigma_3 = -i\sigma_2$</span> の計9通りである。<span class="tex2jax_process">$I$</span> の係数（対称部分＝内積）と <span class="tex2jax_process">$\sigma_1,\sigma_2,\sigma_3$</span> の係数（反対称部分＝ウェッジ積）をそれぞれ集める。
 </p>
-<p>と、これらの添字を逆順にした $\sigma_2\sigma_1 = -i\sigma_3$, $\sigma_3\sigma_2 = -i\sigma_1$, $\sigma_1\sigma_3 = -i\sigma_2$ の計9通りである。$I$ の係数（対称部分＝内積）と $\sigma_1,\sigma_2,\sigma_3$ の係数（反対称部分＝ウェッジ積）をそれぞれ集める。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 I\text{ の係数（内積）} &: v_1w_1 + v_2w_2 + v_3w_3 \;=\; \mathbf{v}\!\cdot\!\mathbf{w} \\
 \sigma_1\text{ の係数（$\wedge$）} &: i\,(v_2w_3 - v_3w_2) \\
 \sigma_2\text{ の係数（$\wedge$）} &: i\,(v_3w_1 - v_1w_3) \\
 \sigma_3\text{ の係数（$\wedge$）} &: i\,(v_1w_2 - v_2w_1)
 \end{aligned}
-$$
+$$</div>
+<span class="tex2jax_process">$\sigma_1,\sigma_2,\sigma_3$</span> の係数カッコ内は、第2章で定義したウェッジ積 <span class="tex2jax_process">$\mathbf{v}\wedge\mathbf{w}$</span> の各成分そのものである。したがって
+<div class="math-block tex2jax_process">$$VW = (\mathbf{v}\!\cdot\!\mathbf{w})\,I \;+\; i\,(\mathbf{v}\times\mathbf{w})\!\cdot\!\bm{\sigma}$$</div>
+<p>と、内積 <span class="tex2jax_process">$+$</span> ウェッジ積の形にまとまる。内積と外積が、<strong>一つの積 <span class="tex2jax_process">$VW$</span> から同時に</strong>現れた。
 </p>
-<p>$\sigma_1,\sigma_2,\sigma_3$ の係数カッコ内は、第2章で定義したウェッジ積 $\mathbf{v}\wedge\mathbf{w}$ の各成分そのものである。したがって
+<p>これが「魔法の箱」の正体だ。パウリ行列の積は、内積（<span class="tex2jax_process">$0$</span>-form に相当するスカラー）と外積（<span class="tex2jax_process">$2$</span>-form に相当するウェッジ積）を、<strong>一つの演算で同時に</strong>生み出す。通常の微分形式では別々の次数に属していたものが、パウリ行列の代数の中では一つの <span class="tex2jax_process">$2\times2$</span> 行列として共存している。
 </p>
-<p>$$VW = (\mathbf{v}\!\cdot\!\mathbf{w})\,I \;+\; i\,(\mathbf{v}\times\mathbf{w})\!\cdot\!\bm{\sigma}$$
-</p>
-<p>と、内積 $+$ ウェッジ積の形にまとまる。内積と外積が、<strong>一つの積 $VW$ から同時に</strong>現れた。
-</p>
-<p>これが「魔法の箱」の正体だ。パウリ行列の積は、内積（$0$-form に相当するスカラー）と外積（$2$-form に相当するウェッジ積）を、<strong>一つの演算で同時に</strong>生み出す。通常の微分形式では別々の次数に属していたものが、パウリ行列の代数の中では一つの $2\times2$ 行列として共存している。
-</p>
-<blockquote><p>**注** （なぜ $2\times2$ なのか）ベクトルを $2\times2$ 行列で表すのは奇妙に思えるかもしれない。しかし、内積とウェッジ積の両方を一つの積で表現するには、少なくとも非可換な代数が必要であり、その最小の実現が $2\times2$ 複素行列なのである。本書の流儀でいえば、$1$-form（横ベクトル $1\times3$）と $2$-form（反対称 $3\times3$ 行列）という次数の異なる二つの対象を、一つの $2\times2$ 行列の中に押し込めた——そう考えればよい。</p>
+<blockquote><p>**注** （なぜ <span class="tex2jax_process">$2\times2$</span> なのか）ベクトルを <span class="tex2jax_process">$2\times2$</span> 行列で表すのは奇妙に思えるかもしれない。しかし、内積とウェッジ積の両方を一つの積で表現するには、少なくとも非可換な代数が必要であり、その最小の実現が <span class="tex2jax_process">$2\times2$</span> 複素行列なのである。本書の流儀でいえば、<span class="tex2jax_process">$1$</span>-form（横ベクトル <span class="tex2jax_process">$1\times3$</span>）と <span class="tex2jax_process">$2$</span>-form（反対称 <span class="tex2jax_process">$3\times3$</span> 行列）という次数の異なる二つの対象を、一つの <span class="tex2jax_process">$2\times2$</span> 行列の中に押し込めた——そう考えればよい。</p>
 </p></blockquote>
 <h4 id="1223-スカラーも混ぜて足す">12.2.3 スカラーも混ぜて足す</h4>
-<p>ここまでで、ベクトル（$1$-form）とウェッジ積（$2$-form）が $VW$ という一通りの計算で同時に出てくることがわかった。さらに一歩進めて、スカラー（$0$-form）そのものも同じ代数に混ぜよう。
+<p>ここまでで、ベクトル（<span class="tex2jax_process">$1$</span>-form）とウェッジ積（<span class="tex2jax_process">$2$</span>-form）が <span class="tex2jax_process">$VW$</span> という一通りの計算で同時に出てくることがわかった。さらに一歩進めて、スカラー（<span class="tex2jax_process">$0$</span>-form）そのものも同じ代数に混ぜよう。
 </p>
-<p>パウリ行列の線形結合で表される最も一般的な $2\times2$ 行列は
+<p>パウリ行列の線形結合で表される最も一般的な <span class="tex2jax_process">$2\times2$</span> 行列は
 </p>
-<p>$$\psi = \varphi\,I + A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3$$
+<div class="math-block tex2jax_process">$$\psi = \varphi\,I + A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3$$</div>
+<p>の形をしている。<span class="tex2jax_process">$\varphi$</span> はスカラー（<span class="tex2jax_process">$0$</span>-form）、<span class="tex2jax_process">$A_1,A_2,A_3$</span> はベクトルの成分（<span class="tex2jax_process">$1$</span>-form）である。さらに <span class="tex2jax_process">$\psi$</span> に左から <span class="tex2jax_process">$\sigma_i$</span> を掛ければ、<span class="tex2jax_process">$2$</span>-form に相当する <span class="tex2jax_process">$i\sigma_k$</span> の項まで現れる。つまり、パウリ行列の代数は <span class="tex2jax_process">$0,1,2,3$</span>-form の<strong>すべての次数</strong>を一つの枠組みで扱えるのだ。
 </p>
-<p>の形をしている。$\varphi$ はスカラー（$0$-form）、$A_1,A_2,A_3$ はベクトルの成分（$1$-form）である。さらに $\psi$ に左から $\sigma_i$ を掛ければ、$2$-form に相当する $i\sigma_k$ の項まで現れる。つまり、パウリ行列の代数は $0,1,2,3$-form の<strong>すべての次数</strong>を一つの枠組みで扱えるのだ。
-</p>
-<blockquote><p>**注** （何ができるようになったのか）微分形式でも異なる次数の形式を直和として形式的に並べることはできる。しかし、内積（縮約）と外積（反対称化）を**一つの積として同時に**扱うには、通常のウェッジ積だけでは足りない。パウリ行列の代数では、それらが一つの積 $VW$ の中で自然に分離・共存する。これが幾何代数の核心である。</p>
+<blockquote><p>**注** （何ができるようになったのか）微分形式でも異なる次数の形式を直和として形式的に並べることはできる。しかし、内積（縮約）と外積（反対称化）を**一つの積として同時に**扱うには、通常のウェッジ積だけでは足りない。パウリ行列の代数では、それらが一つの積 <span class="tex2jax_process">$VW$</span> の中で自然に分離・共存する。これが幾何代数の核心である。</p>
 </p></blockquote>
-<blockquote><p>**注** （全次数の対応）パウリ行列の代数における次数対応を整理しておく。$I$ が $0$-form（スカラー）、$\sigma_1,\sigma_2,\sigma_3$ が $1$-form（ベクトル）、$i\sigma_1,i\sigma_2,i\sigma_3$ が $2$-form（バイベクトル）、$iI$ が $3$-form（擬スカラー）に対応する。最も一般的な元は $\psi = aI + \mathbf{v}\!\cdot\!\bm{\sigma} + i\,\mathbf{w}\!\cdot\!\bm{\sigma} + ibI$ の形で、4つの次数すべてを複素係数で含んでいる。</p>
+<blockquote><p>**注** （全次数の対応）パウリ行列の代数における次数対応を整理しておく。<span class="tex2jax_process">$I$</span> が <span class="tex2jax_process">$0$</span>-form（スカラー）、<span class="tex2jax_process">$\sigma_1,\sigma_2,\sigma_3$</span> が <span class="tex2jax_process">$1$</span>-form（ベクトル）、<span class="tex2jax_process">$i\sigma_1,i\sigma_2,i\sigma_3$</span> が <span class="tex2jax_process">$2$</span>-form（バイベクトル）、<span class="tex2jax_process">$iI$</span> が <span class="tex2jax_process">$3$</span>-form（擬スカラー）に対応する。最も一般的な元は <span class="tex2jax_process">$\psi = aI + \mathbf{v}\!\cdot\!\bm{\sigma} + i\,\mathbf{w}\!\cdot\!\bm{\sigma} + ibI$</span> の形で、4つの次数すべてを複素係数で含んでいる。</p>
 </p></blockquote>
-<blockquote><p>**注** （四元数——すでにあった魔法の箱）実はこの「スカラーとベクトルを一つの数に混ぜる」という発想は、パウリ行列よりもずっと古い。行列代数よりも古い。1843年にハミルトンが発見した**四元数（quaternion）** $q = a + bi + cj + dk$ がまさにそれだ。マクスウェルは自身の電磁気学を四元数で定式化していた。しかしその後、ギブズとヘヴィサイドが四元数からスカラー部分とベクトル部分を**分離**し、現代のベクトル解析（内積とクロス積）が誕生した。パウリ行列は、ギブズが分離したスカラーとベクトルを、約80年後に量子力学の文脈で再び**統合**したものである。歴史は一周したのだ。</p>
+<blockquote><p>**注** （四元数——すでにあった魔法の箱）実はこの「スカラーとベクトルを一つの数に混ぜる」という発想は、パウリ行列よりもずっと古い。行列代数よりも古い。1843年にハミルトンが発見した**四元数（quaternion）** <span class="tex2jax_process">$q = a + bi + cj + dk$</span> がまさにそれだ。マクスウェルは自身の電磁気学を四元数で定式化していた。しかしその後、ギブズとヘヴィサイドが四元数からスカラー部分とベクトル部分を**分離**し、現代のベクトル解析（内積とクロス積）が誕生した。パウリ行列は、ギブズが分離したスカラーとベクトルを、約80年後に量子力学の文脈で再び**統合**したものである。歴史は一周したのだ。</p>
 </p></blockquote>
-<blockquote><p>> **注** （行列なき時代のベクトル解析）ギブズとヘヴィサイドがベクトル解析を整備した1880年代には、まだ行列代数が存在しなかった。行列式はあったが、行列そのものの代数——積の非可換性、固有値、線形変換としての統一的理解——は、ケイリーの先駆的研究を経て、20世紀初頭のヒルベルトらによってようやく整備される。ギブズは線形変換を表すために**ダイアド（dyad）** $\mathbf{a}\mathbf{b}$ という独自の記法を発明したが、これは現代の行列 $\mathbf{a}\mathbf{b}^T$ に相当する。要するに、ベクトル解析は行列代数が存在しない時代に、四元数を切り刻み、ダイアドを継ぎ接ぎして作られた**キメラ**だったのだ。本書が「ナブラ解体新書」と題して $\nabla$ を $d$ と $\ast$ に解体し、最終章でパウリ行列による再統合を見せたことには、この百年越しの負債を清算する意味もある。</p>
+<blockquote><p>> **注** （行列なき時代のベクトル解析）ギブズとヘヴィサイドがベクトル解析を整備した1880年代には、まだ行列代数が存在しなかった。行列式はあったが、行列そのものの代数——積の非可換性、固有値、線形変換としての統一的理解——は、ケイリーの先駆的研究を経て、20世紀初頭のヒルベルトらによってようやく整備される。ギブズは線形変換を表すために**ダイアド（dyad）** <span class="tex2jax_process">$\mathbf{a}\mathbf{b}$</span> という独自の記法を発明したが、これは現代の行列 <span class="tex2jax_process">$\mathbf{a}\mathbf{b}^T$</span> に相当する。要するに、ベクトル解析は行列代数が存在しない時代に、四元数を切り刻み、ダイアドを継ぎ接ぎして作られた**キメラ**だったのだ。本書が「ナブラ解体新書」と題して <span class="tex2jax_process">$\nabla$</span> を <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> に解体し、最終章でパウリ行列による再統合を見せたことには、この百年越しの負債を清算する意味もある。</p>
 </p></blockquote>
 <blockquote><p>> **注** （行列代数が物理学者の標準語でなかったこと）なお、行列代数が物理学者の標準語でなかったことは、1925年の行列力学にもよく現れている。ハイゼンベルク自身は当初、自分の計算が行列の非可換積であることを知らず、それを行列として読んだのはボルンだった。</p>
 </p></blockquote>
 <hr />
 <h3 id="123-ディラック演算子と真のナブラ">§12.3 ディラック演算子と真のナブラ</h3>
-<h4 id="1231--すべてを統合する演算子">12.3.1 $\bm{\sigma}\!\cdot\!\nabla$ —— すべてを統合する演算子</h4>
-<p>パウリ行列とナブラ $\nabla = (\frac{\partial}{\partial x}, \frac{\partial}{\partial y}, \frac{\partial}{\partial z})$ を組み合わせて、次の演算子を定義する。
+<h4 id="1231-span-classtex2jaxprocessspan--すべてを統合する演算子">12.3.1 <span class="tex2jax_process">$\bm{\sigma}\!\cdot\!\nabla$</span> —— すべてを統合する演算子</h4>
+<p>パウリ行列とナブラ <span class="tex2jax_process">$\nabla = (\frac{\partial}{\partial x}, \frac{\partial}{\partial y}, \frac{\partial}{\partial z})$</span> を組み合わせて、次の演算子を定義する。
 </p>
-<p>$$D = \sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z} = \bm{\sigma}\!\cdot\!\nabla$$
+<div class="math-block tex2jax_process">$$D = \sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z} = \bm{\sigma}\!\cdot\!\nabla$$</div>
+<span class="tex2jax_process">$D$</span> は <span class="tex2jax_process">$2\times2$</span> 行列の形をした微分演算子である。これをスカラー場 <span class="tex2jax_process">$\varphi$</span> に作用させてみよう。
+<div class="math-block tex2jax_process">$$D\varphi = \sigma_1\frac{\partial\varphi}{\partial x} + \sigma_2\frac{\partial\varphi}{\partial y} + \sigma_3\frac{\partial\varphi}{\partial z} = (\nabla\varphi)\!\cdot\!\bm{\sigma}$$</div>
+<p>これは <span class="tex2jax_process">$\mathrm{grad}\,\varphi$</span> をパウリ行列で表したものだ。
 </p>
-<p>$D$ は $2\times2$ 行列の形をした微分演算子である。これをスカラー場 $\varphi$ に作用させてみよう。
+<p>次に、ベクトル場 <span class="tex2jax_process">$\mathbf{A} = (A_1, A_2, A_3)$</span> をパウリ行列で <span class="tex2jax_process">$A = \mathbf{A}\!\cdot\!\bm{\sigma}$</span> と書いて <span class="tex2jax_process">$D$</span> を作用させる。11.2.2 の積の公式を思い出そう。
 </p>
-<p>$$D\varphi = \sigma_1\frac{\partial\varphi}{\partial x} + \sigma_2\frac{\partial\varphi}{\partial y} + \sigma_3\frac{\partial\varphi}{\partial z} = (\nabla\varphi)\!\cdot\!\bm{\sigma}$$
-</p>
-<p>これは $\mathrm{grad}\,\varphi$ をパウリ行列で表したものだ。
-</p>
-<p>次に、ベクトル場 $\mathbf{A} = (A_1, A_2, A_3)$ をパウリ行列で $A = \mathbf{A}\!\cdot\!\bm{\sigma}$ と書いて $D$ を作用させる。11.2.2 の積の公式を思い出そう。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 D A &= (\sigma_1\tfrac{\partial}{\partial x} + \sigma_2\tfrac{\partial}{\partial y} + \sigma_3\tfrac{\partial}{\partial z})(A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3) \\[4pt]
 &= \tfrac{\partial A_1}{\partial x}\,\sigma_1\sigma_1 + \tfrac{\partial A_2}{\partial x}\,\sigma_1\sigma_2 + \tfrac{\partial A_3}{\partial x}\,\sigma_1\sigma_3 \\
 &\quad + \tfrac{\partial A_1}{\partial y}\,\sigma_2\sigma_1 + \tfrac{\partial A_2}{\partial y}\,\sigma_2\sigma_2 + \tfrac{\partial A_3}{\partial y}\,\sigma_2\sigma_3 \\
 &\quad + \tfrac{\partial A_1}{\partial z}\,\sigma_3\sigma_1 + \tfrac{\partial A_2}{\partial z}\,\sigma_3\sigma_2 + \tfrac{\partial A_3}{\partial z}\,\sigma_3\sigma_3
 \end{aligned}
-$$
+$$</div>
+<p>11.2.2 と同じ <span class="tex2jax_process">$\sigma_i\sigma_j$</span> の置き換えを9項に適用し、<span class="tex2jax_process">$I$</span> の係数（内積＝発散）と <span class="tex2jax_process">$\sigma_1,\sigma_2,\sigma_3$</span> の係数（ウェッジ積＝回転）を集める。
 </p>
-<p>11.2.2 と同じ $\sigma_i\sigma_j$ の置き換えを9項に適用し、$I$ の係数（内積＝発散）と $\sigma_1,\sigma_2,\sigma_3$ の係数（ウェッジ積＝回転）を集める。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 I\text{ の係数} &: \frac{\partial A_1}{\partial x} + \frac{\partial A_2}{\partial y} + \frac{\partial A_3}{\partial z} = \mathrm{div}\,\mathbf{A} \\
 \sigma_1\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_3}{\partial y} - \frac{\partial A_2}{\partial z}\right) \\
 \sigma_2\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_1}{\partial z} - \frac{\partial A_3}{\partial x}\right) \\
 \sigma_3\text{ の係数（$\wedge$）} &: i\,\left(\frac{\partial A_2}{\partial x} - \frac{\partial A_1}{\partial y}\right)
 \end{aligned}
-$$
-</p>
-<p>$\sigma_k$ の係数カッコ内は $\mathrm{rot}\,\mathbf{A}$ の各成分——外微分 $d$ が $1$-form $\mathbf{A}$ から生み出す $2$-form $d\mathbf{A}$ の成分——にほかならない。したがって
-</p>
-<p>$$D(\mathbf{A}\!\cdot\!\bm{\sigma}) = (\mathrm{div}\,\mathbf{A})\,I \;+\; i\,(\mathrm{rot}\,\mathbf{A})\!\cdot\!\bm{\sigma}$$
-</p>
-<strong>一つの演算子 $D$ が、$\mathrm{grad}$（$D\varphi$）、$\mathrm{div}$（$DA$ の実部）、$\mathrm{rot}$（$DA$ の虚部）をすべて産み出す。</strong> これこそが、$\nabla$ を $d$ と $\ast$ に解体した旅の、逆方向の結論——統合——にほかならない。
-<blockquote><p>**注** （$d$ と $\ast$ で書くと）$D$ は本書の言葉でも表現できる。符号規約を別にすれば、$D$ は $d$（次数を上げる）と $\ast d\ast$（次数を下げる）を合わせた演算子として理解できる。$\ast d\ast$ は**余微分（codifferential）** $\delta$ と呼ばれ、$\delta = \pm\ast d\ast$（符号は次元と次数に依存）と定義される。ここでは厳密な符号には立ち入らず、$D \sim d + \delta$ という構造だけを押さえておく。$d$ が次数を上げ、$\delta$ が次数を下げる——この二つを足した $D$ が、grad・rot・div を一つの演算子に束ねているのだ。</p>
+$$</div>
+<span class="tex2jax_process">$\sigma_k$</span> の係数カッコ内は <span class="tex2jax_process">$\mathrm{rot}\,\mathbf{A}$</span> の各成分——外微分 <span class="tex2jax_process">$d$</span> が <span class="tex2jax_process">$1$</span>-form <span class="tex2jax_process">$\mathbf{A}$</span> から生み出す <span class="tex2jax_process">$2$</span>-form <span class="tex2jax_process">$d\mathbf{A}$</span> の成分——にほかならない。したがって
+<div class="math-block tex2jax_process">$$D(\mathbf{A}\!\cdot\!\bm{\sigma}) = (\mathrm{div}\,\mathbf{A})\,I \;+\; i\,(\mathrm{rot}\,\mathbf{A})\!\cdot\!\bm{\sigma}$$</div>
+<strong>一つの演算子 <span class="tex2jax_process">$D$</span> が、<span class="tex2jax_process">$\mathrm{grad}$</span>（<span class="tex2jax_process">$D\varphi$</span>）、<span class="tex2jax_process">$\mathrm{div}$</span>（<span class="tex2jax_process">$DA$</span> の実部）、<span class="tex2jax_process">$\mathrm{rot}$</span>（<span class="tex2jax_process">$DA$</span> の虚部）をすべて産み出す。</strong> これこそが、<span class="tex2jax_process">$\nabla$</span> を <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> に解体した旅の、逆方向の結論——統合——にほかならない。
+<blockquote><p>**注** （<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> で書くと）<span class="tex2jax_process">$D$</span> は本書の言葉でも表現できる。符号規約を別にすれば、<span class="tex2jax_process">$D$</span> は <span class="tex2jax_process">$d$</span>（次数を上げる）と <span class="tex2jax_process">$\ast d\ast$</span>（次数を下げる）を合わせた演算子として理解できる。<span class="tex2jax_process">$\ast d\ast$</span> は**余微分（codifferential）** <span class="tex2jax_process">$\delta$</span> と呼ばれ、<span class="tex2jax_process">$\delta = \pm\ast d\ast$</span>（符号は次元と次数に依存）と定義される。ここでは厳密な符号には立ち入らず、<span class="tex2jax_process">$D \sim d + \delta$</span> という構造だけを押さえておく。<span class="tex2jax_process">$d$</span> が次数を上げ、<span class="tex2jax_process">$\delta$</span> が次数を下げる——この二つを足した <span class="tex2jax_process">$D$</span> が、grad・rot・div を一つの演算子に束ねているのだ。</p>
 </p></blockquote>
-<h4 id="1232--ラプラシアン">12.3.2 $D^2$ —— ラプラシアン</h4>
-<p>さらに $D$ を二度作用させるとどうなるか。
+<h4 id="1232-span-classtex2jaxprocessspan--ラプラシアン">12.3.2 <span class="tex2jax_process">$D^2$</span> —— ラプラシアン</h4>
+<p>さらに <span class="tex2jax_process">$D$</span> を二度作用させるとどうなるか。
 </p>
-<p>$$D^2 = (\bm{\sigma}\!\cdot\!\nabla)(\bm{\sigma}\!\cdot\!\nabla) = (\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})(\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})$$
-</p>
+<div class="math-block tex2jax_process">$$D^2 = (\bm{\sigma}\!\cdot\!\nabla)(\bm{\sigma}\!\cdot\!\nabla) = (\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})(\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})$$</div>
 <p>9項に展開する。
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 D^2 &= \sigma_1\sigma_1\,\frac{\partial^2}{\partial x^2} + \sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y} + \sigma_1\sigma_3\,\frac{\partial^2}{\partial x\partial z} \\
 &\quad + \sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x} + \sigma_2\sigma_2\,\frac{\partial^2}{\partial y^2} + \sigma_2\sigma_3\,\frac{\partial^2}{\partial y\partial z} \\
 &\quad + \sigma_3\sigma_1\,\frac{\partial^2}{\partial z\partial x} + \sigma_3\sigma_2\,\frac{\partial^2}{\partial z\partial y} + \sigma_3\sigma_3\,\frac{\partial^2}{\partial z^2}
 \end{aligned}
-$$
-</p>
-<p>$\sigma_i\sigma_j$ の反対称部分（$i\neq j$ の項、すなわち $\sigma_1\sigma_2 = i\sigma_3$ など）を含む項は、偏微分の可換性 $\frac{\partial^2}{\partial x\partial y} = \frac{\partial^2}{\partial y\partial x}$ により、符号が逆のペア同士で打ち消し合う。たとえば $\sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y}$ と $\sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x}$ は、$\sigma_2\sigma_1 = -\sigma_1\sigma_2$ かつ $\frac{\partial^2}{\partial y\partial x} = \frac{\partial^2}{\partial x\partial y}$ だから、足してゼロ。残るのは $\sigma_i\sigma_i = I$ の対角項だけである。
-</p>
-<p>$$D^2 = \left(\frac{\partial^2}{\partial x^2} + \frac{\partial^2}{\partial y^2} + \frac{\partial^2}{\partial z^2}\right)I = \nabla^2 I$$
-</p>
-<p>$D^2$ はラプラシアンそのものである。$D$ はラプラシアンの「平方根」なのだ。この事実——微分演算子の平方根をとる——が、ディラックが相対論的量子力学で電子の方程式を導いたときの核心的な洞察だった。
-</p>
+$$</div>
+<span class="tex2jax_process">$\sigma_i\sigma_j$</span> の反対称部分（<span class="tex2jax_process">$i\neq j$</span> の項、すなわち <span class="tex2jax_process">$\sigma_1\sigma_2 = i\sigma_3$</span> など）を含む項は、偏微分の可換性 <span class="tex2jax_process">$\frac{\partial^2}{\partial x\partial y} = \frac{\partial^2}{\partial y\partial x}$</span> により、符号が逆のペア同士で打ち消し合う。たとえば <span class="tex2jax_process">$\sigma_1\sigma_2\,\frac{\partial^2}{\partial x\partial y}$</span> と <span class="tex2jax_process">$\sigma_2\sigma_1\,\frac{\partial^2}{\partial y\partial x}$</span> は、<span class="tex2jax_process">$\sigma_2\sigma_1 = -\sigma_1\sigma_2$</span> かつ <span class="tex2jax_process">$\frac{\partial^2}{\partial y\partial x} = \frac{\partial^2}{\partial x\partial y}$</span> だから、足してゼロ。残るのは <span class="tex2jax_process">$\sigma_i\sigma_i = I$</span> の対角項だけである。
+<div class="math-block tex2jax_process">$$D^2 = \left(\frac{\partial^2}{\partial x^2} + \frac{\partial^2}{\partial y^2} + \frac{\partial^2}{\partial z^2}\right)I = \nabla^2 I$$</div>
+<span class="tex2jax_process">$D^2$</span> はラプラシアンそのものである。<span class="tex2jax_process">$D$</span> はラプラシアンの「平方根」なのだ。この事実——微分演算子の平方根をとる——が、ディラックが相対論的量子力学で電子の方程式を導いたときの核心的な洞察だった。
 <h4 id="1233-マクスウェルを一本に--再訪">12.3.3 マクスウェルを一本に —— 再訪</h4>
-<p>§12.1 では $F + i\ast F$ によって4次元でマクスウェル方程式を一本化した。$D$ を使えば、同じことが3次元の言葉だけで書ける。
+<p>§12.1 では <span class="tex2jax_process">$F + i\ast F$</span> によって4次元でマクスウェル方程式を一本化した。<span class="tex2jax_process">$D$</span> を使えば、同じことが3次元の言葉だけで書ける。
 </p>
-<p>電場 $\mathbf{E}$ と磁場 $\mathbf{B}$ を一つの複素ベクトルに束ねる。これは<strong>リーマン－ジルバーシュタイン・ベクトル</strong>と呼ばれる。
+<p>電場 <span class="tex2jax_process">$\mathbf{E}$</span> と磁場 <span class="tex2jax_process">$\mathbf{B}$</span> を一つの複素ベクトルに束ねる。これは<strong>リーマン－ジルバーシュタイン・ベクトル</strong>と呼ばれる。
 </p>
-<p>$$\mathbf{F} = \mathbf{E} + i\mathbf{B}$$
+<div class="math-block tex2jax_process">$$\mathbf{F} = \mathbf{E} + i\mathbf{B}$$</div>
+<p>パウリ行列で書けば <span class="tex2jax_process">$F = \mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma}$</span> である。<span class="tex2jax_process">$F$</span> はスカラー部を持たない純粋な複素パウリ・ベクトルだ。時間微分を含めた演算子 <span class="tex2jax_process">$D + \frac{\partial}{\partial t}$</span> を作用させる。
 </p>
-<p>パウリ行列で書けば $F = \mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma}$ である。$F$ はスカラー部を持たない純粋な複素パウリ・ベクトルだ。時間微分を含めた演算子 $D + \frac{\partial}{\partial t}$ を作用させる。
+<div class="math-block tex2jax_process">$$(D + \frac{\partial}{\partial t})F = (\bm{\sigma}\!\cdot\!\nabla + \frac{\partial}{\partial t})(\mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma})$$</div>
+<p>§12.3.1 の <span class="tex2jax_process">$D(\mathbf{A}\!\cdot\!\bm{\sigma})$</span> の公式を <span class="tex2jax_process">$\mathbf{E}$</span> と <span class="tex2jax_process">$\mathbf{B}$</span> の両方に適用する。
 </p>
-<p>$$(D + \frac{\partial}{\partial t})F = (\bm{\sigma}\!\cdot\!\nabla + \frac{\partial}{\partial t})(\mathbf{E}\!\cdot\!\bm{\sigma} + i\,\mathbf{B}\!\cdot\!\bm{\sigma})$$
-</p>
-<p>§12.3.1 の $D(\mathbf{A}\!\cdot\!\bm{\sigma})$ の公式を $\mathbf{E}$ と $\mathbf{B}$ の両方に適用する。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 (D + \frac{\partial}{\partial t})F &= (\mathrm{div}\,\mathbf{E})\,I + i\,(\mathrm{rot}\,\mathbf{E})\!\cdot\!\bm{\sigma} + \frac{\partial}{\partial t}\mathbf{E}\!\cdot\!\bm{\sigma} \\
 &\quad + i\,(\mathrm{div}\,\mathbf{B})\,I - (\mathrm{rot}\,\mathbf{B})\!\cdot\!\bm{\sigma} + i\,\frac{\partial}{\partial t}\mathbf{B}\!\cdot\!\bm{\sigma}
 \end{aligned}
-$$
+$$</div>
+<p>実部と虚部、そして <span class="tex2jax_process">$I$</span>（スカラー）と <span class="tex2jax_process">$\bm{\sigma}$</span>（ベクトル）の各成分に整理する。
 </p>
-<p>実部と虚部、そして $I$（スカラー）と $\bm{\sigma}$（ベクトル）の各成分に整理する。
-</p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \begin{aligned}
 \text{実部・}I &: \mathrm{div}\,\mathbf{E} - 0 \\
 \text{実部・}\bm{\sigma} &: \frac{\partial}{\partial t}\mathbf{E} - \mathrm{rot}\,\mathbf{B} \\
 \text{虚部・}I &: 0 + \mathrm{div}\,\mathbf{B} \\
 \text{虚部・}\bm{\sigma} &: \mathrm{rot}\,\mathbf{E} + \frac{\partial}{\partial t}\mathbf{B}
 \end{aligned}
-$$
+$$</div>
+<p>これらをゼロとおけば、真空のマクスウェル方程式4本がすべて現れる。電流 <span class="tex2jax_process">$\mathbf{J}$</span> と電荷 <span class="tex2jax_process">$\rho$</span> がある場合は、右辺に <span class="tex2jax_process">$\rho + \mathbf{J}\!\cdot\!\bm{\sigma}$</span> を置けばよい。
 </p>
-<p>これらをゼロとおけば、真空のマクスウェル方程式4本がすべて現れる。電流 $\mathbf{J}$ と電荷 $\rho$ がある場合は、右辺に $\rho + \mathbf{J}\!\cdot\!\bm{\sigma}$ を置けばよい。
+<div class="math-block tex2jax_process">$$(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$$</div>
+<span class="tex2jax_process">$dF=0$</span> と <span class="tex2jax_process">$d(\ast F)=\mu_0(\ast\mathcal{J})$</span> の2本が、<span class="tex2jax_process">$D$</span> の前ではたった一本の複素方程式に統合された。§12.1 の4次元トリックが特殊な次元に依存していたのに対し、こちらは <span class="tex2jax_process">$D$</span> という統合された演算子そのものが統合を実現している。
+<h4 id="1234-span-classtex2jaxprocessspan--4次元時空のディラック演算子">12.3.4 <span class="tex2jax_process">$\cancel{\partial} F = J$</span> —— 4次元時空のディラック演算子</h4>
+<p>§12.3.3 の <span class="tex2jax_process">$(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$</span> には、時間と空間が分離して現れている。これは3次元のパウリ行列 <span class="tex2jax_process">$\sigma_1,\sigma_2,\sigma_3$</span> をベースに組み立てたからだ。4次元時空を最初から扱えば、この分離すら消える。
 </p>
-<p>$$(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$$
+<p>パウリ行列を <span class="tex2jax_process">$4\times4$</span> に拡張したものが<strong>ガンマ行列</strong> <span class="tex2jax_process">$\gamma^0,\gamma^1,\gamma^2,\gamma^3$</span> である。これらは反可換性 <span class="tex2jax_process">$\gamma^\mu\gamma^\nu + \gamma^\nu\gamma^\mu = 2g^{\mu\nu}I$</span> を満たす（<span class="tex2jax_process">$g^{\mu\nu}$</span> はミンコフスキー計量）。このガンマ行列を用いて、4次元のディラック演算子を
 </p>
-<p>$dF=0$ と $d(\ast F)=\mu_0(\ast\mathcal{J})$ の2本が、$D$ の前ではたった一本の複素方程式に統合された。§12.1 の4次元トリックが特殊な次元に依存していたのに対し、こちらは $D$ という統合された演算子そのものが統合を実現している。
+<div class="math-block tex2jax_process">$$\cancel{\partial} = \gamma^0\frac{\partial}{\partial t} + \gamma^1\frac{\partial}{\partial x} + \gamma^2\frac{\partial}{\partial y} + \gamma^3\frac{\partial}{\partial z}$$</div>
+<p>と定義する。第10章の電磁場 <span class="tex2jax_process">$F$</span>（<span class="tex2jax_process">$4\times4$</span> 反対称行列）をガンマ行列のウェッジ積 <span class="tex2jax_process">$\gamma^\mu\!\wedge\!\gamma^\nu$</span> で展開したものと同一視すれば、マクスウェル方程式は
 </p>
-<h4 id="1234--4次元時空のディラック演算子">12.3.4 $\cancel{\partial} F = J$ —— 4次元時空のディラック演算子</h4>
-<p>§12.3.3 の $(D + \frac{\partial}{\partial t})F = \rho + \mathbf{J}\!\cdot\!\bm{\sigma}$ には、時間と空間が分離して現れている。これは3次元のパウリ行列 $\sigma_1,\sigma_2,\sigma_3$ をベースに組み立てたからだ。4次元時空を最初から扱えば、この分離すら消える。
+<div class="math-block tex2jax_process">$$\cancel{\partial} F = J$$</div>
+<p>の一行になる。<span class="tex2jax_process">$F$</span> は電磁場、<span class="tex2jax_process">$J$</span> は4元電流（<span class="tex2jax_process">$\gamma^\mu$</span> で展開されたもの）。真空では <span class="tex2jax_process">$\cancel{\partial} F = 0$</span>。
 </p>
-<p>パウリ行列を $4\times4$ に拡張したものが<strong>ガンマ行列</strong> $\gamma^0,\gamma^1,\gamma^2,\gamma^3$ である。これらは反可換性 $\gamma^\mu\gamma^\nu + \gamma^\nu\gamma^\mu = 2g^{\mu\nu}I$ を満たす（$g^{\mu\nu}$ はミンコフスキー計量）。このガンマ行列を用いて、4次元のディラック演算子を
-</p>
-<p>$$\cancel{\partial} = \gamma^0\frac{\partial}{\partial t} + \gamma^1\frac{\partial}{\partial x} + \gamma^2\frac{\partial}{\partial y} + \gamma^3\frac{\partial}{\partial z}$$
-</p>
-<p>と定義する。第10章の電磁場 $F$（$4\times4$ 反対称行列）をガンマ行列のウェッジ積 $\gamma^\mu\!\wedge\!\gamma^\nu$ で展開したものと同一視すれば、マクスウェル方程式は
-</p>
-<p>$$\cancel{\partial} F = J$$
-</p>
-<p>の一行になる。$F$ は電磁場、$J$ は4元電流（$\gamma^\mu$ で展開されたもの）。真空では $\cancel{\partial} F = 0$。
-</p>
-<blockquote><p>**注** （$\cancel{\partial} F$ の積について）ここでの積は通常の行列積ではなく、ガンマ行列が生成する幾何代数の積である。第10章の反対称行列 $F$ は、ここでは $\gamma^\mu\!\wedge\!\gamma^\nu$ で展開された2-vectorとして再解釈される。細部は幾何代数の教科書に譲るが、$\sigma_i\sigma_j = \delta_{ij}I + i\varepsilon_{ijk}\sigma_k$（11.2.1）の4次元版がここでも成り立っていると考えればよい。</p>
+<blockquote><p>**注** （<span class="tex2jax_process">$\cancel{\partial} F$</span> の積について）ここでの積は通常の行列積ではなく、ガンマ行列が生成する幾何代数の積である。第10章の反対称行列 <span class="tex2jax_process">$F$</span> は、ここでは <span class="tex2jax_process">$\gamma^\mu\!\wedge\!\gamma^\nu$</span> で展開された2-vectorとして再解釈される。細部は幾何代数の教科書に譲るが、<span class="tex2jax_process">$\sigma_i\sigma_j = \delta_{ij}I + i\varepsilon_{ijk}\sigma_k$</span>（11.2.1）の4次元版がここでも成り立っていると考えればよい。</p>
 </p></blockquote>
-<p>§12.1 の $F + i\ast F$ も、§12.3.3 の $(D + \frac{\partial}{\partial t})F$ も、すべてこの一行に吸収される。これが、$\nabla$ の解体から始まった旅の、最も遠くにある風景である。ディラックが1928年に電子の方程式を導くために発見したこの演算子は、時空の幾何と物理法則を一つの代数で記述する<strong>幾何代数（Geometric Algebra）</strong>の核であり、Doran & Lasenby の Geometric Algebra for Physicists に詳しい。
+<p>§12.1 の <span class="tex2jax_process">$F + i\ast F$</span> も、§12.3.3 の <span class="tex2jax_process">$(D + \frac{\partial}{\partial t})F$</span> も、すべてこの一行に吸収される。これが、<span class="tex2jax_process">$\nabla$</span> の解体から始まった旅の、最も遠くにある風景である。ディラックが1928年に電子の方程式を導くために発見したこの演算子は、時空の幾何と物理法則を一つの代数で記述する<strong>幾何代数（Geometric Algebra）</strong>の核であり、Doran & Lasenby の Geometric Algebra for Physicists に詳しい。
 </p>
-<h3 id="124-演算子">§12.4 演算子$\nabla$</h3>
-<p>さあ、ここで最初の問いに戻ろう。$\nabla$ とは何だったのか。
+<h3 id="124-演算子span-classtex2jaxprocessspan">§12.4 演算子<span class="tex2jax_process">$\nabla$</span></h3>
+<p>さあ、ここで最初の問いに戻ろう。<span class="tex2jax_process">$\nabla$</span> とは何だったのか。
 </p>
-<p>ベクトル解析では、$\nabla$ は「偏微分を並べた形式的なベクトル」として導入され、grad・rot・div の三つの顔を持つ謎めいた記号だった。本書はそれを $d$ と $\ast$ に<strong>解体</strong>することで、各演算の正体を明らかにしてきた。
+<p>ベクトル解析では、<span class="tex2jax_process">$\nabla$</span> は「偏微分を並べた形式的なベクトル」として導入され、grad・rot・div の三つの顔を持つ謎めいた記号だった。本書はそれを <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> に<strong>解体</strong>することで、各演算の正体を明らかにしてきた。
 </p>
-<p>そして今、これを逆方向に辿り、$d$ と $\ast$ というバラバラだった部品が、幾何代数の中で3次元のディラック演算子$D = \bm{\sigma}\!\cdot\!\nabla$ として<strong>統合</strong>され、更にその4次元版のディラック演算子$\cancel{\partial}$が究極のマクスウェル方程式$\cancel{\partial} F = J$を与えた。
+<p>そして今、これを逆方向に辿り、<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> というバラバラだった部品が、幾何代数の中で3次元のディラック演算子<span class="tex2jax_process">$D = \bm{\sigma}\!\cdot\!\nabla$</span> として<strong>統合</strong>され、更にその4次元版のディラック演算子<span class="tex2jax_process">$\cancel{\partial}$</span>が究極のマクスウェル方程式<span class="tex2jax_process">$\cancel{\partial} F = J$</span>を与えた。
 </p>
-<p>ところで、幾何代数の文脈では、この演算子を必ずしも$\cancel{\partial}$ とは書かない。むしろ、この種のベクトル微分演算子を
+<p>ところで、幾何代数の文脈では、この演算子を必ずしも<span class="tex2jax_process">$\cancel{\partial}$</span> とは書かない。むしろ、この種のベクトル微分演算子を
 </p>
-<p>$$
+<div class="math-block tex2jax_process">$$
 \nabla
-$$
-</p>
+$$</div>
 <p>と書く。
 </p>
 <p>\newpage
@@ -5549,19 +5056,19 @@ $$
 </p>
 <p>本書を閉じるにあたり、この奇妙で、いささか強引な構成を持つ『ナブラ解体新書』がいかにして生まれたのか、少しだけ舞台裏の話をさせてほしい。
 </p>
-<p>ことの発端は、私自身の苦い記憶にある。多くの物理学徒と同じように、私もまた「ベクトル解析」の泥沼で溺れかけた一人だった。円柱座標や球座標の $\mathrm{rot}$ や $\mathrm{div}$ を前に、「なぜこんな形になるのか」という問いは「とにかく公式を暗記せよ」という圧力に封殺された。微分形式がその特効薬であることは知っていたが、数学書の公理的アプローチは初学者の私には抽象度が高すぎた。
+<p>ことの発端は、私自身の苦い記憶にある。多くの物理学徒と同じように、私もまた「ベクトル解析」の泥沼で溺れかけた一人だった。円柱座標や球座標の <span class="tex2jax_process">$\mathrm{rot}$</span> や <span class="tex2jax_process">$\mathrm{div}$</span> を前に、「なぜこんな形になるのか」という問いは「とにかく公式を暗記せよ」という圧力に封殺された。微分形式がその特効薬であることは知っていたが、数学書の公理的アプローチは初学者の私には抽象度が高すぎた。
 </p>
-<p>「旧体制の泥沼から抜け出す、安全で強力な『バイパス』は架けられないものか」——そう考えていた私に、第一のブレイクスルーが訪れた。個人的な話になるが、当時の私は量子力学の勉強になかなかのめり込んでおり、ディラックの「ブラ・ケット記法」の扱いに慣れ親しんでいた。状態ベクトル（タテベクトル）を双対ベクトル（ヨコベクトル）として寝かせ、行列の積として颯爽と計算していく、あの感覚である。ふと、この私の中にあった量子力学の直観を、古典的な3次元ユークリッド空間の $dx, dy, dz$ にそのままパッチ当てしてみたらどうだろうかと考えた。積分記号の尻尾の $dx$ を「変位ベクトルから成分を抽出するヨコベクトル（行列）」として定義し直せば、「ベクトルを食べる関数（1-form）」という抽象概念を、誰もが知る「行列の掛け算」へと瞬時に変換できるのだ。
+<p>「旧体制の泥沼から抜け出す、安全で強力な『バイパス』は架けられないものか」——そう考えていた私に、第一のブレイクスルーが訪れた。個人的な話になるが、当時の私は量子力学の勉強になかなかのめり込んでおり、ディラックの「ブラ・ケット記法」の扱いに慣れ親しんでいた。状態ベクトル（タテベクトル）を双対ベクトル（ヨコベクトル）として寝かせ、行列の積として颯爽と計算していく、あの感覚である。ふと、この私の中にあった量子力学の直観を、古典的な3次元ユークリッド空間の <span class="tex2jax_process">$dx, dy, dz$</span> にそのままパッチ当てしてみたらどうだろうかと考えた。積分記号の尻尾の <span class="tex2jax_process">$dx$</span> を「変位ベクトルから成分を抽出するヨコベクトル（行列）」として定義し直せば、「ベクトルを食べる関数（1-form）」という抽象概念を、誰もが知る「行列の掛け算」へと瞬時に変換できるのだ。
 </p>
 <p>しかし、これだけではまだ足りなかった。そこで第二のブレイクスルーをもたらしてくれたのが、W. L. Burke が提唱した「計量導入の遅延（put the metric later and later into the course）」という強烈な教育的哲学だった。私は決意した。この高度な哲学を、読者を巻き込む「目次構成のエンターテインメント」にしてやろう、と。
 </p>
-<p>第1章から第5章までは、計量という概念を形式的に定義せず、実空間 $(x,y,z)$ における小学校以来の素朴な長さ・面積の定義で押し通した。数学者から見れば「面積には計量が必要だ」と眉をひそめられるだろうが、$xyz$ のデカルト座標でピタゴラスの定理が成り立つ限り、それで十分なのだ。計量 $g = J^T J$ が真に必要になるのは、パラメータ空間のような目盛りの歪んだ座標系へ一般化するときである——その事実を、第6章で行列計算を通じて発見的に暴き出した。
+<p>第1章から第5章までは、計量という概念を形式的に定義せず、実空間 <span class="tex2jax_process">$(x,y,z)$</span> における小学校以来の素朴な長さ・面積の定義で押し通した。数学者から見れば「面積には計量が必要だ」と眉をひそめられるだろうが、<span class="tex2jax_process">$xyz$</span> のデカルト座標でピタゴラスの定理が成り立つ限り、それで十分なのだ。計量 <span class="tex2jax_process">$g = J^T J$</span> が真に必要になるのは、パラメータ空間のような目盛りの歪んだ座標系へ一般化するときである——その事実を、第6章で行列計算を通じて発見的に暴き出した。
 </p>
-<p>そして迎えた第6章の冒頭。「筆者もそろそろ飽きてきた」と、数学者へのエクスキューズを打ち切り、内積を正式に定義した。同時に、計量 $g = J^T J$ の正体を明らかにし、ホッジ・スター $\ast$ を「微分形式とベクトル解析を繫ぐ型変換アダプタ」として位置づけた。この発見的構成を通じて、「勾配（ $d$ ）は計量に依存しないが、回転や発散（ $\ast d$ や $\ast d \ast$ ）は計量に依存している」という真理を、読者に骨の髄まで納得してもらうための仕掛けだった。
+<p>そして迎えた第6章の冒頭。「筆者もそろそろ飽きてきた」と、数学者へのエクスキューズを打ち切り、内積を正式に定義した。同時に、計量 <span class="tex2jax_process">$g = J^T J$</span> の正体を明らかにし、ホッジ・スター <span class="tex2jax_process">$\ast$</span> を「微分形式とベクトル解析を繫ぐ型変換アダプタ」として位置づけた。この発見的構成を通じて、「勾配（ <span class="tex2jax_process">$d$</span> ）は計量に依存しないが、回転や発散（ <span class="tex2jax_process">$\ast d$</span> や <span class="tex2jax_process">$\ast d \ast$</span> ）は計量に依存している」という真理を、読者に骨の髄まで納得してもらうための仕掛けだった。
 </p>
-<p>これらのアイデアのうち、Burke の「計量遅延」哲学や Flanders の微分形式の物理応用は、いずれも既存の英語文献に書かれている。本書の内容に数学的な新規性はない。ただ、$dx$ を行列として定義し全編を通じて行列計算で押し切るこの構成は、筆者の知る限り洋書にも見当たらない。東アジアの学生が行列計算に異様に訓練されているだけなのだろうか——などと茶化しつつ、いずれにせよ筆者が自分自身のために書いたものを整理したに過ぎない。本書が立っている巨人たちの肩については、巻末の参考文献を見てほしい。
+<p>これらのアイデアのうち、Burke の「計量遅延」哲学や Flanders の微分形式の物理応用は、いずれも既存の英語文献に書かれている。本書の内容に数学的な新規性はない。ただ、<span class="tex2jax_process">$dx$</span> を行列として定義し全編を通じて行列計算で押し切るこの構成は、筆者の知る限り洋書にも見当たらない。東アジアの学生が行列計算に異様に訓練されているだけなのだろうか——などと茶化しつつ、いずれにせよ筆者が自分自身のために書いたものを整理したに過ぎない。本書が立っている巨人たちの肩については、巻末の参考文献を見てほしい。
 </p>
-<p>本書は、ベクトル解析に挫折したかつての私自身に向けて書いた「サバイバルガイド」である。「ホッジ・スター $\ast$ が空間の歪み（計量）に依存する」というツールの限界を知った今のあなたなら、すでに次の世界への扉を開いている。
+<p>本書は、ベクトル解析に挫折したかつての私自身に向けて書いた「サバイバルガイド」である。「ホッジ・スター <span class="tex2jax_process">$\ast$</span> が空間の歪み（計量）に依存する」というツールの限界を知った今のあなたなら、すでに次の世界への扉を開いている。
 </p>
 <p>ここで、本書を読破したあなたに最後に伝えたいことがある。本書は「計量」と「トポロジー」を分離する方針で始まったが、正直なところ、計量は随所でこっそり漏れ出ている。このあたりの徹底ぶりは Burke の原著には遠く及ばない。ほどほどに分離しつつ、行きつ戻りつしながらようやく辿り着いたのが本書の姿だ。しかし、この不完全さには思いがけない効用がある。骨の髄まで分離の苦しみを味わったあなたは、次に出会う「統合」に備えている。C. Doran と A. Lasenby らが提唱する「幾何代数（Geometric Algebra）」——そこでは、我々が引き裂いてきた内積と外積が、最初から「幾何積」として一つに融合している。抽象的な理論としてではなく、長年の煩わしさからの解放として、それは感じられるはずだ。筆者も未だその全容を掴めず、しかしその魅力に惹かれて探求中である。この苦しみを共有した読者の中から、この先、同じように強く惹きつけられる人が少なからず現れるのではないかと思う。
 </p>
@@ -5578,15 +5085,15 @@ $$
 </p>
 <hr />
 <strong>2. David Bachman, <em>A Geometric Approach to Differential Forms</em>, Birkhäuser</strong>
-<p>【コメント：微分形式の視覚的・幾何学的アプローチ】微分形式を公理や代数ではなく、「平面への投影」などの幾何学的なイメージで視覚的に捉えようとする意欲作。本書の第1章・第2章で「 $dx$ は測定器である」という直観を形成する上で大きなインスピレーションを受けたが、成分計算への摩擦を減らすため、本書ではこの幾何学的直観を「行列計算」へと変換して採用した。
+<p>【コメント：微分形式の視覚的・幾何学的アプローチ】微分形式を公理や代数ではなく、「平面への投影」などの幾何学的なイメージで視覚的に捉えようとする意欲作。本書の第1章・第2章で「 <span class="tex2jax_process">$dx$</span> は測定器である」という直観を形成する上で大きなインスピレーションを受けたが、成分計算への摩擦を減らすため、本書ではこの幾何学的直観を「行列計算」へと変換して採用した。
 </p>
 <hr />
 <strong>3. Harley Flanders, <em>Differential Forms with Applications to the Physical Sciences</em>, Dover Publications</strong>
-<p>【コメント：純粋数学と物理学を繋ぐ古典的バイブル】微分形式を物理学へ応用する際の古典的な名著であり、外微分 $d$ やホッジ・スター $\ast$ の厳密な操作ルールはすべてここにある。ただし、双対空間などの純粋数学的な公理的アプローチから入るため、初学者には敷居が高い。本書は、読者をこの Flanders の実戦レベルまで一気に引き上げることを目標とした。
+<p>【コメント：純粋数学と物理学を繋ぐ古典的バイブル】微分形式を物理学へ応用する際の古典的な名著であり、外微分 <span class="tex2jax_process">$d$</span> やホッジ・スター <span class="tex2jax_process">$\ast$</span> の厳密な操作ルールはすべてここにある。ただし、双対空間などの純粋数学的な公理的アプローチから入るため、初学者には敷居が高い。本書は、読者をこの Flanders の実戦レベルまで一気に引き上げることを目標とした。
 </p>
 <hr />
 <strong>4. William L. Burke, <em>Applied Differential Geometry</em>, Cambridge University Press</strong>
-<p>【コメント：本書の精神的支柱——「計量遅延」の哲学】本書の構成の骨格を決定づけた最重要文献。"metric-blinded symbol pushing"（計量に盲目化された数式いじり）を痛烈に批判し、「計量をコースのどんどん後の方に遅らせる（put the metric later and later into the course）」という強烈な教育的哲学を提唱した。本書の「第6章までの計量の形式的定義の後回しと、第6章での $g = J^T J$ としての発見的導入」という構成は、この Burke の思想へのオマージュである。
+<p>【コメント：本書の精神的支柱——「計量遅延」の哲学】本書の構成の骨格を決定づけた最重要文献。"metric-blinded symbol pushing"（計量に盲目化された数式いじり）を痛烈に批判し、「計量をコースのどんどん後の方に遅らせる（put the metric later and later into the course）」という強烈な教育的哲学を提唱した。本書の「第6章までの計量の形式的定義の後回しと、第6章での <span class="tex2jax_process">$g = J^T J$</span> としての発見的導入」という構成は、この Burke の思想へのオマージュである。
 </p>
 <hr />
 <strong>5. Leonard Susskind & Art Friedman, <em>Quantum Mechanics: The Theoretical Minimum</em>, Basic Books</strong>
@@ -5595,7 +5102,7 @@ $$
 </p>
 <hr />
 <strong>6. Chris Doran & Anthony Lasenby, <em>Geometric Algebra for Physicists</em>, Cambridge University Press</strong>
-<p>【コメント：本書の先にある究極の世界——計量と幾何の統合】本書を終えた読者が次に向かうべき、現代物理学の最前線（幾何代数）。本書では Burke の哲学に倣い「計量」と「幾何」を徹底的に分離（ $d$ と $\ast$ ）したが、幾何代数では「幾何積」として最初からそれらが不可分に統合されている。分離の苦しみを知った読者こそが、この統合のパラダイムの真の美しさを理解できるはずだ。
+<p>【コメント：本書の先にある究極の世界——計量と幾何の統合】本書を終えた読者が次に向かうべき、現代物理学の最前線（幾何代数）。本書では Burke の哲学に倣い「計量」と「幾何」を徹底的に分離（ <span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\ast$</span> ）したが、幾何代数では「幾何積」として最初からそれらが不可分に統合されている。分離の苦しみを知った読者こそが、この統合のパラダイムの真の美しさを理解できるはずだ。
 </p>
 <p>\newpage
 </p>
@@ -5623,17 +5130,17 @@ $$
 <p>  → 第1章 §1.1.6 で「縦ベクトル（変位）」と「横ベクトル（測定器）」の区別を導入しており、これは双対空間の概念の具体的な実装である。より抽象的な双対空間の定式化については第6章および第11章で接続する。
 </p>
 <ul>
-<li>**$dx$ を横ベクトルとして扱う記法は数学書の標準的な表記ではない**</li>
+<li>**<span class="tex2jax_process">$dx$</span> を横ベクトルとして扱う記法は数学書の標準的な表記ではない**</li>
 </ol>
 <p>  → 意図的な選択である。第1章 §1.1 で定義し、全章で一貫して使用している。この記法の狙いは「1-form = ベクトルを食べる関数」という抽象概念を、読者が既知の「行列の掛け算」に翻訳することにある。標準的な微分形式の記法との対応は第11章で示す。また、双対を横ベクトルで表すこと自体は、行列代数・数値計算・量子情報で広く行われている。
 </p>
 <ul>
-<li>**外微分 $d$ は公理（ライプニッツ則や $d^2=0$）から一般的に定義すべきである**</li>
+<li>**外微分 <span class="tex2jax_process">$d$</span> は公理（ライプニッツ則や <span class="tex2jax_process">$d^2=0$</span>）から一般的に定義すべきである**</li>
 </ol>
-<p>  → 本書では公理から始めるのではなく、§4.2–§4.4 で「微小ループを一周したときのズレ」という物理的直感から発見的に $d$ を導出している。$d^2=0$ は §4.4 で積分経路の連続変形から証明される。公理的定義は第11章で補足する。
+<p>  → 本書では公理から始めるのではなく、§4.2–§4.4 で「微小ループを一周したときのズレ」という物理的直感から発見的に <span class="tex2jax_process">$d$</span> を導出している。<span class="tex2jax_process">$d^2=0$</span> は §4.4 で積分経路の連続変形から証明される。公理的定義は第11章で補足する。
 </p>
 <ul>
-<li>**一般の $n$ 次元多様体におけるストークスの定理の完全な証明が記載されていない**</li>
+<li>**一般の <span class="tex2jax_process">$n$</span> 次元多様体におけるストークスの定理の完全な証明が記載されていない**</li>
 </ol>
 <p>  → 本書では3次元デカルト空間での具体的なケース（ガウスの定理・ストークスの定理・グリーンの定理）を積分の定義から直接導出する（第8章）。一般次元のストークスの定理の証明は本書の射程外であり、第11章で道標のみ示す。
 </p>
@@ -5650,7 +5157,7 @@ $$
 <ul>
 <li>**標準的な記法を避けているため、独自流派を主張しているように見える**</li>
 </ol>
-<p>  → 本書の記法は「初学者が行列計算で手を動かせる」ことを最優先に選ばれている。標準的な記法（添字による縮約、$\partial_\mu$ など）を敢えて使わない理由は第11章 §10.1 で説明している。この方針自体は数値計算の分野などでは広く見られるもので、著者が特に新しいことを主張しているつもりはない。意外と和書がなかったので、筆者が書いたまでである。
+<p>  → 本書の記法は「初学者が行列計算で手を動かせる」ことを最優先に選ばれている。標準的な記法（添字による縮約、<span class="tex2jax_process">$\partial_\mu$</span> など）を敢えて使わない理由は第11章 §10.1 で説明している。この方針自体は数値計算の分野などでは広く見られるもので、著者が特に新しいことを主張しているつもりはない。意外と和書がなかったので、筆者が書いたまでである。
 </p>
 <hr />
 <h2 id="II-手法の選択と適用限界について">II. 手法の選択と適用限界について</h2>
@@ -5662,17 +5169,17 @@ $$
 <ul>
 <li>**最初からクリフォード代数（幾何代数）を教えれば外積も内積も統合できる**</li>
 </ol>
-<p>  → 本書はあえて「分離」の道を選んだ。§5.4 で外積（$\wedge$）と内積（$g$）を分けて構成し、その後に §5.3 でホッジ・スター $\ast$ を導入することで「なぜ統合が必要になるのか」を読者が実感できるようにしている。幾何代数による統合は第12章で紹介する。
+<p>  → 本書はあえて「分離」の道を選んだ。§5.4 で外積（<span class="tex2jax_process">$\wedge$</span>）と内積（<span class="tex2jax_process">$g$</span>）を分けて構成し、その後に §5.3 でホッジ・スター <span class="tex2jax_process">$\ast$</span> を導入することで「なぜ統合が必要になるのか」を読者が実感できるようにしている。幾何代数による統合は第12章で紹介する。
 </p>
 <ul>
-<li>**定数行列の計量 $\mathbf{g}$ を前提としているため、空間が曲がった場合に破綻するのではないか**</li>
+<li>**定数行列の計量 <span class="tex2jax_process">$\mathbf{g}$</span> を前提としているため、空間が曲がった場合に破綻するのではないか**</li>
 </ol>
-<p>  → 第6章で $xyz$ 実空間の計量 $\mathbf{g}=I$ から出発し、パラメータ空間では $\mathbf{g}=J^T J$ が場所の関数になることを示している。曲がった空間（リーマン多様体）への一般化は第11章で道標を示す。本書の $\mathbf{g}=J^T J$ という表式は、そのまま一般の計量の定義へ接続可能である。
+<p>  → 第6章で <span class="tex2jax_process">$xyz$</span> 実空間の計量 <span class="tex2jax_process">$\mathbf{g}=I$</span> から出発し、パラメータ空間では <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> が場所の関数になることを示している。曲がった空間（リーマン多様体）への一般化は第11章で道標を示す。本書の <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> という表式は、そのまま一般の計量の定義へ接続可能である。
 </p>
 <ul>
 <li>**第6章の正定値計量の導入から、第10章の擬リーマン計量への適用は論理的に飛躍している**</li>
 </ol>
-<p>  → 第10章 §9.3 の注で明記しているように、第10章では正定値性を放棄する代わりに「計量行列から $\ast$ の辞書を作る」という手順だけを第6章から引き継いでいる。正定値から擬リーマンへの一般化の理論的根拠は第11章で補足する。
+<p>  → 第10章 §9.3 の注で明記しているように、第10章では正定値性を放棄する代わりに「計量行列から <span class="tex2jax_process">$\ast$</span> の辞書を作る」という手順だけを第6章から引き継いでいる。正定値から擬リーマンへの一般化の理論的根拠は第11章で補足する。
 </p>
 <ul>
 <li>**捩れ（トーション）のある空間や非対称な接続を持つ多様体が考慮されていない**</li>
@@ -5687,22 +5194,22 @@ $$
 <ul>
 <li>**行列の成分のみで計算を進めると、背景にある空間の幾何学的性質（計量等）が隠蔽される**</li>
 </ol>
-<p>  → 本書では幾何を隠蔽しているのではなく、アトミックな行列操作と幾何学的直感を常に対応させて与えている。たとえば第6章 §5.1 では、パラメータ空間の計量 $\mathbf{g}=J^T J$ の各成分が「軸方向の目盛りの伸び縮み」を直接表現していることを、行列の対角成分を見ながら確認できる。
+<p>  → 本書では幾何を隠蔽しているのではなく、アトミックな行列操作と幾何学的直感を常に対応させて与えている。たとえば第6章 §5.1 では、パラメータ空間の計量 <span class="tex2jax_process">$\mathbf{g}=J^T J$</span> の各成分が「軸方向の目盛りの伸び縮み」を直接表現していることを、行列の対角成分を見ながら確認できる。
 </p>
 <ul>
 <li>**微分形式を行列表示した際、成分がどの基底に関するものかが判別できない**</li>
 </ol>
-<p>  → 記法上の限界であることは認める。熱力学の偏微分のように独自記法で常に明示しようかとも思ったが、これでも一般記法と乖離しすぎないよう気を付けているので受け入れた。本書では第1章 §1.1.6 と §1.4 から「どの座標系の基底で書いているか」を毎回文中で明示する方針をとっている。ただし、標準的な $dx^i$ のような上付き添字による基底の明示はむしろ相性が悪いと考えて割愛した。添字記法との対応は第11章を参照。
+<p>  → 記法上の限界であることは認める。熱力学の偏微分のように独自記法で常に明示しようかとも思ったが、これでも一般記法と乖離しすぎないよう気を付けているので受け入れた。本書では第1章 §1.1.6 と §1.4 から「どの座標系の基底で書いているか」を毎回文中で明示する方針をとっている。ただし、標準的な <span class="tex2jax_process">$dx^i$</span> のような上付き添字による基底の明示はむしろ相性が悪いと考えて割愛した。添字記法との対応は第11章を参照。
 </p>
 <ul>
-<li>**外微分 $d$ と共変微分 $\nabla$ は別物であり、本書の $d$ の説明だけでは曲がった空間での微分が扱えないのではないか**</li>
+<li>**外微分 <span class="tex2jax_process">$d$</span> と共変微分 <span class="tex2jax_process">$\nabla$</span> は別物であり、本書の <span class="tex2jax_process">$d$</span> の説明だけでは曲がった空間での微分が扱えないのではないか**</li>
 </ol>
-<p>  → その通りであり、意図的な分離である。本書の $d$ は反対称微分（外微分）であり、計量に依存しないトポロジカルな操作である。一方、共変微分 $\nabla$ は計量に依存する対称微分であり、曲がった空間で必要になる。この分離（$d$ と $\nabla$）は Burke の「計量遅延」から強い影響を受けた筆者の解釈であり、第6章と第11章で扱う。
+<p>  → その通りであり、意図的な分離である。本書の <span class="tex2jax_process">$d$</span> は反対称微分（外微分）であり、計量に依存しないトポロジカルな操作である。一方、共変微分 <span class="tex2jax_process">$\nabla$</span> は計量に依存する対称微分であり、曲がった空間で必要になる。この分離（<span class="tex2jax_process">$d$</span> と <span class="tex2jax_process">$\nabla$</span>）は Burke の「計量遅延」から強い影響を受けた筆者の解釈であり、第6章と第11章で扱う。
 </p>
 <ul>
-<li>**曲線座標（円柱座標・極座標）において、本書の $dr$ や $d\theta$ がデカルト座標の $dx$ と同じ「横ベクトル」として扱えるのか不明瞭である**</li>
+<li>**曲線座標（円柱座標・極座標）において、本書の <span class="tex2jax_process">$dr$</span> や <span class="tex2jax_process">$d\theta$</span> がデカルト座標の <span class="tex2jax_process">$dx$</span> と同じ「横ベクトル」として扱えるのか不明瞭である**</li>
 </ol>
-<p>  → 第1章 §1.4 と第3章 §3.5 で明示的に扱っている。パラメータ空間の $dr,d\theta,dz$ もデカルト座標の $dx,dy,dz$ と同様に、パラメータ空間内での横ベクトル（一次形式）である。両者の違いは「引き戻し」によって吸収される。
+<p>  → 第1章 §1.4 と第3章 §3.5 で明示的に扱っている。パラメータ空間の <span class="tex2jax_process">$dr,d\theta,dz$</span> もデカルト座標の <span class="tex2jax_process">$dx,dy,dz$</span> と同様に、パラメータ空間内での横ベクトル（一次形式）である。両者の違いは「引き戻し」によって吸収される。
 </p>
 <hr />
 <h2 id="III-物理的定義と教育的配慮について">III. 物理的定義と教育的配慮について</h2>
@@ -5722,19 +5229,19 @@ $$
 <p>  → その通りである。この流儀自体は Burke や Flanders の先行例があり、数値計算の分野でも見られるアプローチである。意外と和書がなかったため筆者が書いたに過ぎず、新規性を主張する気はない。本書が立っている巨人たちの肩については「参考文献」を参照されたい。
 </p>
 <ul>
-<li>**ホッジ・スター $\ast$ は計量と空間の向きに依存するのに、単なる「次数反転」として扱いすぎではないか**</li>
+<li>**ホッジ・スター <span class="tex2jax_process">$\ast$</span> は計量と空間の向きに依存するのに、単なる「次数反転」として扱いすぎではないか**</li>
 </ol>
-<p>  → 第6章 §5.3 で $\ast$ の定義は計量 $\mathbf{g}$ に依存することを明示している。デカルト座標（$\mathbf{g}=I$）では $\ast(dx)=dy\wedge dz$ という簡潔な辞書になるが、一般の座標系では $\ast$ の係数が場所の関数になることを §5.3.4 と第8章 §7.5 で具体的に示している。
+<p>  → 第6章 §5.3 で <span class="tex2jax_process">$\ast$</span> の定義は計量 <span class="tex2jax_process">$\mathbf{g}$</span> に依存することを明示している。デカルト座標（<span class="tex2jax_process">$\mathbf{g}=I$</span>）では <span class="tex2jax_process">$\ast(dx)=dy\wedge dz$</span> という簡潔な辞書になるが、一般の座標系では <span class="tex2jax_process">$\ast$</span> の係数が場所の関数になることを §5.3.4 と第8章 §7.5 で具体的に示している。
 </p>
 <ul>
 <li>**マクスウェル方程式の微分形式表示において、単位系の正規化・符号規約・計量の符号が曖昧ではないか**</li>
 </ol>
-<p>  → 第10章 §9.1 で $w=ct$ と $\mathbf{B}'=c\mathbf{B}$ による次元の正規化を明示し、§9.3 でミンコフスキー計量の符号規約を定義し、§9.2 の注で $F_{\mu\nu}$ の符号規約を明記し、§9.6 で $F=-dA$ の規約を宣言している。§9.5 の注では $\mathcal{J}$ の正規化が標準的な相対論的記法と係数が異なる場合があることも注記している。
+<p>  → 第10章 §9.1 で <span class="tex2jax_process">$w=ct$</span> と <span class="tex2jax_process">$\mathbf{B}'=c\mathbf{B}$</span> による次元の正規化を明示し、§9.3 でミンコフスキー計量の符号規約を定義し、§9.2 の注で <span class="tex2jax_process">$F_{\mu\nu}$</span> の符号規約を明記し、§9.6 で <span class="tex2jax_process">$F=-dA$</span> の規約を宣言している。§9.5 の注では <span class="tex2jax_process">$\mathcal{J}$</span> の正規化が標準的な相対論的記法と係数が異なる場合があることも注記している。
 </p>
 <ul>
-<li>**$dx$ の行列表現 $\begin{pmatrix}1&0&0\end{pmatrix}$ は座標変換後に同じ行列として残るわけではない**</li>
+<li>**<span class="tex2jax_process">$dx$</span> の行列表現 <span class="tex2jax_process">$\begin{pmatrix}1&0&0\end{pmatrix}$</span> は座標変換後に同じ行列として残るわけではない**</li>
 </ol>
-<p>  → 第1章 §1.4 で明示的に扱っている。デカルト座標での $dx = \begin{pmatrix}1&0&0\end{pmatrix}$ は、円柱座標の目盛りでは $\begin{pmatrix}\cos\theta & -r\sin\theta & 0\end{pmatrix}$ に変わる。これが「引き戻し」の具体化であり、座標変換による行列の成分変化を隠さずに正面から見せている。
+<p>  → 第1章 §1.4 で明示的に扱っている。デカルト座標での <span class="tex2jax_process">$dx = \begin{pmatrix}1&0&0\end{pmatrix}$</span> は、円柱座標の目盛りでは <span class="tex2jax_process">$\begin{pmatrix}\cos\theta & -r\sin\theta & 0\end{pmatrix}$</span> に変わる。これが「引き戻し」の具体化であり、座標変換による行列の成分変化を隠さずに正面から見せている。
 </p>
 <p>\newpage
 </p></article>

--- a/tools/build_html.py
+++ b/tools/build_html.py
@@ -14,10 +14,23 @@ MATHJAX_CONFIG = '''window.MathJax = {
   tex: {
     inlineMath: [['$', '$']],
     displayMath: [['$$', '$$']],
-    processEscapes: false,
-    packages: { '[+]': ['bm'] }
+    processEscapes: true,
+    packages: {'[+]': ['bm']}
   },
-  options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
+  options: {
+    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+    ignoreHtmlClass: 'tex2jax_ignore',
+    processHtmlClass: 'tex2jax_process'
+  },
+  startup: {
+    ready: () => {
+      console.log('MathJax is loaded and ready');
+      MathJax.startup.defaultReady();
+      MathJax.startup.promise.then(() => {
+        console.log('MathJax initial typesetting complete');
+      });
+    }
+  }
 };
 '''
 
@@ -70,17 +83,17 @@ class MathProtector:
 
     def protect(self, text):
         """Replace math with placeholders and store original content."""
-        counter = [0]
-
         def replace_display(match):
             idx = len(self.math_blocks)
-            self.math_blocks.append(match.group(0))
-            return f'MATH_BLOCK_{idx}_END'
+            content = match.group(0)
+            self.math_blocks.append(content)
+            # Use a unique class to ensure MathJax processes it
+            return f'\n\n<div class="math-block tex2jax_process">MATH_BLOCK_{idx}_END</div>\n\n'
 
         def replace_inline(match):
             idx = len(self.inline_math)
             self.inline_math.append(match.group(0))
-            return f'INLINE_MATH_{idx}_END'
+            return f'<span class="tex2jax_process">INLINE_MATH_{idx}_END</span>'
 
         text = re.sub(r'\$\$[\s\S]+?\$\$', replace_display, text)
         text = re.sub(r'(?<!\\)\$[^$\n]+?(?<!\\)\$', replace_inline, text)


### PR DESCRIPTION
## Summary
- Improved MathJax configuration (v3 compatible) with explicit startup and class-based processing.
- Modified `tools/build_html.py` to wrap math blocks in `<div class="math-block tex2jax_process">` to prevent interference from markdown paragraph tags.
- Added console logging to MathJax startup for easier debugging in the browser.
- Verified that LaTeX backslashes are correctly preserved in the generated HTML.