### PR TITLE
English Chapter 3: §3.0–§3.5 (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch03/ch03.md
+++ b/manuscript/en/ch03/ch03.md
@@ -1,115 +1,103 @@
----
-title: "Chapter 3: Measuring Curved Objects — Integrating Forms"
-series: dx-matrix
-chapter: 3
-order: 30
-assumes:
-- displacement_vector
-- dx_as_row_vector
-- one_form
-- wedge_product
-- two_form
-- three_form
-- k_form
-- pullback
-introduces:
-  form_integral:
-    from: definition
-    to: computation
-  jacobian:
-    from: definition
-    to: computation
-previews:
-  exterior_derivative:
-    max_level: intuition
-  stokes_theorem:
-    max_level: intuition
-  metric:
-    max_level: intuition
-  nabla_operators:
-    max_level: intuition
-recap_policy:
-  one_form:
-    max_level: mention
-    max_lines: 3
-  wedge_product:
-    max_level: mention
-    max_lines: 3
-  two_form:
-    max_level: mention
-    max_lines: 3
-  three_form:
-    max_level: mention
-    max_lines: 3
----
+# Chapter 3: What Does It Mean to Integrate? — Count Finite Masses, Then Take the Limit
 
-# Chapter 3: Measuring Curved Objects — Integrating Forms
+### §3.0 Measuring Curved Things — Paying Back a Debt from Elementary School
 
-#### §3.1 Measuring Curved Objects — Paying off a Debt from Elementary School
+In Chapter 2, we defined how to measure <strong>flat figures</strong> such as the area of a parallelogram and the volume of a parallelepiped.
 
-In Chapter 2, we defined how to measure <strong>flat figures</strong> like the area of a parallelogram and the volume of a parallelepiped. $dx \wedge dy$ — feed two vectors into this area meter and it returns signed area; feed three vectors into $dx \wedge dy \wedge dz$ and it returns signed volume. We have redesigned the elementary school intuition of “how many $1 \times 1$ squares fit” into an algebraic measuring device.
+If we feed two vectors to the area-measuring device $dx \wedge dy$, we get a signed area; if we feed three vectors to the volume-measuring device $dx \wedge dy \wedge dz$, we get a signed volume. We redesigned the elementary-school intuition of “how many $1\times 1$ squares fit inside” as algebraic measuring devices.
 
-But what physicists really want to know is not flat figures. It's the length of curves, the area of surfaces, the volume of curved regions — in other words, how to measure <strong>curved things</strong>.
+However, a debt from elementary school still remains.
 
-Circumference $2\pi r$, surface area of a sphere $4\pi r^2$, volume of a sphere $\frac{4}{3}\pi r^3$. Since elementary school, we have used these formulas as “just the way things are.” But have we ever defined them — as an operation of chopping into pieces and adding up — as an integral? No, we haven't.
+We have used the circumference $2\pi r$, the surface area of a sphere $4\pi r^2$, and the volume of a sphere $\frac{4}{3}\pi r^3$ for a long time as “formulas of that kind.” But where do they actually come from?
 
-And that makes sense. To chop a curve finely and add up, we need to decide “what to measure on each small interval and how to add it,” but that is an operation that cannot be defined without a measuring device called a <strong>form</strong>. Now at hand we have the measuring devices built in Chapters 1 and 2 — $0$-form, $1$-form, $2$-form, $3$-form. The task of this chapter is to <strong>apply these along curves, surfaces, and regions, and sum them up</strong>.
+There is only one answer.
 
-The principle is the same for every degree. We'll start with the case where the volume meter with coefficient 1 directly returns the volume of a region, then move down in dimension, checking “where the limitation of coefficient 1 appears.”
+<strong>Chop into finite small pieces, measure each one, add them up, and finally make the mesh infinitely fine.</strong>
 
-In what follows, we assume parameterizations are smooth, and we keep details like orientation reversal and self-intersection at a level that “causes no problem in common physical situations.” Rigorous integrability theory is outside the scope of this book.
+That is integration.
+
+The purpose of this chapter is not to memorize the formulas for a sphere again. Rather, using the familiar sphere as our example, we confirm at the level of Riemann sums what it means to “integrate.”
+
+Therefore, we deliberately do not escape immediately into polar or spherical coordinates. We count small pieces in $x,y,z$, decide which pieces belong to the target, and organize the sum. It is messy — but this messiness is the substance of integration.
+
+Now, on our desk we have the measuring devices built in Chapters 1 and 2: $0$-forms, $1$-forms, $2$-forms, and $3$-forms. The job of this chapter is to <strong>apply them along curves, surfaces, and regions and aggregate the results</strong>.
+
+The principle is the same at every degree. We begin with the case where a volume-measuring device with coefficient $1$ returns the volume of a region as-is, then step down in dimension and check “what does the form measure, and what does it not measure?”
+
+> <strong>Note</strong> (ground rules)  
+> We state this up front as a promise. Below, we treat curves and surfaces as sufficiently smooth, and cases where chopping into small pieces and adding converges in a straightforward way. Details such as orientation reversal and self-intersection are kept at the level of “they do not cause trouble in situations commonly used in physics.” A rigorous theory of integrability is outside the scope of this book.
 
 ---
 
-### §3.2 Volume — 3 Dimensions, Coefficient 1
+### §3.1 Volume — Three Dimensions, Coefficient 1
 
-#### 3.2.1 From Rectangular Solids to Curved Regions — Defined by Riemann Sums
+#### 3.1.1 From Rectangular Boxes to Curved Regions — Defining by Riemann Sums
 
-In Chapter 2, §2.5, we assembled the volume meter $dx \wedge dy \wedge dz$. Feed three vectors $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$ into it, and it returns the signed volume of the parallelepiped they span.
+In Chapter 2 §2.5, we assembled the volume-measuring device $dx \wedge dy \wedge dz$. If we feed it three vectors $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$, we get the signed volume of the parallelepiped they span.
 
-Now we want to measure the volume of a region $V$ in space. No matter how curved the shape of $V$ is, if we chop it finely enough, each small piece can be regarded as approximately a rectangular solid. So we chop $V$ in the $x$-direction, $y$-direction, and $z$-direction, and assign an index $i$ to each small rectangular solid lying inside $V$. Let the three edges of the $i$-th small rectangular solid be
+Now we want to measure the volume of a region $V$ in space. However curved $V$ may be, if we chop finely enough each small piece can be treated as almost a rectangular box. So we slice $V$ in the $x$, $y$, and $z$ directions, label the small boxes inside $V$ by an index $i$, and take the three edge vectors of the $i$th box to be
 
-$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z$$
+$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z.$$
 
-and feed these three vectors into the volume meter $dx \wedge dy \wedge dz$:
+Feed these three vectors to the volume-measuring device $dx \wedge dy \wedge dz$:
 
-$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i$$
+$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i.$$
 
-> <strong>Note</strong> (Contraction of Meter and Figure) What is happening here is exactly the pattern we saw in Chapter 2, §2.5.10. The <strong>$3$-form (volume meter = scale)</strong> eats the <strong>$3$-vector (volume meter = figure)</strong> and spits out a scalar. This contraction is performed for each small rectangular solid.
+> <strong>Note</strong> (contraction of measuring device and figure)  
+> What happens here is exactly the pattern from Chapter 2 §2.5.10. A <strong>$3$-form (volume-measuring device)</strong> eats the <strong>volume element (figure)</strong> spanned by three displacement vectors and spits out a scalar. This contraction is performed on each small box. We call the oriented small box — the tiny volume figure — spanned by these three displacement vectors a <strong>volume element</strong>.
 
-Sum up the scalars $\Delta x_i\,\Delta y_i\,\Delta z_i$ obtained from each small rectangular solid over all such solids inside $V$:
+Add the scalar $\Delta x_i\,\Delta y_i\,\Delta z_i$ from each small box over all boxes inside $V$:
 
-$$\sum_{\text{小直方体 }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i$$
+$$\sum_{\text{small box }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i.$$
 
-Then take the limit as the partition becomes infinitely fine. We denote this limit as---PARA<strong>___\__</strong> . This is the definition of the integral of a $3$-form — the volume integral.
+Then take the limit as the mesh becomes infinitely fine. We <strong>write</strong> this limit as
 
-$$\iiint_V dx \wedge dy \wedge dz$$
+$$\iiint_V dx \wedge dy \wedge dz.$$
 
-> <strong>Note</strong> (On the notation $\iiint$) In this book, we <strong>define $\iiint_V$ here for the first time</strong> as the symbol for “the integral of a $3$-form over a 3-dimensional region $V$.” It is not something extended from high school mathematics; it is the name we give to the limit of the above Riemann sum.
+This is the definition of integration of a $3$-form — a volume integral.
 
-Now we have the definition. But how do we actually compute this sum? When $V$ is a curved region like $x^2+y^2+z^2 \le R^2$, it is cumbersome to determine which small rectangular solids lie inside $V$ while summing. However, by choosing the order of summation cleverly, we can gain clarity. Let's try it in the next section.
+> <strong>Note</strong> (the symbol $\iiint$)  
+> In this book we <strong>define $\iiint_V$ here for the first time</strong> as the symbol for “integration of a $3$-form over a three-dimensional region $V$.” It is not a symbol assumed from high-school volume integrals; it is the name we give to the Riemann-sum limit above.
 
-#### 3.2.2 Volume of a Sphere — Messy, Brute-Force Summation
+We have defined it. But how do we actually compute this sum? When $V$ is a curved region such as $x^2+y^2+z^2 \le R^2$, it is tedious to decide which small boxes lie inside $V$ while adding. If we organize the sum cleverly, however, the picture improves. In the next subsection we try it in practice.
 
-Let's really compute the volume of a sphere $x^2 + y^2 + z^2 \le R^2$ of radius $R$ in a messy, brute-force way. What we want to show is just one thing: even without resorting to a special coordinate system, by simply organizing the Riemann sum in $x, y, z$ in a straightforward manner, we can arrive at the familiar $\frac{4}{3}\pi R^3$. No special coordinate systems. We just stack small rectangular solids $\Delta x\,\Delta y\,\Delta z$ in $x, y, z$ as they are.
+#### 3.1.2 Volume of a Sphere — Adding Messily and Straightforwardly
 
-How can we organize the Riemann sum from §3.2.1 to compute it? If we fix a certain value of $z$ inside the sphere, the condition that $x, y$ must satisfy is $x^2 + y^2 \le R^2 - z^2$. If we further fix $y$, then $x^2 \le R^2 - z^2 - y^2$. Therefore, the range of $x$ is from $-\sqrt{R^2 - z^2 - y^2}$ to $+\sqrt{R^2 - z^2 - y^2}$, the range of $y$ is from $-\sqrt{R^2 - z^2}$ to $+\sqrt{R^2 - z^2}$, and the range of $z$ is from $-R$ to $+R$. Taking the sum in this order — repeating the 1-dimensional Riemann sum from Chapter 1, §1.2 three times — the limit becomes:
+Let us compute the volume of a sphere $x^2 + y^2 + z^2 \le R^2$ of radius $R$ in a truly messy, straightforward way. We want to show only one thing: without fleeing to a special coordinate system, we can reach the familiar $\frac{4}{3}\pi R^3$ simply by organizing the Riemann sum honestly in $x,y,z$. We use no special coordinates. In $x,y,z$ we simply stack small boxes $\Delta x\,\Delta y\,\Delta z$.
 
-On the right-hand side, $dx, dy, dz$ appears as a result of organizing the sums in $dx \wedge dy \wedge dz$ in order. It is not that $\wedge$ is omitted. The meaning is: from the innermost parentheses outward, perform the sum over $x$ ($\int dx$), then the sum over $y$ ($\int dy$), then the sum over $z$ ($\int dz$).
+View the sphere as the region determined by the value of
 
-$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz$$
+$$F(x,y,z)=x^2+y^2+z^2.$$
 
-The innermost sum over $x$ (in the limit, the $x$ integral) can be done immediately:
+The interior is all points with $F\le R^2$; the boundary sphere is $F=R^2$.
 
-Next, the $y$ integral. Set $a = \sqrt{R^2 - z^2}$:
+To read orientation on the boundary or displacement along the sphere, the total differential $dF$ from Chapter 1 is useful. At the stage of counting volume, however, we do not use $dF$ yet. Here we first unpack the condition $F\le R^2$ and count small boxes. The main actor for measuring volume remains $dx\wedge dy\wedge dz$.
 
-$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}$$
+How can we organize the Riemann sum from §3.1.1 so that it can be computed? Fix $z$ at some value. Then $F\le R^2$ becomes
 
-Here we use substitution (high school math). Let $y = a\sin t$. Then $dy = a\cos t\,dt$. When $y$ goes from $-a \to a$ to $t$, $-\pi/2 \to \pi/2$ goes from $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$ to $t \in [-\pi/2,\pi/2]$. Also, $\cos t \ge 0$ (since __PH_0353__ over the range, the absolute value drops). Hence:
+$$x^2+y^2\le R^2-z^2.$$
 
-$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy$$
+So at that height, the allowed $(x,y)$ form a disk of radius $\sqrt{R^2-z^2}$. Fixing $y$ as well gives
 
-Since $\cos^2 t = (1 + \cos 2t)/2$, we have:
+$$x^2\le R^2-z^2-y^2,$$
+
+so $x$ runs from $-\sqrt{R^2 - z^2 - y^2}$ to $+\sqrt{R^2 - z^2 - y^2}$. Similarly, $y$ runs from $-\sqrt{R^2 - z^2}$ to $+\sqrt{R^2 - z^2}$, and $z$ from $-R$ to $+R$.
+
+This is simply unpacking the test $F\le R^2$ in the order $z$, $y$, $x$. If we add in this order — think of stacking the one-dimensional Riemann sums from Chapter 1 §1.1 three times — then in the limit:
+
+$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz.$$
+
+The $dx, dy, dz$ on the right appear as the result of organizing the sum on the left in order; we are not omitting $\wedge$. From inside the parentheses outward: sum over $x$ ($\int dx$), then over $y$ ($\int dy$), then over $z$ ($\int dz$).
+
+The innermost sum over $x$ (the $x$ integral in the limit) is immediate:
+
+$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}.$$
+
+Next the $y$ integral. Set $a = \sqrt{R^2 - z^2}$:
+
+$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy.$$
+
+Use substitution from high-school calculus. With $y = a\sin t$, we have $dy = a\cos t\,dt$. As $y$ goes from $-a$ to $a$, $t$ goes from $-\pi/2$ to $\pi/2$. Also $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$ (for $t \in [-\pi/2,\pi/2]$ we have $\cos t \ge 0$, so the absolute value drops). Therefore:
 
 $$\begin{aligned}
 \int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy
@@ -117,7 +105,7 @@ $$\begin{aligned}
 &= 2a^2\!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
 \end{aligned}$$
 
-Finally the $z$ integral:
+Since $\cos^2 t = (1 + \cos 2t)/2$:
 
 $$\begin{aligned}
 2a^2\!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
@@ -127,608 +115,541 @@ $$\begin{aligned}
 &= \pi a^2 = \pi(R^2 - z^2)
 \end{aligned}$$
 
-> <strong>Note</strong> (Meaning of this computation) What we have done here is nothing but organizing the Riemann sum from §3.2.1. Instead of judging which small rectangular solids lie inside the sphere while summing in $x,y,z$, we arranged the sum order as $x \to y \to z$. Each stage is a 1-variable Riemann sum from Chapter 1, and in the limit it becomes a familiar 1-variable integral. That's all. If we faithfully sum up the contraction of the meter and the figure, we arrive at $\frac{4}{3}\pi R^3$.
+Finally the $z$ integral:
 
-$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3$$
+$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3.$$
 
-Thus, we have confirmed that the integral of $dx \wedge dy \wedge dz$ — <strong>a single meter</strong> — correctly gives the volume $\frac{4}{3}\pi R^3$ of a curved region. In 3 dimensions, the volume meter with coefficient 1 directly measures volume.
+> <strong>Note</strong> (what this calculation means)  
+> What we did here is only the organization of the Riemann sum from §3.1.1. Instead of deciding which small boxes lie inside the sphere while adding in $x,y,z$, we organized the sum in the order $x \to y \to z$. Each stage is a one-variable Riemann sum from Chapter 1; in the limit it becomes a familiar one-variable integral. That is all. If we aggregate the contraction of measuring device and figure honestly, we reach $\frac{4}{3}\pi R^3$.
 
-> <strong>【Checkpoint so far】</strong>
-> - The integral of $dx \wedge dy \wedge dz$ is the limit of a Riemann sum: chop the region into small rectangular solids, feed each volume meter to the volume meter, and sum the values. $\iiint_V$ is the symbol this book gives to that limit.
-> - With coefficient 1, volume is measured directly. The volume of a sphere $\frac{4}{3}\pi R^3$ is obtained by organizing the Riemann sum in the order $x \to y \to z$. No special coordinate system needed.
-> - In the next section, we go down one dimension and measure the area of a surface.
-
-### §3.3 Surface Area — 2 Dimensions, Coefficient 1
+Thus we have confirmed that the integral of the single measuring device $dx \wedge dy \wedge dz$ gives the correct volume $\frac{4}{3}\pi R^3$ of a curved region. In three dimensions, a volume-measuring device with coefficient $1$ measures volume directly.
 
 ---
 
-#### 3.3.1 From Parallelograms to Curved Surfaces
-
-In Chapter 2, §2.4, we assembled the area meter $dx \wedge dy$. Feed two vectors $\mathbf{v}_1, \mathbf{v}_2$ into it, and it returns the signed area of their shadow projected onto the $xy$-plane. Similarly, $dy \wedge dz$ measures the shadow onto the $yz$-plane, and $dz \wedge dx$ measures the shadow onto the $zx$-plane.
-
-So how do we measure the area of a curved surface? First, let's check the flat case. Consider the unit square $\mathbf{r}(u,v) = (u,\,v,\,0),\; 0 \le u,v \le 1$ lying in the $xy$-plane. Since $\mathbf{r}_u = (1,0,0),\; \mathbf{r}_v = (0,1,0)$, we have $(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix}1&0\\0&1\end{pmatrix} = 1$. Summing over the whole region gives $\iint_{[0,1]^2} 1 = 1$ — the area of the square. This is just an extension of the flat parallelogram from Chapter 2, confirming that the surface element meter, on a flat surface, correctly returns area.
-
-What if the surface is curved? In general, suppose a surface $S$ is expressed in two parameters $u, v$ as
-
-When $u, v$ moves over a region $D$ in the plane, $\mathbf{r}(u,v)$ traces out the surface $S$.
-
-$$\mathbf{r}(u,v) = \bigl(x(u,v),\, y(u,v),\, z(u,v)\bigr)$$
-
-Chop the surface into small patches. When we advance by $\Delta u$ in the $u$-direction and by $\Delta v$ in the $v$-direction, the displacement vectors can be approximated using partial derivatives as
-
-(when $\Delta u, \Delta v$ is small enough). The parallelogram spanned by these two vectors approximates a small piece of the surface. Assume $\mathbf{r}_u, \mathbf{r}_v$ are not parallel and indeed span a surface.
-
-$$\mathbf{r}_u = \frac{\partial \mathbf{r}}{\partial u},\qquad \mathbf{r}_v = \frac{\partial \mathbf{r}}{\partial v}$$
-
-> <strong>Note</strong> (For readers unfamiliar with partial derivatives) $\mathbf{r}_u$ can be thought of as “the displacement vector when we fix $v$ and move $u$ a little.” It is a 2-dimensional extension of $\Delta x$ from Chapter 1.
-
-Feed this surface element $\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v$ into the area meter $dx \wedge dy$. Numbering the increments in the $u,v$-direction with index $i,j$, the contribution from the $(i,j)$-th small patch is:
-
-From the definition in Chapter 2, §2.4.4:
-
-$$(dx \wedge dy)(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = (dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$
-
-> <strong>Note</strong> (Contraction of a $2$-form and a $2$-vector) Again, the same picture: the <strong>$2$-form (area meter = scale)</strong> eats the <strong>$2$-vector (surface element = figure)</strong> and returns a scalar (area of the shadow). This contraction happens on each small patch.
-
-$$(dx \wedge dy)(\mathbf{r}_u, \mathbf{r}_v) = \det\begin{pmatrix} \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\ \frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} \end{pmatrix} = \frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$$
-
-Sum this over all small patches in $D$:
-
-Take the limit as the partition becomes infinitely fine. We denote this limit as---PARA<strong>___\__</strong> . This is the definition of the integral of a $2$-form — the surface integral. The construction is the same type as the volume integral in §3.2, only now we feed in two vectors.
-
-$$\sum_{i,j} (\frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u})\,\Delta u\,\Delta v$$
-
-#### 3.3.2 What $dx \wedge dy$ Measures — Testing on a Sphere
-
-$$\iint_S dx \wedge dy$$
-
-Let's actually compute on a sphere. Consider the upper hemisphere ($z \ge 0$) of radius $R$. We can write this surface using $x, y$ itself as parameters (graph representation):
-
-If we express it as parameters $\mathbf{r}(x,y) = (x,\; y,\; f(x,y))$, the partial derivatives are:
-
-Here $\frac{\partial f}{\partial x} = \dfrac{\partial f}{\partial x} = -\dfrac{x}{\sqrt{R^2 - x^2 - y^2}},\; \frac{\partial f}{\partial y} = \dfrac{\partial f}{\partial y} = -\dfrac{y}{\sqrt{R^2 - x^2 - y^2}}$.
-
-$$z = f(x,y) = \sqrt{R^2 - x^2 - y^2},\qquad x^2 + y^2 \le R^2$$
-
-First, feed only $dx \wedge dy$ to the surface:
-
-$$\mathbf{r}_x = \frac{\partial \mathbf{r}}{\partial x} = \begin{pmatrix} 1 \\[2pt] 0 \\[2pt] \frac{\partial f}{\partial x} \end{pmatrix},\qquad \mathbf{r}_y = \frac{\partial \mathbf{r}}{\partial y} = \begin{pmatrix} 0 \\[2pt] 1 \\[2pt] \frac{\partial f}{\partial y} \end{pmatrix}$$
-
-Therefore, the integral of $dx \wedge dy$ over the upper hemisphere is:
-
-The computation of $y$ can be done using the same method as the $a$ integral in §3.2.2 (treat $R$ as $\pi R^2$), and the result is $xy$. This is nothing but the area of the shadow cast by the upper hemisphere onto the $R$-plane — a disk of radius $z = -\sqrt{R^2 - x^2 - y^2}$.
-
-$$(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = \det\begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix} = 1$$
-
-Similarly, computing for the lower hemisphere ($(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) = 1$), the value of $-\pi R^2$ is unchanged (please verify), but because the surface orientation is reversed, the sign flips and the integral becomes $dx \wedge dy$.
-
-$$\iint_{S_{\text{upper}}} dx \wedge dy$$
-
-Hence, the integral of $\pi R^2 + (-\pi R^2) = 0$ over the entire sphere is $dx \wedge dy$. The shadows of the upper and lower hemispheres cancel each other. This makes it clear: <strong>$xy$ measures “the signed area of the shadow onto the $dy \wedge dz$-plane,” not the area of the surface itself.</strong> Similarly, $yz$ measures the shadow onto the $dz \wedge dx$-plane, and $zx$ measures the shadow onto the $u=x,\;v=y$-plane.
-
-#### 3.3.3 From Three Shadows to the True Area
-
-So how do we measure the true area of a surface? At each point, feed the surface element to all three area meters and combine the results.
-
-Let's compute the remaining two for the upper hemisphere (following the example of $A_{yz},\,A_{zx},\,A_{xy}$ in §3.3.1):
-
-These three values — $\hat{e}_y \wedge \hat{e}_z$ — completely encode the <strong>orientation and magnitude</strong> of the surface element at each point. This is the surface version of what we saw in Chapter 2, §2.4.6: “oriented area = linear combination of the three basis $x^2 + y^2 \le R^2$, etc.”
-
-Now, to extract the scalar area of the surface from these three “shadows,” we do exactly what we did in Chapter 2, §2.4.7 for parallelograms — <strong>word for word the same</strong>: take the square root of the sum of the squares of the three values:
-
-$$\begin{aligned}
-(dy \wedge dz)(\mathbf{r}_x, \mathbf{r}_y) &= y_x z_y - y_y z_x = 0\cdot \frac{\partial f}{\partial y} - 1\cdot \frac{\partial f}{\partial x} = -\frac{\partial f}{\partial x} = \frac{x}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
-(dz \wedge dx)(\mathbf{r}_x, \mathbf{r}_y) &= z_x x_y - z_y x_x = \frac{\partial f}{\partial x}\cdot 0 - \frac{\partial f}{\partial y}\cdot 1 = -\frac{\partial f}{\partial y} = \frac{y}{\sqrt{R^2 - x^2 - y^2}} \\[4pt]
-(dx \wedge dy)(\mathbf{r}_x, \mathbf{r}_y) &= 1
-\end{aligned}$$
-
-Integrating this over the entire parameter region $y$ gives the area of the upper hemisphere:
-
-The inner $a = \sqrt{R^2 - x^2}$ integral. Set $y = a\sin t$:
-
-$$\begin{aligned}
-\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}
-&= \sqrt{\Bigl(\frac{x}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + \Bigl(\frac{y}{\sqrt{R^2 - x^2 - y^2}}\Bigr)^2 + 1^2} \\
-&= \sqrt{\frac{x^2 + y^2}{R^2 - x^2 - y^2} + 1} \\
-&= \sqrt{\frac{R^2}{R^2 - x^2 - y^2}}
-= \frac{R}{\sqrt{R^2 - x^2 - y^2}}
-\end{aligned}$$
-
-Use the substitution $dy = a\cos t\,dt$ (same procedure as in §3.2.2). Here $\sqrt{a^2 - y^2} = a\cos t$, $y$, and when $-a \to a$ goes from $t$ to $-\pi/2 \to \pi/2$, $a$ goes from $\pi$ to $2\pi R^2$:
-
-$$\iint_{x^2+y^2 \le R^2} \frac{R}{\sqrt{R^2 - x^2 - y^2}}\;dx \wedge dy = R\int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}} \frac{dy}{\sqrt{R^2 - x^2 - y^2}}\;dx$$
-
-The integral result is $4\pi R^2$ independent of $2$! Therefore:
-
-$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}}$$
-
-This is the area of the upper hemisphere. For the lower hemisphere, some signs are reversed but the sum of squares is the same, so it is also $dx \wedge dy$. Hence the total surface area of the sphere is:
-
-$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}} = \int_{-\pi/2}^{\pi/2} \frac{a\cos t}{a\cos t}\,dt = \int_{-\pi/2}^{\pi/2} dt = \pi$$
-
-Beautifully, we get $xy$. This is <strong>exactly the same pattern</strong> as in Chapter 2, §2.4.7, where we recovered the area of a parallelogram from its three shadows.
-
-$$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2$$
-
-#### 3.3.4 What We Have Learned So Far
-
-$$2\pi R^2 + 2\pi R^2 = 4\pi R^2$$
-
-A $2$-form with coefficient 1 does not, by itself, directly return the area of a curved surface. $x$ alone only measures “the area of the shadow onto the $dy \wedge dz$-plane.” To know the true area of the surface, we must combine the measurements from the three basis $yz$-forms. This is exactly the same situation as with the area of a parallelogram in Chapter 2.
-
-However, in physics, we often want to control “how much weight to give to each direction's shadow at each point.” For example, when measuring the flow of a fluid through a surface, if the flow is strong in the $\iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$-direction, we want to give a large weight to $dx \wedge dy$ (the shadow onto the $xy$-plane). The necessity of such <strong>position-dependent weights</strong> — coefficients — naturally appears here. This is a foreshadowing of §3.5.
-
-> <strong>【Checkpoint so far】</strong>
-> - Surface integral: $2$. On each small patch, feed the surface element to the area meter to get a scalar, then sum.
-> - $4\pi R^2$ alone measures the area of the shadow onto the $dx, dy, dz$-plane. Over the entire sphere, it gives zero net (the shadows of the upper and lower hemispheres cancel).
-> - Taking the square root of the sum of the squares of the measurements from the three basis $1$-forms gives the scalar area of the surface. For the sphere, it is $dx = \begin{pmatrix}1&0&0\end{pmatrix}$.
-> - In the next section, we go down one more dimension and measure the length of a curve. There, the limitation of coefficient 1 becomes most apparent.
-
-### §3.4 Curves — 1 Dimension, Coefficient 1 (The Limitation Becomes Clear)
-
-#### 3.4.1 From Lines to Curves — Defined by Riemann Sums
+> <strong>Checkpoint so far</strong>
+> - The integral of $dx \wedge dy \wedge dz$ is the limit of a Riemann sum that chops a region into small boxes and adds the values obtained by feeding each volume element to the volume-measuring device. $\iiint_V$ is the symbol this book gives to that limit.
+> - With coefficient $1$, volume is measured directly. The sphere volume $\frac{4}{3}\pi R^3$ is obtained by organizing the Riemann sum in the order $x \to y \to z$. No special coordinate system is needed.
+> - In the next section we drop one dimension and measure the area of a surface.
 
 ---
 
-In Chapter 1, we defined $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ as a $dx(\mathbf{v}) = \Delta x$-form (row vector) that eats a vector and returns its components. For $dy, dz$, when $t$, we have $i$. Similarly for $\Delta\mathbf{r}_i = \gamma(t_i + \Delta t) - \gamma(t_i)$.
+### §3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1
 
-Now, what happens if we apply these along a curve and sum up? Represent the curve as a function of time $\Delta t$:
+#### 3.2.1 From Parallelograms to Surfaces
 
-Chop the curve into small intervals. Let the displacement vector of the $\Delta\mathbf{r}_i \approx \gamma'(t_i)\,\Delta t$-th small interval be $dx$. If $\Delta\mathbf{r}_i$ is small enough, we can approximate it as $1$.
+In Chapter 2 §2.4, we assembled the area-measuring device $dx \wedge dy$. If we feed it two vectors $\mathbf{v}_1, \mathbf{v}_2$, we get the signed area of the shadow they cast onto the $xy$ plane. Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
 
-On each small interval, <strong>apply the row matrix $1$ to the displacement vector $1$</strong>:
+So how do we measure the area of a surface? Let us first check the flat case. Take a unit square lying in the $xy$ plane and chop it into fine small squares. The two edges of one small square are
 
-$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$
+$$\Delta\mathbf{x}=\begin{pmatrix}\Delta x\\0\\0\end{pmatrix},\qquad
+\Delta\mathbf{y}=\begin{pmatrix}0\\\Delta y\\0\end{pmatrix}.$$
 
-Sum this over all intervals:
+Feed these to $dx \wedge dy$:
 
-Take the limit as the partition becomes infinitely fine. We denote this limit as---PARA<strong>___\__</strong> . This is the definition of the integral of a $1$-form — the line integral.
+$$(dx \wedge dy)(\Delta\mathbf{x},\Delta\mathbf{y})=\Delta x\,\Delta y.$$
 
-$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i \approx \frac{dx}{dt}\,\Delta t$$
+Adding over all small squares gives area $1$. This is nothing more than the extension of the flat parallelogram from Chapter 2. What we are confirming here is that the $2$-form $dx\wedge dy$ returns the signed area of a small piece on the $xy$ plane as-is.
 
-> <strong>Note</strong> (Contraction of a $1$-form and a $\int_\gamma dy = y(t_1) - y(t_0)$-vector) As in §3.2 and §3.3, a <strong>$\int_\gamma dz = z(t_1) - z(t_0)$-form (row vector = scale)</strong> eats a <strong>$dx, dy, dz$-vector (column vector = figure)</strong> and returns a scalar. This contraction is performed on each small interval and summed. The principle is the same, just the degree differs.
+What if the surface is curved? Chop the surface into sufficiently fine small pieces. On each piece, write the displacement vectors in two adjacent directions as $\Delta\mathbf{a},\Delta\mathbf{b}$. In this chapter we call these two displacement vectors, or the oriented infinitesimal parallelogram they span, a <strong>surface element</strong> of the surface. The finer we chop the surface, the closer the aggregation of these surface elements comes to the aggregation of the surface itself.
 
-$$\sum_i dx(\Delta\mathbf{r}_i) \approx \sum_i \frac{dx}{dt}\,\Delta t$$
+Feed the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span this small piece of surface to the area-measuring device $dx \wedge dy$. From the definition in Chapter 2 §2.4.4, if
 
-This limit is exactly the same form as the substitution integral from Chapter 1, §1.3.5, and we have:
+$$\Delta\mathbf{a}=\begin{pmatrix}\Delta a_x\\\Delta a_y\\\Delta a_z\end{pmatrix},\qquad
+\Delta\mathbf{b}=\begin{pmatrix}\Delta b_x\\\Delta b_y\\\Delta b_z\end{pmatrix},$$
+
+then
+
+$$(dx \wedge dy)(\Delta\mathbf{a},\Delta\mathbf{b})
+=\Delta a_x\Delta b_y-\Delta a_y\Delta b_x.$$
+
+This is the signed area of the shadow that small piece casts onto the $xy$ plane.
+
+We <strong>write</strong> the limit as the mesh becomes infinitely fine as
+
+$$\iint_S dx \wedge dy.$$
+
+This is the definition of integration of a $2$-form — a surface integral. The structure is the same type as the volume integral in §3.1; only the number of vectors fed in has dropped from three to two.
+
+#### 3.2.2 What $dx \wedge dy$ Measures — A Test on the Sphere
+
+Let us actually compute on a sphere. Consider the upper half of a sphere of radius $R$ ($z \ge 0$). A point $(x,y,z)$ on the sphere satisfies
+
+$$x^2+y^2+z^2=R^2,\qquad z=\sqrt{R^2-x^2-y^2}.$$
+
+Here we use the total differential defined in Chapter 1. The total differential of the function
+
+$$F(x,y,z)=x^2+y^2+z^2$$
+
+is
+
+$$dF=2x\,dx+2y\,dy+2z\,dz.$$
+
+As promised in Chapter 1, this is a row vector that eats a displacement vector and reads off the change in $F$. If the displacement vector is tangent to the sphere, then to first order it does not change the value of $F=x^2+y^2+z^2$. Therefore that displacement vector $\mathbf{v}$ satisfies $dF(\mathbf{v})=0$. We choose the two displacement vectors that span a small piece of the sphere to satisfy this condition as well.
+
+For example, take the displacement vector that holds $y$ fixed and advances a small amount $\Delta x$ in the $x$ direction:
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\[2pt]0\\[2pt]\Delta z\end{pmatrix}.$$
+
+Feed this to $dF$:
+
+$$dF(\Delta\mathbf{x}_S)=2x\,\Delta x+2z\,\Delta z.$$
+
+Choosing it so that $dF(\Delta\mathbf{x}_S)=0$ as a direction along the sphere gives $\Delta z=-(x/z)\Delta x$. Likewise, for the displacement vector that holds $x$ fixed and advances a small amount $\Delta y$ in the $y$ direction, we get $\Delta z=-(y/z)\Delta y$.
+
+Therefore the two displacement vectors that span a small piece of the sphere can be written as
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\[2pt]0\\[2pt]-\dfrac{x}{z}\Delta x\end{pmatrix},\qquad
+\Delta\mathbf{y}_S=\begin{pmatrix}0\\[2pt]\Delta y\\[2pt]-\dfrac{y}{z}\Delta y\end{pmatrix}.$$
+
+If we chop the surface sufficiently finely, the aggregation of the parallelograms spanned by these two vectors approaches the aggregation of the sphere itself.
+
+Let us first feed only $dx \wedge dy$ to the surface:
+
+$$(dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)=\Delta x\,\Delta y.$$
+
+Therefore the integral over the upper hemisphere,
+
+$$
+\iint_{S_{\text{upper}}} dx \wedge dy,
+$$
+
+can be computed by the same method as the $y$ integral in §3.1.2, and the result is $\pi R^2$. This is nothing other than the area of the shadow cast by the upper hemisphere onto the $xy$ plane — a disk of radius $R$.
+
+The same calculation works for the lower hemisphere ($z = -\sqrt{R^2 - x^2 - y^2}$). However, if we measure the entire sphere with outward orientation, the orientation of the surface flips on the lower hemisphere and the sign reverses, so the integral becomes $-\pi R^2$.
+
+Therefore the integral of $dx \wedge dy$ over the entire sphere is $\pi R^2 + (-\pi R^2) = 0$. The shadow of the upper hemisphere and the shadow of the lower hemisphere cancel each other. This made it clear: <strong>what $dx \wedge dy$ measures is the signed area of the shadow onto the $xy$ plane, not the scalar area of the surface.</strong> Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
+
+#### 3.2.3 From Three Shadows to Scalar Area
+
+So how do we measure the scalar area of a surface (the area we learned in elementary school)? On each small patch, feed the two displacement vectors that form the surface element to all three area-measuring devices, and combine the results.
+
+Let us compute the remaining two on the upper hemisphere as well. Feeding the two displacement vectors from above,
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\0\\-\dfrac{x}{z}\Delta x\end{pmatrix},\qquad
+\Delta\mathbf{y}_S=\begin{pmatrix}0\\\Delta y\\-\dfrac{y}{z}\Delta y\end{pmatrix},$$
+
+to the three area-measuring devices gives:
+
+$$\begin{aligned}
+(dy \wedge dz)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \frac{x}{z}\,\Delta x\,\Delta y
+= \frac{x}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y \\[4pt]
+(dz \wedge dx)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \frac{y}{z}\,\Delta x\,\Delta y
+= \frac{y}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y \\[4pt]
+(dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \Delta x\,\Delta y
+\end{aligned}$$
+
+The three readings $A_{yz},A_{zx},A_{xy}$ are the signed projected areas of the surface element onto the three coordinate planes. Aligning these three components records the information of the oriented infinitesimal area. This is the surface version of the story from Chapter 2 §2.4.6, where we read the oriented area of a parallelogram as three projected areas.
+
+From here we want to extract the positive area with orientation discarded. So in this chapter we call
+
+$$
+dS(\Delta\mathbf{a},\Delta\mathbf{b})
+= \sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}
+$$
+
+the <strong>scalar surface element</strong> of that small patch.
+
+This is not a $2$-form. Whereas $dx\wedge dy$ eats the two displacement vectors that form a surface element and returns a single projected area, $dS$ is notation that combines the three projected areas by the familiar square root of a sum of squares in orthogonal Cartesian coordinates and returns a positive area with orientation discarded.
+
+However, before we simply add up $dS$, let us see what happens if we integrate each of the three area-measuring devices separately over the entire upper hemisphere. Writing the disk $D=\{(x,y)\mid x^2+y^2\le R^2\}$ that is the shadow of the upper hemisphere onto the $xy$ plane, the three signed shadow areas become the following three integrals:
+
+$$\begin{aligned}
+\iint_{S_{\text{upper}}} dy\wedge dz
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{x}{\sqrt{R^2-x^2-y^2}}\,dy\,dx, \\[4pt]
+\iint_{S_{\text{upper}}} dz\wedge dx
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{y}{\sqrt{R^2-x^2-y^2}}\,dy\,dx, \\[4pt]
+\iint_{S_{\text{upper}}} dx\wedge dy
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+1\,dy\,dx.
+\end{aligned}$$
+
+These three integrals measure the signed shadow areas onto the $yz$ plane, the $zx$ plane, and the $xy$ plane, respectively. In fact, by symmetry the first two are $0$ and the last is $\pi R^2$:
+
+$$
+\iint_{S_{\text{upper}}} dy\wedge dz=0,\qquad
+\iint_{S_{\text{upper}}} dz\wedge dx=0,\qquad
+\iint_{S_{\text{upper}}} dx\wedge dy=\pi R^2.
+$$
+
+Note: taking the square root of the sum of squares of these three integral values afterward does <strong>not</strong> give the area of the upper hemisphere. We must combine the three shadows <strong>on each small patch</strong> before adding them up; otherwise the information about the tilt of the surface is lost along the way.
+
+Therefore, to obtain surface area, on each small patch we find the three projected areas, build the scalar surface element $dS$ from them, and add those up. Writing the three projected areas from above as
+
+$$\begin{aligned}
+A_{yz} &= (dy \wedge dz)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) \\
+A_{zx} &= (dz \wedge dx)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) \\
+A_{xy} &= (dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+\end{aligned}$$
+
+the scalar surface element is
+
+$$
+dS(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+= \sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}.
+$$
+
+Substituting the three outputs we computed above,
+
+$$\begin{aligned}
+dS(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+&= \sqrt{
+\Bigl(\frac{x}{\sqrt{R^2-x^2-y^2}}\Delta x\,\Delta y\Bigr)^2
+{}+ \Bigl(\frac{y}{\sqrt{R^2-x^2-y^2}}\Delta x\,\Delta y\Bigr)^2
+{}+ (\Delta x\,\Delta y)^2} \\[4pt]
+&= \sqrt{\frac{x^2+y^2}{R^2-x^2-y^2}+1}\;\Delta x\,\Delta y \\[4pt]
+&= \frac{R}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y
+\end{aligned}$$
+
+That is, if we chop the disk $x^2+y^2 \le R^2$ — the shadow of the upper hemisphere onto the $xy$ plane — into small patches, the Riemann sum for the area becomes
+
+$$\sum_i\sum_j
+\frac{R}{\sqrt{R^2-x_i^2-y_j^2}}\,
+\Delta x_i\,\Delta y_j.$$
+
+In other words, we are simply adding up the scalar surface element on each small patch in the form
+
+$$\sum_i\sum_j dS(\Delta\mathbf{x}_{S,ij},\Delta\mathbf{y}_{S,ij}).$$
+
+In the limit as the mesh becomes fine:
+
+$$
+\operatorname{Area}(S_{\text{upper}})
+= R\int_{-R}^{R}\biggl(\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{dy}{\sqrt{R^2 - x^2 - y^2}}\biggr)\;dx.
+$$
+
+The inner $y$ integral. Set $a = \sqrt{R^2 - x^2}$:
+
+$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}}.$$
+
+Use the substitution $y = a\sin t$ (the same procedure as in §3.1.2). We have $dy = a\cos t\,dt$, $\sqrt{a^2 - y^2} = a\cos t$, and as $y$ goes from $-a$ to $a$, $t$ goes from $-\pi/2$ to $\pi/2$:
+
+$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}} = \int_{-\pi/2}^{\pi/2} \frac{a\cos t}{a\cos t}\,dt = \int_{-\pi/2}^{\pi/2} dt = \pi.$$
+
+The integral is $\pi$ regardless of $a$. Therefore:
+
+$$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2.$$
+
+This is the area of the upper hemisphere. On the lower hemisphere as well (if we take “outward from the origin” as positive), some signs flip in part, but the sum of squares is the same, so again we get $2\pi R^2$. Therefore the area of the entire sphere is:
+
+$$2\pi R^2 + 2\pi R^2 = 4\pi R^2.$$
+
+Splendid — $4\pi R^2$ appears. It is <strong>exactly the same pattern</strong> as when we recovered the area of a parallelogram from three shadows in Chapter 2 §2.4.7.
+
+#### 3.2.4 What We Have Learned So Far
+
+A basis $2$-form with coefficient $1$ does not, by itself, directly return the scalar area of a surface. $dx \wedge dy$ measures the signed projected area of a small piece of surface onto the $xy$ plane. To obtain the scalar area of a surface, we must combine the three projected components on each small piece to build the scalar surface element $dS$, and then add those up. This is exactly the same situation as for the area of a parallelogram in Chapter 2.
+
+However, in physics we often want to control “which shadow to emphasize, and by how much, at each point.” For example, when measuring fluid flow through a surface, if the flow is strong in the $x$ direction we want to put a large weight on $dy \wedge dz$ (the shadow onto the $yz$ plane). The need for such <strong>weights that vary from place to place</strong> — coefficients — naturally appears here. This is foreshadowing for §3.4.
+
+> <strong>Checkpoint so far</strong>
+> - A surface integral is the operation of feeding the two displacement vectors that form a surface element on each small patch to an area-measuring device and aggregating the scalars obtained.
+> - $dx \wedge dy$ by itself measures the area of the shadow onto the $xy$ plane. Over the entire sphere the net result is zero (the shadows of the upper and lower hemispheres cancel).
+> - Combining the readings of the three basis $2$-forms by the square root of a sum of squares on each small piece gives the scalar surface element $dS$. Adding these up yields the scalar area of the surface. For a sphere, $4\pi R^2$.
+> - In the next section we drop the dimension further and measure the length of a curve. There the limit of coefficient $1$ appears most clearly.
+
+---
+
+### §3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed
+
+#### 3.3.1 From Straight Lines to Curves — Defined by Riemann Sums
+
+In Chapter 1, we defined $dx, dy, dz$ as $1$-forms (measuring devices) that eat a vector and return each component. When $dx = \begin{pmatrix}1&0&0\end{pmatrix}$ and $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$, we have $dx(\mathbf{v}) = \Delta x$. The same holds for $dy$ and $dz$.
+
+So what do we get if we apply these along a curve and aggregate the results?
+
+First, chop the curve into fine subintervals. To each subinterval there corresponds a displacement vector from start to end,
+
+$$
+\Delta\mathbf{r}_i=(\Delta x_i,\Delta y_i,\Delta z_i)
+$$
+
+At this stage we do not yet need to write the curve as a formula. On each subinterval, if we feed $dx$ this displacement vector,
+
+$$dx(\Delta\mathbf{r}_i)=\Delta x_i$$
+
+Similarly, $dy(\Delta\mathbf{r}_i)=\Delta y_i$ and $dz(\Delta\mathbf{r}_i)=\Delta z_i$.
+
+Summing over all subintervals gives
+
+$$
+\sum_i dx(\Delta\mathbf{r}_i)=\sum_i \Delta x_i
+$$
+
+This is nothing but the straightforward sum of the $x$-direction displacements of each small piece along the curve. We <strong>write</strong> the limit as the mesh is made infinitely fine as
 
 $$\int_\gamma dx$$
 
-Similarly, $1$, $R$. That is, <strong>$\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$ — the line integral of the $2\pi R$-form — returns the net displacement of the curve: the difference in coordinates between the start and end points.</strong>
+This is the definition of integration of a $1$-form — a line integral.
 
-#### 3.4.2 Testing on a Circle — Arc Length Does Not Appear
+So the definition is in place. How do we actually compute this sum?
 
-Let's confirm. Parameterize a circle of radius $dx, dy$ as:
+Introducing $t$ here is not abandoning our policy so far. In §3.1 we organized small rectangular boxes inside a sphere in the order $z,y,x$; in §3.2 we organized small pieces on a sphere by projection onto the $xy$ plane. Likewise, on a curve we need a label to arrange the small pieces in order from start to end. We simply call that label $t$.
+
+So we assign a continuous index $t$ to each small piece along the curve and write
+
+$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$
+
+Here $t$ is not a new spatial coordinate. It is a label for arranging the small pieces along the curve from start to end. With this label, the displacement on the $i$th subinterval can be written as
+
+$$
+\Delta\mathbf{r}_i = \gamma(t_i+\Delta t)-\gamma(t_i)
+$$
+
+On each subinterval, <strong>apply the matrix $dx$ to the displacement vector $\Delta\mathbf{r}_i$</strong>:
+
+$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$
+
+The equality here means that applying the fixed $1$-form $dx$ to the displacement vector $\Delta\mathbf{r}_i$ returns the component $\Delta x_i$ exactly. On the other hand, the integral over the whole curve is defined as the limit of a Riemann sum in which the measuring device is evaluated at a representative point on each subinterval and the results are added.
+
+$$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$
+
+The substitution integrals treated in Chapter 1 were precisely this kind of reorganization of a sum. We do the same here. Number the small pieces along the curve by $t$, and organize the change in each component as “rate of change $\times$ subinterval width.” As the mesh is made infinitely fine, the conversion factor converges to the derivative: $\Delta x_i/\Delta t \to dx/dt$.
+
+This computation has exactly the same form as the substitution integral in Chapter 1 §1.2.5:
 
 $$\int_\gamma dx = \int_{t_0}^{t_1} \frac{dx}{dt}\,dt = x(t_1) - x(t_0)$$
 
-Then $dx, dy$, so:
+Similarly, $\int_\gamma dy = y(t_1) - y(t_0)$ and $\int_\gamma dz = z(t_1) - z(t_0)$. In other words, <strong>the line integrals of the $1$-forms $dx, dy, dz$ return the net displacement of the curve — the difference between the coordinates at the end point and those at the start point.</strong>
 
-Both are zero. Since it is a closed curve, the start and end points are the same, and the contributions cancel — a natural result.
+#### 3.3.2 Trying It on a Circle — Arc Length Does Not Appear
 
-But we also know that the arc length of this circle is $dx(\gamma'(t)) = -R\sin t$. With only the coefficient-1 $dy(\gamma'(t)) = R\cos t$, we get zero. So <strong>how can we get the arc length?</strong>
+Let us check. For a circle too, what we have in mind first is the operation of chopping the circle into fine arcs and summing the displacements of each small piece. To compute the sum over one full revolution, however, we need a label that arranges the small pieces in order. Here we use the angle $t$ as that label. A circle of radius $R$ is represented as
 
 $$\gamma(t) = (R\cos t,\; R\sin t,\; 0),\qquad t \in [0, 2\pi]$$
 
-We already have the values measured by $|\gamma'(t)| = R$ at each instant: $2\pi R$ and $dx$. Since these are scalars, we can square them and add:
+Since $\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$:
 
 $$\begin{aligned}
 \int_\gamma dx &= \int_0^{2\pi} dx(\gamma'(t))\,dt = \int_0^{2\pi} (-R\sin t)\,dt = R\bigl[\cos t\bigr]_0^{2\pi} = 0 \\[4pt]
 \int_\gamma dy &= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
 \end{aligned}$$
 
-Taking the square root gives the instantaneous speed $dy$. Integrating over the whole interval:
+Both are zero. It is a closed curve, so the start and end points coincide and the outward and return legs cancel — a natural result.
 
-We get the arc length $1$. What is going on here is important — $2\pi R$ and $t$ individually gave zero on a closed curve, but by taking the square root of the sum of their squares and integrating, the correct arc length appears. The power to measure length, which was absent in the coefficient-1 $dx(\gamma'(t))$-form, is recovered through the algebraic recombination of squaring and summing.
+However, we also know that the arc length of this circle is $2\pi R$. With coefficient-$1$ $dx$ and $dy$ alone we get zero — so <strong>how do we obtain arc length?</strong>
 
-We obtained the arc length $dy(\gamma'(t))$.
+At each label $t$, the values measured by $dx$ and $dy$ are already at hand:
+
+$$
+dx(\gamma'(t)) = -R\sin t,\qquad dy(\gamma'(t)) = R\cos t
+$$
+
+These are scalars, so we can square them and add:
 
 $$dx(\gamma'(t))^2 + dy(\gamma'(t))^2 = R^2\sin^2 t + R^2\cos^2 t = R^2$$
 
-Let's organize what is happening. At each time $\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$, we get two scalars, $t$ and $\mathbf{v}$, take the square root of their sum of squares $\sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$, and integrate over $1$. This is equivalent to integrating a new $1$-form on the curve, which returns $ds$ for a displacement $dx$. Let's write this $dx(\mathbf{v})^2$-form as $1$:
+Taking the square root gives the conversion factor for length per small piece, $|\gamma'(t)| = R$. Integrating over the whole interval:
 
 $$\int_0^{2\pi} \!\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} \!R\,dt = 2\pi R$$
 
-> <strong>Note</strong> (On notation) By the convention from Chapter 1, §1.2.6, the standalone $dx$ is a row vector (operator) and cannot be squared by itself. $\mathbf{v}$ means the square of the <strong>scalar obtained by acting</strong> the $ds$-form $1$ on the vector $\int_\gamma ds$. Keeping this distinction preserves the consistency of this book's notation.
+Arc length $2\pi R$ has appeared. What is happening here is important — $dx$ and $dy$ each gave zero on the closed curve by themselves, yet when we take the square root of the sum of their squares and integrate, the correct arc length emerges. The “power to measure length” that coefficient-$1$ $1$-forms lacked was recovered by the algebraic rearrangement called the sum of squares.
 
-This $1$ is also a legitimate $ds$-form, and $dx$ is an integral of a $dy$-form. However, this $\frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy$ cannot be written as a linear combination of $ds$ and $dx, dy$ — in the form $dx(\mathbf{v})^2 + dy(\mathbf{v})^2$. The definition of $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ involves a square root of a sum of squares, and is not linear in $dx, dy, dz$.
+Let us organize what is happening here. At each label $t$ we obtain two scalars, $dx(\gamma'(t))$ and $dy(\gamma'(t))$, take the square root of their sum of squares, $\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$, and integrate with respect to $t$. This is nothing other than integrating length measurement in Cartesian coordinates along the curve. In three dimensions, we write this line element as
 
-> <strong>Note</strong> (Foreshadowing of the metric) The form $1$ — "sum of squares of components" — is completely parallel to the way we obtained the scalar area of a parallelogram in Chapter 2, §2.4.7 as $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$. This "Pythagorean combination" is nothing other than the natural definition of length in orthogonal Cartesian coordinates. The generalization to arbitrary coordinate systems is done via the metric $g$ in Chapter 5. For now, just remember the fact: "by taking the square root of the sum of squares of the results of applying $1$, we get the positive magnitude (length, area, volume) with orientation discarded."
+$$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$$
 
-$$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$$
+The circle we are considering now lies in the plane $z=0$, so $dz(\gamma'(t))=0$, and only the two components $dx, dy$ remain in the calculation above.
 
-#### 3.4.3 So What Can the $dx, dy, dz$-Form Measure?
+> <strong>Note</strong> (on notation) By the convention of Chapter 1 §1.1.6, a standalone $dx$ is a row vector (operator), and it cannot be squared by itself. $dx(\mathbf{v})^2$ means the square of the <strong>scalar obtained by applying the $1$-form $dx$ to the vector $\mathbf{v}$</strong>. Preserving this distinction is what keeps the notation of this book consistent.
 
-Arc length can be measured as the integral of the $1$-form $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$. This $ds$ cannot be written as a linear combination of $dx$ and $dy$ — it requires the square root of a sum of squares. Generalizing this pattern to arbitrary coordinate systems is the role of the metric $g$ in Chapter 5, but first, let's see what a $dx, dy, dz$-form that can be written as a linear combination — i.e., without requiring a metric — actually measures.
+This $ds$ is a convenient notation for measuring arc length, but it is not itself a $1$-form in the sense of this book. A $1$-form is a measuring device that acts linearly on a displacement $\mathbf{v}$, whereas $ds(\mathbf{v})$ contains a square root of a sum of squares, so in general $ds(\mathbf{v}+\mathbf{w}) = ds(\mathbf{v})+ds(\mathbf{w})$ does not hold. Therefore $ds$ cannot be written as a linear combination of $dx, dy, dz$ — in the form $P\,dx+Q\,dy+R\,dz$.
 
-Suppose a force field $F_x, F_y, F_z$ acts at each point in space. When a particle moves along a curve, the infinitesimal work done by the force on each small interval is the product of the component of the force along the displacement and the magnitude of the displacement — that is, $dx, dy, dz$. Summing this over all intervals gives the total work $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2}$.
+#### 3.3.3 What Can a $1$-Form Measure?
 
-The key point here is that the components of the force $1$ vary <strong>from place to place</strong>. In volume (§3.2) and surface area (§3.3), coefficient 1 sufficed in many parts, but to measure work, coefficients that vary from place to place are indispensable. This shows the necessity of coefficients most vividly.
+Arc length could be measured by integrating the line element $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$. However, this $ds$ cannot be written as a linear combination of $dx, dy, dz$; it requires a square root of a sum of squares. Here we first ask: what does a $1$-form that does not use such a square root of a sum of squares — that is, a $1$-form that can be written as a linear combination of $dx, dy, dz$ — actually measure?
 
-This motivates the introduction of coefficients in the next section.
+Suppose a force field $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ acts at each point in space. When we move a particle along a curve, the infinitesimal work done by the force on each subinterval is the product of the component of the force in the direction of displacement and the magnitude of the displacement — namely, $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$. Summing this over the whole interval gives the work $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$.
 
-> <strong>【Checkpoint so far】</strong>
-> - The line integral of $ds$ returns the “net displacement.” On a closed curve, it is zero.
-> - Arc length can be computed as the integral of a $dx, dy$-form $1$. $dx, dy, dz$ cannot be written as a linear combination of $\times$; it requires the square root of the sum of squares (generalized in Chapter 5).
-> - Without metric, what a $=$-form (linear combination of $\times$) measures is quantities like work. → Proceed to §3.5.
+What matters here is that the components $F_x, F_y, F_z$ of the force <strong>vary from place to place</strong>. For volume (§3.1) and surface area (§3.2), coefficient $1$ was often enough; to measure work, coefficients that vary from place to place are indispensable. This is what most vividly shows the necessity of coefficients.
 
-### §3.5 Adding Coefficients — Product of Density and Geometry
+This is the motivation for introducing coefficients in the next section.
 
-#### 3.5.0 Why Coefficients? What Physics Demands
-
-In §§3.2–3.4, we measured curved figures with coefficient-1 forms. But in real physics, there are countless situations where we want to attach <strong>position-dependent weights</strong> to the measuring device:
+> <strong>Checkpoint so far</strong>
+> - Line integrals of $dx, dy, dz$ return “net displacement.” On a closed curve they are zero.
+> - Arc length can be computed by integrating the line element $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$. $ds$ is not a $1$-form and cannot be written as a linear combination of $dx, dy, dz$ (it requires a square root of a sum of squares).
+> - What a $1$-form that can be written as a linear combination of $dx, dy, dz$ measures is a quantity such as “work.” → §3.4.
 
 ---
 
-- <strong>Force field</strong> (varies with location) $=$ × <strong>Displacement</strong> $\times$ → <strong>Work</strong>
-- <strong>Flow velocity field</strong> (varies with location) $=$ × <strong>Cross-section</strong> $0$ → <strong>Flow rate</strong>
-- <strong>Density field</strong> (varies with location) $k$ × <strong>Volume</strong> $k$ → <strong>Mass</strong>
+### §3.4 Adding Coefficients — Density Times Geometry
 
-The common structure is obvious: <strong>“A position-dependent weight (a $0$-form = scalar field)”</strong> times <strong>“a geometric measure (a $1$-form)”</strong> constitutes a general $(x,y,z)$-form. In Chapter 2, §2.4.8, we said “a $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$-form is a meter that eats zero vectors, i.e., a scalar field” — that was exactly the setup.
+#### 3.4.0 Why Coefficients? — Physics Demands Them
 
-Below, we define integrals of forms with coefficients, in order of 1, 2, and 3 dimensions.
+In §3.1–§3.3, we measured curved shapes using forms with coefficient $1$. But in real physics, there are countless situations where we want to multiply a measuring device by a <strong>weight that varies from place to place</strong>:
 
-#### 3.5.1 Line Integral of a General $1$-Form (Work)
+- <strong>Force field</strong> (varying with location) $\times$ <strong>displacement</strong> $=$ <strong>work</strong>
+- <strong>Velocity field</strong> (varying with location) $\times$ <strong>cross-section</strong> $=$ <strong>flux</strong>
+- <strong>Density field</strong> (varying with location) $\times$ <strong>volume</strong> $=$ <strong>mass</strong>
 
-In real space, take scalar fields $dx, dy, dz$ that depend on the point $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$, and call---PARA<strong>___\__</strong> the general form of a $0$-form. Each $\gamma(t)$ is, as in Chapter 1, a row vector that reads a component from a column vector. The coefficients $\Delta\mathbf{r}_i$ are position-dependent weights — $\omega$-forms.
+The common structure is obvious. The product of <strong>"a weight that varies from place to place ($0$-form $=$ scalar field)"</strong> and <strong>"a geometric way of measuring ($k$-form)"</strong> constitutes a general $k$-form. In Chapter 2 §2.4.8 we said that "$0$-form is a measuring device that eats zero vectors, namely a scalar field" — precisely this setup.
 
-The integral along a curve $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ is simply the Riemann sum from §3.4.1 with coefficients attached. On each small interval, feeding the displacement $\gamma(t_i)$ into $1$ gives:
+Below, we define the integrals of forms with coefficients, in order from one to two to three dimensions.
 
-Here $\gamma'(t)$ is the value at the point $F(x)\,dx$. Summing over all intervals and taking the limit:
+#### 3.4.1 Line Integral of a General $1$-Form (Work)
 
-We denote this limit as
+In real space, take three scalar fields $P, Q, R$ that depend on the point $(x,y,z)$, and call
 
-$$\omega = \frac{\partial f}{\partial x}(x,y,z)\,dx + \frac{\partial f}{\partial y}(x,y,z)\,dy + \frac{\partial f}{\partial z}(x,y,z)\,dz$$
+$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
 
-This is exactly the same type as the coefficient-1 case in §3.4.1: at each instant, a <strong>row vector (coefficient-bearing $\int_\gamma \mathbf{F}\cdot d\mathbf{r}$-form)</strong> eats a <strong>column vector ($\int_\gamma \omega$)</strong> and returns a scalar, which is then summed. This is just a natural extension of $\omega$ from Chapter 1, §1.3.5 to 3 dimensions.
+the <strong>general form of a $1$-form</strong>. Each $dx, dy, dz$ is, as in Chapter 1, a row vector that reads off components from a column vector. The coefficients $P,Q,R$ are weights that vary from place to place — $0$-forms. If $P=\partial f/\partial x,\;Q=\partial f/\partial y,\;R=\partial f/\partial z$ come from a single function $f$, we get the special case $\omega=df$; in general, this need not be so.
 
-> <strong>Note</strong> (Correspondence with vector calculus) In vector calculus, this quantity is written as $\gamma$. The book's $\mathbf{F} = (y,\; x,\; 0)$ is the same, yet it clearly separates <strong>the field $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$</strong> and <strong>the path $\omega = y\,dx + x\,dy$</strong> in notation.
+The integral along a curve $\gamma(t)$ is simply the Riemann sum from §3.3.1 with coefficients multiplied in. Take the representative point of each small segment to be $\gamma(t_i)$, evaluate the coefficients there to get $\omega_{\gamma(t_i)}$, and feed it the displacement $\Delta\mathbf{r}_i$. At the fixed point $\gamma(t_i)$, $\omega_{\gamma(t_i)}$ is a row vector and $\Delta\mathbf{r}_i$ is a column vector, and their contraction can be written as
 
-$$\omega(\Delta\mathbf{r}_i) = \frac{\partial f}{\partial x}\,\Delta x_i + \frac{\partial f}{\partial y}\,\Delta y_i + \frac{\partial f}{\partial z}\,\Delta z_i \approx \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,\Delta t$$
+$$\omega_{\gamma(t_i)}(\Delta\mathbf{r}_i) = P(\gamma(t_i))\,\Delta x_i + Q(\gamma(t_i))\,\Delta y_i + R(\gamma(t_i))\,\Delta z_i$$
 
-Let's look at an example. Compute the work done by the force field $\frac{\partial f}{\partial x} = y,\; \frac{\partial f}{\partial y} = x$ along the unit circle $\frac{\partial f}{\partial x} = \sin t,\; \frac{\partial f}{\partial y} = \cos t$.
+Here "equals" means the contraction of the row vector $\omega_{\gamma(t_i)}$ fixed at one point and the displacement vector $\Delta\mathbf{r}_i$. As the contribution of the whole small segment, this is one term of a Riemann sum with coefficients frozen at the representative point; in the limit as the mesh becomes fine, it becomes a line integral.
 
-$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(\frac{\partial f}{\partial x}\frac{dx}{dt} + \frac{\partial f}{\partial y}\frac{dy}{dt} + \frac{\partial f}{\partial z}\frac{dz}{dt}\bigr)\,dt$$
+Organize the change in each component in the form "finite ratio $\times \Delta t$":
 
-Since $dx/dt = -\sin t,\; dy/dt = \cos t$, the coefficients are $2$. On the curve, $P, Q, R$. Also, from $2$:
+$$\omega(\Delta\mathbf{r}_i) = \bigl(P\frac{\Delta x_i}{\Delta t} + Q\frac{\Delta y_i}{\Delta t} + R\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$
+
+$P,Q,R$ are evaluated at the point $\gamma(t_i)$. Sum over the whole interval and take the limit. Since $\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$:
+
+$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(P\frac{dx}{dt} + Q\frac{dy}{dt} + R\frac{dz}{dt}\bigr)\,dt$$
+
+We write this limit as
 
 $$\int_\gamma \omega$$
 
-Therefore:
+Exactly the same pattern as the coefficient-$1$ case in §3.3.1: at each instant, a <strong>row vector (coefficient-weighted $1$-form)</strong> eats a <strong>column vector ($\gamma'(t)$)</strong>, returns a scalar, and we aggregate. This is nothing but the natural three-dimensional extension of $F(x)\,dx$ from Chapter 1 §1.2.5.
 
-The work is zero. This force field does no net work along the unit circle.
+> <strong>Note</strong> (correspondence with vector analysis)  
+> In vector analysis, this quantity is written $\int_\gamma \mathbf{F}\cdot d\mathbf{r}$. Our $\int_\gamma \omega$ is the same thing, yet <strong>the field $\omega$</strong> and <strong>the path $\gamma$</strong> are clearly separated in the notation.
 
-#### 3.5.2 Surface Integral of a General $\mathbf{r}(u,v)$-Form (Flow)
+Let us look at a concrete example. Compute the work done by the force field $\mathbf{F} = (y,\; x,\; 0)$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$.
 
-Similarly, a general $(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v)$-form with three scalar fields $\eta$ as coefficients:
+Since $\omega = y\,dx + x\,dy$, the coefficients are $P=y,\;Q=x,\;R=0$. On the curve, $P=\sin t,\;Q=\cos t$. Also, from $dx/dt = -\sin t,\; dy/dt = \cos t$:
 
 $$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$
 
-The integral along a surface $\eta$ is again just the Riemann sum from §3.3.1 with coefficients. On each small patch, feed the surface element $D$ into $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$:
+Therefore:
 
 $$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$
 
-Sum over all patches and take the limit. We denote this limit as
+The work is zero. This force field does no net work along the unit circle.
 
-The point is the same as in §3.3: at each point, the surface element is eaten by the area meter $P, Q, R$ to return a scalar, which is then summed over $(P, Q, R)$.
+#### 3.4.2 Surface Integral of a General $2$-Form (Flux)
 
-We saw in §3.3 that $\iint_S \eta$ measures the “area of the shadow” onto each plane. The coefficients $2$ serve to attach <strong>position-dependent weights</strong> to those shadows. Physically, if $3$ are the components of a flow velocity field, then $3$ corresponds to the flux through the surface. However, to organize this correspondence rigorously, we need the metric (inner product). Details will be given in Chapter 5.
+Similarly, with three scalar fields $P,Q,R$ as coefficients,
 
-$$\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy$$
+$$
+\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy
+$$
 
-> <strong>Note</strong> (Here, correspondence with vector calculus is just a guide) The correspondence with flux is merely a bridge for readers already familiar with vector calculus. The main line of this book is the operation “feed a $\rho(x,y,z)$-form and sum,” and lacking knowledge of vector calculus will not hinder the subsequent discussion.
+we call a general $2$-form.
 
-$$\eta(\mathbf{r}_u \Delta u,\; \mathbf{r}_v \Delta v) = \bigl(P\,(dy \wedge dz) + Q\,(dz \wedge dx) + R\,(dx \wedge dy)\bigr)(\mathbf{r}_u, \mathbf{r}_v)\,\Delta u\,\Delta v$$
+The integral over a surface is again just the Riemann sum from §3.2.1 with coefficients multiplied in. At the representative point of each small patch, evaluate the coefficients and feed $\eta$ the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span the patch:
 
-#### 3.5.3 Volume Integral of a General $\rho$-Form (Total Mass)
+$$\eta(\Delta\mathbf{a},\Delta\mathbf{b})
+= P\,(dy \wedge dz)(\Delta\mathbf{a},\Delta\mathbf{b})
+{}+ Q\,(dz \wedge dx)(\Delta\mathbf{a},\Delta\mathbf{b})
+{}+ R\,(dx \wedge dy)(\Delta\mathbf{a},\Delta\mathbf{b})$$
+
+Sum over all patches and take the limit. We denote this limit by
 
 $$\iint_S \eta$$
 
-The general form of a $\Omega$-form, with a scalar field $\rho=1$ as coefficient:
+At each point, the area-measuring device $\eta$ eats the two displacement vectors that form a surface element and returns a scalar; we aggregate over the whole surface — the same point as in §3.2.
 
-We simply multiply the density $\rho$ onto the Riemann sum from §3.2.1. On each small rectangular solid, feed the volume meter into $3$:
+That $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ each measure the "shadow area" onto the corresponding plane was seen in §3.2. The coefficients $P, Q, R$ attach a <strong>weight that varies from place to place</strong> to those shadows. Physically, $(P, Q, R)$ are the components of a velocity field, and $\iint_S \eta$ corresponds to the flux through the surface — but translating this rigorously into the language of vector analysis requires additional correspondence relations. We will do that in a later chapter.
 
-Sum over all and take the limit. We denote this limit as
+> <strong>Note</strong> (correspondence with vector analysis is only a guide rail here)  
+> The connection with flux is nothing more than a bridge for readers who already know vector analysis. The main line of this book remains the operation of "feeding a $2$-form and aggregating." Lack of vector-analysis background will not hinder the discussion from here on.
 
-If $dx \wedge dy \wedge dz$, this reduces to the coefficient-1 case from §3.2. If $\rho$ is mass density, it gives total mass; if charge density, total charge. Since a $dx \wedge dy \wedge dz$-form has only one independent component ($\gamma$), we have a clean separation: <strong>“density ($1$)” and “way of measuring volume ($\omega$)” are nicely separated</strong>, providing good insight.
+#### 3.4.3 Volume Integral of a General $3$-Form (Total Mass)
 
-#### 3.5.4 A Unified View of Lines, Surfaces, and Volumes
+The general form of a $3$-form, with scalar field $\rho(x,y,z)$ as coefficient, is
 
 $$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$
 
-Let's take an overview:
+We need only multiply the Riemann sum from §3.1.1 by the density $\rho$. At the representative point of each small box, evaluate $\rho$ and feed the volume element to $\Omega$:
 
 $$\Omega(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \rho(x_i,y_i,z_i)\,\Delta x_i\,\Delta y_i\,\Delta z_i$$
 
-| Object | Form | Skeleton of Integral | Example of Physical Meaning |
-|:---:|:---|:---|:---|
-| Curve $\displaystyle\int \omega(\gamma')\,dt$ | $S$-form $2$ | $\eta$ | Work |
-| Surface $\displaystyle\iint \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$ | $V$-form $3$ | $\Omega$ | Flux |
-| Region $\displaystyle\iiint \Omega(\hat{e}_x,\hat{e}_y,\hat{e}_z)$ | $k$-form $k$ | $k$ | Total mass |
+Sum over the whole region and take the limit. We write this limit as
 
 $$\iiint_V \Omega$$
 
-All share the same pattern: <strong>“A $0$-form (scale) eats a $k$-vector (figure) and returns a scalar, which is then summed over the entire region.”</strong> As the degree increases, the number of vectors fed in increases, and the alternating property governs the orientation of area and volume. Only the degree differs; the principle is always the same.
+If $\rho=1$, we return to the coefficient-$1$ case from §3.1. If $\rho$ is mass density, we get total mass; if charge density, total charge. A $3$-form has only one independent component, $dx \wedge dy \wedge dz$, so <strong>"density ($\rho$)" and "the way of measuring volume ($dx \wedge dy \wedge dz$)" separate cleanly</strong> and the picture is clear.
 
-> <strong>【Checkpoint so far】</strong>
-> - A general $\int_\gamma \omega$-form is the product of “a position-dependent weight (a $\iint_S \eta$-form)” and “a geometric measure (basis $\iiint_V \Omega$-form).”
-> - Line integral $k$ corresponds to work, surface integral $\omega$ to flux, volume integral $k$ to total mass.
-> - All follow the same principle: contraction of scale and figure, then summation. In the next section, we introduce a method to recompute these integrals in different coordinates — pullback.
+#### 3.4.4 A Unified Picture of Line, Surface, and Volume
 
-#### 3.5.5 General Form of the Integral
+Let us look back at what we have done.
 
-The line, surface, and volume integrals defined separately in §§3.2–3.4 actually fit into a single pattern. We write the operation of integrating a $M$-form $M$ over a $k=1$-dimensional region $\int_\gamma$ as, independent of dimension,
+| Object | Form | Integral notation | Example physical meaning |
+|:---:|:---|:---|:---|
+| Curve $\gamma$ | $1$-form $\omega$ | $\displaystyle\int_\gamma \omega$ | Work |
+| Surface $S$ | $2$-form $\eta$ | $\displaystyle\iint_S \eta$ | Flux |
+| Region $V$ | $3$-form $\Omega$ | $\displaystyle\iiint_V \Omega$ | Total mass |
 
-If $k=2$ is a curve ($\iint_S$), then $k=3$; if a surface ($\iiint_V$), then $M$; if a solid ($k$), then $k$ — the number of integral signs is simply determined by the dimension of $\sum$. The content is always: “chop into small pieces → feed the $k=1,2,3$-form to a $k$-vector → sum $d$ → limit.”
+Written as Riemann sums, they are
 
-<!-- role: foreshadowing -->
-Since the stage of this book is 3-dimensional space, $k=1,2,3$ is sufficient, but it is good to keep in the back of your mind that this construction holds regardless of $k$. In Chapter 4, when we introduce the exterior derivative $d$, this unified view will crystallize into the general form of Stokes' theorem: $\int_{\partial M} \omega = \int_M d\omega$.
+$$
+\int_\gamma \omega
+= \lim_{\text{mesh}\to 0}
+\sum_i \omega(\Delta\mathbf{r}_i),
+$$
 
-### §3.6 Pullback — Recomputing Integrals in Another Cartesian Coordinate System
+$$
+\iint_S \eta
+= \lim_{\text{mesh}\to 0}
+\sum_i\sum_j\eta(\Delta\mathbf{a}_{ij},\Delta\mathbf{b}_{ij}),
+$$
 
-#### 3.6.1 Substitution Was “Another Cartesian Coordinate”
+$$
+\iiint_V \Omega
+= \lim_{\text{mesh}\to 0}
+\sum_i\sum_j\sum_k
+\Omega(\Delta\mathbf{a}_{ijk},\Delta\mathbf{b}_{ijk},\Delta\mathbf{c}_{ijk})
+$$
+
+Here "mesh $\to 0$" means making the size of the coarsest small piece that makes up the curve, surface, or region approach $0$.
+
+All follow the same pattern: a <strong>$k$-form (measuring device) eats $k$ displacement vectors — that is, a $k$-dimensional small piece — returns a scalar, and we aggregate over the whole domain</strong>. As the degree rises, the number of vectors fed in increases, and antisymmetry governs the orientation of area and volume. Only the degree differs; the principle is the same throughout.
+
+> <strong>Checkpoint so far</strong>
+> - A general $k$-form is a linear combination of "basis $k$-forms" with "weights that vary from place to place ($0$-form)."
+> - The line integral $\int_\gamma \omega$ corresponds to work, the surface integral $\iint_S \eta$ to flux, and the volume integral $\iiint_V \Omega$ to total mass.
+> - All follow the same principle: "contraction of measuring device and figure → aggregation." In the next chapter we introduce pullback — the method of recomputing these integrals in different coordinates.
+
+#### 3.4.5 The General Form of Integration
+
+The line, surface, and volume integrals defined separately in §3.1–§3.3 actually fit one pattern. The operation of integrating a $k$-form $\omega$ over a $k$-dimensional region $M$ is written, regardless of dimension, as
 
 $$\int_M \omega$$
 
-Recall the substitution integral from Chapter 1, §1.3.5:
+If $M$ is a curve ($k=1$), we write $\int_\gamma$; if a surface ($k=2$), $\iint_S$; if a solid ($k=3$), $\iiint_V$ — the number of integral signs is determined only by the dimension of $M$. The content is always "chop into small pieces → feed $k$ displacement vectors to the $k$-form → sum $\sum$ → limit."
 
-The left side is an integral in the world of “coordinates $F(x)\,dx$.” The right side is an integral in the world of “coordinates $t$.” Note that both are <strong>Cartesian coordinates with linear scales</strong>.
+The stage of this book is three-dimensional space, so $k=1,2,3$ suffices; but it does no harm to keep in the back of your mind that this formula holds regardless of $k$. When we introduce the exterior derivative $d$ in Chapter 5, this unified viewpoint will bear fruit in the general form of Stokes's theorem, $\int_{\partial M} \omega = \int_M d\omega$.
 
 ---
 
-That is, substitution is: <strong>an operation of moving from coordinates where integration is difficult to coordinates where it is easy</strong>. On the right side, $(x, y, z)$ is a re-expression of the original world's meter $(u, v, 0)$ for the world of $(r, \theta, z)$.
+### §3.5 Summary of This Chapter and Outlook Toward the Next
 
-This idea of “re-expression” is not limited to 1-dimensional substitution; it applies to all integrals over curves, surfaces, and regions in multiple dimensions. That is the subject of this section — <strong>pullback</strong>.
+Over the past three chapters, we have assembled the following three things:
 
-#### 3.6.2 Switching to a Discussion of Variable Transformation — Two Worlds
+1. <strong>Chapter 1</strong>: View $dx$ as a matrix ($1$-form), and read integration as the limit of matrix action
+2. <strong>Chapter 2</strong>: Construct $2$-forms and $3$-forms via the wedge product $\wedge$, and measure area and volume algebraically
+3. <strong>Chapter 3 (this chapter)</strong>: Apply forms to curves, surfaces, and regions, and establish the operation of aggregating their output
 
-$$\int_a^b F(x)\,dx = \int_{t_0}^{t_1} F(x(t))\,\frac{dx}{dt}\,dt$$
+What this chapter established is the following unified principle:
 
-From here, we discuss variable transformations. What we want to understand in this section is: how to compute integrals over curves, surfaces, and regions defined in §§3.2–3.5 using coordinates that are easier to work with.
+<strong>A $k$-form (measuring device) eats $k$ displacement vectors—that is, a $k$-dimensional small piece—and returns a scalar, which is then aggregated over the entire region.</strong> No matter how the degree changes among $0, 1, 2, 3$, this picture stayed the same. Work along a curve, flux across a surface, total mass in a region—all can be written in the same language.
 
-<strong>What is the “other world”?</strong> It is another Cartesian coordinate system spread over a flat grid paper.
+> <strong>Checkpoint so far — Chapter 3</strong>
+> - The integral $\int_M \omega$ of a $k$-form $\omega$ is defined by “chop into small pieces → feed $k$ displacement vectors to the $k$-form → sum → limit.”
+> - The line integral $\int_\gamma \omega$ of a $1$-form is the operation of feeding each small curve segment’s displacement vector to $\omega$ and aggregating. Work is $\int_\gamma \omega$, the same quantity as $\mathbf{F}\cdot d\mathbf{r}$.
+> - The surface integral $\iint_S \eta$ of a $2$-form $\eta$ is the operation of feeding the two displacement vectors that span each small piece to $\eta$ and aggregating. With coefficient $1$, it measures the “shadow” onto each plane; adding up scalar area elements $dS$ built from the three shadows gives scalar area.
+> - The volume integral $\iiint_V \Omega$ of a $3$-form $\Omega$ is the operation of feeding the three displacement vectors that span each small rectangular box to $\Omega$ and aggregating. With coefficient $1$ this is volume directly; with coefficient $\rho$ it is total mass or total charge.
+> - A general $k$-form can be written as a combination of a coefficient ($0$-form) that varies from point to point and a basis $k$-form.
 
-> <strong>Note</strong> (Terminology from Chapter 1) In Chapter 1, §1.5, we called these two worlds <strong>real space</strong> and <strong>parameter space</strong>. In this chapter, we distinguish them as <strong>the original world</strong> (real space) and <strong>the parameter world</strong> (parameter space). The recognition remains the same: both are Cartesian coordinate systems with mutually orthogonal, equally spaced axes; the only difference is whether a conversion factor is interposed.
+However, an important problem remains.
 
-Let's compare the two worlds:
+Up to here, we counted small pieces while keeping the measuring devices of standard Cartesian coordinates $x, y, z$ as much as possible. But in actual calculations, counting in other variables is often overwhelmingly easier. Trace a circle by angle. View a sphere by radius and angles. In physics problems, you cannot get away without such variable changes.
 
-| | Original World (Cartesian coordinate space where figures live) | Parameter World (another Cartesian coordinate space) |
-|:---|:---|:---|
-| Coordinate axes | $\int_\gamma \omega$ | $\iint (\text{普通の }du \wedge dv\text{ 積分})$ or $(x,y,z)$ |
-| Figures | Curved curves, surfaces, regions | Flat rectangles, rectangular solids |
-| Grid | Distorted along the figure | Straight, equally spaced |
-| Integral | $(r,\theta,z)$ (hard to measure) | $\mathbf{v} = \begin{pmatrix}\Delta r \\ \Delta\theta \\ \Delta z\end{pmatrix}$ |
+Then what should we change, and what should we keep?
 
-Integrating over a curved figure in the original world is hard. But the parameter world is a flat grid paper — if we can integrate there, it is much easier.
-
-There is only one problem: if we bring the meter (form) placed in the original world directly into the parameter world, <strong>the scales do not match</strong>. The grid paper of the parameter world has a different scale from the original world, and it stretches and shrinks depending on location. The operation of correcting this stretching and re-expressing the meter for the parameter world — that is <strong>pullback</strong>, and the mechanism that handles this correction is <strong>the chain rule</strong>.
-
-So, how exactly do we do this “re-expression”? The key is to know “how much one step in the parameter world corresponds to a step in the original world.” We'll pursue this in the next subsection.
-
-#### 3.6.3 The Chain Rule — How Much Does One Step in the Parameter World Advance in the Original World?
-
-The heart of pullback is the chain rule. Let's start with intuition.
-
-Consider a transformation from the original world $1$ to cylindrical coordinates $r,\theta,z$ (introduced in Chapter 1, §1.5):
-
-This transformation is a map from 3 dimensions to 3 dimensions. In the parameter world, we also — following the physicist in Chapter 1, §1.1 — keep the pattern: displacement is a column vector, meter is a row vector, the result of action is a scalar.
-
-Let the displacement in the parameter world be $dr(\mathbf{v}) = \Delta r,\; d\theta(\mathbf{v}) = \Delta\theta,\; dz(\mathbf{v}) = \Delta z$. The $dx = \begin{pmatrix}1&0&0\end{pmatrix}$-form in this world — the row vector that extracts the $(x,y,z)$ component — is
-
-with $dx$.
-
-What we want to know is: how is the original world's ruler $dr, d\theta, dz$ (the row vector in $r$ space) expressed as a row vector in the parameter world? That is, what is the linear combination of $\mathbf{v}_r = \begin{pmatrix}\Delta r \\ 0 \\ 0\end{pmatrix}$ that represents $x$?
-
-$$x = r\cos\theta,\qquad y = r\sin\theta,\qquad z = z$$
-
-- A pure step in the $\cos\theta \cdot \Delta r$-direction, $dx$, contributes approximately $dr, d\theta, dz$ to the $dx = a\,dr + b\,d\theta + c\,dz$-direction in the original world. Assuming an expansion $dx(\mathbf{v}_r) = a\,\Delta r$, we have $\cos\theta \cdot \Delta r$. For this to equal $a = \cos\theta$, we must have $\theta$.
-- Similarly, from a step in the $\mathbf{v}_\theta = \begin{pmatrix}0 \\ \Delta\theta \\ 0\end{pmatrix}$-direction $b = -r\sin\theta$, we get $z$.
-- From a step in the $\mathbf{v}_z = \begin{pmatrix}0 \\ 0 \\ \Delta z\end{pmatrix}$-direction $c = 0$, we get $x = r\cos\theta$ (since $z$ does not depend on $dx$).
-
-That is, <strong>the partial derivatives are precisely the components when expanding $\mathbf{v} = \begin{pmatrix}\Delta r \\ \Delta\theta \\ \Delta z\end{pmatrix}$ in terms of the parameter world's row vectors.</strong> Hence:
-
-$$dr = \begin{pmatrix}1&0&0\end{pmatrix},\quad d\theta = \begin{pmatrix}0&1&0\end{pmatrix},\quad dz = \begin{pmatrix}0&0&1\end{pmatrix}$$
-
-> <strong>Note</strong> (Row vector × Column vector → Scalar) For a general step $\mathbf{v}$, we have:
-> $$dx(\mathbf{v}) = \cos\theta\,dr(\mathbf{v}) - r\sin\theta\,d\theta(\mathbf{v}) + 0\cdot dz(\mathbf{v}) = \cos\theta\,\Delta r - r\sin\theta\,\Delta\theta$$
-> <strong>$dx(\mathbf{v})$ is a row vector, $dx$ is a column vector, $dr, d\theta, dz$ is a scalar. </strong>Notice that this pattern — unchanged since Chapter 1, §1.2.3 — is preserved even in the midst of pullback. The chain rule is nothing other than an operation of changing the basis of the row vector.
-
-On the left side, $dx$ is a row vector in the original world. The right side is an expression “re-expressing $dy, dz$ using the row vectors $(x,y,z)$ of the parameter world.” <strong>This is precisely the basic operation of pullback.</strong> We do the same for $(r,\theta,z)$.
-
-In each equation, the left side is a row vector in $F(x)\,dx$ space, and the right side is a linear combination of row vectors in $F(x(t))\,\frac{dx}{dt}\,dt$ space. The dimension is always 3. The pattern is always “row vector × column vector → scalar.” Maintaining this pattern is the only way to correctly understand pullback.
-
-#### 3.6.4 Rereading Substitution in the Language of Pullback
-
-$$dx = \frac{\partial x}{\partial r}\,dr + \frac{\partial x}{\partial \theta}\,d\theta + \frac{\partial x}{\partial z}\,dz = \cos\theta\,dr - r\sin\theta\,d\theta + 0\cdot dz$$
-
-Let's revisit the substitution integral formula from §3.6.1 in terms of the chain rule we just discussed.
-
-On the left, $F(x) \to F(x(t))$ is the meter in the original world; on the right, $x$ is the meter pulled back to the parameter world. Pullback consists of two steps:
-
-$$\begin{aligned}
-dy &= \frac{\partial y}{\partial r}\,dr + \frac{\partial y}{\partial \theta}\,d\theta + \frac{\partial y}{\partial z}\,dz = \sin\theta\,dr + r\cos\theta\,d\theta + 0\cdot dz \\[4pt]
-dz &= \frac{\partial z}{\partial r}\,dr + \frac{\partial z}{\partial \theta}\,d\theta + \frac{\partial z}{\partial z}\,dz = 0\cdot dr + 0\cdot d\theta + 1\cdot dz
-\end{aligned}$$
-
-1. <strong>Coefficient part</strong> $t$: just rewrite the coordinates from $0$ to $dx \to \frac{dx}{dt}\,dt$ (pullback of a $dx = \cos\theta\,dr - r\sin\theta\,d\theta$-form).
-2. <strong>Meter part</strong> $1$: expansion using the chain rule (the 1-variable version of §3.6.3).
-
-What we did in Chapter 1, §1.5 with $\omega = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ was exactly this operation. What we did unconsciously back then is the true identity of what is called pullback.
-
-#### 3.6.5 Pullback of a General $dx, dy, dz$-Form — Procedure
-
-The procedure for pulling back a general $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ is just three steps:
-
-1. <strong>Chain rule</strong>: expand $x = r\cos\theta,\; y = r\sin\theta,\; z = z$ using the total differentials of the parameters.
-2. <strong>Substitute coefficients</strong>: substitute the parameter representation into $\frac{\partial f}{\partial z} = 0$.
-3. <strong>Sum up</strong>.
-
-Let's confirm with a concrete example. Under cylindrical coordinates $z$, pull back $dx, dy$. Since $\frac{\partial f}{\partial x} = -y = -r\sin\theta,\; \frac{\partial f}{\partial y} = x = r\cos\theta$, the $r^2\,d\theta$ component is trivial, but following the pattern of §3.6.3 we always treat all 3 components.
-
-First, expand $-r\sin\theta$ as in §3.6.3:
-
-The coefficients are $r^2$. Substituting them gives:
-
-The pulled-back result is $r^2$. The friends of $1$ we saw in Chapter 1, §1.5 now appear as $2$. This $3$ is the coefficient representing the “distortion of the angular ruler” in polar coordinates.
-
-So far we have seen the pullback of a $\wedge$-form — just two steps: substitute coefficients and expand via the chain rule. Next, we apply the same procedure to $2$-forms and $3$-forms. The alternating property of the wedge product $dx, dy, dz$ will dramatically simplify the expressions, as we shall see.
-
-#### 3.6.6 Pullback of $\wedge$-forms and $dx \wedge dy$-forms
-
-$$dx = \cos\theta\,dr - r\sin\theta\,d\theta,\qquad dy = \sin\theta\,dr + r\cos\theta\,d\theta$$
-
-The principle is the same. Expand each $u, v$ using the chain rule, then organize using the algebra of the wedge product $\wedge$.
-
-$$\begin{aligned}
-\omega &= (r\cos\theta)\,dy - (r\sin\theta)\,dx \\
-&= r\cos\theta\,(\sin\theta\,dr + r\cos\theta\,d\theta) - r\sin\theta\,(\cos\theta\,dr - r\sin\theta\,d\theta) \\
-&= r\cos\theta\sin\theta\,dr + r^2\cos^2\theta\,d\theta - r\sin\theta\cos\theta\,dr + r^2\sin^2\theta\,d\theta \\
-&= r^2(\cos^2\theta + \sin^2\theta)\,d\theta = r^2\,d\theta
-\end{aligned}$$
-
-As an example, let's pull back $du \wedge du = 0$ to two parameters $dv \wedge dv = 0$:
-
-Combine these with $dv \wedge du = -du \wedge dv$:
-
-Here the alternating property from Chapter 2, §2.4.4 — $\frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}$, $\mathbf{r}_u$, $\mathbf{r}_v$ — comes into play:
-
-The coefficient $xy$ is precisely the area of the shadow cast by $3$ and $dx, dy, dz$ onto the $\wedge$-plane. This is exactly the same expression that appeared in the definition of the surface integral in §3.3.1. In other words, <strong>the integration calculations we unconsciously performed in §§3.2 and 3.3 were nothing other than pullback.</strong>
-
-The same goes for a $(u,v,w)$-form: expand each $\Delta u \times \Delta v \times \Delta w$, combine with $(x,y,z)$, and simplify using the alternating property.
-
-$$dx = \frac{\partial x}{\partial u}\,du + \frac{\partial x}{\partial v}\,dv,\qquad dy = \frac{\partial y}{\partial u}\,du + \frac{\partial y}{\partial v}\,dv$$
-
-#### 3.6.7 Volume Stretching and Shrinking — The Grid Ratio Appears Automatically
-
-$$\begin{aligned}
-dx \wedge dy &= (\frac{\partial x}{\partial u}\,du + \frac{\partial x}{\partial v}\,dv) \wedge (\frac{\partial y}{\partial u}\,du + \frac{\partial y}{\partial v}\,dv) \\
-&= \frac{\partial x}{\partial u} \frac{\partial y}{\partial u}\,du \wedge du + \frac{\partial x}{\partial u} \frac{\partial y}{\partial v}\,du \wedge dv + \frac{\partial x}{\partial v} \frac{\partial y}{\partial u}\,dv \wedge du + \frac{\partial x}{\partial v} \frac{\partial y}{\partial v}\,dv \wedge dv
-\end{aligned}$$
-
-This is the most important consequence.
-
-$$dx \wedge dy = (\frac{\partial x}{\partial u} \frac{\partial y}{\partial v} - \frac{\partial x}{\partial v} \frac{\partial y}{\partial u})\,du \wedge dv$$
-
-Consider cutting an equally spaced grid in the new coordinates $(x,y,z)$. How much volume in the original world $dx \wedge dy \wedge dz$ does one grid cell $(r,\theta,z)$ correspond to? In general, it stretches and shrinks depending on location, so we must find the ratio.
-
-Pullback tells us this ratio <strong>automatically</strong>. Let's actually do it.
-
-Pull back the volume meter $\wedge$ from the original world $dr \wedge dr = 0$ to polar coordinates $d\theta \wedge d\theta = 0$. Using the expansions from §3.6.3:
-
-Combine these with $r$:
-
-First expand the two parentheses. Many terms cancel due to $\Delta r \times \Delta\theta \times \Delta z$ and $r$:
-
-Thus:
-
-The coefficient $r$ appears. <strong>This is the grid ratio — the volume in the original world corresponding to one cell $\Delta r$ in the parameter world is multiplied by $\Delta\theta$.</strong>
-
-$$dx = \cos\theta\,dr - r\sin\theta\,d\theta,\qquad dy = \sin\theta\,dr + r\cos\theta\,d\theta,\qquad dz = dz$$
-
-> <strong>Note</strong> (Dimensions of $\Delta z$) $r$ has dimension of length, $r\,\Delta r\,\Delta\theta\,\Delta z$ is dimensionless (radians), and $r$ has dimension of length. The coefficient $r\Delta\theta$ supplies one power of length, so the product $dx, dy, dz$ has the correct dimension of volume (length³). This is the volume version of the “1-form automatically adjusts dimensions” idea we saw in Chapter 1, §1.6.3.
-
-$$\begin{aligned}
-dx \wedge dy \wedge dz &= (\cos\theta\,dr - r\sin\theta\,d\theta) \wedge (\sin\theta\,dr + r\cos\theta\,d\theta) \wedge dz
-\end{aligned}$$
-
-What is remarkable here is that to obtain this $\wedge$, we <strong>did not use any geometric reasoning about the arc length of an angle ($r$) at all.</strong> We simply mechanically expanded $\cos^2\theta + \sin^2\theta = 1$ using the chain rule, combined with $r$, and simplified using the alternating property — $r$ appeared automatically. The algebraic identity $-r\sin\theta$ performed all the geometry for us.
-
-$$\begin{aligned}
-(\cos\theta\,dr - r\sin\theta\,d\theta) \wedge (\sin\theta\,dr + r\cos\theta\,d\theta)
-&= \cos\theta \cdot r\cos\theta\,dr \wedge d\theta - r\sin\theta \cdot \sin\theta\,d\theta \wedge dr \\
-&= r\cos^2\theta\,dr \wedge d\theta - r\sin^2\theta\,(-dr \wedge d\theta) \\
-&= r(\cos^2\theta + \sin^2\theta)\,dr \wedge d\theta \\
-&= r\,dr \wedge d\theta
-\end{aligned}$$
-
-The $dx \wedge dy \wedge dz$ that was hiding among the matrix components in Chapter 1, §1.5.3 now crystallizes as the “volume stretch factor $(u,v,w) \mapsto (x,y,z)$.” The unease we felt when seeing the single matrix component $J(u,v,w)$ back then finds its answer here.
-
-$$dx \wedge dy \wedge dz = r\,dr \wedge d\theta \wedge dz$$
-
-#### 3.6.8 The Same for Any Coordinate Transformation
-
-In general, pulling back the Cartesian volume meter $\Delta u\,\Delta v\,\Delta w$ via an arbitrary coordinate transformation $J$ always yields the following form:
-
-$r$ is a single function representing the <strong>distortion of the grid</strong> at each point — how many times larger a unit cell $J$ becomes in the original world.
-
-In mathematics, this $x,y,z$ is called the <strong>Jacobian determinant</strong>, or simply the <strong>Jacobian</strong>. You don't need to know the name. If you do, you'll recognize that the $u,v,w$ we just saw is a concrete example of the Jacobian in polar coordinates.
-
-Writing the identity of $dx, dy, dz$ explicitly, it is the determinant of the matrix formed by the partial derivatives of $\wedge$ with respect to $3$. But you don't need to memorize that formula. Because every time you expand $J$ using the chain rule and combine with $|J|$, this form always appears.
-
-Therefore, the rule for computing the integral of a $J$-form in a different coordinate system:
-
-$$\Phi^*(dx \wedge dy \wedge dz) = J(u,v,w)\,du \wedge dv \wedge dw$$
-
-is nothing more than the integral version of the geometric fact: <strong>“when the volume meter in the original world is pulled back to the new coordinates, one grid cell is distorted by a factor of $r\,dr\,d\theta$.”</strong> The absolute value $\theta$ on the right-hand side is used when we want to ignore orientation and handle only positive volumes; the essential thing is the signed version $r\Delta\theta$.
-
-> <strong>Note</strong> (For readers who have studied vector calculus) When you learned variable transformation and were told “in polar coordinates, $\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$ appears,” many textbooks gave a geometric explanation: “consider the arc length in the $dx = \cos\theta\,dr - r\sin\theta\,d\theta$ direction, $dx \wedge dy \wedge dz$, then $r\,dr \wedge d\theta \wedge dz$.” That explanation is not wrong, but from the pullback perspective, we don't need to think about the arc length of the angle at all. Only the chain rule and the algebra of the wedge product automatically yield the correct ratio.
-
-> <strong>【Checkpoint so far】</strong>
-> - Pullback is the operation of “re-expressing a meter (form) in the parameter world.” The chain rule governs it entirely.
-> - The $r$ from Chapter 1, §1.5 is the prototype of pullback. Substitution has the same structure.
-> - Pulling back $J$ to polar coordinates gives $(x,y)$. The volume ratio $dx \wedge dy \wedge dz$ of the grid appears purely from algebra, without any geometric reasoning about angles.
-> - For a general coordinate transformation, $z$ (the Jacobian) appears as the grid distortion factor.
-
-## Appendix to Chapter 3: Grid Pullback in 2 Dimensions
-
-$$\iiint_V f\,dx \wedge dy \wedge dz = \iiint_U f(\Phi(u,v,w))\,|J(u,v,w)|\,du \wedge dv \wedge dw$$
-
-> <strong>Note</strong> (Against the policy of this book, but…) Since Chapter 1, §1.1, this book has consistently insisted on “the physicist's 3 dimensions.” However, the distortion of area meters via pullback is hard to draw in 3 dimensions. In this appendix, as a supplementary aid, we temporarily drop to the real 2-dimensional plane $dx \wedge dy \wedge dz = r\,dr \wedge d\theta \wedge dz$ to visually follow the grid correspondence. Omitting $r$ from the 3-dimensional volume meter $z$ strictly violates this book's notational convention — I acknowledge that, and ask you to read it as an <strong>appendix</strong> for gaining intuition.
-
-### Polar Coordinates in the Plane — Overlaying Grids
-
-In §§3.6.3 and 3.6.7, we algebraically derived the equality $xy$. Even if we say the coefficient $x = r\cos\theta,\; y = r\sin\theta$ is the “grid distortion rate,” some readers may not get it from the formula alone. Here we suppress the $(x,y)$ direction and consider only the $\Delta x, \Delta y$-plane.
-
----
-
-The transformation is $\Delta x\,\Delta y$. In the original world's $dx \wedge dy$-plane, draw an equally spaced square grid with spacing $(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y)$. The area of one cell is $(r,\theta)$, which equals the value obtained by feeding the two sides of the cell $r$ into $\theta$.
-
-Looking at the same region in the parameter world $\Delta r, \Delta\theta$, the lines of constant $r$ are concentric circles centered at the origin, and the lines of constant $\Delta r$ are radial lines extending from the origin. A cell of this grid (when $\theta$ is small) is approximately a rectangle, but its size varies with location.
-
-Let's compute one cell concretely. The side in the $r$ direction has length $\Delta\theta$. The side in the $r\Delta\theta$ direction is, on the circle of radius $(r\Delta\theta) \times \Delta r = r\,\Delta r\,\Delta\theta$, the arc length corresponding to the angle $(x,y)$ — <strong>approximately $1$</strong>. Hence the area of one cell is approximately $(r,\theta)$.
-
-That is, one cell of the square grid with area $r$ in the $(r,\theta)$-plane, when transferred to the $r$-plane, has its area multiplied by $r$. The factor varies with location $\theta$ — the farther from the origin (larger $r\Delta\theta$), the larger the cell — which can also be read from this $dx \wedge dy$.---PARA### Algebra Replaces Geometry
-
-Now, in the explanation above, we used a geometric reasoning: “the arc length in the $dr \wedge dr = 0$ direction is approximately $d\theta \wedge d\theta = 0$.” That is intuitive and easy to understand, but the calculation we did in §3.6.7 was completely different — we expanded $r\,dr \wedge d\theta$ using the chain rule and derived $\wedge$ using <strong>only algebraic rules</strong> like $r\Delta\theta$ and $dx \wedge dy$. We never said a word about arc length.
-
-This is the power of pullback. Even for complicated coordinate transformations where geometric intuition fails, the chain rule and the algebra of $xy$ follow the same procedure to compute the correct grid ratio. That we could think in terms of $2$ and geometry here is only because polar coordinates happen to be simple.
-
-> <strong>Note</strong> (Returning to 3 dimensions) When we return to the main text, it is always 3-dimensional. With $dx$ alone, we only measure “the area of the shadow onto the $dx$-plane,” and as we saw in §3.3, to get the area of a curved surface we need the combination of three $1$-forms. This appendix is merely a temporary aid; please understand that it temporarily relaxes the notational convention of the main text (where $\wedge$ is always a 3-component row vector).
-
-### §3.7 Summary of This Chapter and Outlook to Chapter 4
-
-The three steps of Part I, “The True Nature of the Tail of the Integral Sign,” are now complete:
-
-1. <strong>Chapter 1</strong>: View $2$ as a matrix (a $3$-form); read integration as the limit of matrix action.
-2. <strong>Chapter 2</strong>: Construct $k$-forms and $k$-forms using the wedge product $0,1,2,3$; measure area and volume algebraically.
-3. <strong>Chapter 3 (this chapter)</strong>: Apply forms to curves, surfaces, and regions and sum them (integrate). Use pullback to handle coordinate transformations uniformly; see that the grid distortion factor (Jacobian) emerges without any geometric reasoning about angles.
-
-What we have established in this chapter is the following unified principle:
-
-<strong>$r$-form (scale) eats a $1$-vector (figure) and returns a scalar, which is then summed over the entire region.</strong> Even when the degree $\omega$ changes, this picture remained invariant. Work on a curve, flux through a surface, total mass within a region — all can be written in the same language.
-
----
-
-Pullback is a technique to “recompute integrals in a different Cartesian coordinate system,” and its core is the intuition from the chain rule in §3.6.3 — “how much a step in the parameter world advances in the original world.” Combined with the alternating property of the wedge product, the volume ratio in polar coordinates $\int_\gamma \omega$ and the general Jacobian can be derived mechanically through algebraic computation alone, without relying on geometric intuition.
-
-> <strong>【Checkpoint — Chapter 3 and Part I as a whole】</strong>
-> - Line integral of a $\gamma'(t)$-form $\omega$: $\int_\gamma \omega$ — feed $\mathbf{F}\cdot d\mathbf{r}$ into $2$ and sum. Work is $\eta$, which is the same quantity as $\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$.
-> - Surface integral of a $3$-form $\Omega$: $\iiint_V \Omega$. With coefficient 1, it measures the “shadow” on each plane; combining the three shadows gives the scalar area. In general, it measures flux.
-> - Volume integral of a $\rho$-form $\Phi^*$: $dx = \cos\theta\,dr - r\sin\theta\,d\theta$. With coefficient 1, it is volume; with coefficient $3$, it is total mass or total charge.
-> - Pullback $\wedge$ is the operation of “re-expressing a form as a shadow in parameter space.” The $d$ from Chapter 1, §1.5 is a concrete example.
-> - Pullback of a $d$-form yields the volume ratio (Jacobian) of the grid, giving a geometric meaning to the change-of-variables formula. No geometric reasoning about angles needed — the chain rule and the algebra of __PH_0850__ do everything.
-
-<strong>A $k$-form (measuring device) eats a $k$-vector (geometric figure) and returns a scalar, which is then summed over the entire region.</strong> No matter how the degree changes as $0,1,2,3$, this structure remains invariant. Work along a curve, flux across a surface, and total mass within a region — all can be written in the same language.
-
-Pullback is the technique of "recalculating an integral in another Cartesian coordinate system," and its essence is nothing but the intuition of the chain rule we saw in §3.6.3 — "how far a step in the parameter world advances in the original world." Combined with the antisymmetry of the wedge product, the volume ratio $r$ in polar coordinates and the general Jacobian are derived purely by mechanical algebraic calculation without relying on geometric intuition.
-
-> <strong>【Checkpoint So Far — Chapter 3, Part I】</strong>
-> - The line integral of a $1$-form $\omega$, $\int_\gamma \omega$, is the operation of feeding $\gamma'(t)$ to $\omega$ and summing. Work is $\int_\gamma \omega$, the same quantity as $\mathbf{F}\cdot d\mathbf{r}$.
-> - The surface integral of a $2$-form $\eta$, $\iint_S \eta = \iint_D \eta(\mathbf{r}_u, \mathbf{r}_v)\,du \wedge dv$. With coefficient 1, it measures the "shadow" on each plane, and combining the three shadows yields a scalar area. In general, it measures flux.
-> - The volume integral of a $3$-form $\Omega$, $\iiint_V \Omega$. With coefficient 1 it gives volume directly; with coefficient $\rho$ it gives total mass or total charge.
-> - Pullback $\Phi^*$ is the operation of "rebaking a form into its shadow in parameter space." The $dx = \cos\theta\,dr - r\sin\theta\,d\theta$ from §1.5 of Chapter 1 is a concrete example.
-> - In the pullback of a $3$-form, the volume ratio of the grid (Jacobian) appears, giving a geometric meaning to the change-of-variables formula. No angle considerations are needed — the chain rule and the algebra of $\wedge$ do everything.
-
----
-
-From here onward, in <strong>Part II</strong>, we will finally introduce <strong>the exterior derivative $d$</strong>. $d$ is a linear operator that raises the degree of a form by one. It will become clear that gradient, curl, and divergence are <strong>variations of a single operation</strong>. Now that we have the language of integration ready, the stage is set to complete the algebra on the differentiation side.
+In the next chapter (Chapter 4), we reread variable change not as an operation that “moves points,” but as an <strong>operation that rebuilds measuring devices</strong>. This is the <strong>pullback</strong>.

--- a/manuscript/en/ch03/ch03.md
+++ b/manuscript/en/ch03/ch03.md
@@ -20,9 +20,9 @@ The purpose of this chapter is not to memorize the formulas for a sphere again. 
 
 Therefore, we deliberately do not escape immediately into polar or spherical coordinates. We count small pieces in $x,y,z$, decide which pieces belong to the target, and organize the sum. It is messy — but this messiness is the substance of integration.
 
-Now, on our desk we have the measuring devices built in Chapters 1 and 2: $0$-forms, $1$-forms, $2$-forms, and $3$-forms. The job of this chapter is to <strong>apply them along curves, surfaces, and regions and aggregate the results</strong>.
+Now, on our desk we have the measuring devices built in Chapters 1 and 2: $0$-forms, $1$-forms, $2$-forms, and $3$-forms. The job of this chapter is to <strong>apply them to curves, surfaces, and regions and aggregate the results</strong>.
 
-The principle is the same at every degree. We begin with the case where a volume-measuring device with coefficient $1$ returns the volume of a region as-is, then step down in dimension and check “what does the form measure, and what does it not measure?”
+The principle is the same at every degree. We begin with the case where a volume-measuring device with coefficient $1$ returns the volume of a region directly, then step down in dimension and check “what does the form measure, and what does it not measure?”
 
 > <strong>Note</strong> (ground rules)  
 > We state this up front as a promise. Below, we treat curves and surfaces as sufficiently smooth, and cases where chopping into small pieces and adding converges in a straightforward way. Details such as orientation reversal and self-intersection are kept at the level of “they do not cause trouble in situations commonly used in physics.” A rigorous theory of integrability is outside the scope of this book.
@@ -120,7 +120,7 @@ Finally the $z$ integral:
 $$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3.$$
 
 > <strong>Note</strong> (what this calculation means)  
-> What we did here is only the organization of the Riemann sum from §3.1.1. Instead of deciding which small boxes lie inside the sphere while adding in $x,y,z$, we organized the sum in the order $x \to y \to z$. Each stage is a one-variable Riemann sum from Chapter 1; in the limit it becomes a familiar one-variable integral. That is all. If we aggregate the contraction of measuring device and figure honestly, we reach $\frac{4}{3}\pi R^3$.
+> What we did here is only the organization of the Riemann sum from §3.1.1. Instead of deciding which small boxes lie inside the sphere one by one, we organized the actual summation from the inside out in the order $x \to y \to z$. Each stage is a one-variable Riemann sum from Chapter 1; in the limit it becomes a familiar one-variable integral. That is all. If we aggregate the contraction of measuring device and figure honestly, we reach $\frac{4}{3}\pi R^3$.
 
 Thus we have confirmed that the integral of the single measuring device $dx \wedge dy \wedge dz$ gives the correct volume $\frac{4}{3}\pi R^3$ of a curved region. In three dimensions, a volume-measuring device with coefficient $1$ measures volume directly.
 
@@ -148,9 +148,9 @@ Feed these to $dx \wedge dy$:
 
 $$(dx \wedge dy)(\Delta\mathbf{x},\Delta\mathbf{y})=\Delta x\,\Delta y.$$
 
-Adding over all small squares gives area $1$. This is nothing more than the extension of the flat parallelogram from Chapter 2. What we are confirming here is that the $2$-form $dx\wedge dy$ returns the signed area of a small piece on the $xy$ plane as-is.
+Adding over all small squares gives area $1$. This is nothing more than the extension of the flat parallelogram from Chapter 2. What we are confirming here is that the $2$-form $dx\wedge dy$ returns the signed area of a small piece on the $xy$ plane directly.
 
-What if the surface is curved? Chop the surface into sufficiently fine small pieces. On each piece, write the displacement vectors in two adjacent directions as $\Delta\mathbf{a},\Delta\mathbf{b}$. In this chapter we call these two displacement vectors, or the oriented infinitesimal parallelogram they span, a <strong>surface element</strong> of the surface. The finer we chop the surface, the closer the aggregation of these surface elements comes to the aggregation of the surface itself.
+What if the surface is curved? Chop the surface into sufficiently fine small pieces. On each piece, write the displacement vectors in two adjacent directions as $\Delta\mathbf{a},\Delta\mathbf{b}$. In this chapter we call these two displacement vectors, or the oriented infinitesimal parallelogram they span, a <strong>surface element</strong> of the surface. The finer we chop the surface, the more closely the aggregate of these surface elements approximates the surface itself.
 
 Feed the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span this small piece of surface to the area-measuring device $dx \wedge dy$. From the definition in Chapter 2 §2.4.4, if
 
@@ -184,7 +184,7 @@ is
 
 $$dF=2x\,dx+2y\,dy+2z\,dz.$$
 
-As promised in Chapter 1, this is a row vector that eats a displacement vector and reads off the change in $F$. If the displacement vector is tangent to the sphere, then to first order it does not change the value of $F=x^2+y^2+z^2$. Therefore that displacement vector $\mathbf{v}$ satisfies $dF(\mathbf{v})=0$. We choose the two displacement vectors that span a small piece of the sphere to satisfy this condition as well.
+As promised in Chapter 1, this is a row vector that eats a displacement vector and reads off the first-order change in $F$. If the displacement vector is tangent to the sphere, then to first order it does not change the value of $F=x^2+y^2+z^2$. Therefore that displacement vector $\mathbf{v}$ satisfies $dF(\mathbf{v})=0$. We choose the two displacement vectors that span a small piece of the sphere to satisfy this condition as well.
 
 For example, take the displacement vector that holds $y$ fixed and advances a small amount $\Delta x$ in the $x$ direction:
 
@@ -194,7 +194,7 @@ Feed this to $dF$:
 
 $$dF(\Delta\mathbf{x}_S)=2x\,\Delta x+2z\,\Delta z.$$
 
-Choosing it so that $dF(\Delta\mathbf{x}_S)=0$ as a direction along the sphere gives $\Delta z=-(x/z)\Delta x$. Likewise, for the displacement vector that holds $x$ fixed and advances a small amount $\Delta y$ in the $y$ direction, we get $\Delta z=-(y/z)\Delta y$.
+Choosing this as a tangent displacement along the sphere, so that $dF(\Delta\mathbf{x}_S)=0$, gives $\Delta z=-(x/z)\Delta x$. Likewise, for the displacement vector that holds $x$ fixed and advances a small amount $\Delta y$ in the $y$ direction, we get $\Delta z=-(y/z)\Delta y$.
 
 Therefore the two displacement vectors that span a small piece of the sphere can be written as
 
@@ -217,7 +217,7 @@ can be computed by the same method as the $y$ integral in §3.1.2, and the resul
 
 The same calculation works for the lower hemisphere ($z = -\sqrt{R^2 - x^2 - y^2}$). However, if we measure the entire sphere with outward orientation, the orientation of the surface flips on the lower hemisphere and the sign reverses, so the integral becomes $-\pi R^2$.
 
-Therefore the integral of $dx \wedge dy$ over the entire sphere is $\pi R^2 + (-\pi R^2) = 0$. The shadow of the upper hemisphere and the shadow of the lower hemisphere cancel each other. This made it clear: <strong>what $dx \wedge dy$ measures is the signed area of the shadow onto the $xy$ plane, not the scalar area of the surface.</strong> Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
+Therefore the integral of $dx \wedge dy$ over the entire sphere is $\pi R^2 + (-\pi R^2) = 0$. The shadow of the upper hemisphere and the shadow of the lower hemisphere cancel each other. This tells us exactly what $dx \wedge dy$ measures: <strong>the signed area of the shadow onto the $xy$ plane, not the scalar area of the surface.</strong> Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
 
 #### 3.2.3 From Three Shadows to Scalar Area
 
@@ -238,7 +238,7 @@ $$\begin{aligned}
 (dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \Delta x\,\Delta y
 \end{aligned}$$
 
-The three readings $A_{yz},A_{zx},A_{xy}$ are the signed projected areas of the surface element onto the three coordinate planes. Aligning these three components records the information of the oriented infinitesimal area. This is the surface version of the story from Chapter 2 §2.4.6, where we read the oriented area of a parallelogram as three projected areas.
+The three readings $A_{yz},A_{zx},A_{xy}$ are the signed projected areas of the surface element onto the three coordinate planes. Taken together, these three components record the information of the oriented infinitesimal area. This is the surface version of the story from Chapter 2 §2.4.6, where we read the oriented area of a parallelogram as three projected areas.
 
 From here we want to extract the positive area with orientation discarded. So in this chapter we call
 
@@ -332,7 +332,7 @@ The integral is $\pi$ regardless of $a$. Therefore:
 
 $$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2.$$
 
-This is the area of the upper hemisphere. On the lower hemisphere as well (if we take “outward from the origin” as positive), some signs flip in part, but the sum of squares is the same, so again we get $2\pi R^2$. Therefore the area of the entire sphere is:
+This is the area of the upper hemisphere. On the lower hemisphere as well, some projected-area signs flip under the outward orientation, but the sum of squares is the same, so again we get $2\pi R^2$. Therefore the area of the entire sphere is:
 
 $$2\pi R^2 + 2\pi R^2 = 4\pi R^2.$$
 
@@ -346,7 +346,7 @@ However, in physics we often want to control “which shadow to emphasize, and b
 
 > <strong>Checkpoint so far</strong>
 > - A surface integral is the operation of feeding the two displacement vectors that form a surface element on each small patch to an area-measuring device and aggregating the scalars obtained.
-> - $dx \wedge dy$ by itself measures the area of the shadow onto the $xy$ plane. Over the entire sphere the net result is zero (the shadows of the upper and lower hemispheres cancel).
+> - $dx \wedge dy$ by itself measures the signed area of the shadow onto the $xy$ plane. Over the entire sphere the net result is zero (the shadows of the upper and lower hemispheres cancel).
 > - Combining the readings of the three basis $2$-forms by the square root of a sum of squares on each small piece gives the scalar surface element $dS$. Adding these up yields the scalar area of the surface. For a sphere, $4\pi R^2$.
 > - In the next section we drop the dimension further and measure the length of a curve. There the limit of coefficient $1$ appears most clearly.
 
@@ -360,7 +360,7 @@ In Chapter 1, we defined $dx, dy, dz$ as $1$-forms (measuring devices) that eat 
 
 So what do we get if we apply these along a curve and aggregate the results?
 
-First, chop the curve into fine subintervals. To each subinterval there corresponds a displacement vector from start to end,
+First, chop the curve into small subintervals. To each subinterval there corresponds a displacement vector from start to end,
 
 $$
 \Delta\mathbf{r}_i=(\Delta x_i,\Delta y_i,\Delta z_i)
@@ -406,11 +406,11 @@ The equality here means that applying the fixed $1$-form $dx$ to the displacemen
 
 $$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$
 
-The substitution integrals treated in Chapter 1 were precisely this kind of reorganization of a sum. We do the same here. Number the small pieces along the curve by $t$, and organize the change in each component as “rate of change $\times$ subinterval width.” As the mesh is made infinitely fine, the conversion factor converges to the derivative: $\Delta x_i/\Delta t \to dx/dt$.
+The substitution integrals treated in Chapter 1 were precisely this kind of reorganization of a sum. We do the same here. Number the small pieces along the curve by $t$, and organize the change in each component as “rate of change $\times$ subinterval width.” As the mesh is made infinitely fine, the conversion factor converges to the ordinary derivative of the coordinate function: $\Delta x_i/\Delta t \to x'(t)$.
 
 This computation has exactly the same form as the substitution integral in Chapter 1 §1.2.5:
 
-$$\int_\gamma dx = \int_{t_0}^{t_1} \frac{dx}{dt}\,dt = x(t_1) - x(t_0)$$
+$$\int_\gamma dx = \int_{t_0}^{t_1} x'(t)\,dt = x(t_1)-x(t_0).$$
 
 Similarly, $\int_\gamma dy = y(t_1) - y(t_0)$ and $\int_\gamma dz = z(t_1) - z(t_0)$. In other words, <strong>the line integrals of the $1$-forms $dx, dy, dz$ return the net displacement of the curve — the difference between the coordinates at the end point and those at the start point.</strong>
 
@@ -427,7 +427,7 @@ $$\begin{aligned}
 \int_\gamma dy &= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
 \end{aligned}$$
 
-Both are zero. It is a closed curve, so the start and end points coincide and the outward and return legs cancel — a natural result.
+Both are zero. It is a closed curve, so the start and end points coincide and the component displacements cancel over one full turn — a natural result.
 
 However, we also know that the arc length of this circle is $2\pi R$. With coefficient-$1$ $dx$ and $dy$ alone we get zero — so <strong>how do we obtain arc length?</strong>
 
@@ -463,7 +463,7 @@ Arc length could be measured by integrating the line element $ds(\mathbf{v}) = \
 
 Suppose a force field $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ acts at each point in space. When we move a particle along a curve, the infinitesimal work done by the force on each subinterval is the product of the component of the force in the direction of displacement and the magnitude of the displacement — namely, $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$. Summing this over the whole interval gives the work $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$.
 
-What matters here is that the components $F_x, F_y, F_z$ of the force <strong>vary from place to place</strong>. For volume (§3.1) and surface area (§3.2), coefficient $1$ was often enough; to measure work, coefficients that vary from place to place are indispensable. This is what most vividly shows the necessity of coefficients.
+What matters here is that the components $F_x, F_y, F_z$ of the force <strong>vary from place to place</strong>. For the geometric examples in §3.1 and §3.2, coefficient $1$ carried much of the story; to measure work, coefficients that vary from place to place are indispensable. This is what most vividly shows the necessity of coefficients.
 
 This is the motivation for introducing coefficients in the next section.
 
@@ -481,10 +481,10 @@ This is the motivation for introducing coefficients in the next section.
 In §3.1–§3.3, we measured curved shapes using forms with coefficient $1$. But in real physics, there are countless situations where we want to multiply a measuring device by a <strong>weight that varies from place to place</strong>:
 
 - <strong>Force field</strong> (varying with location) $\times$ <strong>displacement</strong> $=$ <strong>work</strong>
-- <strong>Velocity field</strong> (varying with location) $\times$ <strong>cross-section</strong> $=$ <strong>flux</strong>
+- <strong>Velocity field</strong> (varying with location) $\times$ <strong>oriented cross-section</strong> $=$ <strong>flux</strong>
 - <strong>Density field</strong> (varying with location) $\times$ <strong>volume</strong> $=$ <strong>mass</strong>
 
-The common structure is obvious. The product of <strong>"a weight that varies from place to place ($0$-form $=$ scalar field)"</strong> and <strong>"a geometric way of measuring ($k$-form)"</strong> constitutes a general $k$-form. In Chapter 2 §2.4.8 we said that "$0$-form is a measuring device that eats zero vectors, namely a scalar field" — precisely this setup.
+The common structure is obvious. The product of <strong>"a weight that varies from place to place ($0$-form $=$ scalar field)"</strong> and <strong>"a geometric way of measuring ($k$-form)"</strong> gives a general $k$-form. In Chapter 2 §2.4.8 we said that "$0$-form is a measuring device that eats zero vectors, namely a scalar field" — precisely this setup.
 
 Below, we define the integrals of forms with coefficients, in order from one to two to three dimensions.
 
@@ -504,11 +504,21 @@ Here "equals" means the contraction of the row vector $\omega_{\gamma(t_i)}$ fix
 
 Organize the change in each component in the form "finite ratio $\times \Delta t$":
 
-$$\omega(\Delta\mathbf{r}_i) = \bigl(P\frac{\Delta x_i}{\Delta t} + Q\frac{\Delta y_i}{\Delta t} + R\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$
+$$
+\omega_{\gamma(t_i)}(\Delta\mathbf{r}_i)
+= \bigl(P(\gamma(t_i))\frac{\Delta x_i}{\Delta t}
++ Q(\gamma(t_i))\frac{\Delta y_i}{\Delta t}
++ R(\gamma(t_i))\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t.
+$$
 
-$P,Q,R$ are evaluated at the point $\gamma(t_i)$. Sum over the whole interval and take the limit. Since $\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$:
+Sum over the whole interval and take the limit. Since $\Delta x_i/\Delta t \to x'(t)$, $\Delta y_i/\Delta t \to y'(t)$, and $\Delta z_i/\Delta t \to z'(t)$:
 
-$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(P\frac{dx}{dt} + Q\frac{dy}{dt} + R\frac{dz}{dt}\bigr)\,dt$$
+$$
+\sum_i \omega_{\gamma(t_i)}(\Delta\mathbf{r}_i)
+\;\xrightarrow{\Delta t \to 0}\;
+\int_{t_0}^{t_1}
+\bigl(P(\gamma(t))x'(t)+Q(\gamma(t))y'(t)+R(\gamma(t))z'(t)\bigr)\,dt
+$$
 
 We write this limit as
 
@@ -521,7 +531,7 @@ Exactly the same pattern as the coefficient-$1$ case in §3.3.1: at each instant
 
 Let us look at a concrete example. Compute the work done by the force field $\mathbf{F} = (y,\; x,\; 0)$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$.
 
-Since $\omega = y\,dx + x\,dy$, the coefficients are $P=y,\;Q=x,\;R=0$. On the curve, $P=\sin t,\;Q=\cos t$. Also, from $dx/dt = -\sin t,\; dy/dt = \cos t$:
+Since $\omega = y\,dx + x\,dy$, the coefficients are $P=y,\;Q=x,\;R=0$. On the curve, $P=\sin t,\;Q=\cos t$. Also, $x'(t)=-\sin t$ and $y'(t)=\cos t$:
 
 $$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$
 
@@ -539,7 +549,7 @@ $$
 \eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy
 $$
 
-we call a general $2$-form.
+we call $\eta$ a general $2$-form.
 
 The integral over a surface is again just the Riemann sum from §3.2.1 with coefficients multiplied in. At the representative point of each small patch, evaluate the coefficients and feed $\eta$ the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span the patch:
 
@@ -556,7 +566,7 @@ At each point, the area-measuring device $\eta$ eats the two displacement vector
 
 That $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ each measure the "shadow area" onto the corresponding plane was seen in §3.2. The coefficients $P, Q, R$ attach a <strong>weight that varies from place to place</strong> to those shadows. Physically, $(P, Q, R)$ are the components of a velocity field, and $\iint_S \eta$ corresponds to the flux through the surface — but translating this rigorously into the language of vector analysis requires additional correspondence relations. We will do that in a later chapter.
 
-> <strong>Note</strong> (correspondence with vector analysis is only a guide rail here)  
+> <strong>Note</strong> (correspondence with vector analysis is only a guidepost here)
 > The connection with flux is nothing more than a bridge for readers who already know vector analysis. The main line of this book remains the operation of "feeding a $2$-form and aggregating." Lack of vector-analysis background will not hinder the discussion from here on.
 
 #### 3.4.3 Volume Integral of a General $3$-Form (Total Mass)
@@ -637,14 +647,14 @@ Over the past three chapters, we have assembled the following three things:
 
 What this chapter established is the following unified principle:
 
-<strong>A $k$-form (measuring device) eats $k$ displacement vectors—that is, a $k$-dimensional small piece—and returns a scalar, which is then aggregated over the entire region.</strong> No matter how the degree changes among $0, 1, 2, 3$, this picture stayed the same. Work along a curve, flux across a surface, total mass in a region—all can be written in the same language.
+<strong>A $k$-form (measuring device) eats $k$ displacement vectors—that is, a $k$-dimensional small piece—and returns a scalar, which is then aggregated over the entire region.</strong> Across degrees $0,1,2,3$, the picture remains the same. Work along a curve, flux across a surface, total mass in a region—all can be written in the same language.
 
 > <strong>Checkpoint so far — Chapter 3</strong>
 > - The integral $\int_M \omega$ of a $k$-form $\omega$ is defined by “chop into small pieces → feed $k$ displacement vectors to the $k$-form → sum → limit.”
-> - The line integral $\int_\gamma \omega$ of a $1$-form is the operation of feeding each small curve segment’s displacement vector to $\omega$ and aggregating. Work is $\int_\gamma \omega$, the same quantity as $\mathbf{F}\cdot d\mathbf{r}$.
+> - The line integral $\int_\gamma \omega$ of a $1$-form is the operation of feeding each small curve segment’s displacement vector to $\omega$ and aggregating. Work is written as $\int_\gamma \omega$, corresponding to the vector-analysis notation $\int_\gamma \mathbf{F}\cdot d\mathbf{r}$.
 > - The surface integral $\iint_S \eta$ of a $2$-form $\eta$ is the operation of feeding the two displacement vectors that span each small piece to $\eta$ and aggregating. With coefficient $1$, it measures the “shadow” onto each plane; adding up scalar area elements $dS$ built from the three shadows gives scalar area.
 > - The volume integral $\iiint_V \Omega$ of a $3$-form $\Omega$ is the operation of feeding the three displacement vectors that span each small rectangular box to $\Omega$ and aggregating. With coefficient $1$ this is volume directly; with coefficient $\rho$ it is total mass or total charge.
-> - A general $k$-form can be written as a combination of a coefficient ($0$-form) that varies from point to point and a basis $k$-form.
+> - A general $k$-form can be written as a combination of coefficients ($0$-forms) that vary from point to point and basis $k$-forms.
 
 However, an important problem remains.
 
@@ -652,4 +662,4 @@ Up to here, we counted small pieces while keeping the measuring devices of stand
 
 Then what should we change, and what should we keep?
 
-In the next chapter (Chapter 4), we reread variable change not as an operation that “moves points,” but as an <strong>operation that rebuilds measuring devices</strong>. This is the <strong>pullback</strong>.
+In the next chapter (Chapter 4), we reread variable change not as a matter of “moving points,” but as an <strong>operation that rebuilds measuring devices</strong>. This is the <strong>pullback</strong>.

--- a/translation/drafts/ch03-3.2.md
+++ b/translation/drafts/ch03-3.2.md
@@ -1,0 +1,218 @@
+### §3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1
+
+#### 3.2.1 From Parallelograms to Surfaces
+
+In Chapter 2 §2.4, we assembled the area-measuring device $dx \wedge dy$. If we feed it two vectors $\mathbf{v}_1, \mathbf{v}_2$, we get the signed area of the shadow they cast onto the $xy$ plane. Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
+
+So how do we measure the area of a surface? Let us first check the flat case. Take a unit square lying in the $xy$ plane and chop it into fine small squares. The two edges of one small square are
+
+$$\Delta\mathbf{x}=\begin{pmatrix}\Delta x\\0\\0\end{pmatrix},\qquad
+\Delta\mathbf{y}=\begin{pmatrix}0\\\Delta y\\0\end{pmatrix}.$$
+
+Feed these to $dx \wedge dy$:
+
+$$(dx \wedge dy)(\Delta\mathbf{x},\Delta\mathbf{y})=\Delta x\,\Delta y.$$
+
+Adding over all small squares gives area $1$. This is nothing more than the extension of the flat parallelogram from Chapter 2. What we are confirming here is that the $2$-form $dx\wedge dy$ returns the signed area of a small piece on the $xy$ plane as-is.
+
+What if the surface is curved? Chop the surface into sufficiently fine small pieces. On each piece, write the displacement vectors in two adjacent directions as $\Delta\mathbf{a},\Delta\mathbf{b}$. In this chapter we call these two displacement vectors, or the oriented infinitesimal parallelogram they span, a <strong>surface element</strong> of the surface. The finer we chop the surface, the closer the aggregation of these surface elements comes to the aggregation of the surface itself.
+
+Feed the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span this small piece of surface to the area-measuring device $dx \wedge dy$. From the definition in Chapter 2 §2.4.4, if
+
+$$\Delta\mathbf{a}=\begin{pmatrix}\Delta a_x\\\Delta a_y\\\Delta a_z\end{pmatrix},\qquad
+\Delta\mathbf{b}=\begin{pmatrix}\Delta b_x\\\Delta b_y\\\Delta b_z\end{pmatrix},$$
+
+then
+
+$$(dx \wedge dy)(\Delta\mathbf{a},\Delta\mathbf{b})
+=\Delta a_x\Delta b_y-\Delta a_y\Delta b_x.$$
+
+This is the signed area of the shadow that small piece casts onto the $xy$ plane.
+
+We <strong>write</strong> the limit as the mesh becomes infinitely fine as
+
+$$\iint_S dx \wedge dy.$$
+
+This is the definition of integration of a $2$-form — a surface integral. The structure is the same type as the volume integral in §3.1; only the number of vectors fed in has dropped from three to two.
+
+#### 3.2.2 What $dx \wedge dy$ Measures — A Test on the Sphere
+
+Let us actually compute on a sphere. Consider the upper half of a sphere of radius $R$ ($z \ge 0$). A point $(x,y,z)$ on the sphere satisfies
+
+$$x^2+y^2+z^2=R^2,\qquad z=\sqrt{R^2-x^2-y^2}.$$
+
+Here we use the total differential defined in Chapter 1. The total differential of the function
+
+$$F(x,y,z)=x^2+y^2+z^2$$
+
+is
+
+$$dF=2x\,dx+2y\,dy+2z\,dz.$$
+
+As promised in Chapter 1, this is a row vector that eats a displacement vector and reads off the change in $F$. If the displacement vector is tangent to the sphere, then to first order it does not change the value of $F=x^2+y^2+z^2$. Therefore that displacement vector $\mathbf{v}$ satisfies $dF(\mathbf{v})=0$. We choose the two displacement vectors that span a small piece of the sphere to satisfy this condition as well.
+
+For example, take the displacement vector that holds $y$ fixed and advances a small amount $\Delta x$ in the $x$ direction:
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\[2pt]0\\[2pt]\Delta z\end{pmatrix}.$$
+
+Feed this to $dF$:
+
+$$dF(\Delta\mathbf{x}_S)=2x\,\Delta x+2z\,\Delta z.$$
+
+Choosing it so that $dF(\Delta\mathbf{x}_S)=0$ as a direction along the sphere gives $\Delta z=-(x/z)\Delta x$. Likewise, for the displacement vector that holds $x$ fixed and advances a small amount $\Delta y$ in the $y$ direction, we get $\Delta z=-(y/z)\Delta y$.
+
+Therefore the two displacement vectors that span a small piece of the sphere can be written as
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\[2pt]0\\[2pt]-\dfrac{x}{z}\Delta x\end{pmatrix},\qquad
+\Delta\mathbf{y}_S=\begin{pmatrix}0\\[2pt]\Delta y\\[2pt]-\dfrac{y}{z}\Delta y\end{pmatrix}.$$
+
+If we chop the surface sufficiently finely, the aggregation of the parallelograms spanned by these two vectors approaches the aggregation of the sphere itself.
+
+Let us first feed only $dx \wedge dy$ to the surface:
+
+$$(dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)=\Delta x\,\Delta y.$$
+
+Therefore the integral over the upper hemisphere,
+
+$$
+\iint_{S_{\text{upper}}} dx \wedge dy,
+$$
+
+can be computed by the same method as the $y$ integral in §3.1.2, and the result is $\pi R^2$. This is nothing other than the area of the shadow cast by the upper hemisphere onto the $xy$ plane — a disk of radius $R$.
+
+The same calculation works for the lower hemisphere ($z = -\sqrt{R^2 - x^2 - y^2}$). However, if we measure the entire sphere with outward orientation, the orientation of the surface flips on the lower hemisphere and the sign reverses, so the integral becomes $-\pi R^2$.
+
+Therefore the integral of $dx \wedge dy$ over the entire sphere is $\pi R^2 + (-\pi R^2) = 0$. The shadow of the upper hemisphere and the shadow of the lower hemisphere cancel each other. This made it clear: <strong>what $dx \wedge dy$ measures is the signed area of the shadow onto the $xy$ plane, not the scalar area of the surface.</strong> Likewise, $dy \wedge dz$ measures the shadow onto the $yz$ plane, and $dz \wedge dx$ measures the shadow onto the $zx$ plane.
+
+#### 3.2.3 From Three Shadows to Scalar Area
+
+So how do we measure the scalar area of a surface (the area we learned in elementary school)? On each small patch, feed the two displacement vectors that form the surface element to all three area-measuring devices, and combine the results.
+
+Let us compute the remaining two on the upper hemisphere as well. Feeding the two displacement vectors from above,
+
+$$\Delta\mathbf{x}_S=\begin{pmatrix}\Delta x\\0\\-\dfrac{x}{z}\Delta x\end{pmatrix},\qquad
+\Delta\mathbf{y}_S=\begin{pmatrix}0\\\Delta y\\-\dfrac{y}{z}\Delta y\end{pmatrix},$$
+
+to the three area-measuring devices gives:
+
+$$\begin{aligned}
+(dy \wedge dz)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \frac{x}{z}\,\Delta x\,\Delta y
+= \frac{x}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y \\[4pt]
+(dz \wedge dx)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \frac{y}{z}\,\Delta x\,\Delta y
+= \frac{y}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y \\[4pt]
+(dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) &= \Delta x\,\Delta y
+\end{aligned}$$
+
+The three readings $A_{yz},A_{zx},A_{xy}$ are the signed projected areas of the surface element onto the three coordinate planes. Aligning these three components records the information of the oriented infinitesimal area. This is the surface version of the story from Chapter 2 §2.4.6, where we read the oriented area of a parallelogram as three projected areas.
+
+From here we want to extract the positive area with orientation discarded. So in this chapter we call
+
+$$
+dS(\Delta\mathbf{a},\Delta\mathbf{b})
+= \sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}
+$$
+
+the <strong>scalar surface element</strong> of that small patch.
+
+This is not a $2$-form. Whereas $dx\wedge dy$ eats the two displacement vectors that form a surface element and returns a single projected area, $dS$ is notation that combines the three projected areas by the familiar square root of a sum of squares in orthogonal Cartesian coordinates and returns a positive area with orientation discarded.
+
+However, before we simply add up $dS$, let us see what happens if we integrate each of the three area-measuring devices separately over the entire upper hemisphere. Writing the disk $D=\{(x,y)\mid x^2+y^2\le R^2\}$ that is the shadow of the upper hemisphere onto the $xy$ plane, the three signed shadow areas become the following three integrals:
+
+$$\begin{aligned}
+\iint_{S_{\text{upper}}} dy\wedge dz
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{x}{\sqrt{R^2-x^2-y^2}}\,dy\,dx, \\[4pt]
+\iint_{S_{\text{upper}}} dz\wedge dx
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{y}{\sqrt{R^2-x^2-y^2}}\,dy\,dx, \\[4pt]
+\iint_{S_{\text{upper}}} dx\wedge dy
+&= \int_{-R}^{R}\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+1\,dy\,dx.
+\end{aligned}$$
+
+These three integrals measure the signed shadow areas onto the $yz$ plane, the $zx$ plane, and the $xy$ plane, respectively. In fact, by symmetry the first two are $0$ and the last is $\pi R^2$:
+
+$$
+\iint_{S_{\text{upper}}} dy\wedge dz=0,\qquad
+\iint_{S_{\text{upper}}} dz\wedge dx=0,\qquad
+\iint_{S_{\text{upper}}} dx\wedge dy=\pi R^2.
+$$
+
+Note here. Taking the square root of the sum of squares of these three integral values afterward does <strong>not</strong> give the area of the upper hemisphere. We must combine the three shadows <strong>on each small patch</strong> before adding them up; otherwise the information about the tilt of the surface is lost along the way.
+
+Therefore, to obtain surface area, on each small patch we find the three projected areas, build the scalar surface element $dS$ from them, and add those up. Writing the three projected areas from above as
+
+$$\begin{aligned}
+A_{yz} &= (dy \wedge dz)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) \\
+A_{zx} &= (dz \wedge dx)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S) \\
+A_{xy} &= (dx \wedge dy)(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+\end{aligned}$$
+
+the scalar surface element is
+
+$$
+dS(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+= \sqrt{A_{yz}^2+A_{zx}^2+A_{xy}^2}.
+$$
+
+Substituting the three outputs we computed above,
+
+$$\begin{aligned}
+dS(\Delta\mathbf{x}_S,\Delta\mathbf{y}_S)
+&= \sqrt{
+\Bigl(\frac{x}{\sqrt{R^2-x^2-y^2}}\Delta x\,\Delta y\Bigr)^2
+{}+ \Bigl(\frac{y}{\sqrt{R^2-x^2-y^2}}\Delta x\,\Delta y\Bigr)^2
+{}+ (\Delta x\,\Delta y)^2} \\[4pt]
+&= \sqrt{\frac{x^2+y^2}{R^2-x^2-y^2}+1}\;\Delta x\,\Delta y \\[4pt]
+&= \frac{R}{\sqrt{R^2-x^2-y^2}}\,\Delta x\,\Delta y
+\end{aligned}$$
+
+That is, if we chop the disk $x^2+y^2 \le R^2$ — the shadow of the upper hemisphere onto the $xy$ plane — into small patches, the Riemann sum for the area becomes
+
+$$\sum_i\sum_j
+\frac{R}{\sqrt{R^2-x_i^2-y_j^2}}\,
+\Delta x_i\,\Delta y_j.$$
+
+In other words, we are simply adding up the scalar surface element on each small patch in the form
+
+$$\sum_i\sum_j dS(\Delta\mathbf{x}_{S,ij},\Delta\mathbf{y}_{S,ij}).$$
+
+In the limit as the mesh becomes fine:
+
+$$
+\operatorname{Area}(S_{\text{upper}})
+= R\int_{-R}^{R}\biggl(\int_{-\sqrt{R^2-x^2}}^{\sqrt{R^2-x^2}}
+\frac{dy}{\sqrt{R^2 - x^2 - y^2}}\biggr)\;dx.
+$$
+
+The inner $y$ integral. Set $a = \sqrt{R^2 - x^2}$:
+
+$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}}.$$
+
+Use the substitution $y = a\sin t$ (the same procedure as in §3.1.2). We have $dy = a\cos t\,dt$, $\sqrt{a^2 - y^2} = a\cos t$, and as $y$ goes from $-a$ to $a$, $t$ goes from $-\pi/2$ to $\pi/2$:
+
+$$\int_{-a}^{a} \frac{dy}{\sqrt{a^2 - y^2}} = \int_{-\pi/2}^{\pi/2} \frac{a\cos t}{a\cos t}\,dt = \int_{-\pi/2}^{\pi/2} dt = \pi.$$
+
+The integral is $\pi$ regardless of $a$. Therefore:
+
+$$R\int_{-R}^{R} \pi\,dx = R \cdot \pi \cdot 2R = 2\pi R^2.$$
+
+This is the area of the upper hemisphere. On the lower hemisphere as well (if we take “outward from the origin” as positive), some signs flip in part, but the sum of squares is the same, so again we get $2\pi R^2$. Therefore the area of the entire sphere is:
+
+$$2\pi R^2 + 2\pi R^2 = 4\pi R^2.$$
+
+Splendidly, $4\pi R^2$ appears. It is <strong>exactly the same pattern</strong> as when we recovered the area of a parallelogram from three shadows in Chapter 2 §2.4.7.
+
+#### 3.2.4 What We Have Learned So Far
+
+A basis $2$-form with coefficient $1$ does not, by itself, directly return the scalar area of a surface. $dx \wedge dy$ measures the signed projected area of a small piece of surface onto the $xy$ plane. To obtain the scalar area of a surface, we must combine the three projected components on each small piece to build the scalar surface element $dS$, and then add those up. This is exactly the same situation as for the area of a parallelogram in Chapter 2.
+
+However, in physics we often want to control “which shadow to emphasize, and by how much, at each point.” For example, when measuring fluid flow through a surface, if the flow is strong in the $x$ direction we want to put a large weight on $dy \wedge dz$ (the shadow onto the $yz$ plane). The need for such <strong>weights that vary from place to place</strong> — coefficients — naturally appears here. This is foreshadowing for §3.4.
+
+> <strong>Checkpoint so far</strong>
+> - A surface integral is the operation of feeding the two displacement vectors that form a surface element on each small patch to an area-measuring device and aggregating the scalars obtained.
+> - $dx \wedge dy$ by itself measures the area of the shadow onto the $xy$ plane. Over the entire sphere the net result is zero (the shadows of the upper and lower hemispheres cancel).
+> - Combining the readings of the three basis $2$-forms by the square root of a sum of squares on each small piece gives the scalar surface element $dS$. Adding these up yields the scalar area of the surface. For a sphere, $4\pi R^2$.
+> - In the next section we drop the dimension further and measure the length of a curve. There the limit of coefficient $1$ appears most clearly.
+
+---

--- a/translation/drafts/ch03-3.3.md
+++ b/translation/drafts/ch03-3.3.md
@@ -1,0 +1,121 @@
+### §3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed
+
+#### 3.3.1 From Straight Lines to Curves — Defined by Riemann Sums
+
+In Chapter 1, we defined $dx, dy, dz$ as $1$-forms (measuring devices) that eat a vector and return each component. When $dx = \begin{pmatrix}1&0&0\end{pmatrix}$ and $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$, we have $dx(\mathbf{v}) = \Delta x$. The same holds for $dy$ and $dz$.
+
+So what do we get if we apply these along a curve and aggregate the results?
+
+First, chop the curve into fine subintervals. To each subinterval there corresponds a displacement vector from start to end,
+
+$$
+\Delta\mathbf{r}_i=(\Delta x_i,\Delta y_i,\Delta z_i)
+$$
+
+At this stage we do not yet need to write the curve as a formula. On each subinterval, if we feed $dx$ this displacement vector,
+
+$$dx(\Delta\mathbf{r}_i)=\Delta x_i$$
+
+Similarly, $dy(\Delta\mathbf{r}_i)=\Delta y_i$ and $dz(\Delta\mathbf{r}_i)=\Delta z_i$.
+
+Summing over all subintervals gives
+
+$$
+\sum_i dx(\Delta\mathbf{r}_i)=\sum_i \Delta x_i
+$$
+
+This is nothing but the straightforward sum of the $x$-direction displacements of each small piece along the curve. We <strong>write</strong> the limit as the mesh is made infinitely fine as
+
+$$\int_\gamma dx$$
+
+This is the definition of integration of a $1$-form — a line integral.
+
+So the definition is in place. How do we actually compute this sum?
+
+Introducing $t$ here is not abandoning our policy so far. In §3.1 we organized small rectangular boxes inside a sphere in the order $z,y,x$; in §3.2 we organized small pieces on a sphere by projection onto the $xy$ plane. Likewise, on a curve we need a label to arrange the small pieces in order from start to end. We simply call that label $t$.
+
+So we assign a continuous index $t$ to each small piece along the curve and write
+
+$$\gamma(t) = \bigl(x(t),\, y(t),\, z(t)\bigr),\qquad t \in [t_0, t_1]$$
+
+Here $t$ is not a new spatial coordinate. It is a label for arranging the small pieces along the curve from start to end. With this label, the displacement on the $i$th subinterval can be written as
+
+$$
+\Delta\mathbf{r}_i = \gamma(t_i+\Delta t)-\gamma(t_i)
+$$
+
+On each subinterval, <strong>apply the matrix $dx$ to the displacement vector $\Delta\mathbf{r}_i$</strong>:
+
+$$dx(\Delta\mathbf{r}_i) = \begin{pmatrix}1&0&0\end{pmatrix} \begin{pmatrix}\Delta x_i \\ \Delta y_i \\ \Delta z_i\end{pmatrix} = \Delta x_i = \frac{\Delta x_i}{\Delta t}\,\Delta t$$
+
+The equality here means that applying the fixed $1$-form $dx$ to the displacement vector $\Delta\mathbf{r}_i$ returns the component $\Delta x_i$ exactly. On the other hand, the integral over the whole curve is defined as the limit of a Riemann sum in which the measuring device is evaluated at a representative point on each subinterval and the results are added.
+
+$$\sum_i dx(\Delta\mathbf{r}_i) = \sum_i \frac{\Delta x_i}{\Delta t}\,\Delta t$$
+
+The substitution integrals treated in Chapter 1 were precisely this kind of reorganization of a sum. We do the same here. Number the small pieces along the curve by $t$, and organize the change in each component as “rate of change $\times$ subinterval width.” As the mesh is made infinitely fine, the conversion factor converges to the derivative: $\Delta x_i/\Delta t \to dx/dt$.
+
+This computation has exactly the same form as the substitution integral in Chapter 1 §1.2.5:
+
+$$\int_\gamma dx = \int_{t_0}^{t_1} \frac{dx}{dt}\,dt = x(t_1) - x(t_0)$$
+
+Similarly, $\int_\gamma dy = y(t_1) - y(t_0)$ and $\int_\gamma dz = z(t_1) - z(t_0)$. In other words, <strong>the line integrals of the $1$-forms $dx, dy, dz$ return the net displacement of the curve — the difference between the coordinates at the end point and those at the start point.</strong>
+
+#### 3.3.2 Trying It on a Circle — Arc Length Does Not Appear
+
+Let us check. For a circle too, what we have in mind first is the operation of chopping the circle into fine arcs and summing the displacements of each small piece. To compute the sum over one full revolution, however, we need a label that arranges the small pieces in order. Here we use the angle $t$ as that label. A circle of radius $R$ is represented as
+
+$$\gamma(t) = (R\cos t,\; R\sin t,\; 0),\qquad t \in [0, 2\pi]$$
+
+Since $\gamma'(t) = (-R\sin t,\; R\cos t,\; 0)$:
+
+$$\begin{aligned}
+\int_\gamma dx &= \int_0^{2\pi} dx(\gamma'(t))\,dt = \int_0^{2\pi} (-R\sin t)\,dt = R\bigl[\cos t\bigr]_0^{2\pi} = 0 \\[4pt]
+\int_\gamma dy &= \int_0^{2\pi} dy(\gamma'(t))\,dt = \int_0^{2\pi} (R\cos t)\,dt = R\bigl[\sin t\bigr]_0^{2\pi} = 0
+\end{aligned}$$
+
+Both are zero. It is a closed curve, so the start and end points coincide and the outward and return legs cancel — a natural result.
+
+However, we also know that the arc length of this circle is $2\pi R$. With coefficient-$1$ $dx$ and $dy$ alone we get zero — so <strong>how do we obtain arc length?</strong>
+
+At each label $t$, the values measured by $dx$ and $dy$ are already at hand:
+
+$$
+dx(\gamma'(t)) = -R\sin t,\qquad dy(\gamma'(t)) = R\cos t
+$$
+
+These are scalars, so we can square them and add:
+
+$$dx(\gamma'(t))^2 + dy(\gamma'(t))^2 = R^2\sin^2 t + R^2\cos^2 t = R^2$$
+
+Taking the square root gives the conversion factor for length per small piece, $|\gamma'(t)| = R$. Integrating over the whole interval:
+
+$$\int_0^{2\pi} \!\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}\;dt = \int_0^{2\pi} \!R\,dt = 2\pi R$$
+
+Arc length $2\pi R$ has appeared. What is happening here is important — $dx$ and $dy$ each gave zero on the closed curve by themselves, yet when we take the square root of the sum of their squares and integrate, the correct arc length emerges. The “power to measure length” that coefficient-$1$ $1$-forms lacked was recovered by the algebraic rearrangement called the sum of squares.
+
+Let us organize what is happening here. At each label $t$ we obtain two scalars, $dx(\gamma'(t))$ and $dy(\gamma'(t))$, take the square root of their sum of squares, $\sqrt{dx(\gamma'(t))^2 + dy(\gamma'(t))^2}$, and integrate with respect to $t$. This is nothing other than integrating length measurement in Cartesian coordinates along the curve. In three dimensions, we write this line element as
+
+$$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$$
+
+The circle we are considering now lies in the plane $z=0$, so $dz(\gamma'(t))=0$, and only the two components $dx, dy$ remain in the calculation above.
+
+> <strong>Note</strong> (on notation) By the convention of Chapter 1 §1.1.6, a standalone $dx$ is a row vector (operator), and it cannot be squared by itself. $dx(\mathbf{v})^2$ means the square of the <strong>scalar obtained by applying the $1$-form $dx$ to the vector $\mathbf{v}$</strong>. Preserving this distinction is what keeps the notation of this book consistent.
+
+This $ds$ is a convenient notation for measuring arc length, but it is not itself a $1$-form in the sense of this book. A $1$-form is a measuring device that acts linearly on a displacement $\mathbf{v}$, whereas $ds(\mathbf{v})$ contains a square root of a sum of squares, so in general $ds(\mathbf{v}+\mathbf{w}) = ds(\mathbf{v})+ds(\mathbf{w})$ does not hold. Therefore $ds$ cannot be written as a linear combination of $dx, dy, dz$ — in the form $P\,dx+Q\,dy+R\,dz$.
+
+#### 3.3.3 What Can a 1-Form Measure?
+
+Arc length could be measured by integrating the line element $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$. However, this $ds$ cannot be written as a linear combination of $dx, dy, dz$; it requires a square root of a sum of squares. Here we first ask: what does a $1$-form that does not use such a square root of a sum of squares — that is, a $1$-form that can be written as a linear combination of $dx, dy, dz$ — actually measure?
+
+Suppose a force field $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ acts at each point in space. When we move a particle along a curve, the infinitesimal work done by the force on each subinterval is the product of the component of the force in the direction of displacement and the magnitude of the displacement — namely, $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$. Summing this over the whole interval gives the work $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$.
+
+What matters here is that the components $F_x, F_y, F_z$ of the force <strong>vary from place to place</strong>. For volume (§3.1) and surface area (§3.2), coefficient $1$ was often enough; to measure work, coefficients that vary from place to place are indispensable. This is what most vividly shows the necessity of coefficients.
+
+This is the motivation for introducing coefficients in the next section.
+
+> <strong>Checkpoint so far</strong>
+> - Line integrals of $dx, dy, dz$ return “net displacement.” On a closed curve they are zero.
+> - Arc length can be computed by integrating the line element $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$. $ds$ is not a $1$-form and cannot be written as a linear combination of $dx, dy, dz$ (it requires a square root of a sum of squares).
+> - What a $1$-form that can be written as a linear combination of $dx, dy, dz$ measures is a quantity such as “work.” → §3.4.
+
+---

--- a/translation/drafts/ch03-3.4.md
+++ b/translation/drafts/ch03-3.4.md
@@ -1,0 +1,150 @@
+### §3.4 Adding Coefficients — Density Times Geometry
+
+#### 3.4.0 Why Coefficients? — Physics Demands Them
+
+In §3.1–§3.3, we measured curved shapes using forms with coefficient $1$. But in real physics, there are countless situations where we want to multiply a measuring device by a <strong>weight that varies from place to place</strong>:
+
+- <strong>Force field</strong> (varying with location) $\times$ <strong>displacement</strong> $=$ <strong>work</strong>
+- <strong>Velocity field</strong> (varying with location) $\times$ <strong>cross-section</strong> $=$ <strong>flux</strong>
+- <strong>Density field</strong> (varying with location) $\times$ <strong>volume</strong> $=$ <strong>mass</strong>
+
+The common structure is obvious. The product of <strong>"a weight that varies from place to place ($0$-form $=$ scalar field)"</strong> and <strong>"a geometric way of measuring ($k$-form)"</strong> constitutes a general $k$-form. In Chapter 2 §2.4.8 we said that "$0$-form is a measuring device that eats zero vectors, namely a scalar field" — precisely this setup.
+
+Below, we define the integrals of forms with coefficients, in order from one to two to three dimensions.
+
+#### 3.4.1 Line Integral of a General $1$-Form (Work)
+
+In real space, take three scalar fields $P, Q, R$ that depend on the point $(x,y,z)$, and call
+
+$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
+
+the <strong>general form of a $1$-form</strong>. Each $dx, dy, dz$ is, as in Chapter 1, a row vector that reads off components from a column vector. The coefficients $P,Q,R$ are weights that vary from place to place — $0$-forms. If $P=\partial f/\partial x,\;Q=\partial f/\partial y,\;R=\partial f/\partial z$ come from a single function $f$, we get the special case $\omega=df$; in general, this need not be so.
+
+The integral along a curve $\gamma(t)$ is simply the Riemann sum from §3.3.1 with coefficients multiplied in. Take the representative point of each small segment to be $\gamma(t_i)$, evaluate the coefficients there to get $\omega_{\gamma(t_i)}$, and feed it the displacement $\Delta\mathbf{r}_i$. At the fixed point $\gamma(t_i)$, $\omega_{\gamma(t_i)}$ is a row vector and $\Delta\mathbf{r}_i$ is a column vector, and their contraction can be written as
+
+$$\omega_{\gamma(t_i)}(\Delta\mathbf{r}_i) = P(\gamma(t_i))\,\Delta x_i + Q(\gamma(t_i))\,\Delta y_i + R(\gamma(t_i))\,\Delta z_i$$
+
+Here "equals" means the contraction of the row vector $\omega_{\gamma(t_i)}$ fixed at one point and the displacement vector $\Delta\mathbf{r}_i$. As the contribution of the whole small segment, this is one term of a Riemann sum with coefficients frozen at the representative point; in the limit as the mesh becomes fine, it becomes a line integral.
+
+Organize the change in each component in the form "finite ratio $\times \Delta t$":
+
+$$\omega(\Delta\mathbf{r}_i) = \bigl(P\frac{\Delta x_i}{\Delta t} + Q\frac{\Delta y_i}{\Delta t} + R\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$
+
+$P,Q,R$ are evaluated at the point $\gamma(t_i)$. Sum over the whole interval and take the limit. Since $\Delta x_i/\Delta t \to dx/dt,\; \Delta y_i/\Delta t \to dy/dt,\; \Delta z_i/\Delta t \to dz/dt$:
+
+$$\sum_i \omega(\Delta\mathbf{r}_i) \;\xrightarrow{\Delta t \to 0}\; \int_{t_0}^{t_1} \bigl(P\frac{dx}{dt} + Q\frac{dy}{dt} + R\frac{dz}{dt}\bigr)\,dt$$
+
+We write this limit as
+
+$$\int_\gamma \omega$$
+
+Exactly the same pattern as the coefficient-$1$ case in §3.3.1: at each instant, a <strong>row vector (coefficient-weighted $1$-form)</strong> eats a <strong>column vector ($\gamma'(t)$)</strong>, returns a scalar, and we aggregate. This is nothing but the natural three-dimensional extension of $F(x)\,dx$ from Chapter 1 §1.2.5.
+
+> <strong>Note</strong> (correspondence with vector analysis)  
+> In vector analysis, this quantity is written $\int_\gamma \mathbf{F}\cdot d\mathbf{r}$. Our $\int_\gamma \omega$ is the same thing, yet <strong>the field $\omega$</strong> and <strong>the path $\gamma$</strong> are clearly separated in the notation.
+
+Let us look at a concrete example. Compute the work done by the force field $\mathbf{F} = (y,\; x,\; 0)$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0, 2\pi]$.
+
+Since $\omega = y\,dx + x\,dy$, the coefficients are $P=y,\;Q=x,\;R=0$. On the curve, $P=\sin t,\;Q=\cos t$. Also, from $dx/dt = -\sin t,\; dy/dt = \cos t$:
+
+$$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^2\!t = \cos 2t$$
+
+Therefore:
+
+$$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$
+
+The work is zero. This force field does no net work along the unit circle.
+
+#### 3.4.2 Surface Integral of a General $2$-Form (Flux)
+
+Similarly, with three scalar fields $P,Q,R$ as coefficients,
+
+$$
+\eta = P\,dy \wedge dz + Q\,dz \wedge dx + R\,dx \wedge dy
+$$
+
+we call a general $2$-form.
+
+The integral over a surface is again just the Riemann sum from §3.2.1 with coefficients multiplied in. At the representative point of each small patch, evaluate the coefficients and feed $\eta$ the two displacement vectors $\Delta\mathbf{a},\Delta\mathbf{b}$ that span the patch:
+
+$$\eta(\Delta\mathbf{a},\Delta\mathbf{b})
+= P\,(dy \wedge dz)(\Delta\mathbf{a},\Delta\mathbf{b})
+{}+ Q\,(dz \wedge dx)(\Delta\mathbf{a},\Delta\mathbf{b})
+{}+ R\,(dx \wedge dy)(\Delta\mathbf{a},\Delta\mathbf{b})$$
+
+Sum over all patches and take the limit. We denote this limit by
+
+$$\iint_S \eta$$
+
+At each point, the area-measuring device $\eta$ eats the two displacement vectors that form a surface element and returns a scalar; we aggregate over the whole surface — the same point as in §3.2.
+
+That $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ each measure the "shadow area" onto the corresponding plane was seen in §3.2. The coefficients $P, Q, R$ attach a <strong>weight that varies from place to place</strong> to those shadows. Physically, $(P, Q, R)$ are the components of a velocity field, and $\iint_S \eta$ corresponds to the flux through the surface — but translating this rigorously into the language of vector analysis requires additional correspondence relations. We will do that in a later chapter.
+
+> <strong>Note</strong> (correspondence with vector analysis is only a guide rail here)  
+> The connection with flux is nothing more than a bridge for readers who already know vector analysis. The main line of this book remains the operation of "feeding a $2$-form and aggregating." Lack of vector-analysis background will not hinder the discussion from here on.
+
+#### 3.4.3 Volume Integral of a General $3$-Form (Total Mass)
+
+The general form of a $3$-form, with scalar field $\rho(x,y,z)$ as coefficient, is
+
+$$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$
+
+We need only multiply the Riemann sum from §3.1.1 by the density $\rho$. At the representative point of each small box, evaluate $\rho$ and feed the volume element to $\Omega$:
+
+$$\Omega(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \rho(x_i,y_i,z_i)\,\Delta x_i\,\Delta y_i\,\Delta z_i$$
+
+Sum over the whole region and take the limit. We write this limit as
+
+$$\iiint_V \Omega$$
+
+If $\rho=1$, we return to the coefficient-$1$ case from §3.1. If $\rho$ is mass density, we get total mass; if charge density, total charge. A $3$-form has only one independent component, $dx \wedge dy \wedge dz$, so <strong>"density ($\rho$)" and "the way of measuring volume ($dx \wedge dy \wedge dz$)" separate cleanly</strong> and the picture is clear.
+
+#### 3.4.4 A Unified Picture of Line, Surface, and Volume
+
+Let us look back at what we have done.
+
+| Object | Form | Integral notation | Example physical meaning |
+|:---:|:---|:---|:---|
+| Curve $\gamma$ | $1$-form $\omega$ | $\displaystyle\int_\gamma \omega$ | Work |
+| Surface $S$ | $2$-form $\eta$ | $\displaystyle\iint_S \eta$ | Flux |
+| Region $V$ | $3$-form $\Omega$ | $\displaystyle\iiint_V \Omega$ | Total mass |
+
+Written as Riemann sums, they are
+
+$$
+\int_\gamma \omega
+= \lim_{\text{mesh}\to 0}
+\sum_i \omega(\Delta\mathbf{r}_i),
+$$
+
+$$
+\iint_S \eta
+= \lim_{\text{mesh}\to 0}
+\sum_i\sum_j\eta(\Delta\mathbf{a}_{ij},\Delta\mathbf{b}_{ij}),
+$$
+
+$$
+\iiint_V \Omega
+= \lim_{\text{mesh}\to 0}
+\sum_i\sum_j\sum_k
+\Omega(\Delta\mathbf{a}_{ijk},\Delta\mathbf{b}_{ijk},\Delta\mathbf{c}_{ijk})
+$$
+
+Here "mesh $\to 0$" means making the size of the coarsest small piece that makes up the curve, surface, or region approach $0$.
+
+All follow the same pattern: a <strong>$k$-form (measuring device) eats $k$ displacement vectors — that is, a $k$-dimensional small piece — returns a scalar, and we aggregate over the whole domain</strong>. As the degree rises, the number of vectors fed in increases, and antisymmetry governs the orientation of area and volume. Only the degree differs; the principle is the same throughout.
+
+> <strong>Checkpoint so far</strong>
+> - A general $k$-form is a linear combination of "basis $k$-forms" with "weights that vary from place to place ($0$-form)."
+> - The line integral $\int_\gamma \omega$ corresponds to work, the surface integral $\iint_S \eta$ to flux, and the volume integral $\iiint_V \Omega$ to total mass.
+> - All follow the same principle: "contraction of measuring device and figure → aggregation." In the next chapter we introduce pullback — the method of recomputing these integrals in different coordinates.
+
+#### 3.4.5 The General Form of Integration
+
+The line, surface, and volume integrals defined separately in §3.1–§3.3 actually fit one pattern. The operation of integrating a $k$-form $\omega$ over a $k$-dimensional region $M$ is written, regardless of dimension, as
+
+$$\int_M \omega$$
+
+If $M$ is a curve ($k=1$), we write $\int_\gamma$; if a surface ($k=2$), $\iint_S$; if a solid ($k=3$), $\iiint_V$ — the number of integral signs is determined only by the dimension of $M$. The content is always "chop into small pieces → feed $k$ displacement vectors to the $k$-form → sum $\sum$ → limit."
+
+The stage of this book is three-dimensional space, so $k=1,2,3$ suffices; but it does no harm to keep in the back of your mind that this formula holds regardless of $k$. When we introduce the exterior derivative $d$ in Chapter 5, this unified viewpoint will bear fruit in the general form of Stokes's theorem, $\int_{\partial M} \omega = \int_M d\omega$.

--- a/translation/drafts/ch03-3.5.md
+++ b/translation/drafts/ch03-3.5.md
@@ -1,0 +1,26 @@
+### §3.5 Summary of This Chapter and Outlook Toward the Next
+
+Over the past three chapters, we have assembled the following three things:
+
+1. <strong>Chapter 1</strong>: View $dx$ as a matrix ($1$-form), and read integration as the limit of matrix action
+2. <strong>Chapter 2</strong>: Construct $2$-forms and $3$-forms via the wedge product $\wedge$, and measure area and volume algebraically
+3. <strong>Chapter 3 (this chapter)</strong>: Apply forms to curves, surfaces, and regions, and establish the operation of aggregating their output
+
+What this chapter established is the following unified principle:
+
+<strong>A $k$-form (measuring device) eats $k$ displacement vectors—that is, a $k$-dimensional small piece—and returns a scalar, which is then aggregated over the entire region.</strong> No matter how the degree changes among $0, 1, 2, 3$, this picture stayed the same. Work along a curve, flux across a surface, total mass in a region—all can be written in the same language.
+
+> <strong>Checkpoint so far — Chapter 3</strong>
+> - The integral $\int_M \omega$ of a $k$-form $\omega$ is defined by “chop into small pieces → feed $k$ displacement vectors to the $k$-form → sum → limit.”
+> - The line integral $\int_\gamma \omega$ of a $1$-form is the operation of feeding each small curve segment’s displacement vector to $\omega$ and aggregating. Work is $\int_\gamma \omega$, the same quantity as $\mathbf{F}\cdot d\mathbf{r}$.
+> - The surface integral $\iint_S \eta$ of a $2$-form $\eta$ is the operation of feeding the two displacement vectors that span each small piece to $\eta$ and aggregating. With coefficient $1$, it measures the “shadow” onto each plane; adding up scalar area elements $dS$ built from the three shadows gives scalar area.
+> - The volume integral $\iiint_V \Omega$ of a $3$-form $\Omega$ is the operation of feeding the three displacement vectors that span each small rectangular box to $\Omega$ and aggregating. With coefficient $1$ this is volume directly; with coefficient $\rho$ it is total mass or total charge.
+> - A general $k$-form can be written as a combination of a coefficient ($0$-form) that varies from point to point and a basis $k$-form.
+
+However, an important problem remains.
+
+Up to here, we counted small pieces while keeping the measuring devices of standard Cartesian coordinates $x, y, z$ as much as possible. But in actual calculations, counting in other variables is often overwhelmingly easier. Trace a circle by angle. View a sphere by radius and angles. In physics problems, you cannot get away without such variable changes.
+
+Then what should we change, and what should we keep?
+
+In the next chapter (Chapter 4), we reread variable change not as an operation that “moves points,” but as an <strong>operation that rebuilds measuring devices</strong>. This is the <strong>pullback</strong>.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -113,6 +113,7 @@ Per-section Pass status:
 | `translation/drafts/ch03-3.*.md` | integrated into `ch03.md` |
 | `translation/reviews/ch03-pass2.md` | complete |
 | `translation/reviews/ch03-pass3.md` | complete |
+| `translation/reviews/ch03-close-reading-polish.md` | complete (#181) |
 
 ---
 

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -60,6 +60,9 @@ Per-section Pass status (all included in chapter-wide Pass 2 and Pass 3):
 | `translation/reviews/ch01-pass2.md` | ch01 Pass 2 (staged §1.0–§1.6) |
 | `translation/reviews/ch01-pass3.md` | ch01 Pass 3 decisions |
 | `translation/reviews/ch01-close-reading-polish.md` | ch01 close-reading polish (#161) |
+| `translation/reviews/ch03-3.*-review.md` | ch03 per-section Pass 1 |
+| `translation/reviews/ch03-pass2.md` | ch03 Pass 2 |
+| `translation/reviews/ch03-pass3.md` | ch03 Pass 3 |
 
 ---
 
@@ -87,6 +90,29 @@ Per-section Pass status (all included in chapter-wide Pass 2 and Pass 3):
 | §2.6 | 3 | chapter summary |
 | `translation/reviews/ch02-pass2.md` | complete | Pass 2 all stages |
 | `translation/drafts/ch02-*.md` | integrated | optional cleanup after PR |
+
+### English Chapter 3 — `manuscript/en/ch03/ch03.md` (branch `ai/english-translation-ch03`, PR [#162](https://github.com/yokiikoy/nabla-kaitai/pull/162))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 3 (§3.0–§3.5)** | **1 → 2 → 3** | `ch03-pass2.md`, `ch03-pass3.md` |
+
+Per-section Pass status:
+
+| Section | Pass | Section review |
+|---------|------|----------------|
+| §3.0 | **3** | `ch03-3.0-review.md` (#158) |
+| §3.1 | **3** | `ch03-3.1-review.md` (#160) |
+| §3.2 | **3** | `ch03-3.2-review.md` |
+| §3.3 | **3** | `ch03-3.3-review.md` |
+| §3.4 | **3** | `ch03-3.4-review.md` |
+| §3.5 | **3** | `ch03-3.5-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch03-3.*.md` | integrated into `ch03.md` |
+| `translation/reviews/ch03-pass2.md` | complete |
+| `translation/reviews/ch03-pass3.md` | complete |
 
 ---
 

--- a/translation/reviews/ch03-3.0-review.md
+++ b/translation/reviews/ch03-3.0-review.md
@@ -1,0 +1,36 @@
+# Review: Chapter 3 §3.0
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md`
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.0 Measuring Curved Things — Paying Back a Debt from Elementary School`
+GitHub issue: #158
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | pending |
+| Pass 3 | pending |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Flat vs curved, sphere formulas, Riemann-sum philosophy, ground-rules Note preserved. |
+| Mathematical Correctness | 5 | Formulas and form hierarchy correct. |
+| Terminology Consistency | 5 | measuring devices, $k$-forms, area/volume-measuring device; no YAML. |
+| English Information Structure | 4.5 | Clear chapter opener; Pass 2 may tune “debt from elementary school”. |
+| Markdown and Build Compatibility | 5 | Matches ch01–ch02 conventions. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Next: §3.1 (volume, coefficient 1).

--- a/translation/reviews/ch03-3.1-review.md
+++ b/translation/reviews/ch03-3.1-review.md
@@ -1,0 +1,36 @@
+# Review: Chapter 3 §3.1
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md`
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.1 Volume — Three Dimensions, Coefficient 1`
+GitHub issue: #160
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | pending |
+| Pass 3 | pending |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Riemann definition, $\iiint$ introduction, sphere volume derivation preserved. |
+| Mathematical Correctness | 5 | Determinant, nested integrals, substitution steps match source. |
+| Terminology Consistency | 5 | volume-measuring device, volume element, contraction; heading matches TOC. |
+| English Information Structure | 4.5 | Long calculation section; Pass 2 may tighten repeated “organize the sum”. |
+| Markdown and Build Compatibility | 5 | Math blocks valid. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Next: §3.2 (surface area, coefficient 1).

--- a/translation/reviews/ch03-3.2-review.md
+++ b/translation/reviews/ch03-3.2-review.md
@@ -1,0 +1,35 @@
+# Review: Chapter 3 §3.2
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md` (lines 176–394)
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1`
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch03-pass2.md` |
+| Pass 3 | included in `ch03-pass3.md` |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Riemann surface integral, sphere shadow cancellation, $dS$ construction preserved. |
+| Mathematical Correctness | 5 | Hemisphere integrals, symmetry argument, area $4\pi R^2$ match source. |
+| Terminology Consistency | 5 | area-measuring device, shadow/projection, scalar surface element; TOC heading. |
+| English Information Structure | 4.5 | Long §3.2.3 calculation; Pass 2 tightened “Note here.” |
+| Markdown and Build Compatibility | 5 | Math blocks valid; no YAML. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch03-3.2.md`.

--- a/translation/reviews/ch03-3.3-review.md
+++ b/translation/reviews/ch03-3.3-review.md
@@ -1,0 +1,35 @@
+# Review: Chapter 3 §3.3
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md` (lines 395–518)
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed`
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch03-pass2.md` |
+| Pass 3 | included in `ch03-pass3.md` |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Line integral definition, circle example, $ds$ non-form argument preserved. |
+| Mathematical Correctness | 5 | Net displacement zero on circle; arc length via $\sqrt{dx^2+dy^2}$. |
+| Terminology Consistency | 5 | measuring device, displacement vector, row/column contraction. |
+| English Information Structure | 5 | $t$ as ordering label explained clearly. |
+| Markdown and Build Compatibility | 5 | §1.1.6 notation Note preserved. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch03-3.3.md`.

--- a/translation/reviews/ch03-3.4-review.md
+++ b/translation/reviews/ch03-3.4-review.md
@@ -1,0 +1,35 @@
+# Review: Chapter 3 §3.4
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md` (lines 519–667)
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.4 Adding Coefficients — Density Times Geometry`
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch03-pass2.md` |
+| Pass 3 | included in `ch03-pass3.md` |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Work/flux/mass examples, unified table, $\int_M \omega$ general form. |
+| Mathematical Correctness | 5 | Unit-circle work example; Riemann-sum limits match source. |
+| Terminology Consistency | 5 | $0$-form weights, contraction, measuring device; vector-analysis Notes as guide rails. |
+| English Information Structure | 5 | §3.4.0 motivation clear; table readable. |
+| Markdown and Build Compatibility | 5 | Display math and table valid. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch03-3.4.md`.

--- a/translation/reviews/ch03-3.5-review.md
+++ b/translation/reviews/ch03-3.5-review.md
@@ -1,0 +1,35 @@
+# Review: Chapter 3 §3.5
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+Source: `manuscript/ja/ch03/ch03.md` (lines 668–693)
+File: `manuscript/en/ch03/ch03.md`
+Scope: `§3.5 Summary of This Chapter and Outlook Toward the Next`
+
+---
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch03-pass2.md` |
+| Pass 3 | included in `ch03-pass3.md` |
+
+---
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Three-chapter recap, unified principle, Chapter 3 checkpoint, pullback foreshadow. |
+| Mathematical Correctness | 5 | Summary statements accurate. |
+| Terminology Consistency | 5 | measuring device, pullback, scalar area element $dS$. |
+| English Information Structure | 5 | Clean chapter close; transition to Ch. 4. |
+| Markdown and Build Compatibility | 5 | Blockquote checkpoint valid. |
+
+---
+
+## Status
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch03-3.5.md`.

--- a/translation/reviews/ch03-close-reading-polish.md
+++ b/translation/reviews/ch03-close-reading-polish.md
@@ -1,0 +1,66 @@
+# Close-Reading Polish: Chapter 3
+
+Review date: 2026-05-22  
+Branch: `ai/english-translation-ch03`  
+File: `manuscript/en/ch03/ch03.md`  
+GitHub issue: #181  
+PR context: #162
+
+Scope: publication polish after Pass 3 — notational safety (`x'(t)` vs `dx/dt`), first-order wording for `dF(\mathbf{v})`, English naturalness, preservation of authorial voice.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** §3.3.1–§3.4.1: replaced `dx/dt`, `dy/dt`, `dz/dt` with coordinate-function derivatives `x'(t)`, `y'(t)`, `z'(t)`; line-integral limit uses explicit evaluation `P(\gamma(t))x'(t)+\cdots`; Riemann-sum step uses `\omega_{\gamma(t_i)}` with coefficients at `\gamma(t_i)`.
+- **B2** §3.2.2: `dF` reads off the **first-order change** in $F$ (aligned with Chapter 1 `df(\mathbf{v})` polish).
+
+### C items (straightforward)
+
+- **C2** §3.0: `apply them to curves, surfaces, and regions`
+- **C3** §3.0: `returns the volume of a region directly`
+- **C4** §3.1.2: inside-out summation order clarified (`x \to y \to z`)
+- **C5** §3.2.1: `signed area … directly`
+- **C6** §3.2.1: surface-element aggregate wording
+- **C7** §3.2.2: tangent-displacement wording
+- **C8** §3.2.2: `This tells us exactly what … measures`
+- **C9** §3.2.3: `Taken together, these three components`
+- **C10** §3.2.3: lower-hemisphere projected-area signs
+- **C11** §3.2.4 checkpoint: `signed area of the shadow`
+- **C12** §3.3.1: `small subintervals`
+- **C13** §3.3.2: component displacements cancel over one full turn
+- **C15** §3.3.3: geometric examples / coefficient-$1$ sentence
+- **C16** §3.4.0: `oriented cross-section`
+- **C17** §3.4.0: `gives a general $k$-form`
+- **C18** §3.4.1: explicit evaluation in Riemann-sum formula (with B1)
+- **C19** §3.4.2: `we call $\eta$ a general $2$-form`
+- **C20** §3.4.2: `guide rail` → `guidepost`
+- **C22** §3.5: `Across degrees … the picture remains the same`
+- **C23** §3.5 checkpoint: work / vector-analysis correspondence wording
+- **C24** §3.5 checkpoint: `coefficients … and basis $k$-forms`
+- **C26** §3.5: `a matter of "moving points"`
+
+### Intentionally unchanged (D items / optional C)
+
+- **C1** §3.0 sphere-formulas opening rhythm (`"formulas of that kind"`) — preserved authorial voice
+- **C14** §3.3.2 `"power to measure length"` — kept as-is
+- **C21** §3.4.4 Riemann-sum `\omega_{p_i}` notation — optional; current text readable after §3.4.1
+- **C25** §3.5 `cannot get away without` — preserved stronger voice
+- Equator singularity, `messy` / `shadow` / `escape` vocabulary, `ds`/`dS` not-forms statements, full sphere derivations
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches except intentional `\Delta x_i/\Delta t` finite ratios):
+
+- `dx/dt`, `dy/dt`, `dz/dt` — none
+- `reads off the change in $F$` — none
+- `returns the volume of a region as-is` — none
+- `returns the signed area of a small piece on the $xy$ plane as-is` — none
+- `we call a general $2$-form` — none
+- `Work is $\int_\gamma \omega$, the same quantity as` — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch03-pass2.md
+++ b/translation/reviews/ch03-pass2.md
@@ -1,0 +1,53 @@
+# Pass 2 Review: Chapter 3
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+File: `manuscript/en/ch03/ch03.md`
+
+Pass 2 scope: English information structure, naturalness, pedagogical flow. Math unchanged.
+
+---
+
+## Stage 1: §3.0–§3.1 (complete)
+
+- Reviewed on prior commits (#158, #160); no additional Pass 2 edits required beyond chapter-wide scan.
+
+**Passed.**
+
+---
+
+## Stage 2: §3.2–§3.3 (complete)
+
+- `Splendidly` → `Splendid —` in §3.2.3 sphere area payoff (align with ch02).
+- `Note here.` → `Note:` in §3.2.3 shadow-combination warning.
+- Added blank line after `---` before `### §3.3` heading.
+- Renamed §3.3.3 heading to `What Can a $1$-Form Measure?` for notation consistency.
+
+**Passed.**
+
+---
+
+## Stage 3: §3.4–§3.5 (complete)
+
+- Added blank line after `---` before `### §3.4` heading.
+- Unified table and checkpoint wording; no structural changes needed.
+- §3.5 chapter checkpoint and pullback foreshadow read cleanly.
+
+**Passed.**
+
+---
+
+## Stage 4: Whole chapter consistency (complete)
+
+- Terminology scan: area/volume-measuring device, shadow, scalar surface element, mesh, contraction — no rot, no area meter, no YAML.
+- Checkpoint blockquotes consistent with ch01/ch02 style.
+
+**Passed.**
+
+---
+
+# Overall Chapter 3 Pass 2 Result
+
+**Chapter 3 passes Pass 2** on `ai/english-translation-ch03`.
+
+Body: §3.0–§3.5 (~655 lines). Pass 3 complete in `ch03-pass3.md`.

--- a/translation/reviews/ch03-pass3.md
+++ b/translation/reviews/ch03-pass3.md
@@ -1,0 +1,91 @@
+# Pass 3 Review: Chapter 3
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch03`
+File: `manuscript/en/ch03/ch03.md`
+
+Pass 3 scope: authorial voice, note/aside handling, heading quality, publication polish.
+
+Approach: same as Chapters 1–2 — keep distinctive voice; minimal consistency fixes only.
+
+---
+
+## Decisions
+
+### 1. Chapter and section headings
+
+Decision: **maintain** all `### §3.x` and `#### 3.x.x` headings as integrated; aligned with `manuscript/en/toc.md`.
+
+Reason: No genre mismatch; TOC titles already verified for §3.0–§3.1.
+
+### 2. “Elementary school debt” framing (§3.0)
+
+Decision: **keep** the opening metaphor and circumference/sphere formula references.
+
+Reason: Book-specific pedagogical hook; matches Japanese tone.
+
+### 3. Long computational sections (§3.1.2, §3.2.3)
+
+Decision: **keep** full sphere volume and hemisphere area derivations.
+
+Reason: Pass 1 fidelity; these are the chapter’s worked examples.
+
+### 4. Shadow / projection language
+
+Decision: **keep** throughout §3.2 and checkpoints.
+
+Reason: Consistent with Chapter 2 §2.4; central to the book’s geometric picture.
+
+### 5. $ds$ is not a 1-form (§3.3.2–§3.3.3)
+
+Decision: **keep** full argument and §1.1.6 notation Note.
+
+Reason: Critical notational contract; trimming would weaken the arc to §3.4 coefficients.
+
+### 6. Vector-analysis guide-rail Notes (§3.4.1, §3.4.2)
+
+Decision: **keep** “correspondence with vector analysis” Notes as optional bridges.
+
+Reason: Matches ch01/ch02 pattern; main line remains form integration.
+
+### 7. Unified integration table (§3.4.4)
+
+Decision: **keep** table and Riemann-sum display; no split into separate file.
+
+Reason: Japanese source structure; foreshadows Stokes in Ch. 5.
+
+### 8. Minor edits applied (Pass 2, recorded here)
+
+| Location | Change | Reason |
+|----------|--------|--------|
+| §3.2.3 | `Splendidly` → `Splendid —` | ch02 Pass 2 convention |
+| §3.2.3 | `Note here.` → `Note:` | Rhythm |
+| §3.3 / §3.4 | Blank line after section `---` | Integration formatting |
+| §3.3.3 | `1-Form` → `$1$-Form` in heading | Notation consistency |
+
+### 9. No change
+
+- “Foreshadowing for §3.4” explicit callouts.
+- Straight vs curly quotes in §3.4 (mixed but readable; no wholesale normalize).
+- Chapter 3 end checkpoint blockquote length.
+
+---
+
+## Stage log
+
+| Stage | Scope | Outcome |
+|-------|--------|---------|
+| 1 | §3.0–§3.1 | Prior Pass 1; no Pass 3 text change |
+| 2 | §3.2–§3.3 | Pass 2 edits only; voice kept |
+| 3 | §3.4–§3.5 | Recorded; pullback close kept |
+| 4 | Whole chapter | Terminology scan clean |
+
+---
+
+# Overall Chapter 3 Pass 3 Result
+
+**Chapter 3 passes Pass 3** on `ai/english-translation-ch03`.
+
+English Chapter 3 (`manuscript/en/ch03/ch03.md`, §3.0–§3.5) is **Pass 1 + Pass 2 + Pass 3 complete**.
+
+Next: push branch; open PR with base `ai/english-translation-ch02`; begin Chapter 4 Pass 1.


### PR DESCRIPTION
## Summary
- Replace outdated YAML English ch03 draft; translate full Chapter 3 (§3.0–§3.5) from Japanese source.
- §3.2–§3.5 integrated from drafts with section Pass 1 reviews; whole-chapter Pass 2 and Pass 3 recorded.
- Close-reading polish applied (#181, `1b07df5`): `x'(t)` notation, first-order `dF` wording, and publication polish while preserving authorial voice.
- `translation/progress.md` updated: English Chapter 3 is Pass 1 → 2 → 3 complete (~655 lines).

## Scope
| Section | Content |
|---------|---------|
| §3.0 | Curved objects / elementary-school debt framing |
| §3.1 | Volume integral, sphere |
| §3.2 | Surface area, shadows, $dS$, sphere $4\pi R^2$ |
| §3.3 | Line integrals, arc length vs $1$-forms |
| §3.4 | Coefficients: work, flux, mass; unified $\int_M \omega$ |
| §3.5 | Chapter summary; pullback foreshadow |

## Test plan
- [ ] Diff against `manuscript/ja/ch03/ch03.md` for §3.2–§3.5 fidelity
- [ ] Terminology scan: measuring device, shadow, no rot/YAML
- [ ] Review records: `ch03-pass2.md`, `ch03-pass3.md`, `ch03-close-reading-polish.md`
- [ ] Merge to `main` (Chapter 2 already on `main` via #165)