### PR TITLE
Fix preview HTML contrast in Android dark mode

### DIFF
--- a/tools/build_html.py
+++ b/tools/build_html.py
@@ -41,8 +41,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown.min.css">
 <style>
   :root {{ --sidebar-width: 320px; }}
-  body {{ margin: 0; display: flex; background: #fff; line-height: 1.7; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
-  .sidebar {{ width: var(--sidebar-width); height: 100vh; position: sticky; top: 0; background: #f8f9fa; border-right: 1px solid #d0d7de; overflow-y: auto; padding: 1.5rem; box-sizing: border-box; flex-shrink: 0; }}
+  html {{ color-scheme: light; background: #fff; }}
+  body {{ margin: 0; display: flex; background: #fff; color: #24292f; line-height: 1.7; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
+  .sidebar {{ width: var(--sidebar-width); height: 100vh; position: sticky; top: 0; background: #f8f9fa; color: #24292f; border-right: 1px solid #d0d7de; overflow-y: auto; padding: 1.5rem; box-sizing: border-box; flex-shrink: 0; }}
   .sidebar h2 {{ font-size: 1.2rem; border: none; margin-bottom: 0.5rem; color: #24292f; }}
   .sidebar .author {{ font-size: 0.8rem; color: #666; margin-bottom: 1.5rem; }}
   .sidebar .toc {{ font-size: 0.85rem; }}
@@ -56,8 +57,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
   .sidebar a:hover {{ text-decoration: underline; }}
   .sidebar .active {{ color: #cf222e; font-weight: bold; }}
   .sidebar .disabled-link {{ color: #8c959f; cursor: not-allowed; text-decoration: none; }}
-  .main-content {{ flex: 1; min-width: 0; padding: 2rem 4rem; overflow-x: hidden; }}
-  .markdown-body {{ max-width: 850px; margin: 0 auto; min-height: 100vh; }}
+  .main-content {{ flex: 1; min-width: 0; padding: 2rem 4rem; overflow-x: hidden; background: #fff; color: #24292f; }}
+  .markdown-body {{ max-width: 850px; margin: 0 auto; min-height: 100vh; color-scheme: light; background: #fff; color: #24292f; }}
+  .markdown-body p, .markdown-body li {{ color: #24292f; }}
   @media (max-width: 900px) {{ 
     body {{ flex-direction: column; }} 
     .sidebar {{ width: 100%; height: auto; position: static; padding: 1rem; border-right: none; border-bottom: 1px solid #d0d7de; }} 
@@ -65,11 +67,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     .markdown-body {{ padding: 0.5rem; }}
   }}
   blockquote {{ border-left: 4px solid #d0d7de; color: #57606a; background: #f6f8fa; padding: 0.5em 1.2em; margin: 1.5em 0; border-radius: 0 6px 6px 0; }}
+  blockquote p {{ color: #57606a; }}
   .table-wrapper {{ overflow-x: auto; margin: 1.5em 0; }}
   table {{ border-collapse: collapse; width: 100%; font-size: 0.9em; }}
-  th, td {{ border: 1px solid #d0d7de; padding: 6px 13px; }}
+  th, td {{ border: 1px solid #d0d7de; padding: 6px 13px; color: #24292f; }}
   tr:nth-child(even) {{ background-color: #f6f8fa; }}
   th {{ font-weight: 600; background-color: #f6f8fa; }}
+  code, pre {{ color: #24292f; background-color: #f6f8fa; }}
   .nav-buttons {{ display: flex; justify-content: space-between; margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #eee; }}
   .nav-buttons a {{ padding: 0.5rem 1rem; border: 1px solid #d0d7de; border-radius: 6px; color: #0969da; text-decoration: none; font-size: 0.9rem; }}
   .nav-buttons a:hover {{ background: #f6f8fa; }}
@@ -353,7 +357,7 @@ def main():
 
     preview_notice = ""
     if profile.is_preview:
-        preview_notice = '''<div class="preview-notice" style="background: #fff8c5; border: 1px solid #d4a72c; padding: 1rem; border-radius: 6px; margin-bottom: 2rem; font-size: 0.9rem;">
+        preview_notice = '''<div class="preview-notice" style="background: #fff8c5; color: #24292f; border: 1px solid #d4a72c; padding: 1rem; border-radius: 6px; margin-bottom: 2rem; font-size: 0.9rem;">
       <strong>先行公開版のお知らせ:</strong> このドキュメントは先行公開用であり、正式な公開範囲は前付け・第1章・後付類のみです。第2章以降の本文は、現在、誤字脱字、全体の整合性、数学的厳密性と教育的な断言のバランスを調整している最中です。GitHub リポジトリや作業中ブランチを探すと全12章分の草稿が見えてしまう可能性がありますが、それらは正式な公開版ではありません。どうしても読む場合は、こっそり作業場を覗き見たものとして扱い、現時点では批評・レビュー・拡散の対象にしないでください。最新版や正式な公開情報はポータルサイトをご確認ください。
     </div>'''
 


### PR DESCRIPTION
## Summary

Fixes #118.

This PR updates the generated HTML template so preview/full HTML pages explicitly use a stable light color scheme. The goal is to avoid Android / Chrome dark-mode mixing where `github-markdown-css@5` may switch text colors while the generated page background remains white.

### Changes

- Add `color-scheme: light` on `html` and `.markdown-body`
- Explicitly set white backgrounds and GitHub light-theme text colors for `body`, `.main-content`, and `.markdown-body`
- Explicitly set readable colors for paragraphs, list items, blockquotes, tables, code, and the preview notice
- Keep existing layout and link colors unchanged as much as possible

### Validation

Not fully run in this environment.

Please run:

```bash
python3 tools/build_html.py --profile preview
```

Then verify at least:

```txt
preview/index.html
preview/toc.html
preview/intro.html
preview/portal.html
preview/ch01.html
preview/postscript.html
preview/refs.html
preview/appendix.html
```

Also confirm on Android dark mode that the preview HTML is readable without selecting text.

## Notes

This PR currently updates the HTML generation path. If generated `preview/*.html` and `docs/preview/*.html` artifacts are committed/deployed directly, they should be regenerated before merging or in a follow-up commit.

Do not merge until the regenerated preview pages have been checked visually on Android dark mode.