### PR TITLE
Add copyright and portal link footer to all HTML pages

### DIFF
--- a/docs/appendix.html
+++ b/docs/appendix.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -280,6 +283,9 @@
         <a href="refs.html">← 参考文献（と著者からのコメント...</a>
         <span></span>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch01.html
+++ b/docs/ch01.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -1116,6 +1119,9 @@ $$
         <a href="portal.html">← ポータルサイトとちょっとした試...</a>
         <a href="ch02.html">第2章：面積とは何か —— 平... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch02.html
+++ b/docs/ch02.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -837,6 +840,9 @@ $$= x_1 y_2 z_3 + y_1 z_2 x_3 + z_1 x_2 y_3 - y_1 x_2 z_3 - x_1 z_2 y_3 - z_1 y_
         <a href="ch01.html">← 第1章：$dx$ とは何か —...</a>
         <a href="ch03.html">第3章：積分するとは何か ——... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch03.html
+++ b/docs/ch03.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -530,6 +533,9 @@ $$\int_M \omega$$
         <a href="ch02.html">← 第2章：面積とは何か —— 平...</a>
         <a href="ch04.html">第4章：変数変換とは何か ——... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch04.html
+++ b/docs/ch04.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -540,6 +543,9 @@ $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
         <a href="ch03.html">← 第3章：積分するとは何か ——...</a>
         <a href="ch05.html">第5章：微分するとは何か ——... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch05.html
+++ b/docs/ch05.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -718,6 +721,9 @@ $$\mathbf{H}_f := \begin{pmatrix}
         <a href="ch04.html">← 第4章：変数変換とは何か ——...</a>
         <a href="ch06.html">第6章：計量 $g$ とホッジ... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch06.html
+++ b/docs/ch06.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -785,6 +788,9 @@ $$\ast_{2\to1}(\ast_{1\to2}(\omega)) = \begin{pmatrix} P & Q & R \end{pmatrix} =
         <a href="ch05.html">← 第5章：微分するとは何か ——...</a>
         <a href="ch07.html">第7章：ベクトル解析 —— ナ... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch07.html
+++ b/docs/ch07.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -457,6 +460,9 @@ $$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\
         <a href="ch06.html">← 第6章：計量 $g$ とホッジ...</a>
         <a href="ch08.html">第8章：二つの言語 —— 測定... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch08.html
+++ b/docs/ch08.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -446,6 +449,9 @@ $$\nabla \times \mathbf{F} = \begin{pmatrix}
         <a href="ch07.html">← 第7章：ベクトル解析 —— ナ...</a>
         <a href="ch09.html">第9章：実戦 —— 辞書を作り... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch09.html
+++ b/docs/ch09.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -386,6 +389,9 @@ $$d\ast\omega = 0 \quad (\rho \neq 0)$$
         <a href="ch08.html">← 第8章：二つの言語 —— 測定...</a>
         <a href="ch10.html">第10章：マクスウェル方程式 ... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch10.html
+++ b/docs/ch10.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -588,6 +591,9 @@ $$
         <a href="ch09.html">← 第9章：実戦 —— 辞書を作り...</a>
         <a href="ch11.html">第11章：曲がった空間へ ——... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch11.html
+++ b/docs/ch11.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -372,6 +375,9 @@ $$R_{ij} - \frac{1}{2}R\,g_{ij} = \frac{8\pi G}{c^4}\,T_{ij}$$
         <a href="ch10.html">← 第10章：マクスウェル方程式 ...</a>
         <a href="ch12.html">第12章：真のナブラ —— ク... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/ch12.html
+++ b/docs/ch12.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -364,6 +367,9 @@ $$
         <a href="ch11.html">← 第11章：曲がった空間へ ——...</a>
         <a href="postscript.html">おわりに：『ナブラ解体新書』は... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -125,6 +128,9 @@
         <span></span>
         <a href="intro.html">はじめに：$dx$ とは何か、... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/intro.html
+++ b/docs/intro.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -180,6 +183,9 @@ $$
         <a href="index.html">← 著者ノート：かつての私への贈り...</a>
         <a href="portal.html">ポータルサイトとちょっとした試... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/portal.html
+++ b/docs/portal.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -129,6 +132,9 @@
         <a href="intro.html">← はじめに：$dx$ とは何か、...</a>
         <a href="ch01.html">第1章：$dx$ とは何か —... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/postscript.html
+++ b/docs/postscript.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -132,6 +135,9 @@
         <a href="ch12.html">← 第12章：真のナブラ —— ク...</a>
         <a href="refs.html">参考文献（と著者からのコメント... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/refs.html
+++ b/docs/refs.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -142,6 +145,9 @@
         <a href="postscript.html">← おわりに：『ナブラ解体新書』は...</a>
         <a href="appendix.html">付録：本書で語らなかったもの... →</a>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -55,6 +55,9 @@
   .full-toc .toc-part-chapters h3 { font-size: 0.95rem; margin: 0.5em 0 0.2em; }
   .full-toc .toc-part-chapters h3 a { color: #24292f; }
   .full-toc .toc-part-chapters ul { padding-left: 1.5rem; }
+  .site-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }
+  .site-footer a { color: #0969da; text-decoration: none; }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
@@ -279,6 +282,9 @@
         <span></span>
         <span></span>
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>

--- a/tools/build_html.py
+++ b/tools/build_html.py
@@ -85,6 +85,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
   .full-toc .toc-part-chapters h3 {{ font-size: 0.95rem; margin: 0.5em 0 0.2em; }}
   .full-toc .toc-part-chapters h3 a {{ color: #24292f; }}
   .full-toc .toc-part-chapters ul {{ padding-left: 1.5rem; }}
+  .site-footer {{ margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7de; font-size: 0.8rem; color: #57606a; }}
+  .site-footer a {{ color: #0969da; text-decoration: none; }}
+  .site-footer a:hover {{ text-decoration: underline; }}
 </style>
 {KATEX_CDN}
 </head>
@@ -104,6 +107,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         {prev_button}
         {next_button}
       </div>
+      <footer class="site-footer">
+        <p>&copy; yokiikoy. 本書の最新版・PDF・正誤表・改訂履歴・関連情報は<a href="https://covectorspace.xyz/jp/">ポータルサイト</a>をご確認ください。</p>
+      </footer>
     </article>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Add footer with copyright notice and portal site link to every HTML page
- Displayed below nav-buttons at page bottom
- Uses `HTML_TEMPLATE` in `build_html.py` — no markdown changes, PDF unaffected

Closes #102