### PR TITLE
English Chapter 4: §4.0–§4.5 (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch04/ch04.md
+++ b/manuscript/en/ch04/ch04.md
@@ -10,7 +10,7 @@ Yet physics is usually curved.
 Trajectories curve, surfaces curve, and the boundaries of regions curve.
 
 Computation, on the other hand, is boxy.
-We mark off intervals, divide into grids, and slice into boxes. Integration is the technique of tallying curved physical quantities on top of boxy computation.
+We mark off intervals, divide into grids, and slice into boxes. Integration is the technique of tallying curved physical quantities using boxy computation.
 
 Here a problem arises.
 If we change the variables used for computation, we cannot use the measuring devices as they stand.
@@ -28,14 +28,14 @@ In this chapter we pursue this question through three examples.
 
 First, on a finite interval, we see what must be multiplied on the time side so that a piece of work agrees. Next, on a finite grid, we find the factor that makes area agree. Finally, on finite boxes, we find the factor that makes volume agree.
 
-As the partition is refined, a finite ratio becomes a differential coefficient, and a finite determinant becomes the determinant of the matrix built from partial derivatives. The rebuild of measuring devices obtained in that limit is called the pullback, written $\Phi^*$.
+As the partition is refined, a finite ratio becomes a derivative, and a finite determinant becomes the determinant of the matrix built from partial derivatives. The rebuild of measuring devices obtained in that limit is called the pullback, written $\Phi^*$.
 
 So the order of this chapter is as follows.
 
-> Find it on a finite interval.
-> Do the same on a finite grid.
-> Do the same on finite boxes.
-> Finally, $\Phi^*$ appears as the limit $h\to0$.
+> - Find it on a finite interval.
+> - Do the same on a finite grid.
+> - Do the same on finite boxes.
+> - Finally, $\Phi^*$ appears as the limit $h\to0$.
 
 In this chapter we do not memorize formulas; we make things consistent.
 Through three physical quantities—work, area, and volume—we see how $dx$, $dx \wedge dy$, and $dx \wedge dy \wedge dz$ are each rebuilt.
@@ -60,7 +60,7 @@ $$W = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
 
 follows. In this section we reread this derivation through the lens of "how must we rebuild the measuring device so that the same work comes out?" We begin by finding the coefficient needed on the time-side measuring device, interval by interval on a finite partition.
 
-<strong>② Naive substitution—it does not match.</strong> Write the particle's position as $x = \gamma(t)$. The velocity is $v(t)=\frac{d\gamma}{dt}(t)$. The measuring device for work is $F\,dx$—a $1$-form that eats displacement in physical space and returns a piece of work.
+<strong>② Naive substitution—it does not match.</strong> Write the particle's position as $x = \gamma(t)$. The velocity is $v(t)=\gamma'(t)$. The measuring device for work is $F\,dx$—a $1$-form that eats displacement in physical space and returns a piece of work.
 
 But the motion is given by time $t$. So we want to compute work in time.
 
@@ -100,7 +100,7 @@ $$\gamma_h^\square(dx)\bigl(\Delta t_i\bigr)=\Delta x_i$$
 
 As the partition is refined, the finite ratio approaches the velocity
 
-$$\frac{\Delta x_i}{\Delta t_i}\to \frac{d\gamma}{dt}(t)$$
+$$\frac{\Delta x_i}{\Delta t_i}\to \gamma'(t)$$
 
 So in the limit we obtain
 
@@ -109,10 +109,10 @@ $$
 \xrightarrow{h\to0}
 \gamma^*(dx)
 =
-\frac{d\gamma}{dt}(t)\,dt
+\gamma'(t)\,dt
 $$
 
-After the limit we write this measuring device as $\gamma^*(dx)=\frac{d\gamma}{dt}(t)\,dt$. The coefficient $\Delta x_i/\Delta t_i$ found on finite intervals has become the velocity $\frac{d\gamma}{dt}(t)$ in the limit.
+After the limit we write this measuring device as $\gamma^*(dx)=\gamma'(t)\,dt$. The coefficient $\Delta x_i/\Delta t_i$ found on finite intervals has become the velocity $\gamma'(t)$ in the limit.
 
 Henceforth we write the same rebuild for finite grids and boxes collectively as $\Phi_h^\square$.
 
@@ -139,7 +139,7 @@ By this we can recast the measuring device $F\,dx$ for work in physical space in
 $$
 \gamma^*(F(x)\,dx)
 =
-F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+F(\gamma(t))\,\gamma'(t)\,dt
 $$
 
 <strong>⑥ Define it through this transformation.</strong> By now the route from the finite-interval version to the standard version is visible. So for a smooth curve $\gamma: t \mapsto x$, we define the rebuild of the $1$-form $\omega = F(x)\,dx$ by
@@ -147,10 +147,10 @@ $$
 $$
 \gamma^*(F(x)\,dx)
 =
-F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+F(\gamma(t))\,\gamma'(t)\,dt
 $$
 
-This formula is the pullback of a $1$-form used on the time side. The velocity $\frac{d\gamma}{dt}(t)$ is the limit of $\Delta x_i/\Delta t_i$ found on finite intervals and serves as the consistency factor for "recasting the physical-space measuring device $dx$ into the time-axis measuring device $dt$."
+This formula is the pullback of the physical-space $1$-form to the time side. The velocity $\gamma'(t)$ is the limit of $\Delta x_i/\Delta t_i$ found on finite intervals and serves as the consistency factor for "recasting the physical-space measuring device $dx$ into the time-axis measuring device $dt$."
 
 Next we repeat the same procedure for the two-dimensional area-measuring device $dx\wedge dy$. In one dimension we mapped a finite interval and measured the displacement of its image. In two dimensions we will map a finite rectangle and measure the area spanned by two displacement vectors of its image.
 
@@ -158,7 +158,7 @@ Next we repeat the same procedure for the two-dimensional area-measuring device 
 
 $$\gamma^*(F\,dx) = m\frac{dv}{dt}\,v\,dt = m v\,dv$$
 
-we can read ($m\frac{dv}{dt}\,dt$ corresponds to $\gamma^*(dv)$, pulling the velocity-axis measuring device $dv$ back to the time axis). Therefore
+Here $\frac{dv}{dt}\,dt$ can be read as $\gamma^*(dv)$: the velocity-axis measuring device $dv$ pulled back to the time axis. Therefore
 
 $$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int_{v(t_0)}^{v(t_1)} m v\,dv = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
 
@@ -174,18 +174,14 @@ $$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int
 
 <strong>① Start from a physical quantity.</strong> In §4.1 we mapped a one-dimensional finite interval and measured its image. This time we apply the same idea to a two-dimensional finite grid.
 
-> <strong>Note</strong> (For readers without physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.
+> <strong>Note</strong> (for readers without a physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.
 
 Consider a particle moving in a central force field. When the force always points toward the origin, the angular momentum
 
 $$
 L
 =
-m\left(
-x\frac{dy}{dt}
--
-y\frac{dx}{dt}
-\right)
+m\left(x(t)y'(t)-y(t)x'(t)\right)
 $$
 
 is constant in time (the law of conservation of angular momentum). This conservation law has a beautiful geometric meaning—the rate at which the position vector of the particle sweeps out area (<strong>areal velocity</strong>) is constant (Kepler’s second law).
@@ -216,7 +212,7 @@ $$
 
 This is completely different from $\pi C^2$. With $dr \wedge d\theta$ alone, the correct area does not come out.
 
-<strong>③ See the cause on a finite grid.</strong> This time, let us ask what we must feed to the finite grid on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
+<strong>③ See the cause on a finite grid.</strong> This time, let us ask what measuring device should eat a finite cell on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
 
 Cut a grid of finite size $\Delta r \times \Delta\theta$ in $(r,\theta)$ space. Find the two displacement vectors that one cell at coordinates $(r, \theta)$ produces in $(x,y)$ space.
 
@@ -307,7 +303,7 @@ d\theta
 \frac{1}{2}R(\theta)^2\,d\theta
 $$
 
-The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit,
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit, we obtain
 
 $$
 \Phi_h^\square(dx\wedge dy)
@@ -317,15 +313,13 @@ $$
 r\,dr\wedge d\theta
 $$
 
-appears.
-
 > <strong>Note</strong> ($\Delta r,\Delta\theta$ need not be infinitesimal) In the computation of the difference vectors so far, we have used no assumption that $\Delta r$ or $\Delta\theta$ is “sufficiently small.” The $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ found above are formulas that hold exactly no matter how large $\Delta r,\Delta\theta$ may be. By “exact” here we mean that we measure the parallelogram spanned by finite-difference vectors. The passage to infinitesimals is made only in the final stage—the limit of the sum—when we move to $\Phi^*$ and integration.
 
 <strong>④ Write the standard form obtained in the limit.</strong> For the transformation to polar coordinates $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$:
 
 $$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
 
-This is the rebuilding of the $2$-form obtained from the finite-cell version $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency factor corresponding to the velocity $d\gamma/dt$ in §4.1.
+This is the $2$-form rebuilt in the limit from the finite-cell version $\Phi_h^\square$. We denote that limiting rebuild by $\Phi^*$. This $r$ plays the same role for $2$-forms that the velocity $\gamma'(t)$ played for $1$-forms in §4.1.
 
 <strong>⑤ Pullback of a coefficient-carrying $2$-form.</strong> For a $2$-form $G(x,y)\,dx \wedge dy$ with an arbitrary coefficient $G(x,y)$, the same structure holds:
 
@@ -335,7 +329,7 @@ The coefficient $G$ is merely rebuilt in polar coordinates (pullback of a $0$-fo
 
 <strong>⑥ Carry the same discovery to a general transformation.</strong> Nothing here is special to polar coordinates. Consider a transformation between planes $\Phi(u,v)=(x(u,v),y(u,v))$, and map a finite rectangle on the $(u,v)$ side. Measure the two difference vectors in the $u$ and $v$ directions with $dx\wedge dy$, and we get an area value for each finite rectangle.
 
-Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios move to partial-derivative coefficients, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
+Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios converge to partial derivatives, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
 
 $$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\;
 \det\!\begin{pmatrix}
@@ -358,7 +352,7 @@ What we saw on the finite grid,
 
 $$\Delta x_u\,\Delta y_v-\Delta x_v\,\Delta y_u$$
 
-is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors, but in the limit rebuilding written as $\Phi^*$, partial-derivative coefficients are used. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
+is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors. In the limiting rebuild written as $\Phi^*$, these finite ratios are replaced by partial-derivative coefficients. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
 
 <strong>⑦ Return to the physical quantity.</strong> Integrate the area of the sector $D$ over the corresponding polar-coordinate region $D'$ using the pulled-back measuring device:
 
@@ -389,7 +383,7 @@ Integrating in $r$, $\frac{1}{2}r^2$ appears, and the area is reduced to a line 
 $$
 \frac{dA}{dt}
 =
-\frac{1}{2}r(t)^2\,\frac{d\theta}{dt}(t)
+\frac{1}{2}r(t)^2\,\theta'(t)
 $$
 
 From the definition of angular momentum
@@ -397,14 +391,14 @@ From the definition of angular momentum
 $$
 L
 =
-m r^2\frac{d\theta}{dt}
+m r(t)^2\theta'(t)
 $$
 
 the areal velocity is
 
 $$\frac{dA}{dt} = \frac{L}{2m}$$
 
-In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. Exactly the same structure as in §4.1, where the consistency factor $d\gamma/dt$ of a $1$-form described energy conservation, describes conservation of angular momentum through the consistency factor $r$ of a $2$-form.
+In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. This is exactly the same structure as in §4.1: there, the consistency factor $\gamma'(t)$ for a $1$-form described energy conservation; here, the consistency factor $r$ for a $2$-form describes conservation of angular momentum.
 
 
 ---
@@ -532,7 +526,7 @@ $$
 r\,dr \wedge d\theta \wedge dz
 $$
 
-This is the rebuilding of the $3$-form obtained from the finite cell pullback $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency coefficient that carries over the $r$ of §4.2 unchanged.
+This is the limiting rebuild of the $3$-form obtained from the finite-cell version $\Phi_h^\square$. We denote this limiting rebuild by $\Phi^*$. The same consistency coefficient $r$ from §4.2 carries over unchanged.
 
 <strong>⑤ Pullback of a weighted $3$-form.</strong> For a $3$-form $\rho\,dx \wedge dy \wedge dz$ with arbitrary density $\rho(x,y,z)$, the same structure holds:
 
@@ -542,7 +536,7 @@ The coefficient $\rho$ is only re-expressed in new coordinates (pullback of a $0
 
 <strong>⑥ Transfer the same discovery to a general transformation.</strong> More generally, consider a transformation of space $\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$. Mapping a finite box on the $(u,v,w)$ side produces three difference vectors. Measuring them with $dx\wedge dy\wedge dz$ gives the oriented volume of the mapped parallelepiped.
 
-Dividing that volume value by $\Delta u\,\Delta v\,\Delta w$ and refining the partition, the difference ratios pass to partial-derivative coefficients and a $3\times3$ determinant appears. Therefore, after $h\to0$, the pullback is:
+Dividing that volume value by $\Delta u\,\Delta v\,\Delta w$ and refining the partition, the difference ratios converge to partial derivatives and a $3\times3$ determinant appears. Therefore, after $h\to0$, the pullback is:
 
 $$
 \begin{aligned}
@@ -571,11 +565,11 @@ $$\det\!\begin{pmatrix}
 \Delta z_u & \Delta z_v & \Delta z_w
 \end{pmatrix}$$
 
-This is the value obtained by feeding a measuring device on a finite cell to a finite box; for the parallelepiped spanned by the difference vectors, it is an equality. As the partition width $h$ is taken toward $0$, the coefficient obtained by dividing this finite determinant by $\Delta u\,\Delta v\,\Delta w$ converges to the Jacobian $J$ built from partial derivatives.
+This is the measured value assigned to the finite box by the provisional measuring device. For the parallelepiped spanned by the difference vectors, it is an equality. As the partition width $h$ is taken toward $0$, the coefficient obtained by dividing this finite determinant by $\Delta u\,\Delta v\,\Delta w$ converges to the Jacobian $J$ built from partial derivatives.
 
-If $J$ is negative, orientation is reversed. In the formal pullback, we use this signed $J$ as-is. On the other hand, when integrating “positive volume” or density, we need the magnitude with orientation forgotten, so $|J|$ appears. It is important not to confuse $J$ and $|J|$ here.
+If $J$ is negative, orientation is reversed. In the formal pullback, we use this signed $J$ as-is. On the other hand, when we are computing ordinary positive volume or mass density as a non-oriented scalar quantity, we need the magnitude with orientation forgotten, so $|J|$ appears. It is important not to confuse $J$ and $|J|$ here.
 
-For a $1$-form we have a $1 \times 1$ determinant (velocity $dx/dt$), for a $2$-form a $2 \times 2$ determinant, for a $3$-form a $3 \times 3$ determinant ($J$) — as the degree rises, the size of the determinant governing the consistency coefficient grows by one each time. The partial-derivative determinant formula above is precisely <strong>the general definition of the pullback of a $3$-form</strong>.
+For a $1$-form we have a $1 \times 1$ determinant (the velocity $\gamma'(t)$), for a $2$-form a $2 \times 2$ determinant, for a $3$-form a $3 \times 3$ determinant ($J$) — as the degree rises, the size of the determinant governing the consistency coefficient grows by one each time. The partial-derivative determinant formula above is precisely <strong>the general definition of the pullback of a $3$-form</strong>.
 
 > <strong>Note</strong> (for readers who have studied vector analysis) When you learned in a change of variables that “in polar coordinates, $r\,dr\,d\theta$ appears,” many textbooks give a geometric explanation: “consider the arc length $r\Delta\theta$ in the $\theta$ direction and $\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$.” That explanation is not wrong. But in the computation of this book we never consider arc length at all. Only the transformation formulas, trigonometric identities, and the determinant corresponding to $\wedge$ produce the consistency coefficient $r$.
 
@@ -605,13 +599,13 @@ dz
 \rho\cdot\pi C^2H
 $$
 
-We agree with the correct value. To preserve the integral value, the measuring device $dx \wedge dy \wedge dz$ had to be rebuilt as $r\,dr \wedge d\theta \wedge dz$ in $(r,\theta,z)$ space. In exactly the same structure by which the velocity $d\gamma/dt$ of §4.1 describes conservation of energy and the $r$ of §4.2 describes conservation of angular momentum, the $r$ of §4.3 (more generally $J$) describes conservation of mass.
+This agrees with the correct value. To preserve the integral value, the measuring device $dx \wedge dy \wedge dz$ had to be rebuilt as $r\,dr \wedge d\theta \wedge dz$ in $(r,\theta,z)$ space. The same pattern repeats across the chapter: in §4.1 the consistency factor $\gamma'(t)$ describes conservation of energy; in §4.2 the factor $r$ describes conservation of angular momentum; and here, the factor $r$—more generally, $J$—describes conservation of mass.
 
 ---
 
 ### §4.4 Properties of the Pullback — What We Have Established So Far
 
-In §4.1–§4.3 we constructed pullbacks through three concrete examples. Here we organize the algebraic properties common to all of them. At the same time, we define the $3 \times 3$ determinant $J$ that appeared in §4.3 as the <strong>Jacobian (Jacobi determinant)</strong>. The matrix
+In §4.1–§4.3 we constructed pullbacks through three concrete examples. Here we organize the algebraic properties common to all of them. At the same time, we define the $3 \times 3$ determinant $J$ that appeared in §4.3 as the <strong>Jacobian determinant</strong>. The matrix
 
 $$\begin{pmatrix}
 \frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[4pt]
@@ -619,7 +613,7 @@ $$\begin{pmatrix}
 \frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
 \end{pmatrix}$$
 
-is called the <strong>Jacobian matrix</strong>, and its determinant $\det$ is the Jacobian $J$.
+is called the <strong>Jacobian matrix</strong>, and its determinant is the Jacobian $J$.
 
 <strong>① Pullback of a $0$-form (scalar field).</strong> To pull back a scalar field $f(x,y,z)$ by a transformation $\Phi$ is simply to rewrite the coordinates into a parametric representation:
 
@@ -646,10 +640,10 @@ holds. In other words, “assemble then pull back” and “pull back then assem
 $$
 \det
 \begin{pmatrix}
-\frac{dx}{dt}
+\gamma'(t)
 \end{pmatrix}
 =
-\frac{dx}{dt}
+\gamma'(t)
 $$
 
 - $k=2$ ($2$-form): a $2 \times 2$ determinant
@@ -681,7 +675,7 @@ $$
 
 Thus a $1 \times 1$ determinant appears for $1$-forms, a $2 \times 2$ determinant for $2$-forms, and a $3 \times 3$ determinant for $3$-forms. As the degree increases, the size of the determinant that fixes the consistency factor of the measuring device grows by one step at a time. This structure is the same for $k$-forms in higher dimensions as well. Arrange the coefficients obtained by differentiating the transformation formulas, pick out the $k$ directions needed, and form the determinant. That determinant is the consistency factor for rewriting a $k$-dimensional measuring device into a form usable in the variables on the parameter-space side.
 
-> <strong>Note</strong> (The name “Jacobian”) In general, the matrix assembled from the differential coefficients of a change of variables is called the Jacobian matrix, and its determinant is called the Jacobian. In one dimension this is $\frac{dx}{dt}$; in two dimensions it is the $2\times2$ determinant above; in three dimensions it is $J$.
+> <strong>Note</strong> (The name “Jacobian”) In general, the matrix assembled from the partial derivatives of a change of variables is called the Jacobian matrix, and its determinant is called the Jacobian. In one dimension this is the $1\times1$ determinant $\gamma'(t)$; in two dimensions it is the $2\times2$ determinant above; in three dimensions it is $J$.
 >
 > In this book, we often write the $3\times3$ determinant that appears especially as a volume conversion factor as $J$ and call it the Jacobian.
 
@@ -714,11 +708,11 @@ What this chapter established is the following unified principle:
 
 <strong>When counting in different variables, rebuild the measuring devices so that the integral value does not change.</strong> This is the pullback. Whether it is work along a curve, area or flux on a surface, or total mass in a region—all can be handled by the same idea.
 
-The pullback is the technique of rebuilding measuring devices so that integral values are preserved, and its core lies in the discovery-based derivations we saw in §4.1–§4.3. That is, the flow: “the naive attempt does not match → build a provisional measuring device on finite cells → obtain the general form in the limit $h\to0$.” In the finite-cell version $\Phi_h^\square$, the coefficient is the determinant of finite-difference vectors divided by the cell width; in $\Phi^*$, its limit appears as partial-derivative coefficients and the Jacobian. For $1$-forms the velocity $d\gamma/dt$, for $2$-forms $r$, and for $3$-forms the $3\times3$ determinant $J$ all emerged from the computation of measuring finite cells.
+The pullback is the technique of rebuilding measuring devices so that integral values are preserved, and its core lies in the discovery-based derivations we saw in §4.1–§4.3. That is, the flow: “the naive attempt does not match → build a provisional measuring device on finite cells → obtain the general form in the limit $h\to0$.” In the finite-cell version $\Phi_h^\square$, the coefficient is the determinant of finite-difference vectors divided by the cell width; in $\Phi^*$, its limit appears as partial-derivative coefficients and the Jacobian. For $1$-forms the velocity $\gamma'(t)$, for $2$-forms $r$, and for $3$-forms the $3\times3$ determinant $J$ all emerged from measuring finite cells.
 
 > <strong>Checkpoint so far — Chapter 4</strong>
 > - The pullback $\Phi^*$ is the operation of rewriting measuring devices on the physical-space side into a form usable in the variables on the parameter-space side, so that the integral value does not change.
-> - For a $1$-form, the physical-space measuring device $F(x)\,dx$ is rebuilt on the time side as $\gamma^*(F(x)\,dx)=F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt$. On finite intervals, $\Delta x/\Delta t$; in the limit, the velocity $d\gamma/dt$ becomes the consistency factor.
+> - For a $1$-form, the physical-space measuring device $F(x)\,dx$ is rebuilt on the time side as $\gamma^*(F(x)\,dx)=F(\gamma(t))\,\gamma'(t)\,dt$. On finite intervals the consistency factor is $\Delta x/\Delta t$; in the limit, it becomes the velocity $\gamma'(t)$.
 > - For a $2$-form, $dx\wedge dy$ is rebuilt on the polar-coordinate side as $\Phi^*(dx\wedge dy)=r\,dr\wedge d\theta$. On a finite grid, $r\Delta r\sin\Delta\theta$ appears, and in the limit $h\to0$ the coefficient $r$ remains.
 > - For a $3$-form, $dx\wedge dy\wedge dz$ is rebuilt on the cylindrical-coordinate side as $\Phi^*(dx\wedge dy\wedge dz)=r\,dr\wedge d\theta\wedge dz$. For a general transformation, $\Phi^*(dx\wedge dy\wedge dz)=J\,du\wedge dv\wedge dw$.
 > - The finite-cell version $\Phi_h^\square$ is a provisional measuring device used on finite cells. Its coefficient is fixed by “measurement of the figure spanned by finite-difference vectors, divided by the cell width on the parameter-space side.” When we feed this measuring device to a finite cell, the original measurement comes back. In the limit $h\to0$, this coefficient becomes the coefficient of $\Phi^*$.
@@ -727,4 +721,4 @@ The pullback is the technique of rebuilding measuring devices so that integral v
 
 ---
 
-In the next chapter, we finally introduce the <strong>exterior derivative $d$</strong>. We have reached the point of building measuring devices, integrating them, and rebuilding them to suit the variables. What we look at next is change in the measuring devices themselves. The operation that records how things change from place to place as a form one degree higher—that is the exterior derivative $d$.
+In the next chapter, we finally introduce the <strong>exterior derivative $d$</strong>. We have reached the point of building measuring devices, integrating them, and rebuilding them to suit the variables. What we look at next is change in the measuring devices themselves. The operation that records how a form changes from place to place, producing a form one degree higher, is the exterior derivative $d$.

--- a/manuscript/en/ch04/ch04.md
+++ b/manuscript/en/ch04/ch04.md
@@ -1,749 +1,730 @@
----
-title: "Chapter 4: Exterior Derivative $d$ — Extracting Differential Laws from Integrals"
-series: dx-matrix
-chapter: 4
-order: 40
-assumes:
-- one_form
-- two_form
-- three_form
-- k_form
-- wedge_product
-- form_integral
-- pullback
-- jacobian
-introduces:
-  exterior_derivative:
-    from: intuition
-    to: computation
-  stokes_theorem:
-    from: intuition
-    to: formula
-  gauss_theorem:
-    from: intuition
-    to: formula
-previews:
-  hodge_star:
-    max_level: intuition
-    note: Treated only as a dictionary to be defined in Chapter 5. Concrete formulas and calculations are prohibited.
-    allowed_context_patterns:
-    - 次章
-    - 後で
-    - ここでは.*使わない
-    - 具体式.*使わない
-    - 第5章
-    - 後述
-  metric:
-    max_level: intuition
-    note: Foreshadowing only as additional rules for extracting length and magnitude.
-  nabla_operators:
-    max_level: intuition
-    note: Auxiliary lines for those with prior knowledge only. Formalization of grad/rot/div is prohibited.
-    allowed_context_patterns:
-    - 既習者
-    - 見覚え
-    - 後の章
-    - 後で整理
-    - 名前だけ
-  maxwell_forms:
-    max_level: intuition
-    note: 物理法則の局所化の模式的説明のみ許可。形式記法の詳細は禁止。
-recap_policy:
-  one_form:
-    max_level: mention
-    max_lines: 3
-  two_form:
-    max_level: mention
-    max_lines: 3
-  three_form:
-    max_level: mention
-    max_lines: 3
-  wedge_product:
-    max_level: mention
-    max_lines: 3
-  form_integral:
-    max_level: mention
-    max_lines: 4
----
+# Chapter 4: What Is a Change of Variables? — The Pullback $\Phi^*$: Making Measuring Devices Consistent
 
-# Chapter 4: Exterior Derivative $d$ — Extracting Differential Laws from Integrals
+### §4.0 Physics Curves; Computation Uses Boxes
 
-### §4.0 Door to Part II — Observation is Integration, Law is Differentiation
+The quantities we truly want to measure in physics do not depend on the names of coordinates.
 
-In Chapter 3, we defined integrals over curves, surfaces, and domains in terms of $k$-forms. The work along a curve $\gamma$ is $\int_\gamma \omega$, the flux through a surface $S$ is $\iint_S \eta$, and the total mass of a domain $V$ is $\iiint_V \Omega$. All of these followed the same principle: "feed a $k$-form (a measuring instrument) to a $k$-vector (a geometric figure) to obtain a scalar, and then sum over the entire region."
+Work done on a particle must be the same whether we write the trajectory in $x$ or in time $t$. The area swept out by a planet must be the same whether we measure it in Cartesian coordinates or polar coordinates. The mass of an object must be the same whether we integrate in Cartesian coordinates or cylindrical coordinates.
 
-The integrals we have obtained here are all quantities over entire regions (we will call such quantities <strong>global</strong>). Work is the total sum along a curve, flux is the total amount through a surface, and mass is the total over a domain. They depend on how we apply the measuring instrument and how we choose the region.
+Yet physics is usually curved.
+Trajectories curve, surfaces curve, and the boundaries of regions curve.
 
-But this is not what physicists seek. Whether it is Maxwell's equations or the Navier-Stokes equations, the fundamental laws of nature are written as local relationships—differential equations—that describe what holds at each point and each instant in space. This is because global integral quantities depend on the region, but local laws have universality independent of the region.
+Computation, on the other hand, is boxy.
+We mark off intervals, divide into grids, and slice into boxes. Integration is the technique of tallying curved physical quantities on top of boxy computation.
 
-> <strong>Note</strong> (Terminology: global/local) In other books, the same concepts are often called <strong>macro/micro</strong>. Both are essentially the same: the contrast between quantities integrated over entire regions (global/macro) and differential relations at each point (local/micro).
+Here a problem arises.
+If we change the variables used for computation, we cannot use the measuring devices as they stand.
 
-Here arises a fundamental question.
+$dx$ is a measuring device that reads displacement in the $x$ direction; swapping it for $dt$ alone does not measure work correctly.
+$dx \wedge dy$ is an area-measuring device in the $xy$ plane; swapping it for $dr \wedge d\theta$ alone does not measure area correctly.
+$dx \wedge dy \wedge dz$ likewise does not measure volume correctly if we swap it for $dr \wedge d\theta \wedge dz$ alone.
 
-> <strong>How can we extract local laws from integrated quantities?</strong>
+Physical quantities must not change.
+But the boxes used for computation do change.
 
-Answering this question is the subject of this chapter—<strong>the exterior derivative $d$</strong>. $d$ is an operator that acts on a $k$-form and returns a $(k+1)$-form. Combined with the integrals defined in Chapter 3, it translates "global integrals measured on the boundary" into "accumulations of local changes in the interior." In other words, <strong>the exterior derivative $d$ is a device that converts integral laws into differential laws</strong>.
+Then how should we rebuild the measuring devices?
 
-The structure of this chapter is as follows. First, we recall $df$ introduced in Chapter 1 and confirm that it is a "dimension raising" from $0$-form to $1$-form (§4.1). Next, we see that the inverse operation fails for general $1$-forms (§4.2), and from dissecting an infinitesimal loop we discover a "discrepancy per area" $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ (§4.3). Using this discovery, we arrive at the definition of $d$ (§4.4), then extend to three dimensions (§4.5) and proceed to Stokes' theorem (§4.6). We apply the same reasoning to $2$-forms (§4.7) and clarify the structural meaning of $d^2=0$ (§4.8). Finally, we show how this $d$ localizes physical laws (§4.10) and connect to the Hodge star in the next chapter (§4.11).
+In this chapter we pursue this question through three examples.
 
----
+First, on a finite interval, we see what must be multiplied on the time side so that a piece of work agrees. Next, on a finite grid, we find the factor that makes area agree. Finally, on finite boxes, we find the factor that makes volume agree.
 
-### §4.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?
+As the partition is refined, a finite ratio becomes a differential coefficient, and a finite determinant becomes the determinant of the matrix built from partial derivatives. The rebuild of measuring devices obtained in that limit is called the pullback, written $\Phi^*$.
 
-#### 4.1.1 $df$ is "Raising the Dimension"
+So the order of this chapter is as follows.
 
-In Chapter 1 §1.3, we defined the total differential of a function $f(x,y,z)$ as a row vector:
+> Find it on a finite interval.
+> Do the same on a finite grid.
+> Do the same on finite boxes.
+> Finally, $\Phi^*$ appears as the limit $h\to0$.
 
-$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+In this chapter we do not memorize formulas; we make things consistent.
+Through three physical quantities—work, area, and volume—we see how $dx$, $dx \wedge dy$, and $dx \wedge dy \wedge dz$ are each rebuilt.
 
-This is an operation that takes a <strong>$0$-form (scalar field $f$) as input and outputs a $1$-form (row vector $df$)</strong>. The degree has increased from 0 to 1.
+### §4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem
 
-What we should recall here is that $df(\mathbf{v})$ returns the first-order change of $f$ with respect to a displacement $\mathbf{v}$. When $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ is sufficiently small:
+> <strong>Note</strong> (for readers without a physics background) All we use here is that position can be written as $x=\gamma(t)$. Read $F(x)$ as a function of position and $v(t)$ as a function of time.
 
-$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
+<strong>① Start from a physical quantity.</strong> We do not jump straight to general theory. Let us begin from a familiar fact of mechanics.
 
-$df$ alone is not "the change itself" — by the convention of Chapter 1 §1.2.6, $df$ is an operator, and a numerical value is obtained only when it acts on a displacement vector.
+Suppose a force $F$ acts on a particle moving along the $x$ axis. Work is given by
 
-#### 4.1.2 Line Integration Leaves Only the Difference of Endpoints
+$$W = \int F\,dx$$
 
-We integrate this $df$ along a curve $\gamma$. Following the definition in Chapter 3 §3.4.1, we partition the curve into small segments, feed each step's displacement $\Delta\mathbf{r}_i$ into $df$, and sum them up.
+On the other hand, the equation of motion is
 
-On each segment, since $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, the sum over all segments is:
+$$F = m\frac{dv}{dt}$$
 
-$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
+From these two, the familiar work-energy theorem
 
-Expanding this sum, we get:
+$$W = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
 
-$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
+follows. In this section we reread this derivation through the lens of "how must we rebuild the measuring device so that the same work comes out?" We begin by finding the coefficient needed on the time-side measuring device, interval by interval on a finite partition.
 
-Adjacent terms $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ cancel each other out with plus and minus signs — this is a telescoping sum. Only the first and last terms survive. In the limit as the partition becomes infinitely fine:
+<strong>② Naive substitution—it does not match.</strong> Write the particle's position as $x = \gamma(t)$. The velocity is $v(t)=\frac{d\gamma}{dt}(t)$. The measuring device for work is $F\,dx$—a $1$-form that eats displacement in physical space and returns a piece of work.
 
-$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
+But the motion is given by time $t$. So we want to compute work in time.
 
-Here $A$ is the starting point and $B$ the ending point of the curve.
+First on the physical-space side, take uniformly accelerated motion $x(t) = \frac{1}{2}at^2$ and constant force $F = ma$. With endpoint $X = \frac{1}{2}aT^2$,
 
-> <strong>[Checkpoint so far]</strong>
-> - $\int_\gamma df = f(B) - f(A)$. The result of the integration does not depend on the shape of the path at all; it is determined only by the values at the endpoints.
-> - This holds because $df$ is a special $1$-form. In mechanics, this is the mathematical basis for the fact that the work done by a conservative force is path-independent.
+$$W_{\text{phys}} = \int_0^X ma\,dx = ma\,X = \frac{1}{2}ma^2T^2$$
 
-#### 4.1.3 Verification with an Example from Chapter 3
+On the other hand, if we integrate naively on the time side—that is, replace $dx$ by $dt$ as-is—
 
-In Chapter 3 §3.5.1, we computed the integral of $\omega = y\,dx + x\,dy$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ and obtained the result $0$. At that time, we integrated directly along the coefficients, but when we reexamine it in our current language, the story is much simpler.
+$$W_{\text{naive}} = \int_0^T ma\,dt = ma\,T$$
 
-In fact, $y\,dx + x\,dy$ is nothing but $d(xy)$. Because:
+We have $\frac{1}{2}ma^2T^2 \neq ma\,T$, so they clearly do not agree. With $dt$ alone, the value of work changes.
 
-$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
+<strong>③ See the cause on a finite interval.</strong> Consider a small time interval $[t_i, t_{i+1}]$. Let its width be $\Delta t_i = t_{i+1} - t_i$ and the corresponding change in position $\Delta x_i = \gamma(t_{i+1}) - \gamma(t_i)$. One term of work on the physical-space side is $F_i\,\Delta x_i$. One term built naively on the time side is $F_i\,\Delta t_i$. These do not agree because we ignored the consistency factor between $\Delta t_i$ and $\Delta x_i$.
 
-Therefore, $\omega = df$ ($f = xy$), and the telescoping sum argument of §4.1.2 can be applied directly. Since the unit circle is a closed curve, $B = A$, so:
+So multiply the time-side term by a coefficient $c_i$ and try $F_i\,c_i\,\Delta t_i$. For this to agree with $F_i\,\Delta x_i$, we need $c_i\,\Delta t_i = \Delta x_i$. Therefore
 
-$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$
+$$c_i = \frac{\Delta x_i}{\Delta t_i}$$
 
-The calculation of $\int_0^{2\pi} \cos 2t\,dt = 0$ back then mechanically gave zero precisely because $\omega$ was an exact form $d(xy)$.
+Up to here it is just division. Yet this division has meaning. We were asking: what measuring device must eat the time-side interval $\Delta t_i$ so that the same value as the physical-space displacement $\Delta x_i$ comes out? The answer is
 
-> <strong>Note</strong> (Exact form) A $1$-form that can be written as $\omega = df$ is called an exact form. The integral of an exact form along a closed curve always vanishes, provided $f$ is single-valued. However, the converse is not true: just because the integral over a closed curve is zero does not guarantee it is exact. We will examine this point in detail in §4.2.
+$$\frac{\Delta x_i}{\Delta t_i}\,dt$$
 
-> <strong>Note</strong> (Inverse operations of $d$ and $\int$ — how "exact" is each?) We use the symbol $\circ$ to mean "apply successively" ($f \circ g$ means "do $g$ then $f$"). $\int_\gamma df = f(B)-f(A)$ is an inverse operation in the sense that $\int \circ\, d$ always returns to the boundary value. On the other hand, $d \circ \int$ — integrate then exterior differentiate — does not generally return to the original. It is $\omega$ for which this holds that are <strong>exact forms</strong>. Thus, $d$ and $\int$ are in an asymmetric inverse relationship: $\int \circ\, d = \text{id}$ (identity only on one side). This asymmetry is the source of the true value of the exterior derivative $d$, developed from §4.2 onward—its power to detect "discrepancies."
+Indeed, if we feed $\Delta t_i$ to this measuring device,
 
----
+$$\left(\frac{\Delta x_i}{\Delta t_i}\,dt\right)(\Delta t_i)=\Delta x_i$$
 
-### §4.2 "Discrepancy" Revealed by Closed Loops
+So on a finite time interval we can read the same displacement as on the physical-space side.
 
-#### 4.2.1 What About a General $1$-Form?
+Write this provisional measuring device on a finite interval as
 
-Now, a general $1$-form
+$$\gamma_h^\square(dx):=\frac{\Delta x_i}{\Delta t_i}\,dt$$
 
-$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
+where $h$ denotes the maximum width of the partition. Feeding this measuring device to a finite interval gives
 
-How about it? Here, $P, Q, R$ are coefficients (scalar fields) that vary from place to place, and they are the "general $1$-forms" introduced in Chapter 3 §3.5.1.
+$$\gamma_h^\square(dx)\bigl(\Delta t_i\bigr)=\Delta x_i$$
 
-> <strong>Note</strong> (What does "general" mean?) The $df$ treated in §4.1 had the special combination $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$ of coefficients—a triple derived from a single function $f$ via partial derivatives. In contrast, here "general" $\omega$ means the $P, Q, R$ are <strong>three arbitrary scalar fields independent of each other</strong>. In other words, we call a $1$-form that cannot necessarily be written as $\omega = df$ a "general $1$-form." The $y\,dx + x\,dy$ in §4.1.3 happened to be an exact form that could be written as $d(xy)$, but it is actually more common to have forms that are not.
+As the partition is refined, the finite ratio approaches the velocity
 
-$\omega$ does not necessarily represent a force; it represents an arbitrary "measuring instrument that measures along a line."
+$$\frac{\Delta x_i}{\Delta t_i}\to \frac{d\gamma}{dt}(t)$$
 
-For this $\omega$, there is no guarantee that the same telescoping sum as in §4.1 holds. The simplest way to check is to integrate over a closed loop—a curve whose start and end points coincide. If $\int_\gamma \omega$ could be written solely as the difference of endpoint values, then it would have to vanish on a closed loop.
+So in the limit we obtain
 
-We write the line integral along a closed loop as $\oint_\gamma \omega$. In general:
+$$
+\gamma_h^\square(dx)
+\xrightarrow{h\to0}
+\gamma^*(dx)
+=
+\frac{d\gamma}{dt}(t)\,dt
+$$
 
-$$\oint_\gamma \omega \neq 0$$
+After the limit we write this measuring device as $\gamma^*(dx)=\frac{d\gamma}{dt}(t)\,dt$. The coefficient $\Delta x_i/\Delta t_i$ found on finite intervals has become the velocity $\frac{d\gamma}{dt}(t)$ in the limit.
 
-Even if the starting and ending points are the same, the integral $f(A)-f(A)=0$ is not necessarily zero. If you move an object against friction around a closed loop, the work is not zero; if you go around a swirling water current, you receive a net amount of work. This fact—that <strong>"things do not balance out even when closed"</strong> is precisely the signature of local structures such as circulation and vortices.
+Henceforth we write the same rebuild for finite grids and boxes collectively as $\Phi_h^\square$.
 
-> <strong>Note</strong> (No need to know physics) Even if you have not yet studied friction or water currents in physics, there is no need to stop here. What matters now is not the specific physical phenomena, but the intuition that "if the integral around a closed loop is nonzero, there is a local structure like circulation there." We will touch on the detailed physical correspondence in later chapters.
+> <strong>Note</strong> ($\Phi_h^\square$ and $\Phi^*$)
+>
+> $\gamma_h^\square$ and $\Phi_h^\square$ are provisional measuring devices used in this book on finite intervals and finite cells. They are distinguished from $\Phi^*$ after $h\to0$.
+>
+> In the finite cell version, the coefficient is obtained by dividing the measured value of the figure spanned by finite displacement vectors by the cell width on the computation side. Therefore, feeding this measuring device to a finite cell recovers the original measured value.
+>
+> This coefficient is determined cell by cell. To keep the notation light, dependence on the cell index is not written into $\Phi_h^\square$.
+>
+> What we measure here is not the image of a finite cell under the map itself, but the figure spanned by the chosen displacement vectors: displacement in one dimension, a parallelogram in two dimensions, a parallelepiped in three dimensions. For example, the image of a finite polar grid cell is a curved sector, but what we measure here is not that sector itself but the parallelogram spanned by the two chosen displacement vectors.
+>
+> In the limit of partition width $h\to0$, the coefficients of $\gamma_h^\square$ and $\Phi_h^\square$ converge to the coefficients of the pullback $\Phi^*$ after the limit.
 
-#### 4.2.2 Where Does Local Information Reside?
+<strong>④ Write the pullback of the concrete example.</strong> After taking the limit, the measuring device on the time axis (the pulled-back result) is
 
-Then, where does this "discrepancy that remains after going around" come from? If we think of the closed loop at a large global scale all at once, we cannot tell how much each point inside contributes to the discrepancy. Recall how we found $f'(x)$ in Chapter 1—we took the limit of $\Delta x \to 0$ for $\Delta f / \Delta x$ to extract the </strong>rate of change at a single point__PH_0107__.
+$$\gamma^*(F\,dx) = F(\gamma(t))\,v(t)\,dt$$
 
-We use the same idea here. As we make the loop smaller and smaller, what happens to the value of the integral $\oint \omega$ around the loop? If the leading term of $\oint \omega$ is proportional to the </strong>area enclosed by the loop__PH_0109__, then the discrepancy per area—how much things fail to balance per unit area—should become a quantity intrinsic to that point.
+By this we can recast the measuring device $F\,dx$ for work in physical space into one for the time axis.
 
-Conversely, if it is not proportional (for example, proportional to the perimeter of the loop), then it does not settle into a per-area quantity and cannot be called "a property at that point." So the question is:
+<strong>⑤ Pullback of a $1$-form with a coefficient.</strong> For an arbitrary coefficient $F(x)$, the same structure holds. When position is given by $x = \gamma(t)$,
 
-> <strong>When going around an infinitesimal loop, is the leading term of $\oint \omega$ proportional to the enclosed area? If yes, what is the proportionality coefficient?</strong>
+$$
+\gamma^*(F(x)\,dx)
+=
+F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+$$
 
-In the next section, we answer this question concretely for a small rectangle placed in the $xy$ plane.
+<strong>⑥ Define it through this transformation.</strong> By now the route from the finite-interval version to the standard version is visible. So for a smooth curve $\gamma: t \mapsto x$, we define the rebuild of the $1$-form $\omega = F(x)\,dx$ by
+
+$$
+\gamma^*(F(x)\,dx)
+=
+F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+$$
+
+This formula is the pullback of a $1$-form used on the time side. The velocity $\frac{d\gamma}{dt}(t)$ is the limit of $\Delta x_i/\Delta t_i$ found on finite intervals and serves as the consistency factor for "recasting the physical-space measuring device $dx$ into the time-axis measuring device $dt$."
+
+Next we repeat the same procedure for the two-dimensional area-measuring device $dx\wedge dy$. In one dimension we mapped a finite interval and measured the displacement of its image. In two dimensions we will map a finite rectangle and measure the area spanned by two displacement vectors of its image.
+
+<strong>⑦ Return to the physical quantity.</strong> Here, using the equation of motion $F = m\,dv/dt$,
+
+$$\gamma^*(F\,dx) = m\frac{dv}{dt}\,v\,dt = m v\,dv$$
+
+we can read ($m\frac{dv}{dt}\,dt$ corresponds to $\gamma^*(dv)$, pulling the velocity-axis measuring device $dv$ back to the time axis). Therefore
+
+$$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int_{v(t_0)}^{v(t_1)} m v\,dv = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
+
+—work equals the change in kinetic energy.
+
+> <strong>Aside</strong> (why the name "pullback") If we are "sending" a measuring device that lives in physical space into parameter space, is that not a "push forward"?—that is how it feels to me. For me, physical space is "reality" and parameter space is a "tool for computation." But the mathematical map $\gamma$ is always defined in the direction “parameter space $\to$ physical space.” In the mathematical world, parameter space is the departure point. So the movement of a measuring device that goes against the direction of the map, from physical space back to parameter space, is called a pullback. I have made peace with calling it that by convention.
+
+> <strong>Note</strong> ($dx$ is a row vector, $dt$ is too) In the calculations of §4.1, $dx$, $dt$, and $dv$ all keep the same type: "eat displacement and return a scalar." The principle "row vector × column vector → scalar" from Chapter 1 §1.1.3 does not break even in the middle of a pullback. The result $\gamma^*(F\,dx)$ is again a $1$-form (row vector) on the time axis; feeding it the time-side displacement $\Delta t$ yields a scalar (a piece of work)—this consistency is what supports understanding of the pullback.
 
 ---
 
-### §4.3 Dissecting an Infinitesimal Loop — Discrepancy is Proportional to Area
+### §4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity
 
-#### 4.3.1 A Small Rectangle in the $xy$ Plane
+<strong>① Start from a physical quantity.</strong> In §4.1 we mapped a one-dimensional finite interval and measured its image. This time we apply the same idea to a two-dimensional finite grid.
 
-Consider a small rectangle with lower-left corner at point $(x, y, z)$ in space, lying parallel to the $xy$ plane. Let its width in the $x$ direction be $\Delta x$ and its width in the $y$ direction be $\Delta y$. We go around the four sides of this rectangle <strong>counterclockwise (right-handed)</strong> and integrate $\omega = P\,dx + Q\,dy + R\,dz$.
+> <strong>Note</strong> (For readers without physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.
 
-We evaluate the integral on each side using a first-order Taylor expansion (assuming $\Delta x, \Delta y$ is sufficiently small).
+Consider a particle moving in a central force field. When the force always points toward the origin, the angular momentum
 
-> <strong>Note</strong> (About Taylor expansion) There is no need to be intimidated by the term "Taylor expansion." What we use here is the first-order approximation of multivariable functions—the same as in Chapter 1 §1.3.1 where we wrote $\Delta f \approx f'(x)\,\Delta x$. For example, the value of $Q(x+\Delta x, y)$ shifted by $\Delta x$ in the $x$ direction can be approximated using the partial derivative of $Q$ with respect to $x$, $\frac{\partial Q}{\partial x}$, as $Q + \frac{\partial Q}{\partial x}\,\Delta x$. If $\Delta x$ is small enough, terms of second order or higher in $\Delta x$ (like $(\Delta x)^2$ and beyond) are overwhelmingly small compared to $\Delta x$ and can be ignored—that is the meaning of a first-order approximation.
+$$
+L
+=
+m\left(
+x\frac{dy}{dt}
+-
+y\frac{dx}{dt}
+\right)
+$$
 
-Since $z$ is constant, $dz=0$; the $R$ terms do not contribute.
+is constant in time (the law of conservation of angular momentum). This conservation law has a beautiful geometric meaning—the rate at which the position vector of the particle sweeps out area (<strong>areal velocity</strong>) is constant (Kepler’s second law).
 
-<strong>Side 1 (bottom, rightward)</strong>: From $(x, y)$ to $(x+\Delta x, y)$. $y$ is constant, so $dy=0$. $P$ is approximately $P(x, y, z)$. The contribution is $P(x, y, z)\,\Delta x$.
+We may assume the motion takes place in the plane $z=0$. The area of the sector $D$ swept out by the position vector from time $t_0$ to $t_1$ is
 
-<strong>Side 2 (right, upward)</strong>: From $(x+\Delta x, y)$ to $(x+\Delta x, y+\Delta y)$. $dx=0$. Evaluate $Q$ at the position shifted by $\Delta x$ in the $x$ direction:
-$$Q(x+\Delta x, y, z) \approx Q(x, y, z) + \frac{\partial Q}{\partial x}\Delta x$$
-The contribution is $\bigl(Q + \frac{\partial Q}{\partial x}\Delta x\bigr)\,\Delta y$.
+$$A = \iint_D dx \wedge dy$$
 
-<strong>Side 3 (top, leftward)</strong>: From $(x+\Delta x, y+\Delta y)$ to $(x, y+\Delta y)$. Since the direction is negative, the sign flips. Evaluate $P$ at the position shifted by $\Delta y$ in the $y$ direction:
-$$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y$$
-The contribution is $-\bigl(P + \frac{\partial P}{\partial y}\Delta y\bigr)\,\Delta x$.
+Here $dx \wedge dy$ is the area-measuring device ($2$-form) on the $xy$ plane.
 
-<strong>Side 4 (left, downward)</strong>: From $(x, y+\Delta y)$ back to $(x, y)$. The contribution is $-Q(x, y, z)\,\Delta y$.
+> <strong>Note</strong> (For physicists who work in two dimensions) Let us confirm this point. This book consistently assumes the reality of three-dimensional space. Setting $z=0$ in the angular-momentum discussion below is a temporary simplification to make the calculation easier to read; we are still looking at one plane inside three-dimensional space.
 
-Summing the contributions from all four sides:
+<strong>② Naive substitution—it does not match as written.</strong> The sector on the right-hand side is awkward to write in $(x,y)$. So we want to write it in $(r,\theta)$. But what happens if we replace $dx \wedge dy$ directly by $dr \wedge d\theta$? Let us compute the area of a full circle of radius $C$. The correct value is $\pi C^2$. Yet with naive substitution:
+
+$$
+A_{\text{naive}}
+=
+\iint dr \wedge d\theta
+=
+\int_0^{2\pi}
+\biggl(
+  \int_0^C dr
+\biggr)
+d\theta
+=
+2\pi C
+$$
+
+This is completely different from $\pi C^2$. With $dr \wedge d\theta$ alone, the correct area does not come out.
+
+<strong>③ See the cause on a finite grid.</strong> This time, let us ask what we must feed to the finite grid on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
+
+Cut a grid of finite size $\Delta r \times \Delta\theta$ in $(r,\theta)$ space. Find the two displacement vectors that one cell at coordinates $(r, \theta)$ produces in $(x,y)$ space.
+
+Edge in the $\Delta r$ direction: only $r$ changes while $\theta$ is fixed, so the difference is exact:
+
+$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$
+
+Edge in the $\Delta\theta$ direction: use the difference formulas for trigonometric functions:
 
 $$\begin{aligned}
-\oint \omega &\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \\
-&= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \\
-&= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
+\Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
+= -2r\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr) \\[4pt]
+\Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
+= 2r\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr)
 \end{aligned}$$
 
-The terms with $P\Delta x$ and $Q\Delta y$ cancel beautifully, and only $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ remains.
-
-#### 4.3.2 A Decisive Fact
-
-This result tells us one thing:
-
-> <strong>The leading term of the discrepancy after going around is proportional to the enclosed area $\Delta x\,\Delta y$</strong>.
-
-And the proportionality coefficient $\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ is precisely the </strong>discrepancy per unit area__PH_0127__ at the point $(x,y,z)$—a local quantity representing the "strength of vorticity" at that point. More precisely, for a small rectangle $R_{\Delta x,\Delta y}$ we have
-
-$$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\Delta x,\Delta y}}\omega = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$$
-
-in the limit. This is the same spirit of "differentiation" as when we did $f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$ in Chapter 1. The denominator has changed from "distance moved" to "area enclosed," but the philosophy of </strong>extracting the rate of change locally__PH_0129__ remains unchanged.
-
-> <strong>Note</strong> (Why only $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ remains) $\frac{\partial P}{\partial x}$ and $\frac{\partial Q}{\partial y}$ do not appear. The change of $P$ in the $x$ direction ($\frac{\partial P}{\partial x}$) acts in the same orientation on the bottom and top sides and thus cancels; similarly, the change of $Q$ in the $y$ direction ($\frac{\partial Q}{\partial y}$) cancels between the right and left sides. What survives is only the "change of $P$ in the $y$ direction" and the "change of $Q$ in the $x$ direction"—</strong>the difference of partial derivatives in mutually orthogonal directions__PH_0133__. This cross-like structure is the key to everything from the next section onward.
-
-### §4.4 Birth of $d$ — A New Measuring Instrument for Discrepancy per Area
-
----
-
-#### 4.4.1 Reconfirming the Wedge Product
-
-Let us rephrase the $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ obtained in §4.3 in the language of Chapter 2. In Chapter 2 §2.4.4, we defined the area-measuring instrument $dx \wedge dy$. This is a device that, when fed two vectors $\mathbf{v}_1, \mathbf{v}_2$, returns the signed area of the shadow they cast onto the $xy$ plane:
-
-In particular, if we feed the displacement $\Delta x\,\hat{e}_x$ in the $x$ direction and the displacement $\Delta y\,\hat{e}_y$ in the $y$ direction, we get $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$.
-
-$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
-
-#### 4.4.2 Definition of $d\omega$
-
-Writing the result of §4.3 in this language, for the two sides $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ of the small rectangle, a </strong>new $2$-form__PH_0135__ returned the leading term $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$. We call this $2$-form the </strong>exterior derivative__PH_0137__ of $\omega$ and denote it by $d\omega$:
-
-$d\omega$ is a $2$-form—it eats two vectors and returns a scalar. Its value represents "the discrepancy per unit area of a closed loop for the small parallelogram spanned by the two vectors fed to it."
-
-$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
-
-Let us organize what is happening:
-
-- <strong>Input</strong>: $\omega = P\,dx + Q\,dy + R\,dz$ (a $1$-form, a line-measuring instrument that eats one vector)
-- <strong>Output</strong>: $d\omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$ (a $2$-form, an area-measuring instrument that eats two vectors)
-- <strong>Operation</strong>: $d$ </strong>raises the degree by one__PH_0145__ from 1 to 2
-
-This is exactly the same structure as $df$ we saw in §4.1. $d$ acts on a $0$-form $f$ to return a $1$-form $df$, and on a $\omega$-form $1$ to return a $2$-form $d\omega$. The essence of </strong>$d$ is to "raise the degree by one"__PH_0147__.
-
-> <strong>[Checkpoint so far]</strong>
-> - $df$ was the exterior derivative from $0$-form to $1$-form: $\int_\gamma df = f(B)-f(A)$ (depends only on endpoints).
-> - For a general $\omega$, we have $\oint \omega \neq 0$ on a closed loop. To investigate the discrepancy, we shrink the loop.
-> - For a small rectangle in the $xy$ plane, $\oint \omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y +$ plus higher-order terms; the leading discrepancy is proportional to area.
-> <!-- concept-scope: allow(wedge_product) -->
-> - The $2$-form that measures this proportionality coefficient is defined as $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$. $d$ is the operator that raises the degree.
-
-### §4.5 Exterior Derivative of a General $1$-Form — Extension to Three Dimensions
-
----
-
-#### 4.5.1 The $yz$ Plane and $zx$ Plane
-
-In §4.3–§4.4, we only considered loops in the $xy$ plane. But in three-dimensional space, surfaces have three orientations. For a small rectangle in the $yz$ plane, a similar calculation yields $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$; in the $zx$ plane, we get $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$. These correspond to $dy \wedge dz$ and $dz \wedge dx$, respectively.
-
-Guided by intuition, the full formula is:
-
-> <strong>Note</strong> (A $2$-form measures tilted parallelograms) This $d\omega$ is a $2$-form—</strong>a measuring instrument that eats two vectors__PH_0153__. The two vectors fed to it need not be parallel to the $xy$ plane. If you feed the two sides $\mathbf{v}_1, \mathbf{v}_2$ of a small parallelogram floating obliquely in three-dimensional space, it returns the discrepancy per unit area of a closed loop for that face. It is exactly the same as what we did in §4.3—the only difference is that the surface being measured is no longer parallel to a coordinate plane. The mechanism for extracting the area (and orientation) of a parallelogram from two vectors was already verified in Chapter 2 §2.4 when we constructed $dy \wedge dz$ and others as antisymmetric matrices.
-
-$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
-
-#### 4.5.2 Algebraic Derivation — The Leibniz Rule and $d(dx)=0$
-
-The above formula can of course be derived by performing loop calculations separately for each plane. But using the intuition gained from the $xy$-plane example, we can set up the following computational rules to derive it mechanically. Let us do that.
-
-> <strong>Note</strong> (Definition vs. theorem—a mathematician's trick) Many mathematics textbooks take the Leibniz rule and $d(dx)=0$ as the </strong>definition__PH_0157__ of $d$. As a physicist, I find that approach opaque—we started from dissecting infinitesimal loops. What we will now confirm is that the geometric $d$ and the algebraic computational rules are consistent. The rules are for computational convenience; </strong>the meaning lies in §4.3__PH_0159__. Still, when looking ahead to higher dimensions, I cannot deny a grudging appreciation for the elegance of the algebraic definition.
-
-First, for $\omega = P\,dx + Q\,dy + R\,dz$, it should be fine that $d\omega$ is $d(P\,dx) + d(Q\,dy) + d(R\,dz)$. This corresponds to considering a loop around a tilted parallelogram. The problem is $d(P\,dx)$—how to apply $d$ to a $1$-form with coefficient $P$.
-
-Here, the geometric $d$ obtained in §4.3–§4.4 already tells us something. In the case $\omega = P\,dx$ ($Q=R=0$), if we perform the infinitesimal loop calculation not only in the $xy$ plane but also in the $zx$ plane, we see that $d(P\,dx)$ has no component in the $yz$ plane, and
-
-should hold (for a loop in the $xy$ plane we get $(0 - \frac{\partial P}{\partial y}) = -\frac{\partial P}{\partial y}$, and in the $zx$ plane we get $(\frac{\partial P}{\partial z} - 0) = \frac{\partial P}{\partial z}$).
-
-$$d(P\,dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
-
-Now, recall $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$ from §4.1. Taking the wedge product of this with $dx$ gives:
-
-(the term with $\frac{\partial P}{\partial x}$ vanishes because $dx \wedge dx = 0$)
-
-$$dP \wedge dx = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
-
-This </strong>agrees perfectly__PH_0161__ with the geometric calculation! That is, at least for a term of the form $P\,dx$ we have
-
-Comparing the geometric result with the Leibniz rule $d(P\,dx) = dP \wedge dx + P\,d(dx)$, we see that the extra term $P\,d(dx)$ must be zero. Since $P$ is an arbitrary function, for this to always hold we need $d(dx)=0$—that is, we require $d(dx) = 0$.
-
-$$d(P\,dx) = dP \wedge dx$$
-
-Generalizing this observation, we arrive at the following </strong>graded Leibniz rule__PH_0163__. Let $P$ be a $0$-form and $dx$ be a $1$-form; then the behavior of $d$ on the "product" of a $0$-form and a $1$-form is:
-
-$dP$ is already known—from §4.1, $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$. The question is the value of $d(dx)$.
-
-$$d(P\,dx) = (dP) \wedge dx + P\,d(dx)$$
-
-Here, the exterior derivative of the coordinate function $x$ is $dx$ ($d(x) = dx$). The $dx$ of Cartesian coordinates is a standard measuring instrument whose coefficients do not change from place to place. That is, even if we go around an infinitesimal loop with $dx$ itself, no discrepancy per area appears. The same holds for $dy,dz$. Hence, for coordinate bases we set the following computational rule:
-
-Then:
-
-$$d(dx) = d(dy) = d(dz) = 0$$
-
-Using the antisymmetry of $\wedge$ ($dx \wedge dx = 0$, $dy \wedge dx = -dx \wedge dy$):
-
-$$d(P\,dx) = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx + P\,0$$
-
-Similarly:
-
-$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
-
-Adding the three together and rearranging in the order of basis $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ (this cyclic order is a preparation for consistency with the right-handed system in the next chapter):
+Find the area of the parallelogram spanned by the two edges $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ and $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ by a determinant:
 
 $$\begin{aligned}
-d(Q\,dy) &= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \\
-d(R\,dz) &= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
+\det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
+&= 2r\Delta r\,\sin\biggl(\frac{\Delta\theta}{2}\biggr)\biggl[ \cos\theta\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr) + \sin\theta\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr) \biggr] \\
+&= r\Delta r\,\sin\Delta\theta
 \end{aligned}$$
 
-This includes the $xy$ component $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ we derived geometrically in §4.3, and the $yz$ and $zx$ components also align with the same cross pattern.
+The result is
 
-$$\begin{aligned}
-d\omega &= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \\
-&= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
-\end{aligned}$$
+$$\det = r\Delta r\,\sin\Delta\theta$$
 
-#### 4.5.3 Pattern of the Coefficients
+Divide this measured value by the cell width $\Delta r_i\,\Delta\theta_j$ on the $(r,\theta)$ side, and we obtain the coefficient of the provisional measuring device used on a finite cell. That is,
 
-Pay attention to the arrangement of coefficients. The coefficient for $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ is obtained by taking </strong>the partial derivatives of $(P, Q, R)$ in the axis directions other than its own, crossing them, and taking the difference__PH_0165__. There is a cyclic symmetry:
+$$
+\Phi_h^\square(dx\wedge dy)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+$$
 
-> <strong>Note</strong> (For readers with prior knowledge) Those already familiar with vector analysis may recognize the arrangement of these three coefficients. In this book, we first build up the operation $d$ itself without relying on that name; the correspondence will be organized in a later chapter.
+Feed this measuring device to a finite cell, and
 
-$$\begin{aligned}
-dy \wedge dz &\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
-dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \\
-dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
-\end{aligned}$$
+$$
+\begin{aligned}
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+&=
+\left(
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+\right)(\Delta r_i,\Delta\theta_j) \\
+&=
+r_i\,\Delta r_i\,\sin\Delta\theta_j
+\end{aligned}
+$$
 
-> <strong>[Checkpoint so far]</strong>
-> - For a general $1$-form $\omega$, the exterior derivative $d\omega$ is a $2$-form, with coefficients given by the cross-differences of partial derivatives $(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$.
-> - The computational rules are (1) linearity, (2) the Leibniz rule $d(P\,dx) = dP \wedge dx + P \wedge d(dx)$, and (3) $d(dx)=d(dy)=d(dz)=0$.
-> - The result is fully consistent with the infinitesimal loop calculation of §4.3.
+The right-hand side is the signed area of the parallelogram spanned by the two finite-difference vectors.
 
-### §4.6 After Accumulation, Only the Boundary Remains — Stokes' Theorem
+Let $A_h^\square$ denote the total area sum in the finite-cell version. Therefore
+
+$$
+A_h^\square
+:=
+\sum_i\sum_j
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+=
+\sum_i\sum_j r_i\,\Delta r_i\,\sin\Delta\theta_j
+$$
+
+$\sin\Delta\theta_j$ is an exact value for finite $\Delta\theta_j$. What we measure here is not the curved sector area of the polar-coordinate finite grid itself, but the signed area of the parallelogram spanned by two finite-difference vectors. Write the sector swept out by the position vector in physical space as $D$. On the other hand, write the $(r,\theta)$ range corresponding to that region in polar coordinates as $D'$.
+
+In the final stage of taking the limit of the sum,
+
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+
+Therefore the true area $A$ is obtained as
+
+$$
+A
+=
+\lim_{h\to0} A_h^\square
+=
+\iint_{D'} r\,dr\wedge d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit,
+
+$$
+\Phi_h^\square(dx\wedge dy)
+\xrightarrow{h\to0}
+\Phi^*(dx\wedge dy)
+=
+r\,dr\wedge d\theta
+$$
+
+appears.
+
+> <strong>Note</strong> ($\Delta r,\Delta\theta$ need not be infinitesimal) In the computation of the difference vectors so far, we have used no assumption that $\Delta r$ or $\Delta\theta$ is “sufficiently small.” The $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ found above are formulas that hold exactly no matter how large $\Delta r,\Delta\theta$ may be. By “exact” here we mean that we measure the parallelogram spanned by finite-difference vectors. The passage to infinitesimals is made only in the final stage—the limit of the sum—when we move to $\Phi^*$ and integration.
+
+<strong>④ Write the standard form obtained in the limit.</strong> For the transformation to polar coordinates $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$:
+
+$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
+
+This is the rebuilding of the $2$-form obtained from the finite-cell version $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency factor corresponding to the velocity $d\gamma/dt$ in §4.1.
+
+<strong>⑤ Pullback of a coefficient-carrying $2$-form.</strong> For a $2$-form $G(x,y)\,dx \wedge dy$ with an arbitrary coefficient $G(x,y)$, the same structure holds:
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$
+
+The coefficient $G$ is merely rebuilt in polar coordinates (pullback of a $0$-form), while only the $dx \wedge dy$ part changes to $r\,dr \wedge d\theta$. The pullback $\Phi^*$ naturally splits into “rebuilding the coefficient” and “rebuilding the measuring device.”
+
+<strong>⑥ Carry the same discovery to a general transformation.</strong> Nothing here is special to polar coordinates. Consider a transformation between planes $\Phi(u,v)=(x(u,v),y(u,v))$, and map a finite rectangle on the $(u,v)$ side. Measure the two difference vectors in the $u$ and $v$ directions with $dx\wedge dy$, and we get an area value for each finite rectangle.
+
+Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios move to partial-derivative coefficients, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\;
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+\,du \wedge dv$$
+
+That is,
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr)
+=G(\Phi(u,v))\left(
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+\right)\,du\wedge dv$$
+
+The $2\times2$ determinant that appears here is the consistency factor for rebuilding the physical-space area-measuring device $dx\wedge dy$ into a measuring device $du\wedge dv$ usable on the $(u,v)$ side.
+
+What we saw on the finite grid,
+
+$$\Delta x_u\,\Delta y_v-\Delta x_v\,\Delta y_u$$
+
+is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors, but in the limit rebuilding written as $\Phi^*$, partial-derivative coefficients are used. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
+
+<strong>⑦ Return to the physical quantity.</strong> Integrate the area of the sector $D$ over the corresponding polar-coordinate region $D'$ using the pulled-back measuring device:
+
+$$
+A
+=
+\iint_D dx\wedge dy
+=
+\iint_{D'} \Phi^*(dx\wedge dy)
+=
+\iint_{D'} r\,dr\wedge d\theta
+$$
+
+$$
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+Integrating in $r$, $\frac{1}{2}r^2$ appears, and the area is reduced to a line integral of a $1$-form along the $\theta$ axis. Pull back further to the time parameter $t$. If the particle’s orbit is $r = R(t),\, \theta = \Theta(t)$, then
+
+$$
+\frac{dA}{dt}
+=
+\frac{1}{2}r(t)^2\,\frac{d\theta}{dt}(t)
+$$
+
+From the definition of angular momentum
+
+$$
+L
+=
+m r^2\frac{d\theta}{dt}
+$$
+
+the areal velocity is
+
+$$\frac{dA}{dt} = \frac{L}{2m}$$
+
+In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. Exactly the same structure as in §4.1, where the consistency factor $d\gamma/dt$ of a $1$-form described energy conservation, describes conservation of angular momentum through the consistency factor $r$ of a $2$-form.
+
 
 ---
 
-#### 4.6.1 Tiling a Surface
+### §4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals
+
+<strong>① Start from a physical quantity.</strong> The end point is a volume integral. This time we map a three-dimensional finite box and measure it.
+
+Consider the mass of a cylinder of uniform density $\rho$ (radius $C$, height $H$). Computing directly in $(x,y,z)$ space,
+
+$$M = \rho \cdot (\text{volume}) = \rho \cdot \pi C^2 H$$
+
+This $M$ must not change no matter which coordinates we use to compute it.
+
+<strong>② Naive substitution — it does not work as-is.</strong> We want to write the integral in cylindrical coordinates $(r,\theta,z)$. The cylinder ranges over $r \in [0, C],\; \theta \in [0, 2\pi],\; z \in [0, H]$, so if we replace $dx \wedge dy \wedge dz$ outright by $dr \wedge d\theta \wedge dz$:
+
+$$
+M_{\text{naive}}
+=
+\rho \iiint dr\wedge d\theta\wedge dz
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+2\pi\rho C H
+$$
+
+Comparing this with the correct value $\rho \pi C^2 H$, we have $2\pi\rho C H \neq \rho \pi C^2 H$. They clearly do not agree.
+
+<strong>③ Find the cause on a finite mesh.</strong> In three dimensions, we ask what must be fed to a finite box on the $(r,\theta,z)$ side so that we get the same value as the volume on the $(x,y,z)$ side.
+
+Cut a grid of finite size $\Delta r \times \Delta\theta \times \Delta z$ in $(r,\theta,z)$ space. The transformation is $x = r\cos\theta,\; y = r\sin\theta,\; z = z$. The $z$ direction is unchanged by the transformation, so the volume is “mesh-cell area in the $xy$ plane” $\times \Delta z$. The area in the $xy$ plane follows exactly the procedure of §4.2:
 
-In §4.3, we computed $\oint \omega$ around </strong>a single__PH_0171__ small rectangle and found its leading term to be the product of $d\omega$ and the area. Now, what happens if we </strong>tile the entire surface__PH_0173__ with such small rectangles and sum them all up?
+$$\det = r\Delta r\,\sin\Delta\theta$$
+
+Therefore, the volume of one cell is
+
+$$\text{volume} = \bigl(r\Delta r\,\sin\Delta\theta\bigr) \times \Delta z$$
+
+The finite cell in cylindrical coordinates itself is curved in the $\theta$ direction, but what we are measuring here is the signed volume of the parallelepiped spanned by three difference vectors.
+
+Dividing this measured value by the cell widths $\Delta r_i\,\Delta\theta_j\,\Delta z_k$ on the $(r,\theta,z)$ side gives the coefficient of a provisional measuring device used on a finite cell. That is,
+
+$$
+\Phi_h^\square(dx\wedge dy\wedge dz)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta\wedge dz
+$$
+
+Feed this measuring device to a finite box and we get
+
+$$
+\begin{aligned}
+&\Phi_h^\square(dx\wedge dy\wedge dz)
+(\Delta r_i,\Delta\theta_j,\Delta z_k)\\
+&\qquad =
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}
+\Delta r_i\Delta\theta_j\Delta z_k \\
+&\qquad =
+r_i\Delta r_i\sin\Delta\theta_j\Delta z_k
+\end{aligned}
+$$
+
+The right-hand side is the signed volume of the parallelepiped spanned by three finite difference vectors.
+
+Writing the total mass sum in the finite-cell version as $M_h^\square$, we have
+
+$$
+M_h^\square
+:=
+\sum_i\sum_j\sum_k
+\rho\,
+\Phi_h^\square(dx\wedge dy\wedge dz)(\Delta r_i,\Delta\theta_j,\Delta z_k)
+=
+\sum_i\sum_j\sum_k
+\rho\,r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k
+$$
+
+In the final stage, when we take the limit of the sum,
+
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+
+Therefore the true mass $M$ is obtained as
+
+$$
+M
+=
+\lim_{h\to0} M_h^\square
+=
+\rho\iiint_{V'} r\,dr\wedge d\theta\wedge dz
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C r\,dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+\rho\cdot\pi C^2H
+$$
 
-Divide the surface $S$ into small coordinate patches, and on each parameter plane grid it into small rectangles (this is exactly the idea of surface elements from Chapter 3 §3.3). For each small rectangle, the integral of $\omega$ along its four sides traversed counterclockwise has as its leading term the value obtained by feeding the area meter into $d\omega$.
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As $h\to0$, this coefficient again approaches $r$.
 
-#### 4.6.2 Interior Edges Cancel
+<strong>④ Write the standard form obtained in the limit.</strong> For the transformation to cylindrical coordinates $\Phi(r,\theta,z) = (r\cos\theta,\; r\sin\theta,\; z)$:
 
-Here comes a crucial geometric observation. </strong>Look at the edge shared by two adjacent rectangles__PH_0175__. For the left rectangle, that edge is traversed "upward"; for the right rectangle, it is traversed "downward." Because the path direction is opposite, the line integrals of $\omega$ on this edge </strong>cancel completely__PH_0177__.
+$$
+\Phi_h^\square(dx\wedge dy\wedge dz)
+\xrightarrow{h\to0}
+\Phi^*(dx \wedge dy \wedge dz)
+=
+r\,dr \wedge d\theta \wedge dz
+$$
 
-This cancellation happens on </strong>every shared edge__PH_0179__ inside the surface $S$. No matter how finely we partition and sum, the contributions from interior edges cancel in plus-minus pairs.
+This is the rebuilding of the $3$-form obtained from the finite cell pullback $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency coefficient that carries over the $r$ of §4.2 unchanged.
 
-#### 4.6.3 Only the Boundary Survives
+<strong>⑤ Pullback of a weighted $3$-form.</strong> For a $3$-form $\rho\,dx \wedge dy \wedge dz$ with arbitrary density $\rho(x,y,z)$, the same structure holds:
 
-So which edges survive without cancellation? </strong>Edges that have no neighboring rectangle__PH_0183__—that is, the edges along the __PH_0183__boundary $\partial S$__PH_0183__ of the surface $S$.
+$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(r\cos\theta,\, r\sin\theta,\, z)\; r\,dr \wedge d\theta \wedge dz$$
 
-Thus:
+The coefficient $\rho$ is only re-expressed in new coordinates (pullback of a $0$-form); only the part $dx \wedge dy \wedge dz$ changes to $r\,dr \wedge d\theta \wedge dz$.
 
-The left side is "the line integral of $\omega$ along the one-dimensional closed curve that is the boundary of the surface," and the right side is "the sum of the discrepancy densities of countless infinitesimal loops tiling the interior of the surface." In the limit of infinitely fine partitioning, only the cancellation of interior edges remains, and the two sides match.
+<strong>⑥ Transfer the same discovery to a general transformation.</strong> More generally, consider a transformation of space $\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$. Mapping a finite box on the $(u,v,w)$ side produces three difference vectors. Measuring them with $dx\wedge dy\wedge dz$ gives the oriented volume of the mapped parallelepiped.
 
-$$\oint_{\partial S} \omega = \iint_S d\omega$$
+Dividing that volume value by $\Delta u\,\Delta v\,\Delta w$ and refining the partition, the difference ratios pass to partial-derivative coefficients and a $3\times3$ determinant appears. Therefore, after $h\to0$, the pullback is:
 
-This is </strong>Kelvin–Stokes theorem__PH_0185__ (often simply called Stokes' theorem).
+$$
+\begin{aligned}
+&\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) \\
+&= \rho(x(u,v,w), y(u,v,w), z(u,v,w))\,
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[6pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
+\end{pmatrix}
+\,du \wedge dv \wedge dw
+\end{aligned}
+$$
 
-Writing the components of $\omega = P\,dx + Q\,dy + R\,dz$ explicitly:
+Writing this $3 \times 3$ determinant as $J(u,v,w)$, we obtain
 
-Expressed in the language of matrices from Chapter 2, the $2$-form on the right side is represented by an antisymmetric matrix $\mathbf{J}^T - \mathbf{J}$. If we feed the two sides of a surface element $\mathbf{v}_1, \mathbf{v}_2$, we get $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$. All components are written out in Appendix B.3; refer to it as needed.
+$$\Phi^*(\rho\,dx \wedge dy \wedge dz) = \rho(\Phi(u,v,w))\,J\,du \wedge dv \wedge dw$$
 
-$$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$
+This $3\times3$ determinant $J(u,v,w)$ is the consistency coefficient of the $3$-form.
 
-The structure of this theorem is remarkably simple: </strong>the integral measured on the global boundary</strong> $=$ __PH_0189__the accumulation of local discrepancies ($d\omega$) in the interior__PH_0189__. $d$ is </strong>a device that translates__PH_0191__ information about $\omega$ on the boundary $\partial S$ into information about $d\omega$ in the interior $S$.
+Arranging three difference vectors on a finite mesh gives
 
-> <strong>Note</strong> (Correspondence with Chapter 3) When we defined surface integrals in Chapter 3 §3.3.1, we fed $dx \wedge dy$ into the surface element $(\mathbf{r}_u\Delta u,\;\mathbf{r}_v\Delta v)$. Here too, we divide the surface into small surface elements, apply the measuring instrument to each element, and organize the contributions that cancel in the interior.
-
-> <strong>[Checkpoint so far]</strong>
-> - If we tile a surface $S$ with infinitesimal loops, interior edges cancel, and only the contribution from the boundary $\partial S$ remains.
-> - $\int_{\partial S} \omega = \int_S d\omega$. A global boundary integral equals the integral of the local exterior derivative.
-> - Just as with surface integrals in Chapter 3, we divide the surface into small patches, apply the measuring instrument to each patch, and sum.
-
-### §4.7 One More Step — Exterior Derivative of $2$-Forms and Divergence
-
----
-
-#### 4.7.1 A $2$-Form is a Surface Measuring Instrument
-
-In Chapter 3 §3.5.2, we wrote a general $2$-form as:
-
-This is "a measuring instrument that measures flux along a surface." As we saw in Chapter 2 §2.4.5, the three basis $2$-forms measure the areas of shadows onto the $yz$, $zx$, and $xy$ planes, respectively.
-
-$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
-
-#### 4.7.2 Measuring on the Surface of a Small Rectangular Box
-
-Using the same spirit as §4.3, this time we integrate $\eta$ over </strong>all six faces__PH_0197__ of a small rectangular box $[x, x+\Delta x] \times [y, y+\Delta y] \times [z, z+\Delta z]$ in space. We orient the faces outward.
-
-For example, consider the term with $C\,dx \wedge dy$. Look only at the bottom and top faces perpendicular to $z$:
-
-- </strong>Bottom face__PH_0199__ ($z$, outward direction is $-z$): evaluate $C(x,y,z)$ at orientation $-dx \wedge dy$ → approximately $-C(x,y,z)\,\Delta x\,\Delta y$
-- </strong>Top face__PH_0201__ ($z+\Delta z$, outward direction is $+z$): $C(x,y,z+\Delta z) \approx C + \frac{\partial C}{\partial z}\Delta z$ → approximately $(C + \frac{\partial C}{\partial z}\Delta z)\,\Delta x\,\Delta y$
-
-Taking the sum, $C\Delta x\Delta y$ cancels, and $\frac{\partial C}{\partial z}\,\Delta x\,\Delta y\,\Delta z$ remains. The term with $A\,dy \wedge dz$ gives $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$ from faces perpendicular to $x$, and the term with $B\,dz \wedge dx$ gives $\frac{\partial B}{\partial y}\,\Delta x\,\Delta y\,\Delta z$ from faces perpendicular to $y$.
-
-The total over all six faces is:
-
-Again the same structure: </strong>the leading term of the discrepancy measured on the surface is proportional to the enclosed volume__PH_0203__. The proportionality coefficient $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ represents the "outflow per unit volume."
-
-$$\iint_{\partial (\text{直方体})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$
-
-#### 4.7.3 Definition and Algebraic Derivation of $d\eta$
-
-As a $3$-form that feeds the three sides $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ of the box:
-
-This formula can also be derived from the algebraic rules of §4.5.2. Before doing that, let us confirm, as we did in §4.5.2, that the geometric result is consistent with the Leibniz rule for the term $A\,dy \wedge dz$.
-
-$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
-
-According to the geometric calculation of §4.7.2, the contribution from $A\,dy \wedge dz$ was $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$. In the language of $dx \wedge dy \wedge dz$, this is $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$.
-
-On the other hand, applying the Leibniz rule to $d(A\,dy \wedge dz)$ gives:
-
-Here, using $d(dy)=d(dz)=0$ as in §4.5.2, $d(dy \wedge dz)$ becomes:
-
-$$d(A\,dy \wedge dz) = dA \wedge dy \wedge dz + A\,d(dy \wedge dz)$$
-
-Thus the second term vanishes, and only the first term remains:
-
-$$d(dy \wedge dz) = d(dy) \wedge dz - dy \wedge d(dz) = 0 \wedge dz - dy \wedge 0 = 0$$
-
-By the antisymmetry of $\wedge$ ($dy \wedge dy = 0$, $dz \wedge dz = 0$), the terms with $\frac{\partial A}{\partial y}$ and $\frac{\partial A}{\partial z}$ vanish, leaving only $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$. This </strong>agrees perfectly__PH_0205__ with the geometric calculation of §4.7.2.
-
-$$dA \wedge dy \wedge dz = (\frac{\partial A}{\partial x}\,dx + \frac{\partial A}{\partial y}\,dy + \frac{\partial A}{\partial z}\,dz) \wedge dy \wedge dz$$
-
-The terms with $B\,dz \wedge dx$ and $C\,dx \wedge dy$ are similar, and adding all three gives:
-
-$d$ has accomplished the promotion from $2$-form to $3$-form.
-
-$$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
-
-#### 4.7.4 Gauss's Theorem
-
-Applying the same tiling argument as in §4.6—this time filling the solid $V$ with small rectangular boxes—the interior faces cancel, and only the outer surface $\partial V$ remains:
-
-This is </strong>Gauss's theorem__PH_0207__. It has </strong>exactly the same form__PH_0209__ as Stokes' theorem, just shifted by one dimension. Comparing them side by side makes it clear: $\omega$ ($1$-form) $\to$ $d\omega$ ($2$-form) $\to$ surface $S$, and $\eta$ ($2$-form) $\to$ $d\eta$ ($3$-form) $\to$ solid $V$.
-
-$$\iint_{\partial V} \eta = \iiint_V d\eta$$
-
-Writing the components of $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$ explicitly:
-
-> <strong>Note</strong> (For readers with prior knowledge) Those familiar with vector analysis may recognize something familiar in $\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z}$. In this book, we value the order of first obtaining this quantity as the exterior derivative of a $2$-form. The correspondence between names will be organized in a later chapter.
-
-$$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\bigr) = \iiint_V (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
-
-> <strong>[Checkpoint so far]</strong>
-> - The exterior derivative $d\eta$ of a $2$-form $\eta$ is a $3$-form with coefficients $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$.
-> - The derivation follows mechanically from the same algebraic rules as in §4.5 (the Leibniz rule $+$ $d(dx)=0$).
-> - $\iint_{\partial V} \eta = \iiint_V d\eta$. Stokes ($1$-form → surface) and Gauss ($2$-form → solid) are the same structure, differing only in degree.
-
-### §4.8 $d^2 = 0$ — Taking It Twice Always Gives Zero
-
----
-
-In §4.1 we defined $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$. Now apply the exterior derivative once more. Using the formula of §4.5 with $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$:
-
-#### 4.8.1 $d(df) = 0$
-
-By the symmetry of mixed partial derivatives (if $f$ is totally differentiable, then $\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, etc.; see Chapter 1 §1.3), all coefficients vanish:
-
-$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$
-
-> <strong>Note</strong> (An apology to mathematicians—$d^2=0$ and total differentiability) In this book, we have proceeded in the order: "if $f$ is totally differentiable, then mixed partials are commutative, hence $d(df)=0$." However, from an axiomatic perspective on differential forms, </strong>$d^2=0$ itself is part of the definition of $d$__PH_0217__, and $d(df)=0$ is not a theorem but a postulate. Conversely, imposing $d^2=0$ is equivalent to declaring that we are dealing with the class of functions for which mixed partials are symmetric (i.e., totally differentiable functions). Either way you learn it, the two conditions end up being equivalent.
-
-$$d(df) = 0$$
-
-Apply the formula of §4.7 to $d\omega$ of §4.5. Taking $A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$:
-
-#### 4.8.2 $d(d\omega) = 0$
-
-Expanding the parentheses:
-
-$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$
-
-By the symmetry of mixed partials ($\frac{\partial^2 R}{\partial y \partial x}=\frac{\partial^2 R}{\partial x \partial y}$, etc.), the six terms form three pairs that cancel, and the total is zero:
-
-$$\frac{\partial^2 R}{\partial y \partial x} - \frac{\partial^2 Q}{\partial z \partial x} + \frac{\partial^2 P}{\partial z \partial y} - \frac{\partial^2 R}{\partial x \partial y} + \frac{\partial^2 Q}{\partial x \partial z} - \frac{\partial^2 P}{\partial y \partial z}$$
-
-> <strong>[Checkpoint so far]</strong>
-> - $d^2 = 0$: Applying the exterior derivative twice always gives zero. This cancellation arises from the symmetry of mixed partials and the antisymmetry of the wedge product.
-> - Several "second derivative vanishes" identities known to readers with prior knowledge will be organized in later chapters as alternative expressions of this $d^2=0$.
-
-$$d(d\omega) = 0$$
-
-### §4.9 Unification of the Exterior Derivative — One Formula, One Rule
-
----
-
-#### 4.9.1 Stokes and Gauss are the Same Formula
-
-Stokes' theorem $\oint_{\partial S}\omega = \iint_S d\omega$ obtained in §4.6 and Gauss's theorem $\iint_{\partial V}\eta = \iiint_V d\eta$ obtained in §4.7. Lined up, they have the same structure, differing only in the number of integral signs: $\oint$, $\iint$, $\iiint$. If $M$ is a curve, then $\int$ (1-dimensional); if a surface, $\iint$ (2-dimensional); if a solid, $\iiint$ (3-dimensional)—the number of integral symbols is simply determined by the dimension of $M$.
-
-Therefore, independent of dimension, we write uniformly:
-
-Here, $\omega$ is a $k$-form, $M$ is an $(k+1)$-dimensional domain, and $\partial M$ is its $k$-dimensional boundary. For $k=0$ it becomes the fundamental theorem of calculus; for $k=1$ it becomes Stokes' theorem; for $k=2$ it becomes Gauss's theorem. All are absorbed into this single formula.
-
-$$\int_{\partial M} \omega = \int_M d\omega$$
-
-The power of this unified form becomes even more striking when combined with $d^2=0$ from §4.8. If we replace $\omega$ in $\int_{\partial M} \omega = \int_M d\omega$ by $d\omega$, we get:
-
-That is, the geometric fact that </strong>"the boundary of a boundary is always empty"__PH_0221__ ($\partial(\partial M) = \emptyset$) and </strong>$d^2=0$__PH_0223__ are in resonance with each other. $d^2=0$ is an algebraic mirror of this topological truth, expressed in the language of differential forms.
-
-$$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\omega) = 0$$
-
-> <strong>Note</strong> (Three dimensions suffice) The stage of this book is three-dimensional space, so the dimension of $M$ is only 1, 2, or 3, and $\omega$ is a $0$-form, $1$-form, or $2$-form. We do not go into $k=3$ ($M$ in 4 dimensions). Still, it is worth keeping in the back of your mind that this formula holds regardless of $k$.
-
-#### 4.9.2 Exterior Derivative of a General $k$-Form
-
-Similarly, the action of $d$ can be summarized in a single pattern independent of the degree. When an arbitrary $k$-form $\omega$ is written as a sum of coefficients $a_{i_1\cdots i_k}$ times basis $dx^{i_1}\wedge\cdots\wedge dx^{i_k}$:
-
-In this book, we only need the three cases $k=0,1,2$, and we have explicitly written them down in §4.1 ($df$), §4.5 ($d\omega$), and §4.7 ($d\eta$). The general form above merely confirms that at any degree, one follows the single principle: "totally differentiate the coefficient and connect with a wedge product."
-
-$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x^j}\,dx^j \Bigr) \wedge dx^{i_1}\wedge\cdots\wedge dx^{i_k}$$
-
-#### 4.9.3 Summary of Computational Rules
-
-All computations of the exterior derivative $d$ built in this chapter can be condensed into the following four rules:
-
-1. </strong>Action on $0$-forms__PH_0227__: $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ (the definition from Chapter 1 §1.3)
-2. </strong>Linearity__PH_0229__: $d(\omega_1 + \omega_2) = d\omega_1 + d\omega_2$
-3. </strong>Graded Leibniz rule__PH_0231__: $d(f\,\omega) = df \wedge \omega + f\,d\omega$
-4. </strong>Exterior derivative of coordinate bases is zero__PH_0233__: $d(dx) = d(dy) = d(dz) = 0$
-
-Rule 4 reflects the geometric fact that the coordinate bases $dx,dy,dz$ themselves have no position-dependent coefficients; even if we measure with an infinitesimal loop, they produce no local discrepancy. It is also consistent with $d^2=0$ from §4.8.
-
-With these four rules alone, the exterior derivative of any form from $0$-form to $3$-form can be computed mechanically. In fact, every calculation we have done in this chapter is nothing more than a combination of these rules.
-
-> <strong>[Checkpoint so far]</strong>
-> - With a single formula $\int_{\partial M} \omega = \int_M d\omega$, we can unify the fundamental theorem of calculus, Stokes' theorem, and Gauss's theorem.
-> - Computation of $d$ is condensed into four rules ($df$, linearity, Leibniz rule, $d(dx)=0$).
-> - $d^2=0$ and $\partial(\partial M)=\emptyset$ are an echo between algebraic truth and geometric truth.
-
-### §4.10 From Integrals to Differential Equations — Localization of Physical Laws
-
----
-
-#### 4.10.1 Turning Integral Laws into Differential Laws
-
-Let us return to the question posed at the beginning of this chapter.
-
-> </strong>How can we extract local laws from integrated quantities?__PH_0237__
-
-The answer lies in the two tools we have obtained: </strong>Stokes' theorem__PH_0239__ and </strong>the exterior derivative $d$__PH_0241__.
-
-Many fundamental laws of physics are first discovered in </strong>integral form__PH_0243__: a quantity measured on the boundary of a region equals the sum of sources inside that region:
-
-The left side is the integral measured on the boundary (a global observed quantity), and the right side is the integral of sources inside (a global total). $\omega$ and $\eta$ are differential forms of appropriate degrees.
-
-$$\int_{\partial M} \omega = \int_M \eta$$
-
-Now apply Stokes' theorem to the left side. Since $\int_{\partial M} \omega = \int_M d\omega$, we have:
-
-Rearranging:
-
-$$\int_M d\omega = \int_M \eta$$
-
-This is the decisive moment. If this equality holds </strong>for any region $M$__PH_0245__, then the integrand must be identically zero at every point. Why? Because if there were a point where $d\omega - \eta \neq 0$, then integrating over a tiny region around that point would not be zero, leading to a contradiction.
-
-$$\int_M (d\omega - \eta) = 0$$
-
-Therefore:
-
-This is the </strong>local differential law extracted from the integral law__PH_0247__. $d$ indeed functions as "an operator that converts integral equations into differential equations."
-
-$$d\omega = \eta$$
-
-#### 4.10.2 Physical Examples
-
-This pattern also appears in the fundamental laws of electromagnetism. For instance, a law that relates a quantity measured along a closed curve to the quantity passing through the surface it encloses can be transformed into a local relation by converting the left side into a surface integral via Stokes' theorem. Similarly, a law that relates a quantity measured on a closed surface to the total amount inside can be transformed into a relation at each point in the volume via Gauss's theorem.
-
-Here, we do not go into which degree of form describes electric or magnetic fields, how to include time dependence, or how to handle unit systems. The important point is that many physical laws take the form "integral on the boundary = total amount inside," and $d$ provides a common mechanism to localize them.
-
-> <strong>[Checkpoint so far]</strong>
-> - Physical laws are often given as $\int_{\partial M} \omega = \int_M \eta$.
-> - Using Stokes' theorem to rewrite $\int_{\partial M} \omega = \int_M d\omega$ and appealing to the fact that it holds for any $M$, we obtain $d\omega = \eta$ (the local law).
-> - $d$ is the operator that converts integral laws into differential laws.
-
-### §4.11 Outlook for Part II — Foreshadowing the Hodge Star
-
----
-
-In this chapter, we have obtained a powerful operator: the exterior derivative $d$. $d$:
-
-Each time it raises the degree by one, the coefficients are rearranged in a different pattern. And $d^2=0$ guarantees that no inconsistency can sneak in among these tiers.
-
-- $0$-form $\to$ $1$-form：$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$
-- $1$-form $\to$ $2$-form：$d\omega = (\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z})\,dy\wedge dz + (\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x})\,dz\wedge dx + (\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})\,dx\wedge dy$
-- $2$-form $\to$ $3$-form：$d\eta = (\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z})\,dx\wedge dy\wedge dz$
-
-However, one asymmetry catches the eye. $0$-forms and $3$-forms each have one independent component; $1$-forms and $2$-forms each have three independent components—there is a symmetry $1, 3, 3, 1$ (as we saw in Chapter 2 §2.5.9–§2.5.10). This symmetry is not a coincidence. In three-dimensional Cartesian space, by adding rules for measuring lengths, areas, and volumes, a "dictionary" emerges that links forms with the same amount of information.
-
-<!-- role: foreshadowing -->
-That dictionary is the Hodge star $\ast$, to be introduced in the next chapter. However, $\ast$ is not a mere replacement of symbols. It depends on which direction corresponds to which surface, how to measure area and volume, and how to determine orientation. Therefore, in this chapter, we have not yet used concrete correspondence formulas.
-
-What we have built so far is solely $d$. $d$ raises the degree by one, extracts local discrepancies, and converts integral laws into local laws. In the next chapter, by adding rules for "how to measure," we will see the correspondence with the familiar operations of vector analysis.
-
-In the next chapter, we define this $\ast$ and, with $d$ and $\ast$ as two wheels, proceed to the core of Part II—the dismantling of the nabla.
-
-> <strong>[Checkpoint so far — Chapter 4 in full]</strong>
-> - The exterior derivative $d$ is an operator that maps a $k$-form to a $(k+1)$-form. $0$-form $\to$ $1$-form ($df$), $1$-form $\to$ $2$-form, $2$-form $\to$ $3$-form.
-> - There are four computational rules: definition of $df$, linearity, Leibniz rule $d(f\omega) = df\wedge\omega + f\,d\omega$, $d(dx)=d(dy)=d(dz)=0$.
-> - The geometric origin is the infinitesimal loop dissection in §4.3: the discrepancy of a closed loop is proportional to area, and the proportionality coefficient is $d\omega$.
-> - Stokes' theorem $\int_{\partial M} \omega = \int_M d\omega$ is a universal bridge between boundary and interior.
-> - $d^2 = 0$ originates from the symmetry of mixed partials and corresponds geometrically to $\partial(\partial M) = \emptyset$.
-> - $d$ is an operator that converts integral laws into local differential laws—indispensable for formulating physics.
-> - In the next chapter, we add rules for measuring lengths, areas, and volumes, and through the Hodge star $\ast$, we organize the correspondence between $d$ and the operations of vector analysis.
-
----
-
-## Appendix: Matrix Representation of the Exterior Derivative
-
----
-
-In the main body of this chapter, we proceeded with the algebra of basis $dx, dy, dz$ and wedge products. Here, using the book's characteristic approach since Chapter 2—</strong>lining up all components in matrices__PH_0253__—we rewrite the exterior derivative in the language of matrix representation.
-
-### B.1 $0$-form: $df$ as a $1 \times 3$ Row Vector
-
-For $f = f(x,y,z)$, as defined in Chapter 1 §1.3:
-
-As a row vector (a $1 \times 3$ matrix):
-
-$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
-
-### B.2 $1$-form: The Jacobian Matrix $\mathbf{J}$ of Coefficients
-
-$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
-
-For $\omega = P\,dx + Q\,dy + R\,dz$, arrange </strong>all__PH_0255__ partial derivatives of the coefficients $(P,Q,R)$ into a $3 \times 3$ matrix:
-
-This corresponds to the Jacobian matrix of the vector field obtained by "stacking" $(P,Q,R)$ vertically. The reason we said in §4.1 that "a mere matrix of partial derivatives is insufficient" is precisely that this $\mathbf{J}$ is not antisymmetric.
-
-The result of §4.5 is:
-
-$$\mathbf{J} := \begin{pmatrix}
-\frac{\partial P}{\partial x} & \frac{\partial P}{\partial y} & \frac{\partial P}{\partial z} \\
-\frac{\partial Q}{\partial x} & \frac{\partial Q}{\partial y} & \frac{\partial Q}{\partial z} \\
-\frac{\partial R}{\partial x} & \frac{\partial R}{\partial y} & \frac{\partial R}{\partial z}
+$$\det\!\begin{pmatrix}
+\Delta x_u & \Delta x_v & \Delta x_w \\[2pt]
+\Delta y_u & \Delta y_v & \Delta y_w \\[2pt]
+\Delta z_u & \Delta z_v & \Delta z_w
 \end{pmatrix}$$
 
-Following the convention of Chapter 2 §2.4.4, we seek an antisymmetric matrix $\mathbf{M}$ such that for any column vector $\mathbf{v}_1, \mathbf{v}_2$, we have $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$.
+This is the value obtained by feeding a measuring device on a finite cell to a finite box; for the parallelepiped spanned by the difference vectors, it is an equality. As the partition width $h$ is taken toward $0$, the coefficient obtained by dividing this finite determinant by $\Delta u\,\Delta v\,\Delta w$ converges to the Jacobian $J$ built from partial derivatives.
 
-### B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$
+If $J$ is negative, orientation is reversed. In the formal pullback, we use this signed $J$ as-is. On the other hand, when integrating “positive volume” or density, we need the magnitude with orientation forgotten, so $|J|$ appears. It is important not to confuse $J$ and $|J|$ here.
 
-Writing out the components of $\mathbf{J}^T - \mathbf{J}$:
+For a $1$-form we have a $1 \times 1$ determinant (velocity $dx/dt$), for a $2$-form a $2 \times 2$ determinant, for a $3$-form a $3 \times 3$ determinant ($J$) — as the degree rises, the size of the determinant governing the consistency coefficient grows by one each time. The partial-derivative determinant formula above is precisely <strong>the general definition of the pullback of a $3$-form</strong>.
 
-$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+> <strong>Note</strong> (for readers who have studied vector analysis) When you learned in a change of variables that “in polar coordinates, $r\,dr\,d\theta$ appears,” many textbooks give a geometric explanation: “consider the arc length $r\Delta\theta$ in the $\theta$ direction and $\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$.” That explanation is not wrong. But in the computation of this book we never consider arc length at all. Only the transformation formulas, trigonometric identities, and the determinant corresponding to $\wedge$ produce the consistency coefficient $r$.
 
-That is, comparing with the matrix representation of $2$-forms obtained in Chapter 2:
+<strong>⑦ Return to the physical quantity.</strong> Integrating with the pulled-back measuring device,
 
-Thus, </strong>the matrix representation of the exterior derivative $d\omega$ is the antisymmetric matrix obtained by subtracting the transpose of the Jacobian of the coefficients from itself. __PH_0257__
+$$
+M
+=
+\rho\iiint_V dx\wedge dy\wedge dz
+=
+\rho\iiint_{V'} r\,dr\wedge d\theta\wedge dz
+$$
 
-$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
-0 & \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} & \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \\
-\frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} & 0 & \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
-\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
+$$
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C r\,dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+\rho\cdot\pi C^2H
+$$
+
+We agree with the correct value. To preserve the integral value, the measuring device $dx \wedge dy \wedge dz$ had to be rebuilt as $r\,dr \wedge d\theta \wedge dz$ in $(r,\theta,z)$ space. In exactly the same structure by which the velocity $d\gamma/dt$ of §4.1 describes conservation of energy and the $r$ of §4.2 describes conservation of angular momentum, the $r$ of §4.3 (more generally $J$) describes conservation of mass.
+
+---
+
+### §4.4 Properties of the Pullback — What We Have Established So Far
+
+In §4.1–§4.3 we constructed pullbacks through three concrete examples. Here we organize the algebraic properties common to all of them. At the same time, we define the $3 \times 3$ determinant $J$ that appeared in §4.3 as the <strong>Jacobian (Jacobi determinant)</strong>. The matrix
+
+$$\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[4pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
 \end{pmatrix}$$
 
-### B.4 $2$-form: $d\eta$ and the Trace of the Jacobian
+is called the <strong>Jacobian matrix</strong>, and its determinant $\det$ is the Jacobian $J$.
 
-$$d\omega = \mathbf{J}^T - \mathbf{J}$$
+<strong>① Pullback of a $0$-form (scalar field).</strong> To pull back a scalar field $f(x,y,z)$ by a transformation $\Phi$ is simply to rewrite the coordinates into a parametric representation:
 
-For $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$, let the Jacobian matrix of the coefficients $(A,B,C)$ be:
+$$\Phi^*(f) = f(\Phi(u,v,w))$$
 
-Then the result of §4.7, that the coefficient of $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$ is $\mathbf{J}_\eta$, matches the </strong>trace__PH_0259__ (sum of diagonal entries) of __PH_0835__:
+For example, the operation in §4.1 that rewrote $F(x)$ in $F(x)\,dx$ as $F(\gamma(t))$ is nothing but the pullback of the $0$-form $F$.
 
-#### B.4.1 The 27 Components of $d\eta$ — Expanding into Three Matrices
+<strong>② Linearity.</strong> For two $k$-forms $\omega, \eta$ and scalars $a,b$,
 
-$$\mathbf{J}_\eta := \begin{pmatrix}
-\frac{\partial A}{\partial x} & \frac{\partial A}{\partial y} & \frac{\partial A}{\partial z} \\
-\frac{\partial B}{\partial x} & \frac{\partial B}{\partial y} & \frac{\partial B}{\partial z} \\
-\frac{\partial C}{\partial x} & \frac{\partial C}{\partial y} & \frac{\partial C}{\partial z}
-\end{pmatrix}$$
+$$\Phi^*(a\omega + b\eta) = a\,\Phi^*(\omega) + b\,\Phi^*(\eta)$$
 
-The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (others are sign flips or zero). The components $d\eta_{abc} = \frac{\partial \eta_{bc}}{\partial x^a}$ of $d\eta$ are $a,b,c \in \{x,y,z\}$, totaling $3^3=27$. Arranging them into three $3 \times 3$ matrices with fixed $a$:
+holds. This guarantees that sums and scalar multiples of measuring devices stay consistent before and after pullback.
 
-$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$
+<strong>③ Compatibility with the wedge product.</strong> For a $k$-form $\omega$ and an $\ell$-form $\eta$,
 
-When these $27$ components contract with the wedge product of $dx^a \wedge dx^b \wedge dx^c$, terms with duplicate indices (diagonal components or $b=c$, etc.) vanish due to $dx \wedge dx = 0$, and only the $6$ terms where $a,b,c$ are all distinct (the permutations of $3!$) survive. Summing each with sign and including the factor $\frac{1}{2}$ correction, we obtain
+$$\Phi^*(\omega \wedge \eta) = \Phi^*(\omega) \wedge \Phi^*(\eta)$$
 
-That is, $d\eta$ has $6$ surviving terms among the $27$ components, which pair up and converge to the trace of $\mathbf{J}_\eta$.
+holds. In other words, “assemble then pull back” and “pull back then assemble” give the same result. The operation in §4.2 of expanding $dx$ and $dy$ separately and then assembling with $\wedge$ was exactly an instance of this property.
 
-$$d\eta_{x,\cdot,\cdot} = \begin{pmatrix}
-0 & \frac{\partial C}{\partial x} & -\frac{\partial B}{\partial x} \\
--\frac{\partial C}{\partial x} & 0 & \frac{\partial A}{\partial x} \\
-\frac{\partial B}{\partial x} & -\frac{\partial A}{\partial x} & 0
-\end{pmatrix}, \quad
-d\eta_{y,\cdot,\cdot} = \begin{pmatrix}
-0 & \frac{\partial C}{\partial y} & -\frac{\partial B}{\partial y} \\
--\frac{\partial C}{\partial y} & 0 & \frac{\partial A}{\partial y} \\
-\frac{\partial B}{\partial y} & -\frac{\partial A}{\partial y} & 0
-\end{pmatrix}, \quad
-d\eta_{z,\cdot,\cdot} = \begin{pmatrix}
-0 & \frac{\partial C}{\partial z} & -\frac{\partial B}{\partial z} \\
--\frac{\partial C}{\partial z} & 0 & \frac{\partial A}{\partial z} \\
-\frac{\partial B}{\partial z} & -\frac{\partial A}{\partial z} & 0
-\end{pmatrix}$$
+<strong>④ Consistency factors by degree.</strong> For the pullback $\Phi^*$ after taking the limit $h\to0$ from finite cells, we take the Jacobian matrix assembled from the partial derivatives of $\Phi$, pick out the $k$ directions needed, and the $k \times k$ determinant of those entries becomes the consistency factor. Within the scope of this book, it appears in the following forms.
 
-A $3$-form has only one basis $dx \wedge dy \wedge dz$, so it degenerates to a scalar coefficient in matrix form.
+- $k=1$ ($1$-form): a $1 \times 1$ determinant
 
-$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$
+$$
+\det
+\begin{pmatrix}
+\frac{dx}{dt}
+\end{pmatrix}
+=
+\frac{dx}{dt}
+$$
 
-### B.5 $d^2 f = 0$ and the Hessian Matrix
+- $k=2$ ($2$-form): a $2 \times 2$ determinant
 
-For a $0$-form $f$, the Hessian matrix:
+$$
+\det
+\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v}\\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+=
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-
+\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+$$
 
-collects the second-order partial derivatives of $f$. If $f$ is totally differentiable, then $\mathbf{H}_f$ is a symmetric matrix ($\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, etc.).
+- $k=3$ ($3$-form): a $3 \times 3$ determinant
 
-$d(df) = 0$ is obtained by setting $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ in the $d\omega$ formula of §4.5. Since $\mathbf{J} = \mathbf{H}_f$ and $\mathbf{H}_f$ is symmetric, we have $\mathbf{J}^T - \mathbf{J} = 0$, hence $d(df) = 0$. In matrix language, this is equivalent to "the antisymmetric part of the Hessian matrix is zero."
+$$
+J
+=
+\det
+\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w}\\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w}\\[4pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
+\end{pmatrix}
+$$
 
-$$\mathbf{H}_f := \begin{pmatrix}
-\frac{\partial^2 f}{\partial x^2} & \frac{\partial^2 f}{\partial x \partial y} & \frac{\partial^2 f}{\partial x \partial z} \\
-\frac{\partial^2 f}{\partial y \partial x} & \frac{\partial^2 f}{\partial y^2} & \frac{\partial^2 f}{\partial y \partial z} \\
-\frac{\partial^2 f}{\partial z \partial x} & \frac{\partial^2 f}{\partial z \partial y} & \frac{\partial^2 f}{\partial z^2}
-\end{pmatrix}$$
+Thus a $1 \times 1$ determinant appears for $1$-forms, a $2 \times 2$ determinant for $2$-forms, and a $3 \times 3$ determinant for $3$-forms. As the degree increases, the size of the determinant that fixes the consistency factor of the measuring device grows by one step at a time. This structure is the same for $k$-forms in higher dimensions as well. Arrange the coefficients obtained by differentiating the transformation formulas, pick out the $k$ directions needed, and form the determinant. That determinant is the consistency factor for rewriting a $k$-dimensional measuring device into a form usable in the variables on the parameter-space side.
 
-is the arrangement of the second-order partial derivatives of $f$. If $f$ is totally differentiable, $\mathbf{H}_f$ is a symmetric matrix ($\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, etc.).
+> <strong>Note</strong> (The name “Jacobian”) In general, the matrix assembled from the differential coefficients of a change of variables is called the Jacobian matrix, and its determinant is called the Jacobian. In one dimension this is $\frac{dx}{dt}$; in two dimensions it is the $2\times2$ determinant above; in three dimensions it is $J$.
+>
+> In this book, we often write the $3\times3$ determinant that appears especially as a volume conversion factor as $J$ and call it the Jacobian.
 
-$d(df) = 0$ is what you get by setting $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ in the $d\omega$ formula of §4.5. We have $\mathbf{J} = \mathbf{H}_f$, and since $\mathbf{H}_f$ is symmetric, $\mathbf{J}^T - \mathbf{J} = 0$, hence $d(df) = 0$. In the language of matrices, this can be rephrased as "the antisymmetric component of the Hessian matrix is zero."
+<strong>⑤ Relation between the finite-cell version and the pullback after the limit.</strong> In the derivations of this chapter, we did not write partial derivatives right away. First in §4.1, we wrote the rebuilding of the measuring device on a finite interval as $\gamma_h^\square$. There, the finite ratio $\Delta x/\Delta t$ served as the coefficient on each interval, and in the limit $h\to0$ we moved to $\gamma^*$.
+
+In §4.2 and §4.3, we extended this idea to two and three dimensions. The finite-cell version $\Phi_h^\square$ is a provisional measuring device used on finite cells. Its coefficients are fixed by “measurement of the figure spanned by finite-difference vectors, divided by the cell width on the parameter-space side.” When we feed this measuring device to a finite cell, the original measurement comes back.
+
+For example, for a $2$-form, the coefficient is the area of the parallelogram spanned by two difference vectors, divided by $\Delta u\,\Delta v$. For a $3$-form, it is the volume of the parallelepiped spanned by three difference vectors, divided by $\Delta u\,\Delta v\,\Delta w$.
+
+In the limit as the partition width $h\to0$, these coefficients converge to determinants built from partial derivatives. These are the coefficients of the pullback $\Phi^*$ after the limit. Thus the flow of this chapter is a two-stage process: “build a provisional measuring device on finite cells → obtain $\Phi^*$ in the limit $h\to0$.”
+
+> <strong>Note</strong> (Commutation with the exterior derivative $d$ — foreshadowing Chapter 5) In addition to these, there is an important relation between pullback and the exterior derivative $d$:
+> $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
+> In other words, “exterior differentiate then pull back” and “pull back then exterior differentiate” give the same result. We will take up this property again in §5.9 after we formally introduce $d$ in Chapter 5.
+
+We will not go any deeper here. In later chapters we will move on to language for dealing with curved space itself. Even then, the experience with finite cells and determinants that we saw in this chapter will serve as a foothold.
+
+---
+
+### §4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative
+
+Over the past four chapters, we have assembled the following four things:
+
+1. <strong>Chapter 1</strong>: View $dx$ as a matrix ($1$-form), and read integration as the limit of matrix action
+2. <strong>Chapter 2</strong>: Construct $2$-forms and $3$-forms via the wedge product $\wedge$, and measure area and volume algebraically
+3. <strong>Chapter 3</strong>: Apply forms to curves, surfaces, and regions, and establish the operation of aggregating their output
+4. <strong>Chapter 4 (this chapter)</strong>: Through three concrete examples—the work–energy theorem, conservation of angular momentum, and conservation of mass—establish the unified principle that pullback rebuilds measuring devices so that integral values are preserved
+
+What this chapter established is the following unified principle:
+
+<strong>When counting in different variables, rebuild the measuring devices so that the integral value does not change.</strong> This is the pullback. Whether it is work along a curve, area or flux on a surface, or total mass in a region—all can be handled by the same idea.
+
+The pullback is the technique of rebuilding measuring devices so that integral values are preserved, and its core lies in the discovery-based derivations we saw in §4.1–§4.3. That is, the flow: “the naive attempt does not match → build a provisional measuring device on finite cells → obtain the general form in the limit $h\to0$.” In the finite-cell version $\Phi_h^\square$, the coefficient is the determinant of finite-difference vectors divided by the cell width; in $\Phi^*$, its limit appears as partial-derivative coefficients and the Jacobian. For $1$-forms the velocity $d\gamma/dt$, for $2$-forms $r$, and for $3$-forms the $3\times3$ determinant $J$ all emerged from the computation of measuring finite cells.
+
+> <strong>Checkpoint so far — Chapter 4</strong>
+> - The pullback $\Phi^*$ is the operation of rewriting measuring devices on the physical-space side into a form usable in the variables on the parameter-space side, so that the integral value does not change.
+> - For a $1$-form, the physical-space measuring device $F(x)\,dx$ is rebuilt on the time side as $\gamma^*(F(x)\,dx)=F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt$. On finite intervals, $\Delta x/\Delta t$; in the limit, the velocity $d\gamma/dt$ becomes the consistency factor.
+> - For a $2$-form, $dx\wedge dy$ is rebuilt on the polar-coordinate side as $\Phi^*(dx\wedge dy)=r\,dr\wedge d\theta$. On a finite grid, $r\Delta r\sin\Delta\theta$ appears, and in the limit $h\to0$ the coefficient $r$ remains.
+> - For a $3$-form, $dx\wedge dy\wedge dz$ is rebuilt on the cylindrical-coordinate side as $\Phi^*(dx\wedge dy\wedge dz)=r\,dr\wedge d\theta\wedge dz$. For a general transformation, $\Phi^*(dx\wedge dy\wedge dz)=J\,du\wedge dv\wedge dw$.
+> - The finite-cell version $\Phi_h^\square$ is a provisional measuring device used on finite cells. Its coefficient is fixed by “measurement of the figure spanned by finite-difference vectors, divided by the cell width on the parameter-space side.” When we feed this measuring device to a finite cell, the original measurement comes back. In the limit $h\to0$, this coefficient becomes the coefficient of $\Phi^*$.
+> - For $1$-forms a $1\times1$ determinant, for $2$-forms a $2\times2$ determinant, and for $3$-forms a $3\times3$ determinant serve as the consistency factors for rebuilding measuring devices.
+> - Chapter 1 §1.4’s $dx = \cos\theta\,dr - r\sin\theta\,d\theta$ was already a prototype of $1$-form pullback.
+
+---
+
+In the next chapter, we finally introduce the <strong>exterior derivative $d$</strong>. We have reached the point of building measuring devices, integrating them, and rebuilding them to suit the variables. What we look at next is change in the measuring devices themselves. The operation that records how things change from place to place as a form one degree higher—that is the exterior derivative $d$.

--- a/translation/drafts/ch04-4.0-4.1.md
+++ b/translation/drafts/ch04-4.0-4.1.md
@@ -1,0 +1,169 @@
+# Chapter 4: What Is a Change of Variables? — The Pullback $\Phi^*$: Making Measuring Devices Consistent
+
+### §4.0 Physics Curves; Computation Uses Boxes
+
+The quantities we truly want to measure in physics do not depend on the names of coordinates.
+
+Work done on a particle must be the same whether we write the trajectory in $x$ or in time $t$. The area swept out by a planet must be the same whether we measure it in Cartesian coordinates or polar coordinates. The mass of an object must be the same whether we integrate in Cartesian coordinates or cylindrical coordinates.
+
+Yet physics is usually curved.
+Trajectories curve, surfaces curve, and the boundaries of regions curve.
+
+Computation, on the other hand, is boxy.
+We mark off intervals, divide into grids, and slice into boxes. Integration is the technique of tallying curved physical quantities on top of boxy computation.
+
+Here a problem arises.
+If we change the variables used for computation, we cannot use the measuring devices as they stand.
+
+$dx$ is a measuring device that reads displacement in the $x$ direction; swapping it for $dt$ alone does not measure work correctly.
+$dx \wedge dy$ is an area-measuring device in the $xy$ plane; swapping it for $dr \wedge d\theta$ alone does not measure area correctly.
+$dx \wedge dy \wedge dz$ likewise does not measure volume correctly if we swap it for $dr \wedge d\theta \wedge dz$ alone.
+
+Physical quantities must not change.
+But the boxes used for computation do change.
+
+Then how should we rebuild the measuring devices?
+
+In this chapter we pursue this question through three examples.
+
+First, on a finite interval, we see what must be multiplied on the time side so that a piece of work agrees. Next, on a finite grid, we find the factor that makes area agree. Finally, on finite boxes, we find the factor that makes volume agree.
+
+As the partition is refined, a finite ratio becomes a differential coefficient, and a finite determinant becomes the determinant of the matrix built from partial derivatives. The rebuild of measuring devices obtained in that limit is called the pullback, written $\Phi^*$.
+
+So the order of this chapter is as follows.
+
+> Find it on a finite interval.
+> Do the same on a finite grid.
+> Do the same on finite boxes.
+> Finally, $\Phi^*$ appears as the limit $h\to0$.
+
+In this chapter we do not memorize formulas; we make things consistent.
+Through three physical quantities—work, area, and volume—we see how $dx$, $dx \wedge dy$, and $dx \wedge dy \wedge dz$ are each rebuilt.
+
+### §4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem
+
+> <strong>Note</strong> (for readers without a physics background) All we use here is that position can be written as $x=\gamma(t)$. Read $F(x)$ as a function of position and $v(t)$ as a function of time.
+
+<strong>① Start from a physical quantity.</strong> We do not jump straight to general theory. Let us begin from a familiar fact of mechanics.
+
+Suppose a force $F$ acts on a particle moving along the $x$ axis. Work is given by
+
+$$W = \int F\,dx$$
+
+On the other hand, the equation of motion is
+
+$$F = m\frac{dv}{dt}$$
+
+From these two, the familiar work-energy theorem
+
+$$W = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
+
+follows. In this section we reread this derivation through the lens of "how must we rebuild the measuring device so that the same work comes out?" We begin by finding the coefficient needed on the time-side measuring device, interval by interval on a finite partition.
+
+<strong>② Naive substitution—it does not match.</strong> Write the particle's position as $x = \gamma(t)$. The velocity is $v(t)=\frac{d\gamma}{dt}(t)$. The measuring device for work is $F\,dx$—a $1$-form that eats displacement in physical space and returns a piece of work.
+
+But the motion is given by time $t$. So we want to compute work in time.
+
+First on the physical-space side, take uniformly accelerated motion $x(t) = \frac{1}{2}at^2$ and constant force $F = ma$. With endpoint $X = \frac{1}{2}aT^2$,
+
+$$W_{\text{実}} = \int_0^X ma\,dx = ma\,X = \frac{1}{2}ma^2T^2$$
+
+On the other hand, if we integrate naively on the time side—that is, replace $dx$ by $dt$ as-is—
+
+$$W_{\text{素朴}} = \int_0^T ma\,dt = ma\,T$$
+
+We have $\frac{1}{2}ma^2T^2 \neq ma\,T$, so they clearly do not agree. With $dt$ alone, the value of work changes.
+
+<strong>③ See the cause on a finite interval.</strong> Consider a small time interval $[t_i, t_{i+1}]$. Let its width be $\Delta t_i = t_{i+1} - t_i$ and the corresponding change in position $\Delta x_i = \gamma(t_{i+1}) - \gamma(t_i)$. One term of work on the physical-space side is $F_i\,\Delta x_i$. One term built naively on the time side is $F_i\,\Delta t_i$. These do not agree because we ignored the consistency factor between $\Delta t_i$ and $\Delta x_i$.
+
+So multiply the time-side term by a coefficient $c_i$ and try $F_i\,c_i\,\Delta t_i$. For this to agree with $F_i\,\Delta x_i$, we need $c_i\,\Delta t_i = \Delta x_i$. Therefore
+
+$$c_i = \frac{\Delta x_i}{\Delta t_i}$$
+
+Up to here it is just division. Yet this division has meaning. We were asking: what measuring device must eat the time-side interval $\Delta t_i$ so that the same value as the physical-space displacement $\Delta x_i$ comes out? The answer is
+
+$$\frac{\Delta x_i}{\Delta t_i}\,dt$$
+
+Indeed, if we feed $\Delta t_i$ to this measuring device,
+
+$$\left(\frac{\Delta x_i}{\Delta t_i}\,dt\right)(\Delta t_i)=\Delta x_i$$
+
+So on a finite time interval we can read the same displacement as on the physical-space side.
+
+Write this provisional measuring device on a finite interval as
+
+$$\gamma_h^\square(dx):=\frac{\Delta x_i}{\Delta t_i}\,dt$$
+
+where $h$ denotes the maximum width of the partition. Feeding this measuring device to a finite interval gives
+
+$$\gamma_h^\square(dx)\bigl(\Delta t_i\bigr)=\Delta x_i$$
+
+As the partition is refined, the finite ratio approaches the velocity
+
+$$\frac{\Delta x_i}{\Delta t_i}\to \frac{d\gamma}{dt}(t)$$
+
+So in the limit we obtain
+
+$$
+\gamma_h^\square(dx)
+\xrightarrow{h\to0}
+\gamma^*(dx)
+=
+\frac{d\gamma}{dt}(t)\,dt
+$$
+
+After the limit we write this measuring device as $\gamma^*(dx)=\frac{d\gamma}{dt}(t)\,dt$. The coefficient $\Delta x_i/\Delta t_i$ found on finite intervals has become the velocity $\frac{d\gamma}{dt}(t)$ in the limit.
+
+Henceforth we write the same rebuild for finite grids and boxes collectively as $\Phi_h^\square$.
+
+> <strong>Note</strong> ($\Phi_h^\square$ and $\Phi^*$)
+>
+> $\gamma_h^\square$ and $\Phi_h^\square$ are provisional measuring devices used in this book on finite intervals and finite cells. They are distinguished from $\Phi^*$ after $h\to0$.
+>
+> In the finite cell version, the coefficient is obtained by dividing the measured value of the figure spanned by finite displacement vectors by the cell width on the computation side. Therefore, feeding this measuring device to a finite cell recovers the original measured value.
+>
+> This coefficient is determined cell by cell. To keep the notation light, dependence on the cell index is not written into $\Phi_h^\square$.
+>
+> What we measure here is not the image of a finite cell under the map itself, but the figure spanned by the chosen displacement vectors: displacement in one dimension, a parallelogram in two dimensions, a parallelepiped in three dimensions. For example, the image of a finite polar grid cell is a curved sector, but what we measure here is not that sector itself but the parallelogram spanned by the two chosen displacement vectors.
+>
+> In the limit of partition width $h\to0$, the coefficients of $\gamma_h^\square$ and $\Phi_h^\square$ converge to the coefficients of the pullback $\Phi^*$ after the limit.
+
+<strong>④ Write the pullback of the concrete example.</strong> After taking the limit, the measuring device on the time axis (the pulled-back result) is
+
+$$\gamma^*(F\,dx) = F(\gamma(t))\,v(t)\,dt$$
+
+By this we can recast the measuring device $F\,dx$ for work in physical space into one for the time axis.
+
+<strong>⑤ Pullback of a $1$-form with a coefficient.</strong> For an arbitrary coefficient $F(x)$, the same structure holds. When position is given by $x = \gamma(t)$,
+
+$$
+\gamma^*(F(x)\,dx)
+=
+F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+$$
+
+<strong>⑥ Define it through this transformation.</strong> By now the route from the finite-interval version to the standard version is visible. So for a smooth curve $\gamma: t \mapsto x$, we define the rebuild of the $1$-form $\omega = F(x)\,dx$ by
+
+$$
+\gamma^*(F(x)\,dx)
+=
+F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt
+$$
+
+This formula is the pullback of a $1$-form used on the time side. The velocity $\frac{d\gamma}{dt}(t)$ is the limit of $\Delta x_i/\Delta t_i$ found on finite intervals and serves as the consistency factor for "recasting the physical-space measuring device $dx$ into the time-axis measuring device $dt$."
+
+Next we repeat the same procedure for the two-dimensional area-measuring device $dx\wedge dy$. In one dimension we mapped a finite interval and measured the displacement of its image. In two dimensions we will map a finite rectangle and measure the area spanned by two displacement vectors of its image.
+
+<strong>⑦ Return to the physical quantity.</strong> Here, using the equation of motion $F = m\,dv/dt$,
+
+$$\gamma^*(F\,dx) = m\frac{dv}{dt}\,v\,dt = m v\,dv$$
+
+we can read ($m\frac{dv}{dt}\,dt$ corresponds to $\gamma^*(dv)$, pulling the velocity-axis measuring device $dv$ back to the time axis). Therefore
+
+$$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int_{v(t_0)}^{v(t_1)} m v\,dv = \frac{1}{2}mv^2\,\Big|_{t_0}^{t_1}$$
+
+—work equals the change in kinetic energy.
+
+> <strong>Aside</strong> (why the name "pullback") If we are "sending" a measuring device that lives in physical space into parameter space, is that not a "push forward"?—that is how it feels to me. For me, physical space is "reality" and parameter space is a "tool for computation." But the mathematical map $\gamma$ is always defined in the direction “parameter space $\to$ physical space.” In the mathematical world, parameter space is the departure point. So the movement of a measuring device that goes against the direction of the map, from physical space back to parameter space, is called a pullback. I have made peace with calling it that by convention.
+
+> <strong>Note</strong> ($dx$ is a row vector, $dt$ is too) In the calculations of §4.1, $dx$, $dt$, and $dv$ all keep the same type: "eat displacement and return a scalar." The principle "row vector × column vector → scalar" from Chapter 1 §1.1.3 does not break even in the middle of a pullback. The result $\gamma^*(F\,dx)$ is again a $1$-form (row vector) on the time axis; feeding it the time-side displacement $\Delta t$ yields a scalar (a piece of work)—this consistency is what supports understanding of the pullback.

--- a/translation/drafts/ch04-4.2.md
+++ b/translation/drafts/ch04-4.2.md
@@ -1,0 +1,235 @@
+### §4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity
+
+<strong>① Start from a physical quantity.</strong> In §4.1 we mapped a one-dimensional finite interval and measured its image. This time we apply the same idea to a two-dimensional finite grid.
+
+> <strong>Note</strong> (For readers without physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.
+
+Consider a particle moving in a central force field. When the force always points toward the origin, the angular momentum
+
+$$
+L
+=
+m\left(
+x\frac{dy}{dt}
+-
+y\frac{dx}{dt}
+\right)
+$$
+
+is constant in time (the law of conservation of angular momentum). This conservation law has a beautiful geometric meaning—the rate at which the position vector of the particle sweeps out area (<strong>areal velocity</strong>) is constant (Kepler’s second law).
+
+We may assume the motion takes place in the plane $z=0$. The area of the sector $D$ swept out by the position vector from time $t_0$ to $t_1$ is
+
+$$A = \iint_D dx \wedge dy$$
+
+Here $dx \wedge dy$ is the area-measuring device ($2$-form) on the $xy$ plane.
+
+> <strong>Note</strong> (For physicists who work in two dimensions) Let us confirm this point. This book consistently assumes the reality of three-dimensional space. Setting $z=0$ in the angular-momentum discussion below is a temporary simplification to make the calculation easier to read; we are still looking at one plane inside three-dimensional space.
+
+<strong>② Naive substitution—it does not match as written.</strong> The sector on the right-hand side is awkward to write in $(x,y)$. So we want to write it in $(r,\theta)$. But what happens if we replace $dx \wedge dy$ directly by $dr \wedge d\theta$? Let us compute the area of a full circle of radius $C$. The correct value is $\pi C^2$. Yet with naive substitution:
+
+$$
+A_{\text{naive}}
+=
+\iint dr \wedge d\theta
+=
+\int_0^{2\pi}
+\biggl(
+  \int_0^C dr
+\biggr)
+d\theta
+=
+2\pi C
+$$
+
+This is completely different from $\pi C^2$. With $dr \wedge d\theta$ alone, the correct area does not come out.
+
+<strong>③ See the cause on a finite grid.</strong> This time, let us ask what we must feed to the finite grid on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
+
+Cut a grid of finite size $\Delta r \times \Delta\theta$ in $(r,\theta)$ space. Find the two displacement vectors that one cell at coordinates $(r, \theta)$ produces in $(x,y)$ space.
+
+Edge in the $\Delta r$ direction: only $r$ changes while $\theta$ is fixed, so the difference is exact:
+
+$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$
+
+Edge in the $\Delta\theta$ direction: use the difference formulas for trigonometric functions:
+
+$$\begin{aligned}
+\Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
+= -2r\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr) \\[4pt]
+\Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
+= 2r\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr)
+\end{aligned}$$
+
+Find the area of the parallelogram spanned by the two edges $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ and $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ by a determinant:
+
+$$\begin{aligned}
+\det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
+&= 2r\Delta r\,\sin\biggl(\frac{\Delta\theta}{2}\biggr)\biggl[ \cos\theta\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr) + \sin\theta\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr) \biggr] \\
+&= r\Delta r\,\sin\Delta\theta
+\end{aligned}$$
+
+The result is
+
+$$\det = r\Delta r\,\sin\Delta\theta$$
+
+Divide this measured value by the cell width $\Delta r_i\,\Delta\theta_j$ on the $(r,\theta)$ side, and we obtain the coefficient of the provisional measuring device used on a finite cell. That is,
+
+$$
+\Phi_h^\square(dx\wedge dy)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+$$
+
+Feed this measuring device to a finite cell, and
+
+$$
+\begin{aligned}
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+&=
+\left(
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+\right)(\Delta r_i,\Delta\theta_j) \\
+&=
+r_i\,\Delta r_i\,\sin\Delta\theta_j
+\end{aligned}
+$$
+
+The right-hand side is the signed area of the parallelogram spanned by the two finite-difference vectors.
+
+Let $A_h^\square$ denote the total area sum in the finite-cell version. Therefore
+
+$$
+A_h^\square
+:=
+\sum_i\sum_j
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+=
+\sum_i\sum_j r_i\,\Delta r_i\,\sin\Delta\theta_j
+$$
+
+$\sin\Delta\theta_j$ is an exact value for finite $\Delta\theta_j$. What we measure here is not the curved sector area of the polar-coordinate finite grid itself, but the signed area of the parallelogram spanned by two finite-difference vectors. Write the sector swept out by the position vector in physical space as $D$. On the other hand, write the $(r,\theta)$ range corresponding to that region in polar coordinates as $D'$.
+
+In the final stage of taking the limit of the sum,
+
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+
+Therefore the true area $A$ is obtained as
+
+$$
+A
+=
+\lim_{h\to0} A_h^\square
+=
+\iint_{D'} r\,dr\wedge d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit,
+
+$$
+\Phi_h^\square(dx\wedge dy)
+\xrightarrow{h\to0}
+\Phi^*(dx\wedge dy)
+=
+r\,dr\wedge d\theta
+$$
+
+appears.
+
+> <strong>Note</strong> ($\Delta r,\Delta\theta$ need not be infinitesimal) In the computation of the difference vectors so far, we have used no assumption that $\Delta r$ or $\Delta\theta$ is “sufficiently small.” The $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ found above are formulas that hold exactly no matter how large $\Delta r,\Delta\theta$ may be. By “exact” here we mean that we measure the parallelogram spanned by finite-difference vectors. The passage to infinitesimals is made only in the final stage—the limit of the sum—when we move to $\Phi^*$ and integration.
+
+<strong>④ Write the standard form obtained in the limit.</strong> For the transformation to polar coordinates $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$:
+
+$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
+
+This is the rebuilding of the $2$-form obtained from the finite-cell version $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency factor corresponding to the velocity $d\gamma/dt$ in §4.1.
+
+<strong>⑤ Pullback of a coefficient-carrying $2$-form.</strong> For a $2$-form $G(x,y)\,dx \wedge dy$ with an arbitrary coefficient $G(x,y)$, the same structure holds:
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$
+
+The coefficient $G$ is merely rebuilt in polar coordinates (pullback of a $0$-form), while only the $dx \wedge dy$ part changes to $r\,dr \wedge d\theta$. The pullback $\Phi^*$ naturally splits into “rebuilding the coefficient” and “rebuilding the measuring device.”
+
+<strong>⑥ Carry the same discovery to a general transformation.</strong> Nothing here is special to polar coordinates. Consider a transformation between planes $\Phi(u,v)=(x(u,v),y(u,v))$, and map a finite rectangle on the $(u,v)$ side. Measure the two difference vectors in the $u$ and $v$ directions with $dx\wedge dy$, and we get an area value for each finite rectangle.
+
+Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios move to partial-derivative coefficients, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\;
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+\,du \wedge dv$$
+
+That is,
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr)
+=G(\Phi(u,v))\left(
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+\right)\,du\wedge dv$$
+
+The $2\times2$ determinant that appears here is the consistency factor for rebuilding the physical-space area-measuring device $dx\wedge dy$ into a measuring device $du\wedge dv$ usable on the $(u,v)$ side.
+
+What we saw on the finite grid,
+
+$$\Delta x_u\,\Delta y_v-\Delta x_v\,\Delta y_u$$
+
+is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors, but in the limit rebuilding written as $\Phi^*$, partial-derivative coefficients are used. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
+
+<strong>⑦ Return to the physical quantity.</strong> Integrate the area of the sector $D$ over the corresponding polar-coordinate region $D'$ using the pulled-back measuring device:
+
+$$
+A
+=
+\iint_D dx\wedge dy
+=
+\iint_{D'} \Phi^*(dx\wedge dy)
+=
+\iint_{D'} r\,dr\wedge d\theta
+$$
+
+$$
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+Integrating in $r$, $\frac{1}{2}r^2$ appears, and the area is reduced to a line integral of a $1$-form along the $\theta$ axis. Pull back further to the time parameter $t$. If the particle’s orbit is $r = R(t),\, \theta = \Theta(t)$, then
+
+$$
+\frac{dA}{dt}
+=
+\frac{1}{2}r(t)^2\,\frac{d\theta}{dt}(t)
+$$
+
+From the definition of angular momentum
+
+$$
+L
+=
+m r^2\frac{d\theta}{dt}
+$$
+
+the areal velocity is
+
+$$\frac{dA}{dt} = \frac{L}{2m}$$
+
+In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. Exactly the same structure as in §4.1, where the consistency factor $d\gamma/dt$ of a $1$-form described energy conservation, describes conservation of angular momentum through the consistency factor $r$ of a $2$-form.

--- a/translation/drafts/ch04-4.3.md
+++ b/translation/drafts/ch04-4.3.md
@@ -1,0 +1,197 @@
+### §4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals
+
+<strong>① Start from a physical quantity.</strong> The end point is a volume integral. This time we map a three-dimensional finite box and measure it.
+
+Consider the mass of a cylinder of uniform density $\rho$ (radius $C$, height $H$). Computing directly in $(x,y,z)$ space,
+
+$$M = \rho \cdot (\text{volume}) = \rho \cdot \pi C^2 H$$
+
+This $M$ must not change no matter which coordinates we use to compute it.
+
+<strong>② Naive substitution — it does not work as-is.</strong> We want to write the integral in cylindrical coordinates $(r,\theta,z)$. The cylinder ranges over $r \in [0, C],\; \theta \in [0, 2\pi],\; z \in [0, H]$, so if we replace $dx \wedge dy \wedge dz$ outright by $dr \wedge d\theta \wedge dz$:
+
+$$
+M_{\text{naive}}
+=
+\rho \iiint dr\wedge d\theta\wedge dz
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+2\pi\rho C H
+$$
+
+Comparing this with the correct value $\rho \pi C^2 H$, we have $2\pi\rho C H \neq \rho \pi C^2 H$. They clearly do not agree.
+
+<strong>③ Find the cause on a finite mesh.</strong> In three dimensions, we ask what must be fed to a finite box on the $(r,\theta,z)$ side so that we get the same value as the volume on the $(x,y,z)$ side.
+
+Cut a grid of finite size $\Delta r \times \Delta\theta \times \Delta z$ in $(r,\theta,z)$ space. The transformation is $x = r\cos\theta,\; y = r\sin\theta,\; z = z$. The $z$ direction is unchanged by the transformation, so the volume is “mesh-cell area in the $xy$ plane” $\times \Delta z$. The area in the $xy$ plane follows exactly the procedure of §4.2:
+
+$$\det = r\Delta r\,\sin\Delta\theta$$
+
+Therefore, the volume of one cell is
+
+$$\text{volume} = \bigl(r\Delta r\,\sin\Delta\theta\bigr) \times \Delta z$$
+
+The finite cell in cylindrical coordinates itself is curved in the $\theta$ direction, but what we are measuring here is the signed volume of the parallelepiped spanned by three difference vectors.
+
+Dividing this measured value by the cell widths $\Delta r_i\,\Delta\theta_j\,\Delta z_k$ on the $(r,\theta,z)$ side gives the coefficient of a provisional measuring device used on a finite cell. That is,
+
+$$
+\Phi_h^\square(dx\wedge dy\wedge dz)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta\wedge dz
+$$
+
+Feed this measuring device to a finite box and we get
+
+$$
+\begin{aligned}
+&\Phi_h^\square(dx\wedge dy\wedge dz)
+(\Delta r_i,\Delta\theta_j,\Delta z_k)\\
+&\qquad =
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}
+\Delta r_i\Delta\theta_j\Delta z_k \\
+&\qquad =
+r_i\Delta r_i\sin\Delta\theta_j\Delta z_k
+\end{aligned}
+$$
+
+The right-hand side is the signed volume of the parallelepiped spanned by three finite difference vectors.
+
+Writing the total mass sum in the finite-cell version as $M_h^\square$, we have
+
+$$
+M_h^\square
+:=
+\sum_i\sum_j\sum_k
+\rho\,
+\Phi_h^\square(dx\wedge dy\wedge dz)(\Delta r_i,\Delta\theta_j,\Delta z_k)
+=
+\sum_i\sum_j\sum_k
+\rho\,r_i\,\Delta r_i\,\sin\Delta\theta_j\,\Delta z_k
+$$
+
+In the final stage, when we take the limit of the sum,
+
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+
+Therefore the true mass $M$ is obtained as
+
+$$
+M
+=
+\lim_{h\to0} M_h^\square
+=
+\rho\iiint_{V'} r\,dr\wedge d\theta\wedge dz
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C r\,dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+\rho\cdot\pi C^2H
+$$
+
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As $h\to0$, this coefficient again approaches $r$.
+
+<strong>④ Write the standard form obtained in the limit.</strong> For the transformation to cylindrical coordinates $\Phi(r,\theta,z) = (r\cos\theta,\; r\sin\theta,\; z)$:
+
+$$
+\Phi_h^\square(dx\wedge dy\wedge dz)
+\xrightarrow{h\to0}
+\Phi^*(dx \wedge dy \wedge dz)
+=
+r\,dr \wedge d\theta \wedge dz
+$$
+
+This is the rebuilding of the $3$-form obtained from the finite cell pullback $\Phi_h^\square$ as $h\to0$. We write this rebuilding obtained in the limit as $\Phi^*$. This $r$ is the consistency coefficient that carries over the $r$ of §4.2 unchanged.
+
+<strong>⑤ Pullback of a weighted $3$-form.</strong> For a $3$-form $\rho\,dx \wedge dy \wedge dz$ with arbitrary density $\rho(x,y,z)$, the same structure holds:
+
+$$\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) = \rho(r\cos\theta,\, r\sin\theta,\, z)\; r\,dr \wedge d\theta \wedge dz$$
+
+The coefficient $\rho$ is only re-expressed in new coordinates (pullback of a $0$-form); only the part $dx \wedge dy \wedge dz$ changes to $r\,dr \wedge d\theta \wedge dz$.
+
+<strong>⑥ Transfer the same discovery to a general transformation.</strong> More generally, consider a transformation of space $\Phi(u,v,w) = (x(u,v,w), y(u,v,w), z(u,v,w))$. Mapping a finite box on the $(u,v,w)$ side produces three difference vectors. Measuring them with $dx\wedge dy\wedge dz$ gives the oriented volume of the mapped parallelepiped.
+
+Dividing that volume value by $\Delta u\,\Delta v\,\Delta w$ and refining the partition, the difference ratios pass to partial-derivative coefficients and a $3\times3$ determinant appears. Therefore, after $h\to0$, the pullback is:
+
+$$
+\begin{aligned}
+&\Phi^*\bigl(\rho(x,y,z)\,dx \wedge dy \wedge dz\bigr) \\
+&= \rho(x(u,v,w), y(u,v,w), z(u,v,w))\,
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[6pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
+\end{pmatrix}
+\,du \wedge dv \wedge dw
+\end{aligned}
+$$
+
+Writing this $3 \times 3$ determinant as $J(u,v,w)$, we obtain
+
+$$\Phi^*(\rho\,dx \wedge dy \wedge dz) = \rho(\Phi(u,v,w))\,J\,du \wedge dv \wedge dw$$
+
+This $3\times3$ determinant $J(u,v,w)$ is the consistency coefficient of the $3$-form.
+
+Arranging three difference vectors on a finite mesh gives
+
+$$\det\!\begin{pmatrix}
+\Delta x_u & \Delta x_v & \Delta x_w \\[2pt]
+\Delta y_u & \Delta y_v & \Delta y_w \\[2pt]
+\Delta z_u & \Delta z_v & \Delta z_w
+\end{pmatrix}$$
+
+This is the value obtained by feeding a measuring device on a finite cell to a finite box; for the parallelepiped spanned by the difference vectors, it is an equality. As the partition width $h$ is taken toward $0$, the coefficient obtained by dividing this finite determinant by $\Delta u\,\Delta v\,\Delta w$ converges to the Jacobian $J$ built from partial derivatives.
+
+If $J$ is negative, orientation is reversed. In the formal pullback, we use this signed $J$ as-is. On the other hand, when integrating “positive volume” or density, we need the magnitude with orientation forgotten, so $|J|$ appears. It is important not to confuse $J$ and $|J|$ here.
+
+For a $1$-form we have a $1 \times 1$ determinant (velocity $dx/dt$), for a $2$-form a $2 \times 2$ determinant, for a $3$-form a $3 \times 3$ determinant ($J$) — as the degree rises, the size of the determinant governing the consistency coefficient grows by one each time. The partial-derivative determinant formula above is precisely <strong>the general definition of the pullback of a $3$-form</strong>.
+
+> <strong>Note</strong> (for readers who have studied vector analysis) When you learned in a change of variables that “in polar coordinates, $r\,dr\,d\theta$ appears,” many textbooks give a geometric explanation: “consider the arc length $r\Delta\theta$ in the $\theta$ direction and $\Delta V \approx \Delta r \cdot r\Delta\theta \cdot \Delta z$.” That explanation is not wrong. But in the computation of this book we never consider arc length at all. Only the transformation formulas, trigonometric identities, and the determinant corresponding to $\wedge$ produce the consistency coefficient $r$.
+
+<strong>⑦ Return to the physical quantity.</strong> Integrating with the pulled-back measuring device,
+
+$$
+M
+=
+\rho\iiint_V dx\wedge dy\wedge dz
+=
+\rho\iiint_{V'} r\,dr\wedge d\theta\wedge dz
+$$
+
+$$
+=
+\rho
+\int_0^H
+\biggl(
+  \int_0^{2\pi}
+  \biggl(
+    \int_0^C r\,dr
+  \biggr)
+  d\theta
+\biggr)
+dz
+=
+\rho\cdot\pi C^2H
+$$
+
+We agree with the correct value. To preserve the integral value, the measuring device $dx \wedge dy \wedge dz$ had to be rebuilt as $r\,dr \wedge d\theta \wedge dz$ in $(r,\theta,z)$ space. In exactly the same structure by which the velocity $d\gamma/dt$ of §4.1 describes conservation of energy and the $r$ of §4.2 describes conservation of angular momentum, the $r$ of §4.3 (more generally $J$) describes conservation of mass.

--- a/translation/drafts/ch04-4.4-4.5.md
+++ b/translation/drafts/ch04-4.4-4.5.md
@@ -1,0 +1,119 @@
+### §4.4 Properties of the Pullback — What We Have Established So Far
+
+In §4.1–§4.3 we constructed pullbacks through three concrete examples. Here we organize the algebraic properties common to all of them. At the same time, we define the $3 \times 3$ determinant $J$ that appeared in §4.3 as the <strong>Jacobian (Jacobi determinant)</strong>. The matrix
+
+$$\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w} \\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w} \\[4pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
+\end{pmatrix}$$
+
+is called the <strong>Jacobian matrix</strong>, and its determinant $\det$ is the Jacobian $J$.
+
+<strong>① Pullback of a $0$-form (scalar field).</strong> To pull back a scalar field $f(x,y,z)$ by a transformation $\Phi$ is simply to rewrite the coordinates into a parametric representation:
+
+$$\Phi^*(f) = f(\Phi(u,v,w))$$
+
+For example, the operation in §4.1 that rewrote $F(x)$ in $F(x)\,dx$ as $F(\gamma(t))$ is nothing but the pullback of the $0$-form $F$.
+
+<strong>② Linearity.</strong> For two $k$-forms $\omega, \eta$ and scalars $a,b$,
+
+$$\Phi^*(a\omega + b\eta) = a\,\Phi^*(\omega) + b\,\Phi^*(\eta)$$
+
+holds. This guarantees that sums and scalar multiples of measuring devices stay consistent before and after pullback.
+
+<strong>③ Compatibility with the wedge product.</strong> For a $k$-form $\omega$ and an $\ell$-form $\eta$,
+
+$$\Phi^*(\omega \wedge \eta) = \Phi^*(\omega) \wedge \Phi^*(\eta)$$
+
+holds. In other words, “assemble then pull back” and “pull back then assemble” give the same result. The operation in §4.2 of expanding $dx$ and $dy$ separately and then assembling with $\wedge$ was exactly an instance of this property.
+
+<strong>④ Consistency factors by degree.</strong> For the pullback $\Phi^*$ after taking the limit $h\to0$ from finite cells, we take the Jacobian matrix assembled from the partial derivatives of $\Phi$, pick out the $k$ directions needed, and the $k \times k$ determinant of those entries becomes the consistency factor. Within the scope of this book, it appears in the following forms.
+
+- $k=1$ ($1$-form): a $1 \times 1$ determinant
+
+$$
+\det
+\begin{pmatrix}
+\frac{dx}{dt}
+\end{pmatrix}
+=
+\frac{dx}{dt}
+$$
+
+- $k=2$ ($2$-form): a $2 \times 2$ determinant
+
+$$
+\det
+\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v}\\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+=
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-
+\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+$$
+
+- $k=3$ ($3$-form): a $3 \times 3$ determinant
+
+$$
+J
+=
+\det
+\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} & \frac{\partial x}{\partial w}\\[4pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v} & \frac{\partial y}{\partial w}\\[4pt]
+\frac{\partial z}{\partial u} & \frac{\partial z}{\partial v} & \frac{\partial z}{\partial w}
+\end{pmatrix}
+$$
+
+Thus a $1 \times 1$ determinant appears for $1$-forms, a $2 \times 2$ determinant for $2$-forms, and a $3 \times 3$ determinant for $3$-forms. As the degree increases, the size of the determinant that fixes the consistency factor of the measuring device grows by one step at a time. This structure is the same for $k$-forms in higher dimensions as well. Arrange the coefficients obtained by differentiating the transformation formulas, pick out the $k$ directions needed, and form the determinant. That determinant is the consistency factor for rewriting a $k$-dimensional measuring device into a form usable in the variables on the parameter-space side.
+
+> <strong>Note</strong> (The name “Jacobian”) In general, the matrix assembled from the differential coefficients of a change of variables is called the Jacobian matrix, and its determinant is called the Jacobian. In one dimension this is $\frac{dx}{dt}$; in two dimensions it is the $2\times2$ determinant above; in three dimensions it is $J$.
+>
+> In this book, we often write the $3\times3$ determinant that appears especially as a volume conversion factor as $J$ and call it the Jacobian.
+
+<strong>⑤ Relation between the finite-cell version and the pullback after the limit.</strong> In the derivations of this chapter, we did not write partial derivatives right away. First in §4.1, we wrote the rebuilding of the measuring device on a finite interval as $\gamma_h^\square$. There, the finite ratio $\Delta x/\Delta t$ served as the coefficient on each interval, and in the limit $h\to0$ we moved to $\gamma^*$.
+
+In §4.2 and §4.3, we extended this idea to two and three dimensions. The finite-cell version $\Phi_h^\square$ is a provisional measuring device used on finite cells. Its coefficients are fixed by “measurement of the figure spanned by finite-difference vectors, divided by the cell width on the parameter-space side.” When we feed this measuring device to a finite cell, the original measurement comes back.
+
+For example, for a $2$-form, the coefficient is the area of the parallelogram spanned by two difference vectors, divided by $\Delta u\,\Delta v$. For a $3$-form, it is the volume of the parallelepiped spanned by three difference vectors, divided by $\Delta u\,\Delta v\,\Delta w$.
+
+In the limit as the partition width $h\to0$, these coefficients converge to determinants built from partial derivatives. These are the coefficients of the pullback $\Phi^*$ after the limit. Thus the flow of this chapter is a two-stage process: “build a provisional measuring device on finite cells → obtain $\Phi^*$ in the limit $h\to0$.”
+
+> <strong>Note</strong> (Commutation with the exterior derivative $d$ — foreshadowing Chapter 5) In addition to these, there is an important relation between pullback and the exterior derivative $d$:
+> $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
+> In other words, “exterior differentiate then pull back” and “pull back then exterior differentiate” give the same result. We will take up this property again in §5.9 after we formally introduce $d$ in Chapter 5.
+
+We will not go any deeper here. In later chapters we will move on to language for dealing with curved space itself. Even then, the experience with finite cells and determinants that we saw in this chapter will serve as a foothold.
+
+---
+
+### §4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative
+
+Over the past four chapters, we have assembled the following four things:
+
+1. <strong>Chapter 1</strong>: View $dx$ as a matrix ($1$-form), and read integration as the limit of matrix action
+2. <strong>Chapter 2</strong>: Construct $2$-forms and $3$-forms via the wedge product $\wedge$, and measure area and volume algebraically
+3. <strong>Chapter 3</strong>: Apply forms to curves, surfaces, and regions, and establish the operation of aggregating their output
+4. <strong>Chapter 4 (this chapter)</strong>: Through three concrete examples—the work–energy theorem, conservation of angular momentum, and conservation of mass—establish the unified principle that pullback rebuilds measuring devices so that integral values are preserved
+
+What this chapter established is the following unified principle:
+
+<strong>When counting in different variables, rebuild the measuring devices so that the integral value does not change.</strong> This is the pullback. Whether it is work along a curve, area or flux on a surface, or total mass in a region—all can be handled by the same idea.
+
+The pullback is the technique of rebuilding measuring devices so that integral values are preserved, and its core lies in the discovery-based derivations we saw in §4.1–§4.3. That is, the flow: “the naive attempt does not match → build a provisional measuring device on finite cells → obtain the general form in the limit $h\to0$.” In the finite-cell version $\Phi_h^\square$, the coefficient is the determinant of finite-difference vectors divided by the cell width; in $\Phi^*$, its limit appears as partial-derivative coefficients and the Jacobian. For $1$-forms the velocity $d\gamma/dt$, for $2$-forms $r$, and for $3$-forms the $3\times3$ determinant $J$ all emerged from the computation of measuring finite cells.
+
+> <strong>Checkpoint so far — Chapter 4</strong>
+> - The pullback $\Phi^*$ is the operation of rewriting measuring devices on the physical-space side into a form usable in the variables on the parameter-space side, so that the integral value does not change.
+> - For a $1$-form, the physical-space measuring device $F(x)\,dx$ is rebuilt on the time side as $\gamma^*(F(x)\,dx)=F(\gamma(t))\,\frac{d\gamma}{dt}(t)\,dt$. On finite intervals, $\Delta x/\Delta t$; in the limit, the velocity $d\gamma/dt$ becomes the consistency factor.
+> - For a $2$-form, $dx\wedge dy$ is rebuilt on the polar-coordinate side as $\Phi^*(dx\wedge dy)=r\,dr\wedge d\theta$. On a finite grid, $r\Delta r\sin\Delta\theta$ appears, and in the limit $h\to0$ the coefficient $r$ remains.
+> - For a $3$-form, $dx\wedge dy\wedge dz$ is rebuilt on the cylindrical-coordinate side as $\Phi^*(dx\wedge dy\wedge dz)=r\,dr\wedge d\theta\wedge dz$. For a general transformation, $\Phi^*(dx\wedge dy\wedge dz)=J\,du\wedge dv\wedge dw$.
+> - The finite-cell version $\Phi_h^\square$ is a provisional measuring device used on finite cells. Its coefficient is fixed by “measurement of the figure spanned by finite-difference vectors, divided by the cell width on the parameter-space side.” When we feed this measuring device to a finite cell, the original measurement comes back. In the limit $h\to0$, this coefficient becomes the coefficient of $\Phi^*$.
+> - For $1$-forms a $1\times1$ determinant, for $2$-forms a $2\times2$ determinant, and for $3$-forms a $3\times3$ determinant serve as the consistency factors for rebuilding measuring devices.
+> - Chapter 1 §1.4’s $dx = \cos\theta\,dr - r\sin\theta\,d\theta$ was already a prototype of $1$-form pullback.
+
+---
+
+In the next chapter, we finally introduce the <strong>exterior derivative $d$</strong>. We have reached the point of building measuring devices, integrating them, and rebuilding them to suit the variables. What we look at next is change in the measuring devices themselves. The operation that records how things change from place to place as a form one degree higher—that is the exterior derivative $d$.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -147,6 +147,7 @@ Per-section Pass status:
 | `translation/drafts/ch04-4.*.md` | integrated into `ch04.md` |
 | `translation/reviews/ch04-pass2.md` | complete |
 | `translation/reviews/ch04-pass3.md` | complete |
+| `translation/reviews/ch04-close-reading-polish.md` | complete (#182) |
 
 ---
 

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -125,6 +125,29 @@ Per-section Pass status:
 | `translation/reviews/ch03-pass3.md` | complete |
 | `translation/reviews/ch03-close-reading-polish.md` | complete (#181) |
 
+### English Chapter 4 — `manuscript/en/ch04/ch04.md` (branch `ai/english-translation-ch04`, PR [#163](https://github.com/yokiikoy/nabla-kaitai/pull/163))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 4 (§4.0–§4.5)** | **1 → 2 → 3** | `ch04-pass2.md`, `ch04-pass3.md`; old YAML draft replaced |
+
+Per-section Pass status:
+
+| Section | Pass | Section review |
+|---------|------|----------------|
+| §4.0 | **3** | `ch04-4.0-review.md` |
+| §4.1 | **3** | `ch04-4.1-review.md` |
+| §4.2 | **3** | `ch04-4.2-review.md` |
+| §4.3 | **3** | `ch04-4.3-review.md` |
+| §4.4 | **3** | `ch04-4.4-review.md` |
+| §4.5 | **3** | `ch04-4.5-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch04-4.*.md` | integrated into `ch04.md` |
+| `translation/reviews/ch04-pass2.md` | complete |
+| `translation/reviews/ch04-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/reviews/ch04-4.0-review.md
+++ b/translation/reviews/ch04-4.0-review.md
@@ -1,0 +1,23 @@
+# Review: Chapter 4 §4.0
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.0 Physics Curves; Computation Uses Boxes`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Physics vs computation framing, three-example roadmap, $\Phi^*$ foreshadow. |
+| Terminology Consistency | 5 | measuring device, pullback, finite interval/grid/box sequence. |
+| English Information Structure | 5 | Blockquote chapter outline preserved. |
+
+**Pass 1 passed.**

--- a/translation/reviews/ch04-4.1-review.md
+++ b/translation/reviews/ch04-4.1-review.md
@@ -1,0 +1,23 @@
+# Review: Chapter 4 §4.1
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Steps ①–⑦, $\gamma_h^\square$, work-energy theorem, Aside on naming. |
+| Mathematical Correctness | 5 | Finite interval → velocity limit; $\gamma^*(F\,dx)$ formula. |
+| Terminology Consistency | 5 | consistency factor, row vector Note, $\Phi_h^\square$. |
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch04-4.0-4.1.md`.

--- a/translation/reviews/ch04-4.2-review.md
+++ b/translation/reviews/ch04-4.2-review.md
@@ -1,0 +1,23 @@
+# Review: Chapter 4 §4.2
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Polar finite grid, $r\,dr\wedge d\theta$, general $2\times2$ Jacobian, Kepler. |
+| Mathematical Correctness | 5 | $\sin\Delta\theta$ finite cell; areal velocity $L/2m$. |
+| Terminology Consistency | 5 | area-measuring device, areal velocity, consistency factor. |
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch04-4.2.md`.

--- a/translation/reviews/ch04-4.3-review.md
+++ b/translation/reviews/ch04-4.3-review.md
@@ -1,0 +1,23 @@
+# Review: Chapter 4 §4.3
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Cylinder mass, finite box, $r\,dr\wedge d\theta\wedge dz$, general $J$. |
+| Mathematical Correctness | 5 | $M_{\text{naive}}$ vs correct mass; determinant as consistency factor. |
+| Terminology Consistency | 5 | volume-measuring device, Jacobian, cylindrical coordinates. |
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch04-4.3.md`.

--- a/translation/reviews/ch04-4.4-review.md
+++ b/translation/reviews/ch04-4.4-review.md
@@ -1,0 +1,22 @@
+# Review: Chapter 4 §4.4
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.4 Properties of the Pullback — What We Have Established So Far`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Five properties, Jacobian definition, $d$ commutation foreshadow. |
+| Terminology Consistency | 5 | parameter-space / physical-space side, wedge compatibility. |
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch04-4.4-4.5.md`.

--- a/translation/reviews/ch04-4.5-review.md
+++ b/translation/reviews/ch04-4.5-review.md
@@ -1,0 +1,22 @@
+# Review: Chapter 4 §4.5
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+Scope: `§4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative`
+
+## Pass scope
+
+| Pass | Status |
+|------|--------|
+| Pass 1 | **passed** |
+| Pass 2 | included in `ch04-pass2.md` |
+| Pass 3 | included in `ch04-pass3.md` |
+
+## Scores (Pass 1)
+
+| Item | Score | Notes |
+|---|---:|---|
+| Source Fidelity | 5 | Four-chapter recap, unified pullback principle, Chapter 4 checkpoint. |
+| Terminology Consistency | 5 | exterior derivative foreshadow; finite-cell summary bullets. |
+
+**Pass 1 passed.** Integrated from `translation/drafts/ch04-4.4-4.5.md`.

--- a/translation/reviews/ch04-close-reading-polish.md
+++ b/translation/reviews/ch04-close-reading-polish.md
@@ -1,9 +1,9 @@
 # Close-Reading Polish: Chapter 4
 
-Review date: 2026-05-22  
-Branch: `ai/english-translation-ch04`  
-File: `manuscript/en/ch04/ch04.md`  
-GitHub issue: #182  
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+File: `manuscript/en/ch04/ch04.md`
+GitHub issue: #182
 PR context: #163
 
 Scope: publication polish after Pass 3 — derivative notation (`\gamma'(t)`, `\theta'(t)`), modern English for derivatives, `J` vs `|J|` clarity, preservation of finite-cell discovery arc.

--- a/translation/reviews/ch04-close-reading-polish.md
+++ b/translation/reviews/ch04-close-reading-polish.md
@@ -1,0 +1,67 @@
+# Close-Reading Polish: Chapter 4
+
+Review date: 2026-05-22  
+Branch: `ai/english-translation-ch04`  
+File: `manuscript/en/ch04/ch04.md`  
+GitHub issue: #182  
+PR context: #163
+
+Scope: publication polish after Pass 3 — derivative notation (`\gamma'(t)`, `\theta'(t)`), modern English for derivatives, `J` vs `|J|` clarity, preservation of finite-cell discovery arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** §4.0, §4.4: `differential coefficient(s)` → `derivative` / `partial derivatives`
+- **B2** §4.1–§4.5: coordinate-function derivatives use `\gamma'(t)`, `x'(t)`, `y'(t)`, `\theta'(t)`; removed `dx/dt`, `dy/dt`, `d\theta/dt`, `d\gamma/dt` from determinants, checkpoints, and summaries; **kept** `dv/dt` in work-energy derivation (§4.1)
+- **B3** §4.3: clarified signed `J` (formal pullback) vs `|J|` (non-oriented volume/mass)
+
+### C items (straightforward)
+
+- **C1** §4.0: `using boxy computation`
+- **C2** §4.0: chapter-order blockquote → bullet list
+- **C3** §4.1: pullback of physical-space $1$-form to time side
+- **C4** §4.1: `\frac{dv}{dt}\,dt` / `\gamma^*(dv)` wording
+- **C7** §4.2: note heading capitalization
+- **C8** §4.2: measuring device eats finite cell
+- **C9** §4.2: folded standalone `appears.` into preceding sentence
+- **C10** §4.2: limiting rebuild wording for $\Phi^*$
+- **C11** §4.2: consistency factor comparison to §4.1
+- **C12** §4.2: difference ratios converge to partial derivatives
+- **C13** §4.2: finite-cell / limiting rebuild split
+- **C14** §4.2: final conservation sentence
+- **C15–C16** §4.3: finite-cell version / limiting rebuild wording
+- **C17** §4.3: consistency coefficient carries over
+- **C18** §4.3: difference ratios wording
+- **C19** §4.3: measured value assigned to finite box
+- **C20** §4.3: `This agrees with the correct value.`
+- **C21** §4.3: cross-chapter conservation pattern sentence
+- **C22–C23** §4.4: Jacobian determinant wording
+- **C25–C26** §4.5: checkpoint and summary consistency-factor wording
+- **C27** §4.5: exterior derivative closing sentence
+
+### Intentionally unchanged (D items / optional C)
+
+- **C5** §4.1 work integral chain (`\int F\,dx = \int_{\gamma} F\,dx = \cdots`) — kept pedagogical step
+- **C6** §4.1 pullback Aside (`push forward` typography) — preserved authorial voice
+- **C24** §4.4 wedge compatibility sentence — kept as-is
+- `boxy`, `make things consistent`, `rebuild measuring devices`, steps ①–⑦, full pullback Aside, `\Phi_h^\square` vs `\Phi^*`, curved cell vs parallelogram distinction, vector-analysis bridge notes, cylindrical mass calculation, exterior-derivative foreshadow
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- `differential coefficient`, `differential coefficients` — none
+- `dx/dt`, `dy/dt`, `d\theta/dt` — none
+- `velocity $d\gamma/dt$` — none
+- `Jacobi determinant` — none
+- `finite cell pullback` — none
+- `We agree with the correct value` — none
+
+`dv/dt` retained in §4.1 work-energy derivation (intentional).
+
+`git diff --check` passes.

--- a/translation/reviews/ch04-pass2.md
+++ b/translation/reviews/ch04-pass2.md
@@ -1,0 +1,52 @@
+# Pass 2 Review: Chapter 4
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+File: `manuscript/en/ch04/ch04.md`
+
+Pass 2 scope: English information structure, naturalness, pedagogical flow. Math unchanged.
+
+---
+
+## Stage 1: §4.0–§4.1 (complete)
+
+- Replaced outdated YAML draft (wrong chapter: exterior derivative).
+- $W_{\text{実}}$, $W_{\text{素朴}}$ → $W_{\text{phys}}$, $W_{\text{naive}}$ for English subscripts (aligns with $M_{\text{naive}}$ in §4.3).
+- Kept numbered discovery steps ①–⑦ and $\Phi_h^\square$ Note block.
+
+**Passed.**
+
+---
+
+## Stage 2: §4.2–§4.3 (complete)
+
+- Polar / cylindrical finite-cell derivations read cleanly; no structural edits.
+- Terminology: consistency factor, areal velocity, Jacobian — consistent with glossary.
+
+**Passed.**
+
+---
+
+## Stage 3: §4.4–§4.5 (complete)
+
+- Properties list and Chapter 4 checkpoint preserved.
+- Transition to exterior derivative $d$ clear.
+
+**Passed.**
+
+---
+
+## Stage 4: Whole chapter (complete)
+
+- Terminology scan: measuring device, pullback, no area meter, no rot, no YAML.
+- Section `---` separators between §4.1/§4.2/§4.3/§4.4.
+
+**Passed.**
+
+---
+
+# Overall Chapter 4 Pass 2 Result
+
+**Chapter 4 passes Pass 2** on `ai/english-translation-ch04`.
+
+Body: §4.0–§4.5 (~730 lines). Pass 3 in `ch04-pass3.md`.

--- a/translation/reviews/ch04-pass3.md
+++ b/translation/reviews/ch04-pass3.md
@@ -1,0 +1,71 @@
+# Pass 3 Review: Chapter 4
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch04`
+File: `manuscript/en/ch04/ch04.md`
+
+Pass 3 scope: authorial voice, note/aside handling, heading quality, publication polish.
+
+Approach: same as Chapters 1–3 — keep distinctive voice; minimal consistency fixes only.
+
+---
+
+## Decisions
+
+### 1. Chapter title and § headings
+
+Decision: **maintain** as integrated; aligned with `manuscript/en/toc.md` (pullback chapter, not exterior derivative).
+
+### 2. Discovery-based numbered steps (①–⑦)
+
+Decision: **keep** throughout §4.1–§4.3.
+
+Reason: Central pedagogical device of this chapter; matches Japanese “finite cell → limit” arc.
+
+### 3. “Pullback” naming Aside (§4.1)
+
+Decision: **keep** full authorial Aside (“push forward” vs pullback, parameter space as departure point).
+
+Reason: Book-specific voice; same class as ch02 “biased glasses” and ch03 elementary-school debt.
+
+### 4. Physics background Notes
+
+Decision: **keep** Notes for readers without physics (§4.1, §4.2).
+
+Reason: Explicit in source; reduces barrier without dumbing down math.
+
+### 5. $\Phi_h^\square$ vs $\Phi^*$ Note (§4.1)
+
+Decision: **keep** full multi-paragraph Note (parallelogram vs curved sector image).
+
+Reason: Terminologically critical for later chapters; trimming would lose clarity.
+
+### 6. Vector-analysis bridge Notes (§4.3)
+
+Decision: **keep** as guide rails only.
+
+Reason: Matches §3.4 pattern.
+
+### 7. Minor edits applied (Pass 2)
+
+| Location | Change | Reason |
+|----------|--------|--------|
+| §4.1 | $W_{\text{実/素朴}}$ → $W_{\text{phys/naive}}$ | English subscripts |
+| §4.1–§4.4 | `---` between major sections | Integration formatting |
+
+### 8. No change
+
+- “Make things consistent” / つじつま framing.
+- Long cylindrical-coordinate mass calculation (§4.3).
+- §4.4 $d$-commutation foreshadow.
+- Chapter 4 checkpoint blockquote length.
+
+---
+
+# Overall Chapter 4 Pass 3 Result
+
+**Chapter 4 passes Pass 3** on `ai/english-translation-ch04`.
+
+English Chapter 4 (`manuscript/en/ch04/ch04.md`, §4.0–§4.5) is **Pass 1 + Pass 2 + Pass 3 complete**.
+
+Next: push branch; open PR with base `ai/english-translation-ch03`; begin Chapter 5.


### PR DESCRIPTION
## Summary
- Replace outdated YAML English ch04 draft (mislabeled as exterior derivative) with full pullback chapter from Japanese source.
- Translate §4.0–§4.5: finite-cell discovery arc for 1/2/3-form pullbacks, properties, chapter summary.
- Pass 2/3 recorded in `translation/reviews/ch04-pass{2,3}.md`; per-section Pass 1 reviews for §4.0–§4.5.
- Branch replayed on current `main` after #162 merge; diff is ch04-only.

## Scope
| Section | Content |
|---------|---------|
| §4.0 | Physics curves / computation uses boxes |
| §4.1 | 1-form pullback, work-energy theorem, $\Phi_h^\square$ |
| §4.2 | 2-form pullback, polar grid, areal velocity / Kepler |
| §4.3 | 3-form pullback, cylindrical coords, Jacobian |
| §4.4 | Pullback properties, $d$-commutation foreshadow |
| §4.5 | Chapter summary; exterior derivative outlook |

## Test plan
- [ ] Diff against `manuscript/ja/ch04/ch04.md`
- [ ] Terminology: pullback, measuring device, consistency factor; no YAML
- [ ] Review records: `ch04-pass2.md`, `ch04-pass3.md`
- [ ] Merge to `main` (Chapter 3 already on `main` via #162)