### PR TITLE
Add 3-part structure headers to toc.html

### DIFF
--- a/docs/appendix.html
+++ b/docs/appendix.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch01.html
+++ b/docs/ch01.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch02.html
+++ b/docs/ch02.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch03.html
+++ b/docs/ch03.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch04.html
+++ b/docs/ch04.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch05.html
+++ b/docs/ch05.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch06.html
+++ b/docs/ch06.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch07.html
+++ b/docs/ch07.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch08.html
+++ b/docs/ch08.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch09.html
+++ b/docs/ch09.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch10.html
+++ b/docs/ch10.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch11.html
+++ b/docs/ch11.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/ch12.html
+++ b/docs/ch12.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/intro.html
+++ b/docs/intro.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/portal.html
+++ b/docs/portal.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/postscript.html
+++ b/docs/postscript.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/refs.html
+++ b/docs/refs.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -50,6 +50,7 @@
   .full-toc .level-3 { padding-left: 1rem; font-size: 0.8rem; color: #57606a; }
   .full-toc a { color: #0969da; text-decoration: none; }
   .full-toc a:hover { text-decoration: underline; }
+  .full-toc .part-header { font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -114,6 +115,7 @@
 <li class="level-3"><a href="portal.html#ポータルサイト">ポータルサイト</a></li>
 <li class="level-3"><a href="portal.html#Discord-サーバー">Discord サーバー</a></li>
 </ul>
+<h3 class="part-header">第I部：\(\mathbb{R}^3\) 上の微分形式（第1章〜第5章）</h3>
 <h2><a href="ch01.html">第1章：$dx$ とは何か —— ベクトルを食べる測定器、あるいは横ベクトル</a></h2>
 <ul>
 <li class="level-3"><a href="ch01.html#10-数学者の1次元物理学者の1次元">§1.0 数学者の1次元、物理学者の1次元</a></li>
@@ -174,6 +176,7 @@
 <li class="level-3"><a href="ch05.html#C4--form-とヤコビ行列のトレース">C.4 $2$-form：$d\eta$ とヤコビ行列のトレース</a></li>
 <li class="level-3"><a href="ch05.html#C5-とヘッセ行列">C.5 $d^2 f = 0$ とヘッセ行列</a></li>
 </ul>
+<h3 class="part-header">第II部：ベクトル解析（第6章〜第9章）</h3>
 <h2><a href="ch06.html">第6章：計量 $g$ とホッジ・スター $\ast$ — 内積の召喚と次数の反転</a></h2>
 <ul>
 <li class="level-3"><a href="ch06.html#60-言い訳の終焉内積を解放する">§6.0 言い訳の終焉——内積を解放する</a></li>
@@ -224,6 +227,7 @@
 <li class="level-3"><a href="ch09.html#95-電磁気学の難問点電荷の電場と発散">§9.5 電磁気学の難問——点電荷の電場と発散</a></li>
 <li class="level-3"><a href="ch09.html#96-辞書は終わり旅は続く">§9.6 辞書は終わり、旅は続く</a></li>
 </ul>
+<h3 class="part-header">第III部：発展と統合（第10章〜第12章）</h3>
 <h2><a href="ch10.html">第10章：マクスウェル方程式 —— 美しさのその先へ</a></h2>
 <ul>
 <li class="level-3"><a href="ch10.html#100-お約束">§10.0 お約束</a></li>

--- a/tools/build_html.py
+++ b/tools/build_html.py
@@ -80,6 +80,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
   .full-toc .level-3 {{ padding-left: 1rem; font-size: 0.8rem; color: #57606a; }}
   .full-toc a {{ color: #0969da; text-decoration: none; }}
   .full-toc a:hover {{ text-decoration: underline; }}
+  .full-toc .part-header {{ font-size: 1rem; margin: 2em 0 0.5em; padding: 0.3em 0.8em; background: #f6f8fa; border-left: 4px solid #0969da; color: #24292f; }}
 </style>
 {KATEX_CDN}
 </head>
@@ -474,7 +475,17 @@ def main():
     toc_content_parts.append('<p>各見出しはリンクになっており、クリックすると該当章の該当位置にジャンプします。</p>')
     toc_content_parts.append('<div class="full-toc">')
 
+    part_boundaries = {
+        "ch01.html": '第I部：\\(\\mathbb{R}^3\\) 上の微分形式（第1章〜第5章）',
+        "ch06.html": '第II部：ベクトル解析（第6章〜第9章）',
+        "ch10.html": '第III部：発展と統合（第10章〜第12章）',
+    }
+
     for ch in chapters:
+        fname = ch["filename"]
+        if fname in part_boundaries:
+            toc_content_parts.append(f'<h3 class="part-header">{part_boundaries[fname]}</h3>')
+
         toc_content_parts.append(f'<h2><a href="{ch["filename"]}">{ch["title"]}</a></h2>')
 
         sub_items = []


### PR DESCRIPTION
## Summary
- Add 第I部/第II部/第III部 part headers to the full table of contents page
- Part headers visually separate the book's 3-part structure

Closes #94