### PR TITLE
English Chapter 5: §5.0–§5.11 + Appendices B–C (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch05/ch05.md
+++ b/manuscript/en/ch05/ch05.md
@@ -1,594 +1,1049 @@
----
-title: "Chapter 5: The Metric $g$ — The Conversion Matrix Connecting Two Cartesian Coordinates"
-series: dx-matrix
-chapter: 5
-order: 50
-assumes:
-- one_form
-- two_form
-- three_form
-- wedge_product
-- exterior_derivative
-- stokes_theorem
-- gauss_theorem
-introduces:
-  metric:
-    from: definition
-    to: computation
-  hodge_star:
-    from: definition
-    to: computation
-  nabla_operators:
-    from: intuition
-    to: formula
-previews:
-  unified_stokes:
-    max_level: mention
-  maxwell_forms:
-    max_level: intuition
-recap_policy:
-  exterior_derivative:
-    max_level: mention
-    max_lines: 4
-  wedge_product:
-    max_level: mention
-    max_lines: 3
----
+# Chapter 5: What Does It Mean to Differentiate? — The Exterior Derivative $d$: Integral Quantities and Local Laws
 
-# Chapter 5: The Metric $g$ — The Conversion Matrix Connecting Two Cartesian Coordinates
+### §5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential
 
-### §5.0 End of Excuses — Liberating the Inner Product
+In Chapter 3 we defined integration over curves, surfaces, and regions in the language of $k$-forms. Work along a curve $\gamma$ is $\int_\gamma \omega$, flux through a surface $S$ is $\iint_S \eta$, and the total mass of a region $V$ is $\iiint_V \Omega$. Each followed the same principle: feed $k$ displacement vectors to a $k$-form (measuring device), obtain a scalar, and aggregate over the entire region.
 
-When we derived the surface area $4\pi R^2$ of a sphere in Chapter 2, and when we measured arc length as the square root of the sum of squares in Chapter 3 — every time this book has computed lengths or areas up to now, we have padded the text with excuses like "a mathematician would scold us for not having a metric, but let us brazenly press on."
+In Chapter 4 we introduced the operation that rebuilds measuring devices to compute the same integral in different variables—the pullback $\Phi^*$. With that, we also gained a tool for changing the variables of computation while preserving the integral value.
 
-The reader is probably growing tired of this by now. To be honest, the author is also weary of it.
+The integrals we now have in hand are all quantities that span an <strong>entire region</strong> (below we call such quantities <strong>global</strong>). Work is the total sum over an entire curve, flux is the total amount crossing an entire surface, and mass is the grand total over an entire region. They depend on how the measuring device is applied and on the choice of region.
 
-After all, we are computing on the orthogonal Cartesian coordinates $(x,y,z)$ of real space. The Pythagorean theorem holds in this space. Whose permission do we need? Let us use the **inner product** without further apology.
+But this alone is not what physicists ultimately want. Behind the laws observed as integral quantities, they want to see local relations that hold at each point. Whether Maxwell's equations or the Navier–Stokes equations, the fundamental laws of nature are written as <strong>local</strong> relations—differential equations—that describe <strong>what holds at each point in space and each instant in time</strong>. Global integral quantities depend on the region, but local laws have a universality that does not depend on the region.
 
-What is the inner product? We have already encountered it many times. In Chapter 2, when we obtained the oriented area, we said that the square root of the sum of squares of the three shadow components $A_{yz}, A_{zx}, A_{xy}$ matches the elementary-school area — that very "sum of squares" is the inner product (or rather, the square root thereof) with itself. More generally, we call the **inner product** the scalar quantity obtained by multiplying the corresponding components of an $n$-form (a horizontal vector) in real space and adding them up, or by multiplying the corresponding components of an $n$-vector (a vertical vector) and adding them up.
+> <strong>Note</strong> (the terms global / local) Other books sometimes call a similar contrast <strong>macro / micro</strong>. In this chapter, however, we use global / local to mean the contrast between a quantity integrated over an entire region and a relation that holds at each point—not so much a difference of scale.
 
-...That is all. Many readers likely learned the inner product in high school mathematics, so they may think, "Why state the obvious?" Nevertheless, it is true that this book has not defined the inner product head-on until now. There is a reason for that.
+Here a fundamental question arises.
 
-Mathematicians hold that "addition and subtraction of vectors" and "the inner product" are not inseparable — they believe the two can be considered entirely separately. That is why they make a point of distinguishing between "spaces endowed with an inner product" and "spaces without one." And they call the matrix that defines the inner product the **metric tensor**.
+> <strong>How do we extract a local law from an integrated quantity?</strong>
 
-But wait — there is an important distinction to make here.
+The subject of this chapter—the <strong>exterior derivative $d$</strong>—answers this question. $d$ is an operator that acts on a $k$-form and returns a $(k+1)$-form; combined with the integrals defined in Chapter 3, it translates a "global integral measured on the boundary" into "an accumulation of local changes in the interior." In short, <strong>$d$ is the device that converts integral laws into differential laws</strong>.
 
-Since Chapter 1, we have performed countless calculations in which a horizontal vector times a vertical vector yields a scalar. So what is the difference between that and the inner product?
-
-In a word: they are **entirely different things**. Multiplying a horizontal vector by a vertical vector is a computation between "different types of vectors — horizontal and vertical." The inner product, by contrast, is a computation between **vectors of the same type** — "horizontal and horizontal" or "vertical and vertical."
-
-Indeed, the matter is deeper than the reader might suppose. In the special setting of real space, these two happen to return the same numerical value in many cases, and this has led to their conflation — and on that conflation, the vast edifice of vector calculus has been built. The goal of this chapter is to clarify this distinction, then to derive the metric $g$ as a natural generalization of the inner product, and from there to expose the true nature of the Hodge star $\ast$.
+The structure of this chapter is as follows. First we recall the $df$ introduced in Chapter 1 and build $d\omega$ from the mismatch that remains when a general $1$-form is measured on a closed loop. Next we extend the same idea to $2$-forms and unify Stokes' theorem and Gauss' theorem into a single form. Finally we look at the structure $d^2=0$ and at how the exterior derivative localizes physical laws, connecting to the Hodge star in the next chapter.
 
 ---
 
-### §5.1 Inner Product in Parameter Space — The True Nature of the Metric $g$
+### §5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?
 
-#### 5.1.1 Inner Product in Real Space
+#### 5.1.1 $df$ Is "Raising the Degree"
 
-Let us write two vertical vectors in real space $(x,y,z)$ in components.
+In Chapter 1 §1.2 we defined the total differential of a function $f(x,y,z)$ as a row vector:
 
-$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
 
-In this book we define the **inner product** (dot product) as the operation of multiplying components with the same index and taking the sum, denoted by the symbol $\cdot$.
+This is an operation that takes a <strong>$0$-form (the scalar field $f$) as input and outputs a $1$-form (the row vector $df$)</strong>. The degree rises from 0 to 1.
 
-$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
+Recall here that $df(\mathbf{v})$ returns the first-order change in $f$ for a displacement $\mathbf{v}$. When $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ is sufficiently small:
 
-As long as we use $xyz$ coordinates, no further apparatus is needed to compute the inner product.
+$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
 
-#### 5.1.2 Taking the Inner Product in Parameter Space
+$df$ by itself is not "the change itself"—as agreed in Chapter 1 §1.1.6, $df$ is an operator; a numerical value is obtained only when it acts on a displacement vector.
 
-What happens, then, if we express the same two vectors in the language of parameter space $(r,\theta,z)$? Physicists often use the technique of transferring computations in real space onto parameter space coordinates — typically when a judicious choice of parameter space makes the integration region rectangular. But naively computing $\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$ in parameter space does not give the correct inner product in real space. This is because the correspondence between the tick marks of real space and parameter space varies with location.
+#### 5.1.2 A Line Integral Leaves Only the Difference of Endpoints
 
-What correction, then, must we apply to make the sum of products of parameter space components coincide with the inner product in real space?
+Integrate this $df$ along a curve $\gamma$. As in Chapter 3 §3.3.1, partition the curve into small intervals, feed $df$ each step's displacement $\Delta\mathbf{r}_i$, and add up the results.
 
-In Chapter 1 §1.5 we learned the rule for converting a displacement in parameter space into a displacement in real space — multiply by the Jacobian matrix $J$.
+On each interval $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
 
-$$J = \begin{pmatrix}
-\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
-\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
-\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
-\end{pmatrix}$$
+$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
 
-Computing the partial derivatives from the cylindrical coordinate conversion formulas $x = r\cos\theta,\; y = r\sin\theta,\; z = z$, we obtain:
+Expanding this sum:
 
-$$J = \begin{pmatrix}
-\cos\theta & -r\sin\theta & 0 \\
-\sin\theta & r\cos\theta & 0 \\
-0 & 0 & 1
-\end{pmatrix}$$
+$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
 
-Write the vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space in components.
+Adjacent terms $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ cancel in plus and minus—a <strong>telescoping sum</strong>. Only the first and last survive. In the limit of infinitely fine partition:
 
-$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
 
-Pulling these back to real space yields $J\mathbf{v}_1$ and $J\mathbf{v}_2$, respectively. Now that they are inhabitants of real space, we simply take the inner product in real space.
+where $A$ is the starting point of the curve and $B$ is the endpoint.
 
-$$\text{inner product} = (J\mathbf{v}_1) \cdot (J\mathbf{v}_2)$$
+> <strong>Checkpoint so far</strong>
+> - $\int_\gamma df = f(B) - f(A)$. The result of the integral depends entirely on the endpoint values, not at all on the shape of the path.
+> - This holds precisely because $df$ is a special $1$-form. In mechanics, it is the mathematical reason why "the work of a conservative force does not depend on the path."
 
-Here we can deliberately recast this into a matrix product using a theorem of linear algebra — that is, using the transpose theorem to write $(J\mathbf{v}_1)^T (J\mathbf{v}_2)$. Since $(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$, we have:
+#### 5.1.3 Checking with a Chapter 3 Example
 
-$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
+In Chapter 3 §3.4.1 we integrated $\omega = y\,dx + x\,dy$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ and found the result to be $0$. At the time we integrated straightforwardly along the coefficients, but viewed in today's language the story is much simpler.
 
-Now let us actually compute $J^T J$. $J^T$ is $J$ with rows and columns interchanged.
+In fact $y\,dx + x\,dy$ is nothing other than $d(xy)$. For:
 
-$$J^T = \begin{pmatrix}
-\cos\theta & \sin\theta & 0 \\
--r\sin\theta & r\cos\theta & 0 \\
-0 & 0 & 1
-\end{pmatrix}$$
+$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
 
-Therefore,
+Therefore $\omega = df$ (with $f = xy$), and the telescoping-sum argument of §5.1.2 applies as-is. The unit circle is a closed curve, so $B = A$, and hence:
 
-$$J^T J = \begin{pmatrix}
-\cos\theta & \sin\theta & 0 \\
--r\sin\theta & r\cos\theta & 0 \\
-0 & 0 & 1
-\end{pmatrix}
-\begin{pmatrix}
-\cos\theta & -r\sin\theta & 0 \\
-\sin\theta & r\cos\theta & 0 \\
-0 & 0 & 1
-\end{pmatrix}
-= \begin{pmatrix}
-1 & 0 & 0 \\
-0 & r^2 & 0 \\
-0 & 0 & 1
-\end{pmatrix}$$
+$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$
 
-The algebraic identity $\cos^2\theta + \sin^2\theta = 1$ acts as the proxy for all the geometry, leaving $1, r^2, 1$ on the diagonal. We never once thought about the arc length in the $\theta$ direction — this is a purely algebraic transformation that used only the properties of matrix multiplication and transpose.
+The calculation $\int_0^{2\pi} \cos 2t\,dt = 0$ from back then mechanically gave zero precisely because $\omega$ was an <strong>exact form</strong>, namely $d(xy)$.
 
-**And so something new has emerged.** To obtain the same result as the inner product in real space using vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space, we simply insert the matrix $J^T J$ between them. This matrix has appeared as a consequence of following the natural procedure of "pull back to real space and take the inner product" — nothing more.
+> <strong>Note</strong> (exact forms) A $1$-form that can be written as $\omega = df$ is called an <strong>exact form</strong>. Integrating an exact form along a closed curve always gives zero, as long as $f$ is a single-valued function. On the other hand, beware: "the integral along some closed curve was zero" does not necessarily mean the form is exact (whether the integral is zero on all closed curves also depends on the topology of the region). We examine this point in detail in §5.2.
 
-In mathematics this $J^T J$ is called the **metric matrix $\mathbf{g}$**.
-
-$$\mathbf{g} = J^T J$$
-
-The reason we never needed the concept of $g$ while working in $xyz$ coordinates is not that $J$ effectively becomes $I$. Rather, in $xyz$ coordinates the operation of "pulling back" is itself unnecessary. Only when we come to parameter space do we need this matrix to compute the inner product correctly — and its contents can be obtained mechanically from partial derivatives and matrix multiplication so long as we know the Jacobian $J$. There is no room here for new axioms of geometry to creep in.
-
-Let us verify this with concrete numbers for good measure. Consider the point $r=2,\; \theta=\pi/3$. Here $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$, so:
-
-$$J = \begin{pmatrix}
-1/2 & -\sqrt{3} & 0 \\
-\sqrt{3}/2 & 1 & 0 \\
-0 & 0 & 1
-\end{pmatrix}$$
-
-In parameter space, consider the vector $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$, a unit displacement in the $\theta$ direction. We have $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, and now $r=2$ so $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$. Computing the inner product (squared length) in parameter space:
-
-$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
-\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
-\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
-
-Meanwhile, pulling the same $\mathbf{v}$ back to real space:
-
-$$J\mathbf{v} = \begin{pmatrix}
-1/2 & -\sqrt{3} & 0 \\
-\sqrt{3}/2 & 1 & 0 \\
-0 & 0 & 1
-\end{pmatrix}
-\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
-
-The inner product (squared length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed coincide. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (a unit displacement in the $r$ direction), we similarly obtain $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$, which coincide. Thus $\mathbf{g} = J^T J$ connects the inner products of parameter space and real space without contradiction.
-
-Although we computed in cylindrical coordinates $(r,\theta,z)$ here, the same approach using $J$ yields $\mathbf{g}$ for spherical coordinates $(r,\theta,\phi)$ as well.
-
-$$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
-
-$r^2$ and $r^2\sin^2\theta$ appear on the diagonal, but these too are conversion coefficients derived mechanically from the chain rule alone.
-
-> **Note** ($g$ in real space and parameter space) In real space $(x,y,z)$ no pullback is needed, so $g$ never makes an appearance. But if we formally write $g=I$, we can write the inner product uniformly in the form $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$, just as in parameter space with $g = J^T J$. $g=I$ is the result — not the cause.
-
-With this $g$ as intermediary, we can consistently compute the inner product (length, angle) in any coordinate system. Moreover, the specification of the Hodge star $\ast$, which we treat in the second half, can also be read naturally from these rules of the inner product.
+> <strong>Note</strong> (the relation between $d$ and $\int$—a boundary formula, not an inverse map) $\int_\gamma df = f(B)-f(A)$ does not mean that integration is a global inverse of the exterior derivative $d$. Integration is a functional that depends on the choice of curve $\gamma$; it is not an operation that reconstructs the entire original function $f$ from $df$. This formula is the fundamental theorem of calculus: "integrating an exact form along a curve leaves only the boundary, namely the endpoints." It is safest to think of it as the $0$-form version of the Stokes-type formulas we will see later.
 
 ---
 
-### §5.2 Conversion Between Vertical and Horizontal Vectors via $g$
+### §5.2 The "Mismatch" Revealed by a Closed Loop
 
-#### 5.2.1 $\mathbf{v}^T \mathbf{g}$ is a Horizontal Vector
+#### 5.2.1 What About a General $1$-Form?
 
-Let us look once more at the inner product expression $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ derived in §5.1. Matrix multiplication proceeds from left to right, so this expression can be read as: first compute $\mathbf{v}_1^T \mathbf{g}$, then multiply that result by $\mathbf{v}_2$.
+What about a general $1$-form
 
-$\mathbf{v}_1$ is a vertical vector, but transposed, $\mathbf{v}_1^T$ is a horizontal vector. Multiplying a horizontal vector by a square matrix yields a horizontal vector again. That is, if we extract the subexpression $\mathbf{v}_1^T \mathbf{g}$, we have:
+$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
 
-$$\omega = \mathbf{v}^T \mathbf{g}$$
+? Here $P, Q, R$ are coefficients that vary from place to place (scalar fields)—the "general $1$-form" introduced in Chapter 3 §3.4.1.
 
-This is a $1 \times 3$ **horizontal vector**. The metric $g$ is, as it emerges naturally from the matrix form of the inner product, a **device that converts vertical vectors into horizontal vectors**.
+> <strong>Note</strong> (what "general" means) The $df$ treated in §5.1 had coefficients of the special combination $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$—a triple derived from partial derivatives of a single function $f$. By contrast, the "general" $\omega$ here has $P, Q, R$ as <strong>three arbitrary scalar fields unrelated to one another</strong>. In other words, we call a $1$-form "general" when it cannot necessarily be written as $\omega = df$. The $y\,dx + x\,dy$ of §5.1.3 happened to be an exact form writable as $d(xy)$, but forms that are not of that kind are rather the norm.
 
-Let us consider the meaning of this conversion. Since Chapter 1, we have distinguished between "the figure being measured (a vertical vector $\mathbf{v}$)" and "the measuring device (a horizontal vector $\omega$)." The two were inhabitants of different worlds. But by way of $g$, a vertical vector that belongs to the side of figures transforms into a denizen of the side of scales — a horizontal vector. The reason the same arrow varies in its "sensitivity as a scale" depending on location is that $\mathbf{g}$ absorbs all the local differences in tick marks.
+$\omega$ need not represent a force; it can represent any "measuring device for measuring along a line."
 
-In real space ($\mathbf{g}=I$), $\omega = \mathbf{v}^T$ and the components of the vertical vector directly become the components of the horizontal vector. In parameter space, $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, so $\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$. The fact that only the $\theta$ component gets multiplied by $r^2$ reflects that the tick marks in the $\theta$ direction are stretched by a factor of $r$.
+For this $\omega$, there is no guarantee that the same telescoping sum as in §5.1 works. The most concise way to decide is to integrate on a <strong>closed loop</strong>—a curve whose start and end coincide. If $\int_\gamma \omega$ could be written only as the difference of endpoint values, then on a closed loop we would have to get $f(A)-f(A)=0$.
 
-Without $g$, "the figure being measured" and "the measuring device" are mutually untransformable. $g$ is the sole mediator that connects the two.
+We write the line integral along a closed loop as $\oint_\gamma \omega$. In general:
 
-#### 5.2.2 What the Metric Provides — The Geometric Size of a $k$-Parallelotope
+$$\oint_\gamma \omega \neq 0$$
 
-The most fundamental role of the metric $g$ is to define the **actual geometric size** (length, area, volume) of the **$k$-parallelotope** spanned by $k$ vectors.
+If you drag an object once around against friction, the work is not zero; if you go once around a swirling current, you receive net work. This <strong>fact that "closing the loop still does not balance the books" is evidence of local structure such as circulation or vorticity</strong>.
 
-In the preceding chapters of this book, we have performed "oriented counting" by feeding $k$ vectors to a $k$-form. $dx(\mathbf{v})$ is the number called the $x$-component of $\mathbf{v}$; $dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ is the number called the oriented area of the parallelogram spanned by $\mathbf{v}_1$ and $\mathbf{v}_2$. But these are at best measurements of shadows — the **true geometric size** — how many meters of line segment the vectors actually span, how many square meters of parallelogram they span — is determined only once the metric $g$ is given.
+> <strong>Note</strong> (no physics background needed) Readers who have not yet treated friction or water flow in physics need not stop here. What matters now is not the specific physical phenomenon but only the sense that "if the integral on a closed loop is not zero, there is local structure like circulation in that field." The detailed physical correspondences will be touched on in later chapters.
 
-For $k=1$ (the line segment spanned by a single vector $\mathbf{v}$), its squared length is defined as the inner product with itself. This is exactly what we derived in §5.1.
+#### 5.2.2 Where Does the Local Information Live?
 
-$$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
+Then where does this "mismatch left after one circuit" come from? If we think of the closed loop only at a global scale all at once, we cannot tell which points inside contributed how much to the mismatch. Recall how we found $f'(x)$ in Chapter 1—we extracted a rate of change <strong>at a single point</strong> by taking the limit $\Delta x \to 0$ of $\Delta f / \Delta x$.
 
-In real space $(\mathbf{g}=I)$, $|\mathbf{v}|^2 = \Delta r^2 + \Delta\theta^2 + \Delta z^2$. In parameter space, $|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$.
+We use the same idea here. As we shrink the loop more and more, what happens to the value of the integral $\oint \omega$ around one circuit? If the leading term of $\oint \omega$ shrinks in proportion to the <strong>area enclosed</strong> by the loop, then the mismatch per unit area—how much the books fail to balance per unit area—should be determined as a value intrinsic to that point.
 
-For $k=0$ (zero vectors, i.e., a point), the "size" of a $0$-form scalar field $f$ is simply its absolute value $|f|$.
+Conversely, if it does not scale that way (for example, if it scales with the perimeter of the loop), it cannot be fixed as a per-area quantity, and we cannot call it "a property at that point." So the question is:
 
-The same applies for $k=2$ (the area of the parallelogram spanned by two vectors) and $k=3$ (the volume of the parallelepiped spanned by three vectors). As we saw in Chapter 2 §2.4.7, the square root of the sum of squares of the coefficients $A_{xy}, A_{yz}, A_{zx}$ of the three basis $2$-forms $dx \wedge dy, dy \wedge dz, dz \wedge dx$ — that is, $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$ — gives the unsigned area of the parallelogram. In $xyz$ coordinates, all that is needed for this computation is the coefficients of the basis $2$-forms; no further information is required.
+> <strong>When a tiny loop is traversed once, does the leading term of $\oint \omega$ scale with the enclosed area? If so, what is the proportionality constant?</strong>
 
-The role of the metric $g$ is to generalize this "computation in $xyz$" to coordinate systems where the tick marks are distorted, such as parameter space. In every case, **once $g$ is determined, a consistent geometric size can be defined for $k$-parallelotopes of every degree** — this is the most fundamental role of the metric.
-
-#### 5.2.3 Axioms of the Inner Product — Properties That Hold in General Dimensions
-
-Just as we summarized the properties of the exterior derivative $d$ in Chapter 4 (linearity, raising degree, $d^2=0$, Leibniz rule), let us collect the universal properties of the inner product that are independent of coordinate system or dimension. Mathematicians call these the **axioms of the inner product**.
-
-1. **Symmetry**: $\mathbf{v}_1 \cdot \mathbf{v}_2 = \mathbf{v}_2 \cdot \mathbf{v}_1$. Let us apply this to the matrix form $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ derived in §5.1. We have $\mathbf{v}_2 \cdot \mathbf{v}_1 = \mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1$, but a scalar is unchanged by transposition, so $\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1 = (\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1)^T = \mathbf{v}_1^T \mathbf{g}^T \mathbf{v}_2$. For this to equal $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$, we must have $\mathbf{g} = \mathbf{g}^T$. That is to say, the symmetry of the inner product implies that $\mathbf{g}$ must be a **symmetric matrix**.
-
-2. **Linearity** (bilinearity): $(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$. Linear in each argument.
-
-3. **Positive definiteness**: $\mathbf{v} \cdot \mathbf{v} > 0$ (for $\mathbf{v} \neq \mathbf{0}$). This guarantees that "squared length" is positive. This is not always the case when signs are mixed, as in special relativity, but it always holds in the three-dimensional real space that is this book's stage.
-
-> **Note** (Contrast between symmetric and antisymmetric matrices)
-> The fact that the area measuring device in Chapter 2 required an antisymmetric matrix ($M = -M^T$),
-> and the fact that the inner product here requires a symmetric matrix ($\mathbf{g} = \mathbf{g}^T$),
-> form a perfect pair. The former is derived from the natural requirement "if they overlap, the result is zero," the latter from the equally natural requirement "the same value regardless of order." In the world of matrices, antisymmetry governs oriented counting (signed area and volume), while symmetry governs unoriented size (unsigned area and volume) and angle.
-
-#### 5.2.4 Embedding the Geometry of the Metric Matrix in Its Components
-
-The diagonal components of $\mathbf{g}$ represent "how much a step along that axis contributes to length," while the off-diagonal components represent "how much steps along different axes interfere with each other." The reason $\mathbf{g}$ for cylindrical coordinates was a diagonal matrix is that the axes $r, \theta, z$ are mutually orthogonal. In any case, the single matrix $\mathbf{g}$ bears, in its components, all the properties of the "ruler" at that location.
-
-> **Note** (The mathematician's inner product — reversal of axioms and matrix order) In standard linear algebra textbooks, the above axioms are defined first, and then the theorem is derived that "an operation satisfying these can, upon choosing a basis, always be written in the form $\mathbf{v}^T \mathbf{g} \mathbf{w}$ using a symmetric matrix $\mathbf{g}$." The logical order is the reverse of ours. For a mathematician, the matrix representation is merely one expression of an abstract truth, realized in a particular coordinate system. But for a physicist, **this matrix $\mathbf{g}$ is itself the tick marks of space**, the starting point of all measurement. We do not derive the matrix from the axioms; rather, it is because the matrix is there that space is endowed with properties — this book takes the latter stance. It is not a question of which is correct. The mathematician looks at the abstraction; we look at the implementation. We are simply facing different directions.
-
-> **【Checkpoint — §5.0–§5.2】**
-> - The inner product is an operation that takes the sum of products of components between vectors of the same type (horizontal × horizontal, or vertical × vertical). It is distinct from horizontal × vertical.
-> - To compute the inner product in parameter space, we first pull back to real space and then compute. In that process $J^T J$ naturally appears. This is the true nature of the metric $g$.
-> - $g$ converts vertical vectors into horizontal vectors. With $g$ as intermediary, the geometric size of a $k$-parallelotope of any degree can be defined.
-> - The axioms of the inner product (symmetry, linearity, positive definiteness) imply the symmetry of $g$. This pairs with the antisymmetry of the area measuring device $\wedge$.
+In the next section we actually answer this question with a tiny rectangle placed in the $xy$ plane.
 
 ---
 
-### §5.3 The Hodge Star $\ast$ — A Translator Connecting Two Methods
+### §5.3 Dismantling an Infinitesimal Loop — The Mismatch Is Proportional to Area
 
-#### 5.3.1 Two Ways to Obtain a Scalar
+#### 5.3.1 A Tiny Rectangle in the $xy$ Plane
 
-By now the true nature of $g = J^T J$ is clear, and we can compute the inner product in any coordinate system. Let us step back and survey the bigger picture. In physics, when we wish to obtain a meaningful scalar quantity (energy, work, etc.) at each point in space, we have in principle **two distinct methods**.
+Consider a tiny rectangle parallel to the $xy$ plane, with the point $(x, y, z)$ as its lower-left vertex. Let the width in the $x$ direction be $\Delta x$ and the width in the $y$ direction be $\Delta y$. Traverse the four edges of this rectangle once in the <strong>counterclockwise (right-handed) direction</strong>, and integrate $\omega = P\,dx + Q\,dy + R\,dz$.
 
-**Method ① (the method of differential forms)**: Prepare a measuring device (horizontal vector: a $1$-form, etc.) and a figure to be measured (vertical vector: a vector field, etc.), then obtain a scalar via the horizontal × vertical computation. No metric is required for this. It is the pure logic of counting.
+Let us evaluate the integral on each edge using a first-order Taylor approximation (with $\Delta x, \Delta y$ sufficiently small).
 
-**Method ② (the method of the inner product)**: Unify all quantities as "arrows of the same kind" and obtain a scalar through the inner product of vectors of the same type (vertical × vertical, or horizontal × horizontal). This computation indispensably requires a metric. Most readers will be familiar with this method from their school education.
+> <strong>Note</strong> (on Taylor expansion) There is no need to be intimidated by the words "Taylor expansion." What we use here is the first-order approximation of a multivariable function—the same thing as $\Delta f \approx f'(x)\,\Delta x$ in Chapter 1 §1.2.1. For example, the value of $Q(x+\Delta x, y)$ shifted by $\Delta x$ in the $x$ direction can be approximated as $Q + \frac{\partial Q}{\partial x}\,\Delta x$ using the partial derivative of $Q$ with respect to $x$. When $\Delta x$ is sufficiently small, terms of order $(\Delta x)^2$ and higher are overwhelmingly smaller than $\Delta x$ and may be ignored—that is what first-order approximation means.
 
-In fact, whichever method one adopts, the final physical result is the same. This is merely a difference of representation.
+$z$ is fixed, so $dz=0$ and the $R$ term contributes nothing.
 
-However, a practical problem arises here. In the framework of Method ②, quantities that should properly be measured as "surfaces" ($2$-forms) and quantities measured as "lines" ($1$-forms) are all packed into the same "three-component arrow." To handle the concepts of area and volume from Method ① within the "inner product of arrows" framework of Method ②, a **mechanism for type conversion** is needed.
+<strong>Edge 1 (bottom edge, rightward)</strong>: from $(x, y)$ to $(x+\Delta x, y)$. With $y$ fixed, $dy=0$. $P$ is approximately $P(x, y, z)$. Contribution: $P(x, y, z)\,\Delta x$.
 
-The number of independent components of a $k$-form has a characteristic symmetry. As we saw in Chapter 2 §2.5.9, in three-dimensional space a $0$-form has $1$ component, a $1$-form has $3$ components, a $2$-form also has $3$ components, and a $3$-form has $1$ component — symmetric about the middle, $1, 3, 3, 1$. There must exist some correspondence between $1$-forms and $2$-forms, and between $0$-forms and $3$-forms, which have the same number of independent components. The device that provides this correspondence is precisely the **Hodge star $\ast$**.
+<strong>Edge 2 (right edge, upward)</strong>: from $(x+\Delta x, y)$ to $(x+\Delta x, y+\Delta y)$. $dx=0$. Evaluate $Q$ at the position shifted by $\Delta x$ in the $x$ direction:
+$$Q(x+\Delta x, y, z) \approx Q(x, y, z) + \frac{\partial Q}{\partial x}\Delta x$$
+Contribution: $\bigl(Q + \frac{\partial Q}{\partial x}\Delta x\bigr)\,\Delta y$.
 
-$\ast$ reads in the information of the inner product (that is, $g$) and converts a given form into another form such that their inner product yields the volume. Many of the operations treated in vector calculus textbooks as surface directions or cross products are in fact nothing other than this type conversion by $\ast$. In this book, we will construct this $\ast$ concretely using matrix representation.
+<strong>Edge 3 (top edge, leftward)</strong>: from $(x+\Delta x, y+\Delta y)$ to $(x, y+\Delta y)$. The direction is negative, so the sign flips. Evaluate $P$ at the position shifted by $\Delta y$ in the $y$ direction:
+$$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y$$
+Contribution: $-\bigl(P + \frac{\partial P}{\partial y}\Delta y\bigr)\,\Delta x$.
 
-> **Note** (Between the two methods) There is no need to restrict oneself to only one of Method ① or Method ②. The author's ideal is to be able to move freely between both. The reason this book started from Method ① (differential forms) is to build a solid foundation that does not depend on the distortion of space. On top of that foundation, translate to the language of Method ② when necessary — and $\ast$ is the tool for that translation.
+<strong>Edge 4 (left edge, downward)</strong>: from $(x, y+\Delta y)$ back to $(x, y)$. Contribution: $-Q(x, y, z)\,\Delta y$.
 
-#### 5.3.2 Constructing $\ast$ from Matrices
-
-In the appendix of Chapter 2, we learned how to represent $2$-forms as matrices. The three basis $2$-forms $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$ can each be represented by a $3 \times 3$ antisymmetric matrix.
-
-Now, let us pose a naive question. An arbitrary $1$-form $\omega = P\,dx + Q\,dy + R\,dz$ is written, in the convention of this book, as the horizontal coefficient vector $\begin{pmatrix} P & Q & R \end{pmatrix}$. Can we distribute each component of this horizontal vector as the coefficient of the corresponding basis $2$-form matrix — that is, multiply $P$ by the matrix for $dy \wedge dz$, $Q$ by the matrix for $dz \wedge dx$, and $R$ by the matrix for $dx \wedge dy$, and add them?
-
-In matrix terms,
-
-$$
-\ast\omega
-=
-P
-\begin{pmatrix}
-0 & 0 & 0 \\
-0 & 0 & 1 \\
-0 & -1 & 0
-\end{pmatrix}
-+
-Q
-\begin{pmatrix}
-0 & 0 & -1 \\
-0 & 0 & 0 \\
-1 & 0 & 0
-\end{pmatrix}
-+
-R
-\begin{pmatrix}
-0 & 1 & 0 \\
--1 & 0 & 0 \\
-0 & 0 & 0
-\end{pmatrix}.
-$$
-
-This is nothing other than a simple linear combination that distributes the components of the horizontal vector to three antisymmetric matrices. Let us write this with the symbol $\ast$.
-
-Computing this concretely:
-
-$$
-\ast\omega
-=
-\begin{pmatrix}
-0 & R & -Q \\
--R & 0 & P \\
-Q & -P & 0
-\end{pmatrix}.
-$$
-
-This $3 \times 3$ antisymmetric matrix is the matrix representation of $\ast\omega$. The coefficients $P, Q, R$ of the original $1$-form sit directly in fixed positions of the matrix. Moreover, this matrix coincides perfectly with the cross product matrix we saw in Chapter 2 §2.4.9.
-
-> **Note** (The geometric meaning of $\ast$) The $2$-form represented by $\ast\omega$ is an area measuring device that measures the plane orthogonal to the coefficient vector $(P, Q, R)$ of $\omega$. A line segment in the $x$-axis direction ($dx$) corresponds to the plane perpendicular to the $x$-axis ($dy \wedge dz$). What vector calculus treats as a three-component arrow is, in the language of this book, a way of rereading this area measuring device.
-
-#### 5.3.3 The $\ast$ Dictionary in Real Space
-
-Rewriting the above matrix representation in the language of $dx, dy, dz$, we obtain the following concise dictionary:
+Summing the contributions from all four edges:
 
 $$\begin{aligned}
-\ast(1) &= dx \wedge dy \wedge dz, \qquad &\ast(dx \wedge dy \wedge dz) &= 1 \\
-\ast(dx) &= dy \wedge dz, \qquad &\ast(dy \wedge dz) &= dx \\
-\ast(dy) &= dz \wedge dx, \qquad &\ast(dz \wedge dx) &= dy \\
-\ast(dz) &= dx \wedge dy, \qquad &\ast(dx \wedge dy) &= dz
+\oint \omega &\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \\
+&= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \\
+&= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
 \end{aligned}$$
 
-The meaning of this dictionary is simple. A line segment in the $x$-axis direction ($dx$) corresponds to the plane perpendicular to the $x$-axis ($dy \wedge dz$). Similarly $y \leftrightarrow dz \wedge dx$, $z \leftrightarrow dx \wedge dy$. And the scalar $1$ ($0$-form) and the volume element $dx \wedge dy \wedge dz$ ($3$-form) correspond to each other. This is precisely the manifestation of the symmetry $1, 3, 3, 1$ of the independent component counts that we saw in Chapter 2.
+The terms $P\Delta x$ and $Q\Delta y$ cancel beautifully, leaving only $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$.
 
-> **Note** (Why this dictionary is correct) $\ast dx = dy \wedge dz$ holds because $dx, dy, dz$ form an orthonormal basis (mutually orthogonal and of length $1$), and because we have taken the orientation of space to be right-handed, with $dx \wedge dy \wedge dz$ positive. Under these conditions, the above dictionary is uniquely determined. The dictionary of $\ast$ depends on the metric $g$ and the choice of orientation of space — if $g$ were not $I$, the dictionary coefficients would become more complicated.
+#### 5.3.2 The Decisive Fact
 
-#### 5.3.4 $\ast\ast = \mathrm{id}$
+This result tells us just one thing:
 
-As is immediately apparent from the above dictionary, applying $\ast$ twice in succession returns us to the original:
+> <strong>The leading term of the mismatch left after one circuit is proportional to the enclosed area $\Delta x\,\Delta y$.</strong>
 
-$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx$$
+And the proportionality constant $\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ is precisely the <strong>mismatch per unit area</strong> at the point $(x,y,z)$—a local quantity representing the "strength of vorticity" at that point. More precisely, for the tiny rectangle $R_{\Delta x,\Delta y}$,
 
-In general, in three-dimensional Cartesian real space, $\ast\ast = \mathrm{id}$ (the identity map) holds. Applying $\ast$ once inverts the degree of the form; applying it twice restores the original.
+$$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\Delta x,\Delta y}}\omega = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$$
 
-> **【Checkpoint — §5.3】**
-> - There are two methods for obtaining a scalar: Method ① (horizontal × vertical, no metric required) and Method ② (inner product of same-type vectors, metric required).
-> - The symmetry $1,3,3,1$ seen in Chapter 2 suggests that a correspondence can be established between $1$-forms and $2$-forms, which have the same number of independent components.
-> - The Hodge star $\ast$ can be constructed as an operation that distributes the coefficients of a $1$-form directly to the basis matrices of a $2$-form. Its matrix representation coincides with the cross product matrix.
-> - The $\ast$ dictionary in real space: $\ast dx = dy \wedge dz$, etc. $\ast\ast = \mathrm{id}$.
+is the quantity extracted by this limit.
 
----
+This is "differentiation" in the same spirit as $f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$ in Chapter 1. Only the denominator has changed—from "distance moved" to "area enclosed"—but the spirit of <strong>extracting a rate of change locally</strong> is unchanged.
 
-### §5.4 Translation in Practice — Correspondence Between Differential Forms and Vector Calculus
-
-#### 5.4.1 Joule Heat $P=VI$ — Two Paths
-
-Let us verify concretely in an actual computation how $\ast$ connects differential forms and vector calculus.
-
-> **Note** (No prior knowledge of electromagnetism is required) From here onward, we will use terminology from electromagnetism for the sake of exposition. Readers who have not yet studied physics, as well as those who studied electromagnetism through vector calculus, need not fully understand the meaning of the formulas. We ask only that they observe how $\ast$ operates within the structure of the computation.
-
-Reconsider the high school physics formula "electric power = voltage × current ($P=VI$)" as a phenomenon occurring at each point in space.
-
-- The electric field **$E$**, which is the source of voltage, is a **$1$-form** that counts along line segments.
-- The current density **$J$**, which is the source of current, is a **$2$-form** that counts the charge piercing a surface.
-
-First, let us compute using **Method ① (differential forms)**. Take the wedge product of the $1$-form $E$ and the $2$-form $J$.
-
-$$E \wedge J$$
-
-The wedge product of a $1$-form and a $2$-form is a $3$-form (a volume density). This represents "electric power per unit volume (W/m³)." Integrating this over a spatial region ($\int_V E \wedge J$) yields the total power consumption (watts) for the entire space. The metric $g$ is not used at all.
-
-Next, let us see how the same computation is performed in **Method ② (vector calculus)**. In vector calculus textbooks, the power density is written as the inner product of two "vectors," $E \cdot J$. But $J$ is intrinsically a $2$-form, so to treat it as a $1$-form (a vector) we must convert it with $\ast$:
-
-$$\text{vector } J \longleftrightarrow \ast J$$
-
-Now we have two $1$-forms, $E$ and $\ast J$. Take their inner product (dot product). To write the inner product of $1$-forms in differential forms, we apply $\ast$ to one of them to make a $2$-form, form the wedge product to obtain a $3$-form, and then apply $\ast$ to the whole to drop it to a $0$-form:
-
-$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
-
-Here, by $\ast\ast = \mathrm{id}$, the inner $\ast(\ast J) = J$, yielding:
-
-$$\ast(E \wedge J)$$
-
-The expression inside the parentheses, $E \wedge J$, is exactly the same $3$-form we obtained in Method ①. The outer $\ast$ strips away the volume element $dx \wedge dy \wedge dz$ from the $3$-form and converts it to a scalar value. This is why, in vector calculus, when we compute the total electric power over space, we manually multiply the scalar $E \cdot J$ back by the infinitesimal volume $dV$ and integrate.
-
-**In other words, $\ast$ converts the $3$-form of Method ① into the scalar of Method ②, connecting the two without contradiction.** It is precisely because $\ast\ast = \mathrm{id}$ holds that both paths lead to the same result.
-
-#### 5.4.2 Helicity $\mathbf{A} \cdot (\nabla \times \mathbf{A})$ — Round Trip of $\ast$
-
-Let us examine the workings of $\ast$ further with another example. In vector calculus there is a quantity called helicity — the inner product of a vector field $\mathbf{A}$ with its curl:
-
-$$\mathbf{A} \cdot (\nabla \times \mathbf{A})$$
-
-We represent $\mathbf{A}$ by the $1$-form $\alpha$, and $\nabla \times \mathbf{A}$ by the $2$-form $d\alpha$ (as we shall see in §5.5, the curl is $d$ followed by $\ast$).
-
-First, compute using **Method ①**. The wedge product of the $1$-form $\alpha$ and the $2$-form $d\alpha$:
-
-$$\alpha \wedge d\alpha$$
-
-The wedge product of a $1$-form and a $2$-form is a $3$-form. Neither the metric nor $\ast$ is needed.
-
-Next, let us examine the internal structure of the same computation in **Method ②**. Since vector calculus cannot handle the $2$-form $d\alpha$ directly, we convert it to a $1$-form with $\ast$:
-
-$$\nabla \times \mathbf{A} \longleftrightarrow \ast d\alpha$$
-
-Now we have two $1$-forms, $\alpha$ and $\ast d\alpha$. Take the inner product:
-
-$$\mathbf{A} \cdot (\nabla \times \mathbf{A}) \longleftrightarrow \ast(\alpha \wedge \ast(\ast d\alpha))$$
-
-By $\ast\ast = \mathrm{id}$, the inner $\ast(\ast d\alpha) = d\alpha$. Hence,
-
-$$\ast(\alpha \wedge d\alpha)$$
-
-The expression inside the parentheses is the same $3$-form $\alpha \wedge d\alpha$ from Method ①. The outer $\ast$ converts it to a scalar.
-
-**What we should note here is that $\ast$ appears twice, and they cancel each other via $\ast\ast = \mathrm{id}$.** Inside Method ②, $d\alpha$ (a $2$-form) is dropped to a $1$-form with $\ast$, and then $\ast$ is summoned again to take the inner product. This round trip of type conversion is cancelled out by $\ast\ast = \mathrm{id}$.
-
-> **Note** (Why the round trip of $\ast$ occurs) Vector calculus lacks the concept of "degree of a form" and treats everything uniformly as "three-component arrows." To represent a $2$-form as an arrow, one has no choice but to use $\ast$ to drop it to a $1$-form, and for the inner product computation one can do nothing but use $\ast$ to convert it back. $\ast$ is nothing other than the packaging of this type conversion mechanism into a single operator.
-
-> **【Checkpoint — §5.4】**
-> - In the computation of Joule heat, Method ① ($E \wedge J$) and Method ② ($E \cdot J = \ast(E \wedge J)$) coincide via $\ast$.
-> - In the computation of helicity, $\ast$ is used twice and they cancel via $\ast\ast = \mathrm{id}$. Method ① ($\alpha \wedge d\alpha$) and Method ② ($\mathbf{A} \cdot (\nabla \times \mathbf{A})$) give the same result.
-> - $\ast$ is the type converter that connects differential forms and vector calculus, and $\ast\ast = \mathrm{id}$ guarantees the consistency of the conversion.
+> <strong>Note</strong> (why only $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ survives) $\frac{\partial P}{\partial x}$ and $\frac{\partial Q}{\partial y}$ do not appear. The change of $P$ in the $x$ direction ($\frac{\partial P}{\partial x}$) acts in the same direction on the bottom and top edges and cancels; the change of $Q$ in the $y$ direction ($\frac{\partial Q}{\partial y}$) likewise cancels on the right and left edges. What survives is only "the change of $P$ in the $y$ direction" and "the change of $Q$ in the $x$ direction"—the difference of <strong>partial derivatives in mutually orthogonal directions</strong>. This crosswise structure is the key to everything from the next section onward.
 
 ---
 
-### §5.5 Dismantling the Three Siblings of Nabla
+---
 
-We now have the two operators $d$ (Chapter 4) and $\ast$ (this chapter). By combining the two, the three operations — gradient (grad), curl (rot), and divergence (div) — can be written within a single unified framework.
+### §5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area
 
-> **Note** (For readers familiar with vector calculus) The grad, rot, and div defined here are identical to those written as $\nabla f,\; \nabla \times \mathbf{F},\; \nabla \cdot \mathbf{F}$ in vector calculus. Readers who have not yet studied vector calculus need only understand them as combinations of $d$ and $\ast$.
+#### 5.4.1 Revisiting the Wedge Product
 
-From here on, we denote by $\omega = F_x\,dx + F_y\,dy + F_z\,dz$ the $1$-form corresponding to a vector field $\mathbf{F} = (F_x, F_y, F_z)$.
+Let us restate the $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ obtained in §5.3 in the language of Chapter 2. In Chapter 2 §2.4.4 we defined the area-measuring device $dx \wedge dy$. This was a device that, when fed two vectors $\mathbf{v}_1, \mathbf{v}_2$, returns the signed area of the shadow they cast onto the $xy$ plane:
 
-#### 5.5.1 Gradient $\mathrm{grad}\,f = df$
+$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
 
-We already know this one. The exterior derivative $df$ of a $0$-form (a scalar field) $f$ is a $1$-form, and its coefficients are the partial derivatives:
+In particular, if we feed the displacement $\Delta x\,\hat{e}_x$ in the $x$ direction and the displacement $\Delta y\,\hat{e}_y$ in the $y$ direction, we get $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$.
 
-$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
+#### 5.4.2 Definition of $d\omega$
 
-We call the components $(\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$ of this horizontal vector the **gradient** and write $\mathrm{grad}\,f$.
+Written in this language, the result of §5.3 says that for the two edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ of an infinitesimal rectangle, some <strong>new $2$-form</strong> returned the leading term $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$. We call this $2$-form the <strong>exterior derivative</strong> of $\omega$, and write it $d\omega$:
 
-$$\mathrm{grad}\,f = df$$
+$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
 
-$d$ raises the degree $0 \to 1$. This is the true nature of the gradient. The gradient alone uses no $\ast$ — it is accomplished by pure counting (topology).
+$d\omega$ is a $2$-form—it eats two vectors and returns a scalar. Its value represents the mismatch per unit area of a closed loop over the infinitesimal parallelogram spanned by the two vectors fed to it.
 
-#### 5.5.2 Curl $\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$
+Let us organize what is happening here:
 
-Applying $d$ to the $1$-form $\omega$ yields the $2$-form $d\omega$. Its coefficients are as we derived in Chapter 4:
+- <strong>Input</strong>: $\omega = P\,dx + Q\,dy + R\,dz$ ($1$-form, a line measuring device that eats one vector)
+- <strong>Output</strong>: $d\omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$ ($2$-form, a surface measuring device that eats two vectors)
+- <strong>Operation</strong>: $d$ <strong>raises the degree by one</strong>, from 1 to 2
+
+This is exactly the same structure as the $df$ we saw in §5.1. $d$ acts on a $0$-form $f$ and returns the $1$-form $df$; it acts on a $1$-form $\omega$ and returns the $2$-form $d\omega$. <strong>One of the great roles of $d$ is to raise the degree by one.</strong>
+
+> <strong>Checkpoint</strong>
+> - $df$ was the exterior derivative from $0$-form to $1$-form. $\int_\gamma df = f(B)-f(A)$ (depends only on the endpoints).
+> - For a general $\omega$, $\oint \omega \neq 0$ on a closed loop. To investigate this mismatch, we shrink the loop.
+> - On an infinitesimal rectangle in the $xy$ plane, $\oint \omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y +$ higher-order terms. The leading term of the mismatch is proportional to area.
+> - We define the $2$-form that measures this proportionality coefficient as $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$. $d$ is the operator that raises the degree.
+
+---
+
+### §5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions
+
+#### 5.5.1 The $yz$ Plane and the $zx$ Plane
+
+In §5.3–§5.4 we considered loops only in the $xy$ plane. But in three-dimensional space there are three orientations of surface. On an infinitesimal rectangle in the $yz$ plane, a similar calculation gives $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$; on the $zx$ plane we get $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$. These correspond to $dy \wedge dz$ and $dz \wedge dx$, respectively.
+
+The complete formula that follows from this intuition is:
 
 $$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
 
-Applying $\ast$ here converts the $2$-form to a $1$-form. Using the dictionary of §5.3.3:
+> <strong>Note</strong> ($2$-forms measure tilted parallelograms) This $d\omega$ is a $2$-form—a <strong>measuring device that eats two vectors</strong>. The two vectors fed to it need not be parallel to the $xy$ plane. If we feed the two edges $\mathbf{v}_1, \mathbf{v}_2$ of an infinitesimal parallelogram floating obliquely in three-dimensional space, it returns the mismatch per unit area of a closed loop over that surface. It is exactly the same thing we did in §5.3—the only difference is that the surface being measured need not be parallel to a coordinate plane. The mechanism for extracting the area (and orientation) of a parallelogram from two vectors was already verified in Chapter 2 §2.4, when we constructed $dy \wedge dz$ and the like as antisymmetric matrices.
 
-$$\ast(d\omega) = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dx + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dy + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dz$$
+#### 5.5.2 Algebraic Derivation — Leibniz Rule and $d(dx)=0$
 
-We call the coefficients $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ of this $1$-form the **curl** and write $\mathrm{rot}\,\mathbf{F}$.
+The formula above can of course be derived by doing separate loop calculations on each plane. But drawing a loop and adding four edges every time is tedious. What we do here is recast the exterior derivative introduced geometrically in §5.3 as computational algebraic rules, and confirm that these rules do indeed reproduce the exterior derivative. In other words, using the intuition from the $xy$-plane example, we move to a form that can be computed mechanically.
 
-$$\mathrm{rot}\,\mathbf{F} = \ast\,d\,\omega$$
+> <strong>Note</strong> (Relation to the axiomatic definition) Many mathematics books take Leibniz's rule and $d(dx)=0$ as the <strong>definition</strong> of $d$. That definition is concise, but it is hard to see why those rules should hold. In this book we start from the dissection of an infinitesimal loop. What we are about to verify is that this geometric $d$ and the algebraic computational rules are consistent. The rules are for computational convenience; <strong>the meaning is in §5.3</strong>. Still, when one looks ahead to higher dimensions, this algebraic definition is indeed very concise.
 
-$\ast\,d$ is the operation $1$-form $\to$ $2$-form $\to$ $1$-form — raising the degree and then lowering it. This "raise and lower" is precisely the algebraic structure of the curl.
+First, for $\omega = P\,dx + Q\,dy + R\,dz$, it should be uncontroversial that $d\omega = d(P\,dx) + d(Q\,dy) + d(R\,dz)$. This is the same as considering loops around tilted parallelograms. The question is $d(P\,dx)$—how does $d$ act on the $1$-form $dx$ with coefficient $P$?
 
-#### 5.5.3 Divergence $\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$
+Here, the geometric $d$ obtained in §5.3–§5.4 has already taught us something. For $\omega = P\,dx$ ($Q=R=0$), if we carry out the infinitesimal loop calculation of §5.3 not only in the $xy$ plane but also in the $zx$ plane, $d(P\,dx)$ should have no component on the $yz$ face, and
 
-Going further, we chain three operators: $\ast\,d\,\ast$. First, $\ast\,\omega$ converts the $1$-form to a $2$-form; then $d$ raises it to a $3$-form; finally $\ast$ drops it to a $0$-form (a scalar field):
+$$d(P\,dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
 
-$$\ast(d(\ast\omega)) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+(the loop on the $xy$ face gives $(0 - \frac{\partial P}{\partial y}) = -\frac{\partial P}{\partial y}$; the loop on the $zx$ face gives $(\frac{\partial P}{\partial z} - 0) = \frac{\partial P}{\partial z}$).
 
-We call this scalar field the **divergence** and write $\mathrm{div}\,\mathbf{F}$.
+Now recall $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$ (§5.1). Taking its wedge product with $dx$:
 
-$$\mathrm{div}\,\mathbf{F} = \ast\,d\,\ast\,\omega$$
+$$dP \wedge dx = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
 
-$\ast\,d\,\ast$ is the operation $1$-form $\to$ $2$-form $\to$ $3$-form $\to$ $0$-form — repeatedly raising the degree and then dropping it all at once.
+(the term with $\frac{\partial P}{\partial x}$ vanishes because $dx \wedge dx = 0$)
 
-> **Note** (Why the formulas for rot and div are complex in vector calculus textbooks) Readers who have studied vector calculus will have seen formulas for rot and div in cylindrical or spherical coordinates that span several lines. The reason should now be clear. rot uses $\ast$ once, and div uses $\ast$ twice. The dictionary of $\ast$ depends on the metric $g$, and $g = J^T J$ is a function of position. The complexity of the formulas is merely the result of $\ast$ and $g$ being applied repeatedly behind the scenes.
+This <strong>agrees completely</strong> with the geometric calculation. That is, at least for a term of the form $P\,dx$:
 
-#### 5.5.4 Natural Consequences of $d^2 = 0$
+$$d(P\,dx) = dP \wedge dx$$
 
-Let us recall $d^2 = 0$, which we learned in Chapter 4. From this single fact, two identities follow automatically.
+So only the variation of the coefficient $P$ from place to place attaches to the measuring device in the $dx$ direction as a new area-measuring device.
 
-$\mathrm{rot}(\mathrm{grad}\,f) = 0$ is nothing other than $\ast\,d\,(df) = \ast\,(d^2 f) = 0$.
+Comparing the geometric result with Leibniz's rule $d(P\,dx) = dP \wedge dx + P\,d(dx)$, the extra term $P\,d(dx)$ must be zero. Since $P$ is an arbitrary function, this can hold in general only if $d(dx)=0$—that is, $d(dx) = 0$ is required.
 
-Likewise, $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$ is $\ast\,d\,\ast(\ast\,d\,\omega) = \ast\,d\,(d\,\omega) = \ast\,(d^2 \omega) = 0$.
+Generalizing this observation, we arrive at the following <strong>graded Leibniz rule</strong>. $P$ is a $0$-form and $dx$ is a $1$-form; the behavior of $d$ on the “product” of a $0$-form and a $1$-form is:
 
-These are not cases of "it happened to turn out zero when we computed." A single algebraic truth, $d^2 = 0$, merely manifests itself in two different guises in the combinations of nabla.
+$$d(P\,dx) = (dP) \wedge dx + P\,d(dx)$$
+
+$dP$ is known—from §5.1, $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$. The question is the value of $d(dx)$.
+
+Here, the exterior derivative of the coordinate function $x$ is $dx$ ($d(x) = dx$). The $dx$ of Cartesian coordinates is a reference measuring device whose coefficients do not change from place to place. So even if we send $dx$ itself once around an infinitesimal loop, no mismatch per unit area appears. The same holds for $dy$ and $dz$. Therefore, for the coordinate basis, we adopt the following computational rule:
+
+$$d(dx) = d(dy) = d(dz) = 0$$
+
+Then:
+
+$$d(P\,dx) = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx + P\,0$$
+
+Using the antisymmetry of $\wedge$ ($dx \wedge dx = 0$, $dy \wedge dx = -dx \wedge dy$):
+
+$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+
+Similarly:
+
+$$\begin{aligned}
+d(Q\,dy) &= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \\
+d(R\,dz) &= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
+\end{aligned}$$
+
+Adding the three and collecting in the order of the basis $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ (this cyclic order is foreshadowing for consistency with the right-handed system in the next chapter):
+
+$$\begin{aligned}
+d\omega &= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \\
+&= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
+\end{aligned}$$
+
+This includes the $xy$ component $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ derived geometrically in §5.3, and the $yz$ and $zx$ components follow the same cross pattern.
+
+#### 5.5.3 The Pattern of the Coefficients
+
+Notice how the coefficients are arranged. $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ are obtained by taking partial derivatives of $(P, Q, R)$ <strong>with respect to axes other than their own, crossing them, and taking differences</strong>. There is a cyclic symmetry:
+
+$$\begin{aligned}
+dy \wedge dz &\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \\
+dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
+\end{aligned}$$
+
+> <strong>Note</strong> (A guide rail for experienced readers) Readers who already know vector analysis will find these three coefficients familiar. In this book we do not rely on their names; we first build the operation $d$ itself. The correspondence will be organized in later chapters.
+
+> <strong>Checkpoint</strong>
+> - The exterior derivative $d\omega$ of a general $1$-form $\omega$ is a $2$-form whose coefficients are the cross differences of partial derivatives $(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$.
+> - The computational rules are threefold: (1) linearity, (2) Leibniz rule $d(P\,dx) = dP \wedge dx + P\,d(dx)$, (3) $d(dx)=d(dy)=d(dz)=0$.
+> - The result is fully consistent with the infinitesimal loop calculation of §5.3.
 
 ---
 
-### §5.6 Closing Part II — Toward Part III
+### §5.6 Accumulate It, and Only the Boundary Remains — Stokes' Theorem
 
-In Chapter 4 we obtained the exterior derivative $d$, and in this chapter we obtained the metric $g$ and the Hodge star $\ast$. As combinations of these two operators:
+#### 5.6.1 Tiling a Surface
 
-| Operation | Decomposition | Degree transition | Number of $\ast$ applications |
-|---|---|---|---|
-| $\mathrm{grad}$ | $d$ | $0 \to 1$ | 0 times |
-| $\mathrm{rot}$ | $\ast\,d$ | $1 \to 2 \to 1$ | 1 time |
-| $\mathrm{div}$ | $\ast\,d\,\ast$ | $1 \to 2 \to 3 \to 0$ | 2 times |
+In §5.3 we computed $\oint \omega$ around <strong>a single</strong> infinitesimal rectangle and saw that its leading term is the product of $d\omega$ and area. What happens if we <strong>tile an entire surface</strong> with these infinitesimal rectangles and add everything up?
 
-The true identity of the seemingly cryptic symbol nabla $\nabla$ was nothing more than a combination of two fundamental operators, $d$ and $\ast$.
+Divide a surface $S$ into small coordinate patches and cut each into infinitesimal rectangles on its parameter plane (this is exactly the idea of a surface element from Chapter 3 §3.2). For each infinitesimal rectangle, the integral of $\omega$ around the boundary in the orientation matching the surface has, as its leading term, the value obtained by feeding the surface element to $d\omega$.
 
-> **Note** (The conclusion of this chapter) Written in differential forms, grad = $d$, rot = $\ast d$, div = $\ast d \ast$ — three lines suffice. And yet vector calculus textbooks take three pages each to explain these three lines, and moreover make students memorize different formulas for each coordinate system. The reason, as we have seen throughout this chapter, is that vector calculus lacks the concept of "degree of a form," and consequently applies $\ast$ and $g$ repeatedly behind the scenes, all of whose computational steps surface as the complexity of the formulas. Once that structure is visible, there is no longer any need to memorize formulas by rote for each coordinate system.
+Here we consider the case where the surface can be smoothly parameterized and a natural orientation is induced on the boundary as well. Reversing the orientation of the surface simultaneously reverses the direction in which the boundary is traced. Only after fixing this “pairing of surface orientation and boundary orientation” do the signs on the two sides agree.
 
-In Part III, we will push this perspective further. In Chapter 7 we will reconsider Stokes's theorem $\int_{\partial M} \omega = \int_M d\omega$, obtained in Chapter 4, through the dictionary of $\ast$, and confirm that the fundamental theorem of calculus, the Kelvin–Stokes theorem, and Gauss's divergence theorem all collapse into this single line. In Chapter 8, we will concretely construct the dictionary of $\ast$ in parameter spaces such as cylindrical and spherical coordinates, and assemble the tools for practical computation.
+#### 5.6.2 Interior Edges Cancel
 
-> **Note** (Merely by changing one sign of the metric) In this chapter we assumed a positive-definite metric ($\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$). However, in the four-dimensional spacetime that is the stage of special relativity, an indefinite metric appears, where the sign of the time component flips: $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$. Since this book is fixed to three-dimensional Cartesian real space, we do not step further into this, but the idea of "inserting the matrix $\mathbf{g}$" learned in this chapter can be extended to four-dimensional spacetime as it stands. When the need arises, the reader should return to this chapter.
+Here is the decisive geometric observation. Focus on <strong>the edge shared by two adjacent rectangles</strong>. For the rectangle on the left, that edge is traced “upward”; for the rectangle on the right, it is traced “downward.” Because the paths run in opposite directions, the line integral of $\omega$ <strong>cancels completely</strong> on this edge.
+
+This cancellation occurs on <strong>every shared edge</strong> in the interior of the surface $S$. No matter how finely we partition and add, the contributions from interior edges vanish in plus-minus pairs.
+
+#### 5.6.3 Only the Boundary Survives
+
+Then which edges survive without cancellation—<strong>edges for which no adjacent rectangle exists</strong>, that is, edges along the <strong>boundary $\partial S$</strong> of the surface $S$.
+
+In other words:
+
+$$\oint_{\partial S} \omega = \iint_S d\omega$$
+
+The left-hand side is “the line integral of $\omega$ along the one-dimensional closed curve that is the boundary of the surface”; the right-hand side is “the sum of mismatch densities from the countless infinitesimal loops tiled in the interior of the surface.” In the limit of a finer and finer partition, only the cancellation of interior edges remains, and the two sides agree.
+
+This is the <strong>Kelvin–Stokes theorem</strong> (also called simply Stokes' theorem).
+
+Writing out the components for $\omega = P\,dx + Q\,dy + R\,dz$ explicitly:
+
+$$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$
+
+In the matrix language we have used since Chapter 2, the $2$-form on the right-hand side is represented by the antisymmetric matrix $\mathbf{J}^T - \mathbf{J}$. If $\mathbf{v}_1, \mathbf{v}_2$ are the two edges of a surface element, then $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$. All components are written out in Appendix B.3; consult it as needed.
+
+The structure of this theorem is remarkably simple. <strong>Integral measured on the global boundary</strong> $=$ <strong>accumulation of local mismatch ($d\omega$) in the interior</strong>. $d$ is the device that <strong>translates</strong> information about $\omega$ on the boundary $\partial S$ into information about $d\omega$ in the interior $S$.
+
+> <strong>Note</strong> (Assumptions used in localization) The tiling explanation here assumes a sufficiently smooth surface and field that can be divided into sufficiently fine coordinate patches. When there are cusps on the boundary, self-intersections, singular points, and the like, patch decomposition and orientation must be handled separately. In this book we treat the smooth cases ordinarily used in physics.
+
+> <strong>Note</strong> (Correspondence with Chapter 3) When we defined surface integrals in Chapter 3 §3.2.1, we fed $dx \wedge dy$ to the surface element $(\mathbf{r}_u\Delta u,\;\mathbf{r}_v\Delta v)$. Here too, we divide the surface into small surface elements, act with the measuring device on each element, and organize the contributions that cancel in the interior.
+
+> <strong>Checkpoint</strong>
+> - If we tile a surface $S$ with infinitesimal loops, interior edges cancel and only the contribution from the boundary $\partial S$ remains.
+> - $\int_{\partial S} \omega = \int_S d\omega$. A global boundary integral equals an integral of the local exterior derivative.
+> - As with surface integrals in Chapter 3, we divide the surface into small patches, act with the measuring device on each patch, and aggregate.
 
 ---
 
-> **【Checkpoint — Entire Chapter 5】**
-> - The inner product is an operation that takes the sum of products of components between vectors of the same type (horizontal × horizontal, or vertical × vertical). It is distinct from the horizontal × vertical computation.
-> - In real space the inner product matrix is the identity matrix $I$. In parameter space it is $\mathbf{g}=J^T J$, obtained from the chain rule alone. That is to say, the metric $g$ is none other than the matrix that appears in the middle when we pull back to real space and take the inner product.
-> - $\mathbf{v}^T \mathbf{g}$ converts a vertical vector into a horizontal vector. Without $g$, objects and instruments are mutually untransformable.
-> - There are two methods for obtaining a scalar: Method ① (horizontal × vertical, metric unnecessary) and Method ② (inner product of same-type vectors, metric necessary). The Hodge star $\ast$ is the type conversion operator that connects the two.
-> - $\ast$ can be constructed by distributing the coefficients of a $1$-form as matrices to the bases of a $2$-form. In real space, the dictionary is $\ast dx = dy \wedge dz$, etc., and it satisfies $\ast\ast = \mathrm{id}$.
-> - The calculation examples of Joule heat and helicity show that Method ① and Method ② give the same result through $\ast$ and $\ast\ast = \mathrm{id}$.
-> - $\mathrm{grad} = d$, $\mathrm{rot} = \ast\,d$, $\mathrm{div} = \ast\,d\,\ast$, and from $d^2=0$ it follows as a natural consequence that $\mathrm{rot}(\mathrm{grad})=0$ and $\mathrm{div}(\mathrm{rot})=0$.
 
 ---
 
-## Appendix C: The Array Representation of $\ast_{1\to2}$
+### §5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence
 
-### C.1 $\ast_{1\to2}$ as a Vertical Vector of Matrices
+#### 5.7.1 A $2$-Form Is a Measuring Device for Surfaces
 
-The operation seen in §5.3.2 appeared as "distributing the coefficients of a $1$-form to the matrix bases of a $2$-form." But pushing one step further, it can be reread as a natural extension of the Chapter-1 structure "horizontal vector × vertical vector = scalar" to matrix-valued components.
+In Chapter 3 §3.4.2 we wrote a general $2$-form in the form
 
-A $1$-form $\omega = \begin{pmatrix} P & Q & R \end{pmatrix}$ is a horizontal vector. Meanwhile, $\ast$ assigns a $3 \times 3$ antisymmetric matrix to each basis $1$-form. That is, the output of $\ast$ is a "matrix," and three matrices line up for the three bases. Stacking these vertically, $\ast_{1\to2}$ can be written as a **vertical vector of matrices**.
+$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
+
+This is a "measuring device that measures flux along a surface." As we saw in Chapter 2 §2.4.5, the three basis $2$-forms each measure the area of the projection onto the $yz$, $zx$, and $xy$ planes, respectively.
+
+#### 5.7.2 Measuring on the Faces of a Tiny Rectangular Box
+
+In the same spirit as §5.3, we now integrate $\eta$ over <strong>all six faces</strong> of a tiny rectangular box in space, $[x, x+\Delta x] \times [y, y+\Delta y] \times [z, z+\Delta z]$. We align the orientations outward.
+
+For the term $C\,dx \wedge dy$, consider only the bottom and top faces perpendicular to $z$:
+
+- <strong>Bottom face</strong> ($z$, outward direction is $-z$): evaluate $C(x,y,z)$ with the orientation of $-dx \wedge dy$ → approximately $-C(x,y,z)\,\Delta x\,\Delta y$
+- <strong>Top face</strong> ($z+\Delta z$, outward direction is $+z$): $C(x,y,z+\Delta z) \approx C + \frac{\partial C}{\partial z}\Delta z$ → approximately $(C + \frac{\partial C}{\partial z}\Delta z)\,\Delta x\,\Delta y$
+
+Summing, the $C\Delta x\Delta y$ terms cancel and $\frac{\partial C}{\partial z}\,\Delta x\,\Delta y\,\Delta z$ remains. The term $A\,dy \wedge dz$ contributes $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$ from the faces perpendicular to $x$, and the term $B\,dz \wedge dx$ contributes $\frac{\partial B}{\partial y}\,\Delta x\,\Delta y\,\Delta z$ from the faces perpendicular to $y$.
+
+The total over all six faces is:
+
+$$\iint_{\partial (\text{box})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$
+
+Here too the structure is the same—<strong>the leading term of the mismatch measured on the surface is proportional to the enclosed volume</strong>. The proportionality constant $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ represents the "outflow per unit volume."
+
+#### 5.7.3 Definition of $d\eta$ and Algebraic Derivation
+
+As a $3$-form that eats the three edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ of the box:
+
+$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+This formula can also be derived from the algebraic rules of §5.5.2. First, as we did in §5.5.2, let us confirm for the term $A\,dy \wedge dz$ that the geometric result is consistent with the Leibniz rule.
+
+According to the geometric calculation in §5.7.2, the contribution of $A\,dy \wedge dz$ was $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$. In the language of $dx \wedge dy \wedge dz$, this is $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$.
+
+On the other hand, applying the Leibniz rule to $d(A\,dy \wedge dz)$ gives:
+
+$$d(A\,dy \wedge dz) = dA \wedge dy \wedge dz + A\,d(dy \wedge dz)$$
+
+Here, as in §5.5.2, using $d(dy)=d(dz)=0$:
+
+$$d(dy \wedge dz) = d(dy) \wedge dz - dy \wedge d(dz) = 0 \wedge dz - dy \wedge 0 = 0$$
+
+so the second term vanishes and only the first remains:
+
+$$dA \wedge dy \wedge dz = (\frac{\partial A}{\partial x}\,dx + \frac{\partial A}{\partial y}\,dy + \frac{\partial A}{\partial z}\,dz) \wedge dy \wedge dz$$
+
+By antisymmetry of $\wedge$ ($dy \wedge dy = 0$, $dz \wedge dz = 0$), the terms with $\frac{\partial A}{\partial y}$ and $\frac{\partial A}{\partial z}$ vanish, leaving only $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$. This <strong>agrees completely</strong> with the geometric calculation in §5.7.2.
+
+The terms $B\,dz \wedge dx$ and $C\,dx \wedge dy$ are similar; adding the three yields:
+
+$$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+$d$ has accomplished the promotion $2$-form $\to$ $3$-form.
+
+#### 5.7.4 Gauss' Theorem
+
+By the same tiling argument as in §5.6—this time filling the solid $V$ with tiny rectangular boxes—internal faces cancel and only the outer surface $\partial V$ remains:
+
+$$\iint_{\partial V} \eta = \iiint_V d\eta$$
+
+This is <strong>Gauss' theorem</strong>. It has <strong>exactly the same form</strong> as Stokes' theorem, only with the dimension shifted by one. Placed side by side, the parallel is obvious: $\omega$ ($1$-form) $\to$ $d\omega$ ($2$-form) $\to$ surface $S$, $\eta$ ($2$-form) $\to$ $d\eta$ ($3$-form) $\to$ solid $V$.
+
+Writing out the components explicitly for $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$:
+
+$$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\bigr) = \iiint_V (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+> <strong>Note</strong> (a guide for readers already familiar with vector calculus) Readers who already know vector analysis may recognize $\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z}$. In this book we first obtain this quantity as the exterior derivative of a $2$-form, and we keep that order of presentation. The correspondence with names will be organized in a later chapter.
+
+> <strong>Checkpoint so far</strong>
+> - The exterior derivative $d\eta$ of a $2$-form $\eta$ is a $3$-form whose coefficient is $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$.
+> - The derivation can be done mechanically with the same algebraic rules as §5.5 (Leibniz rule $+$ $d(dx)=0$).
+> - $\iint_{\partial V} \eta = \iiint_V d\eta$. Stokes ($1$-form $\to$ surface) and Gauss ($2$-form $\to$ solid) differ only in degree; the structure is the same.
+
+---
+
+### §5.8 $d^2 = 0$ — The Mismatch of a Mismatch Leaves Nothing Behind
+
+Before unifying Stokes' theorem and Gauss' theorem in the next section, let us confirm one more basic structure of the exterior derivative. $d$ raises the degree by one, but applying it twice in succession leaves no new mismatch. This fact is also connected to the geometric structure we will see later: "the boundary of a boundary cancels as an oriented sum."
+
+#### 5.8.1 $d(df) = 0$
+
+In §5.1 we defined $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$. Let us apply the exterior derivative once more. Using the formula from §5.5 with $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$:
+
+$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$
+
+By symmetry of mixed partial derivatives (if $f$ is $C^2$ (twice continuously differentiable), then $\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, etc.; see Chapter 1 §1.2), every coefficient vanishes:
+
+$$d(df) = 0$$
+
+> <strong>Note</strong> ($d^2=0$ in the axiomatic viewpoint and the $C^2$ condition) When we compute concretely in coordinates, we see that $d^2=0$ is inevitable from symmetry of mixed partial derivatives and antisymmetry of the wedge product. From the axiomatic standpoint of differential forms, one may instead read things the other way around: requiring $d^2=0$ (as part of the definition) means we are implicitly working with a class of functions for which symmetry of mixed partial derivatives holds ($C^2$ functions). In this book we first understand it through concrete calculation, as the mechanism that prevents contradictions in the hierarchy of physical laws.
+
+#### 5.8.2 $d(d\omega) = 0$
+
+Apply the formula of §5.7 to the $d\omega$ of §5.5. With $A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$:
+
+$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$
+
+Expanding and rearranging the expression in parentheses:
+
+$$\left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z}\right) + \left(\frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x}\right) + \left(\frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right)$$
+
+By symmetry of mixed partial derivatives ($\frac{\partial^2 R}{\partial y \partial x}=\frac{\partial^2 R}{\partial x \partial y}$, etc.), the six terms cancel in three pairs and the sum is zero:
+
+$$d(d\omega) = 0$$
+
+> <strong>Checkpoint so far</strong>
+> - $d^2 = 0$: applying the exterior derivative twice always gives zero. Symmetry of mixed partial derivatives and antisymmetry of the wedge produce the cancellation.
+> - Several identities familiar to readers who already know vector calculus—"it vanishes when you differentiate twice"—will be organized in a later chapter as other expressions of this $d^2=0$.
+
+---
+
+### §5.9 Unifying the Exterior Derivative — One Formula, One Rule
+
+#### 5.9.1 Stokes and Gauss Were the Same Formula
+
+Stokes' theorem $\oint_{\partial S}\omega = \iint_S d\omega$ from §5.6 and Gauss' theorem $\iint_{\partial V}\eta = \iiint_V d\eta$ from §5.7. Placed side by side, only the number of integral signs differs—$\oint$, $\iint$, $\iiint$—yet the structure is identical. If $M$ is a curve, we write $\int$ (1-dimensional); if a surface, $\iint$ (2-dimensional); if a solid, $\iiint$ (3-dimensional)—the number of integral signs is determined only by the dimension of $M$.
+
+So, regardless of dimension, we write uniformly:
+
+$$\int_{\partial M} \omega = \int_M d\omega$$
+
+Here $\omega$ is a $k$-form, $M$ is a $(k+1)$-dimensional region, and $\partial M$ is its $k$-dimensional boundary. For $k=0$ this is the fundamental theorem of calculus, $\int_{\partial M} f = f(B)-f(A) = \int_M df$; for $k=1$ it is Stokes' theorem; for $k=2$ it is Gauss' theorem. All are absorbed into this single line.
+
+The power of this unified form stands out even more in combination with $d^2=0$ from §5.8. Replacing $\omega$ by $d\omega$ in $\int_{\partial M} \omega = \int_M d\omega$:
+
+$$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\omega) = 0$$
+
+That is, <strong>"the boundary of a boundary is zero as an oriented sum"</strong> ($\partial^2 M = 0$) and <strong>$d^2=0$</strong> correspond to each other. This does not mean that the second boundary is always empty as a set. For example, if we subdivide the boundary of a polygon further into boundary pieces, vertices appear—but counted with orientation, contributions from adjacent edges cancel. $d^2=0$ is the algebraic portrait of this topological cancellation.
+
+> <strong>Note</strong> (three dimensions suffice) Because the stage of this book is three-dimensional space, the dimension of $M$ is 1, 2, or 3, and $\omega$ is a $0$-form, $1$-form, or $2$-form. We do not enter $k=3$ ($M$ four-dimensional). Still, it does no harm to keep in the back of your mind that this formula holds regardless of $k$.
+
+#### 5.9.2 Exterior Derivative of a General $k$-Form
+
+Likewise, the action of $d$ collapses into one pattern regardless of degree. When an arbitrary $k$-form $\omega$ is written as a sum of coefficients $a_{i_1\cdots i_k}$ and basis elements $dx_{i_1}\wedge\cdots\wedge dx_{i_k}$:
+
+$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x_j}\,dx_j \Bigr) \wedge dx_{i_1}\wedge\cdots\wedge dx_{i_k}$$
+
+For this book we need only the three cases $k=0,1,2$, written out concretely in §5.1 ($df$), §5.5 ($d\omega$), and §5.7 ($d\eta$). The general form above is only confirmation that "at every degree, take the total differential of the coefficients and attach with the wedge"—a single principle.
+
+#### 5.9.3 Summary of Computational Rules
+
+All computations of the exterior derivative $d$ built in this chapter are summarized in the following four rules:
+
+1. <strong>Action on a $0$-form</strong>: $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ (the definition since Chapter 1 §1.2)
+2. <strong>Linearity</strong>: $d(\omega_1 + \omega_2) = d\omega_1 + d\omega_2$
+3. <strong>Graded Leibniz rule</strong>: $d(f\,\omega) = df \wedge \omega + f\,d\omega$
+4. <strong>Exterior derivative of coordinate bases is zero</strong>: $d(dx) = d(dy) = d(dz) = 0$
+
+Rule 4 reflects the geometric fact that the coordinate bases $dx, dy, dz$ themselves have no coefficients that vary with position, so measuring them on a tiny loop produces no local mismatch. It is also consistent with $d^2=0$ in §5.8.
+
+With only these four rules, the exterior derivative of any form from $0$-form to $3$-form can be computed mechanically. In fact, every calculation treated in this chapter is nothing but a combination of these rules.
+
+> <strong>Note</strong> (commutativity with pullback—payoff of a Chapter 4 foreshadowing) As foreshadowed in Chapter 4, between pullback $\Phi^*$ and exterior derivative $d$ there holds the commutation relation
+> $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
+> "differentiate then pull back" and "pull back then differentiate" give the same result. This property cannot be derived directly from the four rules above, but if we recall that $d$ is the operation that "measures local mismatch" and $\Phi^*$ is the operation that "relabels coordinates," it is natural—the structure of local mismatch does not depend on how coordinates are chosen. This fact will be an important footing when we consider differential forms on general manifolds in Chapter 11.
+
+> <strong>Checkpoint so far</strong>
+> - A single line $\int_{\partial M} \omega = \int_M d\omega$ unifies the fundamental theorem of calculus, Stokes' theorem, and Gauss' theorem.
+> - Computation of $d$ is summarized in four rules ($df$, linearity, Leibniz rule, $d(dx)=0$).
+> - $d^2=0$ and $\partial^2 M=0$ echo each other as algebraic truth and geometric truth.
+
+---
+
+---
+
+### §5.10 From Integrals to Differential Equations — Localizing Physical Laws
+
+#### 5.10.1 Turning Integral Laws into Differential Laws
+
+Let us return to the question posed at the opening of this chapter.
+
+> <strong>How do we extract a local law from an integrated quantity?</strong>
+
+The answer lies in the two tools we have developed—<strong>Stokes' theorem</strong> and the <strong>exterior derivative $d$</strong>.
+
+Many fundamental laws of physics are discovered first in <strong>integral form</strong>. They take the shape: a quantity measured on the boundary of a region equals the total of sources inside:
+
+$$\int_{\partial M} \omega = \int_M \eta$$
+
+The left-hand side is the integral measured on the boundary (a global observable); the right-hand side is the integral of sources in the interior (a global total). $\omega$ and $\eta$ are differential forms of the appropriate degrees.
+
+Apply Stokes' theorem to the left-hand side. Since $\int_{\partial M} \omega = \int_M d\omega$:
+
+$$\int_M d\omega = \int_M \eta$$
+
+Rearranging:
+
+$$\int_M (d\omega - \eta) = 0$$
+
+This is the decisive moment. If this equality holds for <strong>every smooth region $M$</strong>, including sufficiently small ones, the integrand form must vanish identically at each point. For if there were a point where $d\omega - \eta \neq 0$, the integral over a tiny region around that point would not be zero—a contradiction. Here too we are considering the case where the fields are sufficiently smooth and contain no singular concentrated sources.
+
+Therefore:
+
+$$d\omega = \eta$$
+
+This is the <strong>local differential law extracted from the integral law</strong>. $d$ has functioned precisely as the operator that converts an integral equation into a differential equation.
+
+In other words, the exterior derivative $d$ is not merely a symbol that raises the degree of a form. It is the operator that translates a law observed on the boundary into a law that holds at each point in the interior.
+
+#### 5.10.2 Examples from Physics
+
+A typical instance of this pattern is the fundamental laws of electromagnetism.
+
+> <strong>Note</strong> (For readers who have not yet studied electromagnetism) In this section we are not after the detailed content of electromagnetism, but after the mechanism by which an integral law becomes a local one. Think of $E,D,B,H,J,\rho$ not so much as names of physical quantities as symbols standing for "quantities measured along a line," "quantities measured through a surface," and "quantities measured over a volume."
+
+> <strong>Note</strong> (For readers who learned electromagnetism through vector calculus) Here we choose the degree of each form according to the dimension of the object over which we integrate, rather than treating the fields as ordinary three-component vectors. Because $E$ and $H$ are integrated along lines, they are $1$-forms; because $D,B,J$ are integrated through surfaces, they are $2$-forms; because $\rho$ is integrated over volume, it is a $3$-form. The correspondence with the usual vector-calculus notation will be organized after we introduce the Hodge star.
+
+In electromagnetism, the object of integration depends on the kind of quantity: some are measured along lines, some through surfaces, some over volume. Schematically, we can read the situation as follows.
+
+| Quantity | What is measured | Form |
+| --- | --- | --- |
+| $E,H$ | along a line | $1$-form |
+| $D,B,J$ | through a surface | $2$-form |
+| $\rho$ | over a volume | $3$-form |
+
+For example, Gauss's law for charge takes the form
 
 $$
-\ast_{1\to2} = \begin{pmatrix}
-\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} \\[1em]
-\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} \\[1em]
-\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-\end{pmatrix}.
+\int_{\partial V}D=\int_V\rho
 $$
 
-The components correspond, from top to bottom, to $dx, dy, dz$. The first component is $\ast(dx)=dy\wedge dz$, the second is $\ast(dy)=dz\wedge dx$, and the third is $\ast(dz)=dx\wedge dy$.
-
-Now, multiply this vertical vector by the horizontal vector of the $1$-form — carrying out the contraction from Chapter 1, now with matrices as components.
+The left-hand side is the total flux of $D$ passing outward through the closed surface $\partial V$; the right-hand side is the total charge contained in the interior $V$. By Stokes' theorem,
 
 $$
-\ast(\omega) = \omega \, \ast_{1\to2}
-= \begin{pmatrix} P & Q & R \end{pmatrix}
-\begin{pmatrix}
-\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} \\[1em]
-\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} \\[1em]
-\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+\int_{\partial V}D=\int_V dD
+$$
+
+so
+
+$$
+\int_V dD=\int_V\rho
+$$
+
+If this holds for every region $V$, then
+
+$$
+dD=\rho
+$$
+
+Similarly, the law that the net magnetic flux through a closed surface is zero can be written
+
+$$
+\int_{\partial V}B=0
+$$
+
+By Stokes' theorem,
+
+$$
+\int_V dB=0
+$$
+
+and if this holds for every $V$, then
+
+$$
+dB=0
+$$
+
+Laws that include time variation have the same type. For a surface $S$,
+
+$$
+\int_{\partial S}E
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+implies
+
+$$
+dE=-\frac{\partial B}{\partial t}
+$$
+
+and
+
+$$
+\int_{\partial S}H
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+implies
+
+$$
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+Here $d$ is the exterior derivative in the spatial directions, and time variation is represented by $\partial/\partial t$.
+
+Thus the fundamental equations of electromagnetism appear, in the language of this chapter, as expressions of the same type:
+
+$$
+dD=\rho,\qquad
+dB=0,\qquad
+dE=-\frac{\partial B}{\partial t},\qquad
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+What matters here is not to memorize these as new formulas of electromagnetism. The single point is that an integral law measured on the boundary passes, via the exterior derivative $d$, to a local law in the interior.
+
+On the other hand, relating $E$ to $D$, or $B$ to $H$, requires a convention for how space and the medium are measured. Likewise, matching quantities measured along lines to quantities measured through surfaces requires additional rules for how length, area, and volume are measured. The Hodge star, which we introduce in the next chapter, is the tool that supplies this correspondence.
+
+A detailed development including component formulas is deferred to Appendix C, "Integral Forms of Electromagnetism and Differential Forms."
+
+> <strong>Checkpoint so far</strong>
+> - Physical laws are often given in the form $\int_{\partial M} \omega = \int_M \eta$.
+> - By Stokes' theorem, rewrite $\int_{\partial M} \omega = \int_M d\omega$; since the equality holds for every $M$, we obtain $d\omega = \eta$ (the local law).
+> - This localization, however, is an argument in regions where the fields are sufficiently smooth and contain no singular concentrated sources.
+> - $d$ is the operator that converts integral laws into differential laws.
+
+---
+
+### §5.11 Outlook Toward Part II — Foreshadowing the Hodge Star
+
+In this chapter we have acquired the powerful operator called the exterior derivative $d$. $d$ maps:
+
+- $0$-form $\to$ $1$-form: $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$
+- $1$-form $\to$ $2$-form: $d\omega = (\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z})\,dy\wedge dz + (\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x})\,dz\wedge dx + (\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})\,dx\wedge dy$
+- $2$-form $\to$ $3$-form: $d\eta = (\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z})\,dx\wedge dy\wedge dz$
+
+Each time the degree rises by one step, the coefficients rearrange in a different pattern. And $d^2=0$ guarantees that no contradiction can slip in among these levels.
+
+Yet one asymmetry stands out. A $0$-form and a $3$-form each have 1 independent component; a $1$-form and a $2$-form each have 3—symmetry in the pattern $1, 3, 3, 1$ (as we saw in Chapter 2 §2.5.9–§2.5.10). This symmetry is no accident. In three-dimensional space with Cartesian coordinates, once we add rules for measuring length, area, and volume, a "dictionary" appears that links forms of the same information content.
+
+That dictionary is the <strong>Hodge star</strong> $\ast$, which we introduce in the next chapter. But $\ast$ is not a mere relabeling of symbols. It depends on which direction corresponds to which face, how area and volume are measured, and how orientation is fixed. For that reason we do not yet use concrete correspondence formulas in this chapter.
+
+What we have built so far is, after all, only $d$. $d$ raises the degree by one, extracts local mismatch, and converts integral laws into local laws. Yet $d$ alone cannot yet reconstruct the familiar operations of vector analysis. To match $1$-forms with $2$-forms, we need the additional rules for how length, area, and volume are measured in space—the <strong>metric</strong>.
+
+In the next chapter we define those rules of "measurement" as the Hodge star $\ast$. To the $d$ constructed in Chapter 5 we add $\ast$ in Chapter 6, and use the two together to rebuild the familiar operations of vector analysis in later chapters. From here we move into the core of Part II—unmasking div, grad, and curl.
+
+---
+
+> <strong>Checkpoint so far — Chapter 5</strong>
+> - The exterior derivative $d$ is the operator that maps a $k$-form to a $(k+1)$-form: $0$-form $\to$ $1$-form ($df$), $1$-form $\to$ $2$-form, $2$-form $\to$ $3$-form.
+> - There are four computational rules: the definition of $df$, linearity, the Leibniz rule $d(f\omega) = df\wedge\omega + f\,d\omega$, and $d(dx)=d(dy)=d(dz)=0$.
+> - The geometric origin is §5.3's dissection of a tiny loop: the mismatch around a closed loop scales with area, and the proportionality constant is $d\omega$.
+> - Stokes' theorem $\int_{\partial M} \omega = \int_M d\omega$ is the universal bridge linking boundary and interior.
+> - $d^2 = 0$ comes from the symmetry of mixed partial derivatives and the antisymmetry of the wedge product; geometrically it corresponds to "the boundary of a boundary is zero as an oriented sum."
+> - $d$ is the operator that converts integral laws into local differential laws—an indispensable role in the formulation of physics.
+> - In the next chapter we add rules for measuring length, area, and volume, and organize the correspondence between $d$ and the operations of vector analysis through the Hodge star $\ast$.
+
+---
+
+## Appendix B: Matrix Representation of the Exterior Derivative
+
+The main text of this chapter proceeded with the basis $dx, dy, dz$ and the algebra of the wedge product. Here we rewrite the exterior derivative in the language of matrix representations, following the book's convention since Chapter 2 — <strong>arranging every component without exception into matrices</strong>.
+
+### B.1 $0$-form: the $1 \times 3$ row vector of $df$
+
+For $f = f(x,y,z)$, as defined in Chapter 1 §1.2:
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
+
+As a row vector ($1 \times 3$ matrix):
+
+$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+### B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients
+
+For $\omega = P\,dx + Q\,dy + R\,dz$, the $3 \times 3$ matrix that arranges <strong>all</strong> partial derivatives of the coefficients $(P,Q,R)$ is:
+
+$$\mathbf{J} := \begin{pmatrix}
+\frac{\partial P}{\partial x} & \frac{\partial P}{\partial y} & \frac{\partial P}{\partial z} \\
+\frac{\partial Q}{\partial x} & \frac{\partial Q}{\partial y} & \frac{\partial Q}{\partial z} \\
+\frac{\partial R}{\partial x} & \frac{\partial R}{\partial y} & \frac{\partial R}{\partial z}
+\end{pmatrix}$$
+
+This is the Jacobian matrix of the vector field obtained by stacking $(P,Q,R)$ as a column. The reason §5.1 said that "a mere matrix of partial derivatives is not enough" is precisely that this $\mathbf{J}$ is not antisymmetric.
+
+### B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$
+
+The result of §5.5 is:
+
+$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+Following the convention of Chapter 2 §2.4.4, we seek the antisymmetric matrix $\mathbf{M}$ such that $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$ for arbitrary column vectors $\mathbf{v}_1, \mathbf{v}_2$.
+
+Writing out the entries of $\mathbf{J}^T - \mathbf{J}$:
+
+$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
+0 & \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} & \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \\
+\frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} & 0 & \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
+\end{pmatrix}$$
+
+That is, comparing with the matrix representation of a $2$-form found in Chapter 2:
+
+$$d\omega = \mathbf{J}^T - \mathbf{J}$$
+
+Thus, <strong>the matrix representation of the exterior derivative $d\omega$ is the antisymmetric matrix obtained by subtracting the Jacobian matrix of the coefficients from its transpose.</strong>
+
+### B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix
+
+For $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$, let the Jacobian matrix of the coefficients $(A,B,C)$ be:
+
+$$\mathbf{J}_\eta := \begin{pmatrix}
+\frac{\partial A}{\partial x} & \frac{\partial A}{\partial y} & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial x} & \frac{\partial B}{\partial y} & \frac{\partial B}{\partial z} \\
+\frac{\partial C}{\partial x} & \frac{\partial C}{\partial y} & \frac{\partial C}{\partial z}
+\end{pmatrix}$$
+
+Then the coefficient in the result of §5.7, $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$, agrees with the <strong>trace</strong> (sum of diagonal entries) of $\mathbf{J}_\eta$:
+
+$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$
+
+#### B.4.1 The 27 components of $d\eta$ — expanded into three matrices
+
+The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (the others are sign reversals or $0$). Write the components of $d\eta$ as $(d\eta)_{abc} = \partial_a \eta_{bc}$, where $\partial_x=\frac{\partial}{\partial x}$, $\partial_y=\frac{\partial}{\partial y}$, $\partial_z=\frac{\partial}{\partial z}$, and $a,b,c \in \{x,y,z\}$, so there are $3^3=27$ components. Arranging them into three $3 \times 3$ matrices with $a$ fixed gives:
+
+$$
+\begin{aligned}
+d\eta_{x,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial x} & -\frac{\partial B}{\partial x} \\
+-\frac{\partial C}{\partial x} & 0 & \frac{\partial A}{\partial x} \\
+\frac{\partial B}{\partial x} & -\frac{\partial A}{\partial x} & 0
+\end{pmatrix}, \\
+d\eta_{y,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial y} & -\frac{\partial B}{\partial y} \\
+-\frac{\partial C}{\partial y} & 0 & \frac{\partial A}{\partial y} \\
+\frac{\partial B}{\partial y} & -\frac{\partial A}{\partial y} & 0
+\end{pmatrix}, \\
+d\eta_{z,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial z} & -\frac{\partial B}{\partial z} \\
+-\frac{\partial C}{\partial z} & 0 & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial z} & -\frac{\partial A}{\partial z} & 0
 \end{pmatrix}
+\end{aligned}
 $$
 
-Expanding this contraction component-wise:
+When these $27$ components are contracted with the corresponding basis wedge products of $1$-forms (for example, if $a=x,\;b=y,\;c=z$, then $dx \wedge dy \wedge dz$), terms with repeated indices (diagonal entries, $b=c$, and so on) vanish because $dx \wedge dx = 0$, and only the $6$ terms with all of $a,b,c$ distinct (permutations of $3!$) survive. Each is summed with its sign. Because each component is antisymmetrized and arranged in a matrix here, we are double-counting; as in Chapter 2 §2.4.4 and Appendix D, a factor of $\frac{1}{2}$ enters:
+
+$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$
+
+In other words, of the $27$ components of $d\eta$, $6$ survive and pair up to converge to the trace of $\mathbf{J}_\eta$.
+
+A $3$-form has only the single basis element $dx \wedge dy \wedge dz$, so as a matrix it degenerates to a scalar coefficient.
+
+### B.5 $d^2 f = 0$ and the Hessian
+
+The Hessian of a $0$-form $f$:
+
+$$\mathbf{H}_f := \begin{pmatrix}
+\frac{\partial^2 f}{\partial x^2} & \frac{\partial^2 f}{\partial x \partial y} & \frac{\partial^2 f}{\partial x \partial z} \\
+\frac{\partial^2 f}{\partial y \partial x} & \frac{\partial^2 f}{\partial y^2} & \frac{\partial^2 f}{\partial y \partial z} \\
+\frac{\partial^2 f}{\partial z \partial x} & \frac{\partial^2 f}{\partial z \partial y} & \frac{\partial^2 f}{\partial z^2}
+\end{pmatrix}$$
+
+arranges the second partial derivatives of $f$. If $f$ is $C^2$, then $\mathbf{H}_f$ is a symmetric matrix ($\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, and so on).
+
+$d(df) = 0$ is the §5.5 formula for $d\omega$ with $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$. We have $\mathbf{J} = \mathbf{H}_f$, and because $\mathbf{H}_f$ is symmetric, $\mathbf{J}^T - \mathbf{J} = 0$; hence $d(df) = 0$. In the language of matrices, this is rephrased as "the antisymmetric part of the Hessian is zero."
+
+## Appendix C: Integral Forms of Electromagnetism and Differential Forms
+
+This appendix verifies, in component form, the passage from the integral forms of the four fundamental equations of electromagnetism to their local forms. What we use here are the exterior derivative $d$ and the degree of a differential form. The metric of space does not appear in this localization itself.
+
+### C.1 Degrees of physical quantities
+
+Quantities measured along a line are placed as $1$-forms, quantities measured through a surface as $2$-forms, and quantities measured over a volume as $3$-forms. In components:
 
 $$
-= P \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix}
-+ Q \begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix}
-+ R \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+E = E_x\,dx+E_y\,dy+E_z\,dz,
+\qquad
+H = H_x\,dx+H_y\,dy+H_z\,dz
 $$
 
-$$= \begin{pmatrix} 0 & R & -Q \\ -R & 0 & P \\ Q & -P & 0 \end{pmatrix}.$$
+$$D = D_x\,dy\wedge dz + D_y\,dz\wedge dx + D_z\,dx\wedge dy$$
 
-This is the complete matrix representation of $\ast\omega$. All twenty-seven numbers are contained within this structure.
+$$B = B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$
 
-> **Note** (On notation) It may look odd that $\ast_{1\to2}$ sits to the right of $\omega$. But since a $1$-form is a horizontal vector and $\ast$ is a vertical vector, the contraction is naturally written $\omega \, \ast_{1\to2}$. By the convention of linear algebra, linear operators on horizontal vectors are multiplied from the right — and the output is the $2$-form as a matrix.
-
-The core of this viewpoint is that **multiplication of a horizontal vector by a vertical vector works exactly as before, even when the components are matrices**. The contraction "measuring device (horizontal) × figure being measured (vertical)" that yielded a scalar in Chapter 1 is here extended to "$1$-form (horizontal) × vertical vector of matrices = $2$-form (matrix)." The Hodge star is the linear map from $1$-forms to $2$-forms — and that map itself exists as a single vertical vector whose components are matrices.
-
-### C.2 $\ast_{2\to1}$ — The Reverse Correspondence
-
-Reading the dictionary of §5.3.3 in reverse, the $2\text{-form} \to 1\text{-form}$ correspondence is equally clear. First, consider the linear map that sends the matrix representation of $dy \wedge dz$,
-
-$$\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix},$$
-
-to $\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}$. Writing this matrix as a horizontal vector $(0,0,0,0,0,1,0,-1,0)$ in row-major order, the matrix that contracts this 9-dimensional vector to 3 dimensions — namely, a $9 \times 3$ vertical vector — is $\ast_{2\to1}$.
+$$J = J_x\,dy\wedge dz + J_y\,dz\wedge dx + J_z\,dx\wedge dy$$
 
 $$
-\ast_{2\to1} = \begin{pmatrix}
-0 & 0 & 0 \\
-0 & 0 & 1 \\
-0 & 0 & 0 \\
-0 & 0 & 0 \\
-0 & 0 & 0 \\
-1 & 0 & 0 \\
-0 & 1 & 0 \\
-0 & 0 & 0 \\
-0 & 0 & 0
-\end{pmatrix}.
+\rho = \rho\,dx\wedge dy\wedge dz
 $$
 
-The rows are in the order of matrix entries $(1,1),(1,2),(1,3),(2,1),(2,2),(2,3),(3,1),(3,2),(3,3)$. Taking the row-major horizontal vector of a $2$-form matrix $M$ and multiplying from the left,
+To keep the notation simple, we write both the coefficient representing charge density and the $3$-form obtained by multiplying it by the volume form with the same symbol $\rho$.
+
+$E$ and $H$ are $1$-forms measured along a line; $D$, $B$, and $J$ are $2$-forms measured through a surface; $\rho$ is a $3$-form measured over a volume.
+
+### C.2 Gauss's law for charge
+
+The integral form is:
 
 $$
-M \, \ast_{2\to1}
-= \begin{pmatrix} M_{23} & M_{31} & M_{12} \end{pmatrix}.
+\int_{\partial V}D=\int_V\rho
 $$
 
-While $\ast_{1\to2}$ was a vertical vector whose components were matrices, $\ast_{2\to1}$ is a vertical vector of numerical entries that contracts a vectorized matrix back to a horizontal vector — a $1$-form. Vertical and horizontal form a pair, and $\ast\ast = \mathrm{id}$ is nothing other than their mutual cancellation.
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_{\partial V}D=\int_V dD
+$$
+
+Therefore, if
+
+$$
+\int_V dD=\int_V\rho
+$$
+
+holds for every region $V$, the local form is:
+
+$$
+dD=\rho
+$$
+
+Expanding in components:
+
+$$
+dD
+=
+\left(\frac{\partial D_x}{\partial x}
+{}+\frac{\partial D_y}{\partial y}
+{}+\frac{\partial D_z}{\partial z}\right)
+dx\wedge dy\wedge dz
+$$
+
+Hence:
+
+$$
+\frac{\partial D_x}{\partial x}
+{}+\frac{\partial D_y}{\partial y}
+{}+\frac{\partial D_z}{\partial z}
+=\rho
+$$
+
+### C.3 The law of magnetic flux
+
+The integral form stating that the net magnetic flux through a closed surface is zero is:
+
+$$
+\int_{\partial V}B=0
+$$
+
+By the generalized Stokes' theorem:
+
+$$
+\int_V dB=0
+$$
+
+If this holds for every region $V$, the local form is:
+
+$$
+dB=0
+$$
+
+Expanding in components:
+
+$$
+dB
+=
+\left(\frac{\partial B_x}{\partial x}
+{}+\frac{\partial B_y}{\partial y}
+{}+\frac{\partial B_z}{\partial z}\right)
+dx\wedge dy\wedge dz
+$$
+
+Therefore:
+
+$$
+\frac{\partial B_x}{\partial x}
+{}+\frac{\partial B_y}{\partial y}
+{}+\frac{\partial B_z}{\partial z}
+=0
+$$
+
+### C.4 Faraday's law
+
+The integral form is:
+
+$$
+\int_{\partial S}E
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_S dE
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+If this holds for every surface $S$, the local form is:
+
+$$
+dE=-\frac{\partial B}{\partial t}
+$$
+
+Expanding in components:
+
+$$dE = \left(\frac{\partial E_z}{\partial y}-\frac{\partial E_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial E_x}{\partial z}-\frac{\partial E_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial E_y}{\partial x}-\frac{\partial E_x}{\partial y}\right)dx\wedge dy$$
+
+On the other hand,
+
+$$
+-\frac{\partial B}{\partial t}
+=
+-\frac{\partial B_x}{\partial t}\,dy\wedge dz
+-\frac{\partial B_y}{\partial t}\,dz\wedge dx
+-\frac{\partial B_z}{\partial t}\,dx\wedge dy
+$$
+
+so the components are:
+
+$$
+\frac{\partial E_z}{\partial y}
+-
+\frac{\partial E_y}{\partial z}
+=
+-\frac{\partial B_x}{\partial t}
+$$
+
+$$
+\frac{\partial E_x}{\partial z}
+-
+\frac{\partial E_z}{\partial x}
+=
+-\frac{\partial B_y}{\partial t}
+$$
+
+$$
+\frac{\partial E_y}{\partial x}
+-
+\frac{\partial E_x}{\partial y}
+=
+-\frac{\partial B_z}{\partial t}
+$$
+
+### C.5 Ampère–Maxwell's law
+
+The integral form is:
+
+$$
+\int_{\partial S}H
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_S dH
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+If this holds for every surface $S$, the local form is:
+
+$$
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+Expanding in components:
+
+$$dH = \left(\frac{\partial H_z}{\partial y}-\frac{\partial H_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial H_x}{\partial z}-\frac{\partial H_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial H_y}{\partial x}-\frac{\partial H_x}{\partial y}\right)dx\wedge dy$$
+
+Also,
+
+$$J+\frac{\partial D}{\partial t} = \left(J_x+\frac{\partial D_x}{\partial t}\right)dy\wedge dz + \left(J_y+\frac{\partial D_y}{\partial t}\right)dz\wedge dx + \left(J_z+\frac{\partial D_z}{\partial t}\right)dx\wedge dy$$
+
+so the components are:
+
+$$
+\frac{\partial H_z}{\partial y}
+-
+\frac{\partial H_y}{\partial z}
+=
+J_x+\frac{\partial D_x}{\partial t}
+$$
+
+$$
+\frac{\partial H_x}{\partial z}
+-
+\frac{\partial H_z}{\partial x}
+=
+J_y+\frac{\partial D_y}{\partial t}
+$$
+
+$$
+\frac{\partial H_y}{\partial x}
+-
+\frac{\partial H_x}{\partial y}
+=
+J_z+\frac{\partial D_z}{\partial t}
+$$
+
+### C.6 Where a metric is needed
+
+The four local forms above can be written using only the exterior derivative $d$ and the degree of differential forms. At this stage, no metric for measuring lengths or angles is used.
+
+A metric becomes necessary when relating $E$ to $D$ and $B$ to $H$. It is also needed when pairing $1$-forms with $2$-forms so that the usual three-component fields can be treated as objects of the same kind.
+
+The Hodge star, introduced in the next chapter, is the tool that provides this correspondence.

--- a/manuscript/en/ch05/ch05.md
+++ b/manuscript/en/ch05/ch05.md
@@ -42,7 +42,7 @@ $df$ by itself is not "the change itself"—as agreed in Chapter 1 §1.1.6, $df$
 
 Integrate this $df$ along a curve $\gamma$. As in Chapter 3 §3.3.1, partition the curve into small intervals, feed $df$ each step's displacement $\Delta\mathbf{r}_i$, and add up the results.
 
-On each interval $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
+To first order on each interval, $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
 
 $$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
 
@@ -70,7 +70,7 @@ $$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y
 
 Therefore $\omega = df$ (with $f = xy$), and the telescoping-sum argument of §5.1.2 applies as-is. The unit circle is a closed curve, so $B = A$, and hence:
 
-$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$
+$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy(\gamma(2\pi))-xy(\gamma(0))=0$$
 
 The calculation $\int_0^{2\pi} \cos 2t\,dt = 0$ from back then mechanically gave zero precisely because $\omega$ was an <strong>exact form</strong>, namely $d(xy)$.
 
@@ -92,7 +92,7 @@ $$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
 
 > <strong>Note</strong> (what "general" means) The $df$ treated in §5.1 had coefficients of the special combination $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$—a triple derived from partial derivatives of a single function $f$. By contrast, the "general" $\omega$ here has $P, Q, R$ as <strong>three arbitrary scalar fields unrelated to one another</strong>. In other words, we call a $1$-form "general" when it cannot necessarily be written as $\omega = df$. The $y\,dx + x\,dy$ of §5.1.3 happened to be an exact form writable as $d(xy)$, but forms that are not of that kind are rather the norm.
 
-$\omega$ need not represent a force; it can represent any "measuring device for measuring along a line."
+$\omega$ need not represent a force; it can be any measuring device applied along a line.
 
 For this $\omega$, there is no guarantee that the same telescoping sum as in §5.1 works. The most concise way to decide is to integrate on a <strong>closed loop</strong>—a curve whose start and end coincide. If $\int_\gamma \omega$ could be written only as the difference of endpoint values, then on a closed loop we would have to get $f(A)-f(A)=0$.
 
@@ -150,7 +150,9 @@ $$\begin{aligned}
 &= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
 \end{aligned}$$
 
-The terms $P\Delta x$ and $Q\Delta y$ cancel beautifully, leaving only $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$.
+The omitted terms are higher order in $\Delta x$ and $\Delta y$.
+
+The terms $P\Delta x$ and $Q\Delta y$ cancel beautifully, leaving only $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ as the leading term.
 
 #### 5.3.2 The Decisive Fact
 
@@ -167,8 +169,6 @@ is the quantity extracted by this limit.
 This is "differentiation" in the same spirit as $f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$ in Chapter 1. Only the denominator has changed—from "distance moved" to "area enclosed"—but the spirit of <strong>extracting a rate of change locally</strong> is unchanged.
 
 > <strong>Note</strong> (why only $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ survives) $\frac{\partial P}{\partial x}$ and $\frac{\partial Q}{\partial y}$ do not appear. The change of $P$ in the $x$ direction ($\frac{\partial P}{\partial x}$) acts in the same direction on the bottom and top edges and cancels; the change of $Q$ in the $y$ direction ($\frac{\partial Q}{\partial y}$) likewise cancels on the right and left edges. What survives is only "the change of $P$ in the $y$ direction" and "the change of $Q$ in the $x$ direction"—the difference of <strong>partial derivatives in mutually orthogonal directions</strong>. This crosswise structure is the key to everything from the next section onward.
-
----
 
 ---
 
@@ -224,7 +224,7 @@ The formula above can of course be derived by doing separate loop calculations o
 
 > <strong>Note</strong> (Relation to the axiomatic definition) Many mathematics books take Leibniz's rule and $d(dx)=0$ as the <strong>definition</strong> of $d$. That definition is concise, but it is hard to see why those rules should hold. In this book we start from the dissection of an infinitesimal loop. What we are about to verify is that this geometric $d$ and the algebraic computational rules are consistent. The rules are for computational convenience; <strong>the meaning is in §5.3</strong>. Still, when one looks ahead to higher dimensions, this algebraic definition is indeed very concise.
 
-First, for $\omega = P\,dx + Q\,dy + R\,dz$, it should be uncontroversial that $d\omega = d(P\,dx) + d(Q\,dy) + d(R\,dz)$. This is the same as considering loops around tilted parallelograms. The question is $d(P\,dx)$—how does $d$ act on the $1$-form $dx$ with coefficient $P$?
+First, for $\omega = P\,dx + Q\,dy + R\,dz$, we take $d$ to act linearly: $d\omega = d(P\,dx) + d(Q\,dy) + d(R\,dz)$. This is the same as considering loops around tilted parallelograms. The question is $d(P\,dx)$—how does $d$ act on the $1$-form $dx$ with coefficient $P$?
 
 Here, the geometric $d$ obtained in §5.3–§5.4 has already taught us something. For $\omega = P\,dx$ ($Q=R=0$), if we carry out the infinitesimal loop calculation of §5.3 not only in the $xy$ plane but also in the $zx$ plane, $d(P\,dx)$ should have no component on the $yz$ face, and
 
@@ -290,7 +290,7 @@ dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial
 dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
 \end{aligned}$$
 
-> <strong>Note</strong> (A guide rail for experienced readers) Readers who already know vector analysis will find these three coefficients familiar. In this book we do not rely on their names; we first build the operation $d$ itself. The correspondence will be organized in later chapters.
+> <strong>Note</strong> (A guidepost for experienced readers) Readers who already know vector analysis will find these three coefficients familiar. In this book we do not rely on their names; we first build the operation $d$ itself. The correspondence will be organized in later chapters.
 
 > <strong>Checkpoint</strong>
 > - The exterior derivative $d\omega$ of a general $1$-form $\omega$ is a $2$-form whose coefficients are the cross differences of partial derivatives $(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$.
@@ -331,7 +331,7 @@ Writing out the components for $\omega = P\,dx + Q\,dy + R\,dz$ explicitly:
 
 $$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$
 
-In the matrix language we have used since Chapter 2, the $2$-form on the right-hand side is represented by the antisymmetric matrix $\mathbf{J}^T - \mathbf{J}$. If $\mathbf{v}_1, \mathbf{v}_2$ are the two edges of a surface element, then $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$. All components are written out in Appendix B.3; consult it as needed.
+In the matrix language we have used since Chapter 2, the $2$-form on the right-hand side is represented by the antisymmetric matrix $\mathbf{J}^T - \mathbf{J}$, where $\mathbf{J}$ is the Jacobian matrix of the coefficient vector $(P,Q,R)$. If $\mathbf{v}_1, \mathbf{v}_2$ are the two edges of a surface element, then $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$. All components are written out in Appendix B.3; consult it as needed.
 
 The structure of this theorem is remarkably simple. <strong>Integral measured on the global boundary</strong> $=$ <strong>accumulation of local mismatch ($d\omega$) in the interior</strong>. $d$ is the device that <strong>translates</strong> information about $\omega$ on the boundary $\partial S$ into information about $d\omega$ in the interior $S$.
 
@@ -341,11 +341,8 @@ The structure of this theorem is remarkably simple. <strong>Integral measured on
 
 > <strong>Checkpoint</strong>
 > - If we tile a surface $S$ with infinitesimal loops, interior edges cancel and only the contribution from the boundary $\partial S$ remains.
-> - $\int_{\partial S} \omega = \int_S d\omega$. A global boundary integral equals an integral of the local exterior derivative.
+> - $\oint_{\partial S} \omega = \iint_S d\omega$. A global boundary integral equals an integral of the local exterior derivative.
 > - As with surface integrals in Chapter 3, we divide the surface into small patches, act with the measuring device on each patch, and aggregate.
-
----
-
 
 ---
 
@@ -357,7 +354,7 @@ In Chapter 3 §3.4.2 we wrote a general $2$-form in the form
 
 $$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
 
-This is a "measuring device that measures flux along a surface." As we saw in Chapter 2 §2.4.5, the three basis $2$-forms each measure the area of the projection onto the $yz$, $zx$, and $xy$ planes, respectively.
+This is a measuring device for flux through a surface. As we saw in Chapter 2 §2.4.5, the three basis $2$-forms each measure the area of the projection onto the $yz$, $zx$, and $xy$ planes, respectively.
 
 #### 5.7.2 Measuring on the Faces of a Tiny Rectangular Box
 
@@ -467,13 +464,13 @@ $$d(d\omega) = 0$$
 
 #### 5.9.1 Stokes and Gauss Were the Same Formula
 
-Stokes' theorem $\oint_{\partial S}\omega = \iint_S d\omega$ from §5.6 and Gauss' theorem $\iint_{\partial V}\eta = \iiint_V d\eta$ from §5.7. Placed side by side, only the number of integral signs differs—$\oint$, $\iint$, $\iiint$—yet the structure is identical. If $M$ is a curve, we write $\int$ (1-dimensional); if a surface, $\iint$ (2-dimensional); if a solid, $\iiint$ (3-dimensional)—the number of integral signs is determined only by the dimension of $M$.
+Place Stokes' theorem $\oint_{\partial S}\omega = \iint_S d\omega$ from §5.6 and Gauss' theorem $\iint_{\partial V}\eta = \iiint_V d\eta$ from §5.7 side by side. Only the number of integral signs differs—$\oint$, $\iint$, $\iiint$—yet the structure is identical. If $M$ is a curve, we write $\int$ (1-dimensional); if a surface, $\iint$ (2-dimensional); if a solid, $\iiint$ (3-dimensional)—the number of integral signs is determined only by the dimension of $M$.
 
 So, regardless of dimension, we write uniformly:
 
 $$\int_{\partial M} \omega = \int_M d\omega$$
 
-Here $\omega$ is a $k$-form, $M$ is a $(k+1)$-dimensional region, and $\partial M$ is its $k$-dimensional boundary. For $k=0$ this is the fundamental theorem of calculus, $\int_{\partial M} f = f(B)-f(A) = \int_M df$; for $k=1$ it is Stokes' theorem; for $k=2$ it is Gauss' theorem. All are absorbed into this single line.
+Here $\omega$ is a $k$-form, $M$ is a $(k+1)$-dimensional region, and $\partial M$ is its $k$-dimensional boundary. For $k=0$, with the oriented boundary $\partial M=\{B\}-\{A\}$, this is the fundamental theorem of calculus: $\int_{\partial M} f=f(B)-f(A)=\int_M df$; for $k=1$ it is Stokes' theorem; for $k=2$ it is Gauss' theorem. All fit into this single line.
 
 The power of this unified form stands out even more in combination with $d^2=0$ from §5.8. Replacing $\omega$ by $d\omega$ in $\int_{\partial M} \omega = \int_M d\omega$:
 
@@ -515,8 +512,6 @@ With only these four rules, the exterior derivative of any form from $0$-form to
 
 ---
 
----
-
 ### §5.10 From Integrals to Differential Equations — Localizing Physical Laws
 
 #### 5.10.1 Turning Integral Laws into Differential Laws
@@ -555,9 +550,9 @@ In other words, the exterior derivative $d$ is not merely a symbol that raises t
 
 A typical instance of this pattern is the fundamental laws of electromagnetism.
 
-> <strong>Note</strong> (For readers who have not yet studied electromagnetism) In this section we are not after the detailed content of electromagnetism, but after the mechanism by which an integral law becomes a local one. Think of $E,D,B,H,J,\rho$ not so much as names of physical quantities as symbols standing for "quantities measured along a line," "quantities measured through a surface," and "quantities measured over a volume."
+> <strong>Note</strong> (for readers who have not yet studied electromagnetism) In this section we are not after the detailed content of electromagnetism, but after the mechanism by which an integral law becomes a local one. Think of $E,D,B,H,J,\rho$ not so much as names of physical quantities as symbols standing for "quantities measured along a line," "quantities measured through a surface," and "quantities measured over a volume."
 
-> <strong>Note</strong> (For readers who learned electromagnetism through vector calculus) Here we choose the degree of each form according to the dimension of the object over which we integrate, rather than treating the fields as ordinary three-component vectors. Because $E$ and $H$ are integrated along lines, they are $1$-forms; because $D,B,J$ are integrated through surfaces, they are $2$-forms; because $\rho$ is integrated over volume, it is a $3$-form. The correspondence with the usual vector-calculus notation will be organized after we introduce the Hodge star.
+> <strong>Note</strong> (for readers who learned electromagnetism through vector calculus) Here we choose the degree of each form according to the dimension of the object over which we integrate, rather than treating the fields as ordinary three-component vectors. Because $E$ and $H$ are integrated along lines, they are $1$-forms; because $D,B,J$ are integrated through surfaces, they are $2$-forms; because $\rho$ is integrated over volume, it is a $3$-form. The correspondence with the usual vector-calculus notation will be organized after we introduce the Hodge star.
 
 In electromagnetism, the object of integration depends on the kind of quantity: some are measured along lines, some through surfaces, some over volume. Schematically, we can read the situation as follows.
 
@@ -628,7 +623,7 @@ and
 $$
 \int_{\partial S}H
 =
-\int_SJ+\frac{\partial}{\partial t}\int_S D
+\int_S J+\frac{\partial}{\partial t}\int_S D
 $$
 
 implies
@@ -735,7 +730,7 @@ $$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
 \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
 \end{pmatrix}$$
 
-That is, comparing with the matrix representation of a $2$-form found in Chapter 2:
+With the Chapter 2 convention for representing a $2$-form by an antisymmetric matrix, this gives:
 
 $$d\omega = \mathbf{J}^T - \mathbf{J}$$
 
@@ -757,7 +752,7 @@ $$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial
 
 #### B.4.1 The 27 components of $d\eta$ — expanded into three matrices
 
-The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (the others are sign reversals or $0$). Write the components of $d\eta$ as $(d\eta)_{abc} = \partial_a \eta_{bc}$, where $\partial_x=\frac{\partial}{\partial x}$, $\partial_y=\frac{\partial}{\partial y}$, $\partial_z=\frac{\partial}{\partial z}$, and $a,b,c \in \{x,y,z\}$, so there are $3^3=27$ components. Arranging them into three $3 \times 3$ matrices with $a$ fixed gives:
+The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (the others are sign reversals or $0$). To see where all entries go, first arrange the raw derivative components $\partial_a\eta_{bc}$, where $\partial_x=\frac{\partial}{\partial x}$, $\partial_y=\frac{\partial}{\partial y}$, $\partial_z=\frac{\partial}{\partial z}$, and $a,b,c\in\{x,y,z\}$, so there are $3^3=27$ entries before antisymmetrization. Arranging them into three $3 \times 3$ matrices with $a$ fixed gives:
 
 $$
 \begin{aligned}
@@ -782,13 +777,13 @@ d\eta_{z,\cdot,\cdot}
 \end{aligned}
 $$
 
-When these $27$ components are contracted with the corresponding basis wedge products of $1$-forms (for example, if $a=x,\;b=y,\;c=z$, then $dx \wedge dy \wedge dz$), terms with repeated indices (diagonal entries, $b=c$, and so on) vanish because $dx \wedge dx = 0$, and only the $6$ terms with all of $a,b,c$ distinct (permutations of $3!$) survive. Each is summed with its sign. Because each component is antisymmetrized and arranged in a matrix here, we are double-counting; as in Chapter 2 §2.4.4 and Appendix D, a factor of $\frac{1}{2}$ enters:
+When these $27$ components are contracted with the corresponding basis wedge products of $1$-forms (for example, if $a=x,\;b=y,\;c=z$, then $dx \wedge dy \wedge dz$), terms with repeated indices (diagonal entries, $b=c$, and so on) vanish because $dx \wedge dx = 0$, and only the $6$ terms with all of $a,b,c$ distinct (permutations of $3!$) survive. Each is summed with its sign. The factor convention is the same as in Chapter 2 §2.4.4: the matrix stores each antisymmetric pair twice, while the form stores it once. With that convention, the six surviving signed terms combine to
 
 $$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$
 
-In other words, of the $27$ components of $d\eta$, $6$ survive and pair up to converge to the trace of $\mathbf{J}_\eta$.
+In other words, of the $27$ components of $d\eta$, $6$ survive and pair up and combine into the trace of $\mathbf{J}_\eta$.
 
-A $3$-form has only the single basis element $dx \wedge dy \wedge dz$, so as a matrix it degenerates to a scalar coefficient.
+A $3$-form has only the single basis element $dx \wedge dy \wedge dz$, so in this representation it reduces to a scalar coefficient.
 
 ### B.5 $d^2 f = 0$ and the Hessian
 
@@ -989,7 +984,7 @@ The integral form is:
 $$
 \int_{\partial S}H
 =
-\int_SJ+\frac{\partial}{\partial t}\int_S D
+\int_S J+\frac{\partial}{\partial t}\int_S D
 $$
 
 Applying the generalized Stokes' theorem to the left-hand side:
@@ -997,7 +992,7 @@ Applying the generalized Stokes' theorem to the left-hand side:
 $$
 \int_S dH
 =
-\int_SJ+\frac{\partial}{\partial t}\int_S D
+\int_S J+\frac{\partial}{\partial t}\int_S D
 $$
 
 If this holds for every surface $S$, the local form is:

--- a/translation/drafts/ch05-5.0-5.3.md
+++ b/translation/drafts/ch05-5.0-5.3.md
@@ -1,0 +1,171 @@
+# Chapter 5: What Does It Mean to Differentiate? — The Exterior Derivative $d$: Integral Quantities and Local Laws
+
+### §5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential
+
+In Chapter 3 we defined integration over curves, surfaces, and regions in the language of $k$-forms. Work along a curve $\gamma$ is $\int_\gamma \omega$, flux through a surface $S$ is $\iint_S \eta$, and the total mass of a region $V$ is $\iiint_V \Omega$. Each followed the same principle: feed $k$ displacement vectors to a $k$-form (measuring device), obtain a scalar, and aggregate over the entire region.
+
+In Chapter 4 we introduced the operation that rebuilds measuring devices to compute the same integral in different variables—the pullback $\Phi^*$. With that, we also gained a tool for changing the variables of computation while preserving the integral value.
+
+The integrals we now have in hand are all quantities that span an <strong>entire region</strong> (below we call such quantities <strong>global</strong>). Work is the total sum over an entire curve, flux is the total amount crossing an entire surface, and mass is the grand total over an entire region. They depend on how the measuring device is applied and on the choice of region.
+
+But this alone is not what physicists ultimately want. Behind the laws observed as integral quantities, they want to see local relations that hold at each point. Whether Maxwell's equations or the Navier–Stokes equations, the fundamental laws of nature are written as <strong>local</strong> relations—differential equations—that describe <strong>what holds at each point in space and each instant in time</strong>. Global integral quantities depend on the region, but local laws have a universality that does not depend on the region.
+
+> <strong>Note</strong> (the terms global / local) Other books sometimes call a similar contrast <strong>macro / micro</strong>. In this chapter, however, we use global / local to mean the contrast between a quantity integrated over an entire region and a relation that holds at each point—not so much a difference of scale.
+
+Here a fundamental question arises.
+
+> <strong>How do we extract a local law from an integrated quantity?</strong>
+
+The subject of this chapter—the <strong>exterior derivative $d$</strong>—answers this question. $d$ is an operator that acts on a $k$-form and returns a $(k+1)$-form; combined with the integrals defined in Chapter 3, it translates a "global integral measured on the boundary" into "an accumulation of local changes in the interior." In short, <strong>$d$ is the device that converts integral laws into differential laws</strong>.
+
+The structure of this chapter is as follows. First we recall the $df$ introduced in Chapter 1 and build $d\omega$ from the mismatch that remains when a general $1$-form is measured on a closed loop. Next we extend the same idea to $2$-forms and unify Stokes' theorem and Gauss' theorem into a single form. Finally we look at the structure $d^2=0$ and at how the exterior derivative localizes physical laws, connecting to the Hodge star in the next chapter.
+
+---
+
+### §5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?
+
+#### 5.1.1 $df$ Is "Raising the Degree"
+
+In Chapter 1 §1.2 we defined the total differential of a function $f(x,y,z)$ as a row vector:
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+This is an operation that takes a <strong>$0$-form (the scalar field $f$) as input and outputs a $1$-form (the row vector $df$)</strong>. The degree rises from 0 to 1.
+
+Recall here that $df(\mathbf{v})$ returns the first-order change in $f$ for a displacement $\mathbf{v}$. When $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ is sufficiently small:
+
+$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
+
+$df$ by itself is not "the change itself"—as agreed in Chapter 1 §1.1.6, $df$ is an operator; a numerical value is obtained only when it acts on a displacement vector.
+
+#### 5.1.2 A Line Integral Leaves Only the Difference of Endpoints
+
+Integrate this $df$ along a curve $\gamma$. As in Chapter 3 §3.3.1, partition the curve into small intervals, feed $df$ each step's displacement $\Delta\mathbf{r}_i$, and add up the results.
+
+On each interval $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
+
+$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
+
+Expanding this sum:
+
+$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
+
+Adjacent terms $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ cancel in plus and minus—a <strong>telescoping sum</strong>. Only the first and last survive. In the limit of infinitely fine partition:
+
+$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
+
+where $A$ is the starting point of the curve and $B$ is the endpoint.
+
+> <strong>Checkpoint so far</strong>
+> - $\int_\gamma df = f(B) - f(A)$. The result of the integral depends entirely on the endpoint values, not at all on the shape of the path.
+> - This holds precisely because $df$ is a special $1$-form. In mechanics, it is the mathematical reason why "the work of a conservative force does not depend on the path."
+
+#### 5.1.3 Checking with a Chapter 3 Example
+
+In Chapter 3 §3.4.1 we integrated $\omega = y\,dx + x\,dy$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ and found the result to be $0$. At the time we integrated straightforwardly along the coefficients, but viewed in today's language the story is much simpler.
+
+In fact $y\,dx + x\,dy$ is nothing other than $d(xy)$. For:
+
+$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
+
+Therefore $\omega = df$ (with $f = xy$), and the telescoping-sum argument of §5.1.2 applies as-is. The unit circle is a closed curve, so $B = A$, and hence:
+
+$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy\Big|_A^A = \cos 0\cdot\sin 0 - \cos 0\cdot\sin 0 = 0$$
+
+The calculation $\int_0^{2\pi} \cos 2t\,dt = 0$ from back then mechanically gave zero precisely because $\omega$ was an <strong>exact form</strong>, namely $d(xy)$.
+
+> <strong>Note</strong> (exact forms) A $1$-form that can be written as $\omega = df$ is called an <strong>exact form</strong>. Integrating an exact form along a closed curve always gives zero, as long as $f$ is a single-valued function. On the other hand, beware: "the integral along some closed curve was zero" does not necessarily mean the form is exact (whether the integral is zero on all closed curves also depends on the topology of the region). We examine this point in detail in §5.2.
+
+> <strong>Note</strong> (the relation between $d$ and $\int$—a boundary formula, not an inverse map) $\int_\gamma df = f(B)-f(A)$ does not mean that integration is a global inverse of the exterior derivative $d$. Integration is a functional that depends on the choice of curve $\gamma$; it is not an operation that reconstructs the entire original function $f$ from $df$. This formula is the fundamental theorem of calculus: "integrating an exact form along a curve leaves only the boundary, namely the endpoints." It is safest to think of it as the $0$-form version of the Stokes-type formulas we will see later.
+
+---
+
+### §5.2 The "Mismatch" That Appears on a Closed Loop
+
+#### 5.2.1 What About a General $1$-Form?
+
+What about a general $1$-form
+
+$$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
+
+? Here $P, Q, R$ are coefficients that vary from place to place (scalar fields)—the "general $1$-form" introduced in Chapter 3 §3.4.1.
+
+> <strong>Note</strong> (what "general" means) The $df$ treated in §5.1 had coefficients of the special combination $\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z}$—a triple derived from partial derivatives of a single function $f$. By contrast, the "general" $\omega$ here has $P, Q, R$ as <strong>three arbitrary scalar fields unrelated to one another</strong>. In other words, we call a $1$-form "general" when it cannot necessarily be written as $\omega = df$. The $y\,dx + x\,dy$ of §5.1.3 happened to be an exact form writable as $d(xy)$, but forms that are not of that kind are rather the norm.
+
+$\omega$ need not represent a force; it can represent any "measuring device for measuring along a line."
+
+For this $\omega$, there is no guarantee that the same telescoping sum as in §5.1 works. The most concise way to decide is to integrate on a <strong>closed loop</strong>—a curve whose start and end coincide. If $\int_\gamma \omega$ could be written only as the difference of endpoint values, then on a closed loop we would have to get $f(A)-f(A)=0$.
+
+We write the line integral along a closed loop as $\oint_\gamma \omega$. In general:
+
+$$\oint_\gamma \omega \neq 0$$
+
+If you drag an object once around against friction, the work is not zero; if you go once around a swirling current, you receive net work. This <strong>fact that "closing the loop still does not balance the books" is evidence of local structure such as circulation or vorticity</strong>.
+
+> <strong>Note</strong> (no physics background needed) Readers who have not yet treated friction or water flow in physics need not stop here. What matters now is not the specific physical phenomenon but only the sense that "if the integral on a closed loop is not zero, there is local structure like circulation in that field." The detailed physical correspondences will be touched on in later chapters.
+
+#### 5.2.2 Where Does the Local Information Live?
+
+Then where does this "mismatch left after one circuit" come from? If we think of the closed loop only at a global scale all at once, we cannot tell which points inside contributed how much to the mismatch. Recall how we found $f'(x)$ in Chapter 1—we extracted a rate of change <strong>at a single point</strong> by taking the limit $\Delta x \to 0$ of $\Delta f / \Delta x$.
+
+We use the same idea here. As we shrink the loop more and more, what happens to the value of the integral $\oint \omega$ around one circuit? If the leading term of $\oint \omega$ shrinks in proportion to the <strong>area enclosed</strong> by the loop, then the mismatch per unit area—how much the books fail to balance per unit area—should be determined as a value intrinsic to that point.
+
+Conversely, if it does not scale that way (for example, if it scales with the perimeter of the loop), it cannot be fixed as a per-area quantity, and we cannot call it "a property at that point." So the question is:
+
+> <strong>When a tiny loop is traversed once, does the leading term of $\oint \omega$ scale with the enclosed area? If so, what is the proportionality constant?</strong>
+
+In the next section we actually answer this question with a tiny rectangle placed in the $xy$ plane.
+
+---
+
+### §5.3 Dissecting a Tiny Loop — Mismatch Scales with Area
+
+#### 5.3.1 A Tiny Rectangle in the $xy$ Plane
+
+Consider a tiny rectangle parallel to the $xy$ plane, with the point $(x, y, z)$ as its lower-left vertex. Let the width in the $x$ direction be $\Delta x$ and the width in the $y$ direction be $\Delta y$. Traverse the four edges of this rectangle once in the <strong>counterclockwise (right-handed) direction</strong>, and integrate $\omega = P\,dx + Q\,dy + R\,dz$.
+
+Let us evaluate the integral on each edge using a first-order Taylor approximation (with $\Delta x, \Delta y$ sufficiently small).
+
+> <strong>Note</strong> (on Taylor expansion) There is no need to be intimidated by the words "Taylor expansion." What we use here is the first-order approximation of a multivariable function—the same thing as $\Delta f \approx f'(x)\,\Delta x$ in Chapter 1 §1.2.1. For example, the value of $Q(x+\Delta x, y)$ shifted by $\Delta x$ in the $x$ direction can be approximated as $Q + \frac{\partial Q}{\partial x}\,\Delta x$ using the partial derivative of $Q$ with respect to $x$. When $\Delta x$ is sufficiently small, terms of order $(\Delta x)^2$ and higher are overwhelmingly smaller than $\Delta x$ and may be ignored—that is what first-order approximation means.
+
+$z$ is fixed, so $dz=0$ and the $R$ term contributes nothing.
+
+<strong>Edge 1 (bottom edge, rightward)</strong>: from $(x, y)$ to $(x+\Delta x, y)$. With $y$ fixed, $dy=0$. $P$ is approximately $P(x, y, z)$. Contribution: $P(x, y, z)\,\Delta x$.
+
+<strong>Edge 2 (right edge, upward)</strong>: from $(x+\Delta x, y)$ to $(x+\Delta x, y+\Delta y)$. $dx=0$. Evaluate $Q$ at the position shifted by $\Delta x$ in the $x$ direction:
+$$Q(x+\Delta x, y, z) \approx Q(x, y, z) + \frac{\partial Q}{\partial x}\Delta x$$
+Contribution: $\bigl(Q + \frac{\partial Q}{\partial x}\Delta x\bigr)\,\Delta y$.
+
+<strong>Edge 3 (top edge, leftward)</strong>: from $(x+\Delta x, y+\Delta y)$ to $(x, y+\Delta y)$. The direction is negative, so the sign flips. Evaluate $P$ at the position shifted by $\Delta y$ in the $y$ direction:
+$$P(x, y+\Delta y, z) \approx P(x, y, z) + \frac{\partial P}{\partial y}\Delta y$$
+Contribution: $-\bigl(P + \frac{\partial P}{\partial y}\Delta y\bigr)\,\Delta x$.
+
+<strong>Edge 4 (left edge, downward)</strong>: from $(x, y+\Delta y)$ back to $(x, y)$. Contribution: $-Q(x, y, z)\,\Delta y$.
+
+Summing the contributions from all four edges:
+
+$$\begin{aligned}
+\oint \omega &\approx P\Delta x + (Q + \frac{\partial Q}{\partial x}\Delta x)\Delta y - (P + \frac{\partial P}{\partial y}\Delta y)\Delta x - Q\Delta y \\
+&= P\Delta x + Q\Delta y + \frac{\partial Q}{\partial x}\Delta x\Delta y - P\Delta x - \frac{\partial P}{\partial y}\Delta x\Delta y - Q\Delta y \\
+&= (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y
+\end{aligned}$$
+
+The terms $P\Delta x$ and $Q\Delta y$ cancel beautifully, leaving only $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$.
+
+#### 5.3.2 The Decisive Fact
+
+This result tells us just one thing:
+
+> <strong>The leading term of the mismatch left after one circuit is proportional to the enclosed area $\Delta x\,\Delta y$.</strong>
+
+And the proportionality constant $\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$ is precisely the <strong>mismatch per unit area</strong> at the point $(x,y,z)$—a local quantity representing the "strength of vorticity" at that point. More precisely, for the tiny rectangle $R_{\Delta x,\Delta y}$,
+
+$$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\Delta x,\Delta y}}\omega = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$$
+
+is the quantity extracted by this limit.
+
+This is "differentiation" in the same spirit as $f'(x) = \lim_{\Delta x\to 0} \frac{\Delta f}{\Delta x}$ in Chapter 1. Only the denominator has changed—from "distance moved" to "area enclosed"—but the spirit of <strong>extracting a rate of change locally</strong> is unchanged.
+
+> <strong>Note</strong> (why only $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ survives) $\frac{\partial P}{\partial x}$ and $\frac{\partial Q}{\partial y}$ do not appear. The change of $P$ in the $x$ direction ($\frac{\partial P}{\partial x}$) acts in the same direction on the bottom and top edges and cancels; the change of $Q$ in the $y$ direction ($\frac{\partial Q}{\partial y}$) likewise cancels on the right and left edges. What survives is only "the change of $P$ in the $y$ direction" and "the change of $Q$ in the $x$ direction"—the difference of <strong>partial derivatives in mutually orthogonal directions</strong>. This crosswise structure is the key to everything from the next section onward.
+
+---

--- a/translation/drafts/ch05-5.10-5.11.md
+++ b/translation/drafts/ch05-5.10-5.11.md
@@ -1,0 +1,173 @@
+### §5.10 From Integrals to Differential Equations — Localizing Physical Laws
+
+#### 5.10.1 Turning Integral Laws into Differential Laws
+
+Let us return to the question posed at the opening of this chapter.
+
+> <strong>How do we extract a local law from an integrated quantity?</strong>
+
+The answer lies in the two tools we have developed—<strong>Stokes's theorem</strong> and the <strong>exterior derivative $d$</strong>.
+
+Many fundamental laws of physics are discovered first in <strong>integral form</strong>. They take the shape: a quantity measured on the boundary of a region equals the total of sources inside:
+
+$$\int_{\partial M} \omega = \int_M \eta$$
+
+The left-hand side is the integral measured on the boundary (a global observable); the right-hand side is the integral of sources in the interior (a global total). $\omega$ and $\eta$ are differential forms of the appropriate degrees.
+
+Apply Stokes's theorem to the left-hand side. Since $\int_{\partial M} \omega = \int_M d\omega$:
+
+$$\int_M d\omega = \int_M \eta$$
+
+Rearranging:
+
+$$\int_M (d\omega - \eta) = 0$$
+
+This is the decisive moment. If this equality holds for <strong>every smooth region $M$</strong>, including sufficiently small ones, the integrand form must vanish identically at each point. For if there were a point where $d\omega - \eta \neq 0$, the integral over a tiny region around that point would not be zero—a contradiction. Here too we are considering the case where the fields are sufficiently smooth and contain no singular concentrated sources.
+
+Therefore:
+
+$$d\omega = \eta$$
+
+This is the <strong>local differential law extracted from the integral law</strong>. $d$ has functioned precisely as the operator that converts an integral equation into a differential equation.
+
+In other words, the exterior derivative $d$ is not merely a symbol that raises the degree of a form. It is the operator that translates a law observed on the boundary into a law that holds at each point in the interior.
+
+#### 5.10.2 Examples from Physics
+
+A typical instance of this pattern is the fundamental laws of electromagnetism.
+
+> <strong>Note</strong> (For readers who have not yet studied electromagnetism) In this section we are not after the detailed content of electromagnetism, but after the mechanism by which an integral law becomes a local one. Think of $E,D,B,H,J,\rho$ not so much as names of physical quantities as symbols standing for "quantities measured along a line," "quantities measured through a surface," and "quantities measured over a volume."
+
+> <strong>Note</strong> (For readers who learned electromagnetism through vector calculus) Here we choose the degree of each form according to the dimension of the object over which we integrate, rather than treating the fields as ordinary three-component vectors. Because $E$ and $H$ are integrated along lines, they are $1$-forms; because $D,B,J$ are integrated through surfaces, they are $2$-forms; because $\rho$ is integrated over volume, it is a $3$-form. The correspondence with the usual vector-calculus notation will be organized after we introduce the Hodge star.
+
+In electromagnetism, the object of integration depends on the kind of quantity: some are measured along lines, some through surfaces, some over volume. Schematically, we can read the situation as follows.
+
+| Quantity | What is measured | Form |
+| --- | --- | --- |
+| $E,H$ | along a line | $1$-form |
+| $D,B,J$ | through a surface | $2$-form |
+| $\rho$ | over a volume | $3$-form |
+
+For example, Gauss's law for charge takes the form
+
+$$
+\int_{\partial V}D=\int_V\rho
+$$
+
+The left-hand side is the total flux of $D$ passing outward through the closed surface $\partial V$; the right-hand side is the total charge contained in the interior $V$. By Stokes's theorem,
+
+$$
+\int_{\partial V}D=\int_V dD
+$$
+
+so
+
+$$
+\int_V dD=\int_V\rho
+$$
+
+If this holds for every region $V$, then
+
+$$
+dD=\rho
+$$
+
+Similarly, the law that the net magnetic flux through a closed surface is zero can be written
+
+$$
+\int_{\partial V}B=0
+$$
+
+By Stokes's theorem,
+
+$$
+\int_V dB=0
+$$
+
+and if this holds for every $V$, then
+
+$$
+dB=0
+$$
+
+Laws that include time variation have the same type. For a surface $S$,
+
+$$
+\int_{\partial S}E
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+implies
+
+$$
+dE=-\frac{\partial B}{\partial t}
+$$
+
+and
+
+$$
+\int_{\partial S}H
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+implies
+
+$$
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+Here $d$ is the exterior derivative in the spatial directions, and time variation is represented by $\partial/\partial t$.
+
+Thus the fundamental equations of electromagnetism appear, in the language of this chapter, as expressions of the same type:
+
+$$
+dD=\rho,\qquad
+dB=0,\qquad
+dE=-\frac{\partial B}{\partial t},\qquad
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+What matters here is not to memorize these as new formulas of electromagnetism. The single point is that an integral law measured on the boundary passes, via the exterior derivative $d$, to a local law in the interior.
+
+On the other hand, relating $E$ to $D$, or $B$ to $H$, requires a convention for how space and the medium are measured. Likewise, matching quantities measured along lines to quantities measured through surfaces requires additional rules for how length, area, and volume are measured. The Hodge star, which we introduce in the next chapter, is the tool that supplies this correspondence.
+
+A detailed development including component formulas is deferred to Appendix C, "Integral Forms of Electromagnetism and Differential Forms."
+
+> <strong>Checkpoint so far</strong>
+> - Physical laws are often given in the form $\int_{\partial M} \omega = \int_M \eta$.
+> - By Stokes's theorem, rewrite $\int_{\partial M} \omega = \int_M d\omega$; since the equality holds for every $M$, we obtain $d\omega = \eta$ (the local law).
+> - This localization, however, is an argument in regions where the fields are sufficiently smooth and contain no singular concentrated sources.
+> - $d$ is the operator that converts integral laws into differential laws.
+
+---
+
+### §5.11 Outlook Toward Part II — Foreshadowing the Hodge Star
+
+In this chapter we have acquired the powerful operator called the exterior derivative $d$. $d$ maps:
+
+- $0$-form $\to$ $1$-form: $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$
+- $1$-form $\to$ $2$-form: $d\omega = (\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z})\,dy\wedge dz + (\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x})\,dz\wedge dx + (\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})\,dx\wedge dy$
+- $2$-form $\to$ $3$-form: $d\eta = (\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z})\,dx\wedge dy\wedge dz$
+
+Each time the degree rises by one step, the coefficients rearrange in a different pattern. And $d^2=0$ guarantees that no contradiction can slip in among these levels.
+
+Yet one asymmetry stands out. A $0$-form and a $3$-form each have 1 independent component; a $1$-form and a $2$-form each have 3—symmetry in the pattern $1, 3, 3, 1$ (as we saw in Chapter 2 §2.5.9–§2.5.10). This symmetry is no accident. In three-dimensional space with Cartesian coordinates, once we add rules for measuring length, area, and volume, a "dictionary" appears that links forms of the same information content.
+
+That dictionary is the <strong>Hodge star</strong> $\ast$, which we introduce in the next chapter. But $\ast$ is not a mere relabeling of symbols. It depends on which direction corresponds to which face, how area and volume are measured, and how orientation is fixed. For that reason we do not yet use concrete correspondence formulas in this chapter.
+
+What we have built so far is, after all, only $d$. $d$ raises the degree by one, extracts local mismatch, and converts integral laws into local laws. Yet $d$ alone cannot yet reconstruct the familiar operations of vector analysis. To match $1$-forms with $2$-forms, we need the additional rules for how length, area, and volume are measured in space—the <strong>metric</strong>.
+
+In the next chapter we define those rules of "measurement" as the Hodge star $\ast$. To the $d$ constructed in Chapter 5 we add $\ast$ in Chapter 6, and use the two together to rebuild the familiar operations of vector analysis in later chapters. From here we move into the core of Part II—unmasking div, grad, and curl.
+
+---
+
+> <strong>Checkpoint so far — Chapter 5</strong>
+> - The exterior derivative $d$ is the operator that maps a $k$-form to a $(k+1)$-form: $0$-form $\to$ $1$-form ($df$), $1$-form $\to$ $2$-form, $2$-form $\to$ $3$-form.
+> - There are four computational rules: the definition of $df$, linearity, the Leibniz rule $d(f\omega) = df\wedge\omega + f\,d\omega$, and $d(dx)=d(dy)=d(dz)=0$.
+> - The geometric origin is §5.3's dissection of a tiny loop: the mismatch around a closed loop scales with area, and the proportionality constant is $d\omega$.
+> - Stokes's theorem $\int_{\partial M} \omega = \int_M d\omega$ is the universal bridge linking boundary and interior.
+> - $d^2 = 0$ comes from the symmetry of mixed partial derivatives and the antisymmetry of the wedge product; geometrically it corresponds to "the boundary of a boundary is zero as an oriented sum."
+> - $d$ is the operator that converts integral laws into local differential laws—an indispensable role in the formulation of physics.
+> - In the next chapter we add rules for measuring length, area, and volume, and organize the correspondence between $d$ and the operations of vector analysis through the Hodge star $\ast$.

--- a/translation/drafts/ch05-5.4-5.6.md
+++ b/translation/drafts/ch05-5.4-5.6.md
@@ -1,0 +1,173 @@
+### §5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area
+
+#### 5.4.1 Revisiting the Wedge Product
+
+Let us restate the $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ obtained in §5.3 in the language of Chapter 2. In Chapter 2 §2.4.4 we defined the area-measuring device $dx \wedge dy$. This was a device that, when fed two vectors $\mathbf{v}_1, \mathbf{v}_2$, returns the signed area of the shadow they cast onto the $xy$ plane:
+
+$$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
+
+In particular, if we feed the displacement $\Delta x\,\hat{e}_x$ in the $x$ direction and the displacement $\Delta y\,\hat{e}_y$ in the $y$ direction, we get $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$.
+
+#### 5.4.2 Definition of $d\omega$
+
+Written in this language, the result of §5.3 says that for the two edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ of an infinitesimal rectangle, some <strong>new $2$-form</strong> returned the leading term $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$. We call this $2$-form the <strong>exterior derivative</strong> of $\omega$, and write it $d\omega$:
+
+$$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+$d\omega$ is a $2$-form—it eats two vectors and returns a scalar. Its value represents the mismatch per unit area of a closed loop over the infinitesimal parallelogram spanned by the two vectors fed to it.
+
+Let us organize what is happening here:
+
+- <strong>Input</strong>: $\omega = P\,dx + Q\,dy + R\,dz$ ($1$-form, a line measuring device that eats one vector)
+- <strong>Output</strong>: $d\omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$ ($2$-form, a surface measuring device that eats two vectors)
+- <strong>Operation</strong>: $d$ <strong>raises the degree by one</strong>, from 1 to 2
+
+This is exactly the same structure as the $df$ we saw in §5.1. $d$ acts on a $0$-form $f$ and returns the $1$-form $df$; it acts on a $1$-form $\omega$ and returns the $2$-form $d\omega$. <strong>One of the great roles of $d$ is to raise the degree by one.</strong>
+
+> <strong>Checkpoint</strong>
+> - $df$ was the exterior derivative from $0$-form to $1$-form. $\int_\gamma df = f(B)-f(A)$ (depends only on the endpoints).
+> - For a general $\omega$, $\oint \omega \neq 0$ on a closed loop. To investigate this mismatch, we shrink the loop.
+> - On an infinitesimal rectangle in the $xy$ plane, $\oint \omega = (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y +$ higher-order terms. The leading term of the mismatch is proportional to area.
+> - We define the $2$-form that measures this proportionality coefficient as $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$. $d$ is the operator that raises the degree.
+
+---
+
+### §5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions
+
+#### 5.5.1 The $yz$ Plane and the $zx$ Plane
+
+In §5.3–§5.4 we considered loops only in the $xy$ plane. But in three-dimensional space there are three orientations of surface. On an infinitesimal rectangle in the $yz$ plane, a similar calculation gives $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$; on the $zx$ plane we get $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$. These correspond to $dy \wedge dz$ and $dz \wedge dx$, respectively.
+
+The complete formula that follows from this intuition is:
+
+$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+> <strong>Note</strong> ($2$-forms measure tilted parallelograms) This $d\omega$ is a $2$-form—a <strong>measuring device that eats two vectors</strong>. The two vectors fed to it need not be parallel to the $xy$ plane. If we feed the two edges $\mathbf{v}_1, \mathbf{v}_2$ of an infinitesimal parallelogram floating obliquely in three-dimensional space, it returns the mismatch per unit area of a closed loop over that surface. It is exactly the same thing we did in §5.3—the only difference is that the surface being measured need not be parallel to a coordinate plane. The mechanism for extracting the area (and orientation) of a parallelogram from two vectors was already verified in Chapter 2 §2.4, when we constructed $dy \wedge dz$ and the like as antisymmetric matrices.
+
+#### 5.5.2 Algebraic Derivation — Leibniz Rule and $d(dx)=0$
+
+The formula above can of course be derived by doing separate loop calculations on each plane. But drawing a loop and adding four edges every time is tedious. What we do here is recast the exterior derivative introduced geometrically in §5.3 as computational algebraic rules, and confirm that these rules do indeed reproduce the exterior derivative. In other words, using the intuition from the $xy$-plane example, we move to a form that can be computed mechanically.
+
+> <strong>Note</strong> (Relation to the axiomatic definition) Many mathematics books take Leibniz's rule and $d(dx)=0$ as the <strong>definition</strong> of $d$. That definition is concise, but it is hard to see why those rules should hold. In this book we start from the dissection of an infinitesimal loop. What we are about to verify is that this geometric $d$ and the algebraic computational rules are consistent. The rules are for computational convenience; <strong>the meaning is in §5.3</strong>. Still, when one looks ahead to higher dimensions, this algebraic definition is indeed very concise.
+
+First, for $\omega = P\,dx + Q\,dy + R\,dz$, it should be uncontroversial that $d\omega = d(P\,dx) + d(Q\,dy) + d(R\,dz)$. This is the same as considering loops around tilted parallelograms. The question is $d(P\,dx)$—how does $d$ act on the $1$-form $dx$ with coefficient $P$?
+
+Here, the geometric $d$ obtained in §5.3–§5.4 has already taught us something. For $\omega = P\,dx$ ($Q=R=0$), if we carry out the infinitesimal loop calculation of §5.3 not only in the $xy$ plane but also in the $zx$ plane, $d(P\,dx)$ should have no component on the $yz$ face, and
+
+$$d(P\,dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+
+(the loop on the $xy$ face gives $(0 - \frac{\partial P}{\partial y}) = -\frac{\partial P}{\partial y}$; the loop on the $zx$ face gives $(\frac{\partial P}{\partial z} - 0) = \frac{\partial P}{\partial z}$).
+
+Now recall $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$ (§5.1). Taking its wedge product with $dx$:
+
+$$dP \wedge dx = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+
+(the term with $\frac{\partial P}{\partial x}$ vanishes because $dx \wedge dx = 0$)
+
+This <strong>agrees completely</strong> with the geometric calculation. That is, at least for a term of the form $P\,dx$:
+
+$$d(P\,dx) = dP \wedge dx$$
+
+So only the variation of the coefficient $P$ from place to place attaches to the measuring device in the $dx$ direction as a new area-measuring device.
+
+Comparing the geometric result with Leibniz's rule $d(P\,dx) = dP \wedge dx + P\,d(dx)$, the extra term $P\,d(dx)$ must be zero. Since $P$ is an arbitrary function, this can hold in general only if $d(dx)=0$—that is, $d(dx) = 0$ is required.
+
+Generalizing this observation, we arrive at the following <strong>graded Leibniz rule</strong>. $P$ is a $0$-form and $dx$ is a $1$-form; the behavior of $d$ on the “product” of a $0$-form and a $1$-form is:
+
+$$d(P\,dx) = (dP) \wedge dx + P\,d(dx)$$
+
+$dP$ is known—from §5.1, $dP = \frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz$. The question is the value of $d(dx)$.
+
+Here, the exterior derivative of the coordinate function $x$ is $dx$ ($d(x) = dx$). The $dx$ of Cartesian coordinates is a reference measuring device whose coefficients do not change from place to place. So even if we send $dx$ itself once around an infinitesimal loop, no mismatch per unit area appears. The same holds for $dy$ and $dz$. Therefore, for the coordinate basis, we adopt the following computational rule:
+
+$$d(dx) = d(dy) = d(dz) = 0$$
+
+Then:
+
+$$d(P\,dx) = (\frac{\partial P}{\partial x}\,dx + \frac{\partial P}{\partial y}\,dy + \frac{\partial P}{\partial z}\,dz) \wedge dx + P\,0$$
+
+Using the antisymmetry of $\wedge$ ($dx \wedge dx = 0$, $dy \wedge dx = -dx \wedge dy$):
+
+$$d(P\,dx) = \frac{\partial P}{\partial x}\,(dx \wedge dx) + \frac{\partial P}{\partial y}\,(dy \wedge dx) + \frac{\partial P}{\partial z}\,(dz \wedge dx) = \frac{\partial P}{\partial z}\,(dz \wedge dx) - \frac{\partial P}{\partial y}\,(dx \wedge dy)$$
+
+Similarly:
+
+$$\begin{aligned}
+d(Q\,dy) &= (\frac{\partial Q}{\partial x}\,dx + \frac{\partial Q}{\partial y}\,dy + \frac{\partial Q}{\partial z}\,dz) \wedge dy = \frac{\partial Q}{\partial x}\,(dx \wedge dy) - \frac{\partial Q}{\partial z}\,(dy \wedge dz) \\
+d(R\,dz) &= (\frac{\partial R}{\partial x}\,dx + \frac{\partial R}{\partial y}\,dy + \frac{\partial R}{\partial z}\,dz) \wedge dz = -\frac{\partial R}{\partial x}\,(dz \wedge dx) + \frac{\partial R}{\partial y}\,(dy \wedge dz)
+\end{aligned}$$
+
+Adding the three and collecting in the order of the basis $dy \wedge dz,\; dz \wedge dx,\; dx \wedge dy$ (this cyclic order is foreshadowing for consistency with the right-handed system in the next chapter):
+
+$$\begin{aligned}
+d\omega &= (-\frac{\partial Q}{\partial z} + \frac{\partial R}{\partial y})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (-\frac{\partial P}{\partial y} + \frac{\partial Q}{\partial x})\,dx \wedge dy \\
+&= (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy
+\end{aligned}$$
+
+This includes the $xy$ component $(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$ derived geometrically in §5.3, and the $yz$ and $zx$ components follow the same cross pattern.
+
+#### 5.5.3 The Pattern of the Coefficients
+
+Notice how the coefficients are arranged. $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})$ are obtained by taking partial derivatives of $(P, Q, R)$ <strong>with respect to axes other than their own, crossing them, and taking differences</strong>. There is a cyclic symmetry:
+
+$$\begin{aligned}
+dy \wedge dz &\longleftrightarrow \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+dz \wedge dx &\longleftrightarrow \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} \\
+dx \wedge dy &\longleftrightarrow \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}
+\end{aligned}$$
+
+> <strong>Note</strong> (A guide rail for experienced readers) Readers who already know vector analysis will find these three coefficients familiar. In this book we do not rely on their names; we first build the operation $d$ itself. The correspondence will be organized in later chapters.
+
+> <strong>Checkpoint</strong>
+> - The exterior derivative $d\omega$ of a general $1$-form $\omega$ is a $2$-form whose coefficients are the cross differences of partial derivatives $(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z},\; \frac{\partial P}{\partial z}-\frac{\partial R}{\partial x},\; \frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y})$.
+> - The computational rules are threefold: (1) linearity, (2) Leibniz rule $d(P\,dx) = dP \wedge dx + P\,d(dx)$, (3) $d(dx)=d(dy)=d(dz)=0$.
+> - The result is fully consistent with the infinitesimal loop calculation of §5.3.
+
+---
+
+### §5.6 Accumulate It, and Only the Boundary Remains — Stokes' Theorem
+
+#### 5.6.1 Tiling a Surface
+
+In §5.3 we computed $\oint \omega$ around <strong>a single</strong> infinitesimal rectangle and saw that its leading term is the product of $d\omega$ and area. What happens if we <strong>tile an entire surface</strong> with these infinitesimal rectangles and add everything up?
+
+Divide a surface $S$ into small coordinate patches and cut each into infinitesimal rectangles on its parameter plane (this is exactly the idea of a surface element from Chapter 3 §3.2). For each infinitesimal rectangle, the integral of $\omega$ around the boundary in the orientation matching the surface has, as its leading term, the value obtained by feeding the surface element to $d\omega$.
+
+Here we consider the case where the surface can be smoothly parameterized and a natural orientation is induced on the boundary as well. Reversing the orientation of the surface simultaneously reverses the direction in which the boundary is traced. Only after fixing this “pairing of surface orientation and boundary orientation” do the signs on the two sides agree.
+
+#### 5.6.2 Interior Edges Cancel
+
+Here is the decisive geometric observation. Focus on <strong>the edge shared by two adjacent rectangles</strong>. For the rectangle on the left, that edge is traced “upward”; for the rectangle on the right, it is traced “downward.” Because the paths run in opposite directions, the line integral of $\omega$ <strong>cancels completely</strong> on this edge.
+
+This cancellation occurs on <strong>every shared edge</strong> in the interior of the surface $S$. No matter how finely we partition and add, the contributions from interior edges vanish in plus-minus pairs.
+
+#### 5.6.3 Only the Boundary Survives
+
+Then which edges survive without cancellation—<strong>edges for which no adjacent rectangle exists</strong>, that is, edges along the <strong>boundary $\partial S$</strong> of the surface $S$.
+
+In other words:
+
+$$\oint_{\partial S} \omega = \iint_S d\omega$$
+
+The left-hand side is “the line integral of $\omega$ along the one-dimensional closed curve that is the boundary of the surface”; the right-hand side is “the sum of mismatch densities from the countless infinitesimal loops tiled in the interior of the surface.” In the limit of a finer and finer partition, only the cancellation of interior edges remains, and the two sides agree.
+
+This is the <strong>Kelvin–Stokes theorem</strong> (also called simply Stokes' theorem).
+
+Writing out the components for $\omega = P\,dx + Q\,dy + R\,dz$ explicitly:
+
+$$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy \Bigr)$$
+
+In the matrix language we have used since Chapter 2, the $2$-form on the right-hand side is represented by the antisymmetric matrix $\mathbf{J}^T - \mathbf{J}$. If $\mathbf{v}_1, \mathbf{v}_2$ are the two edges of a surface element, then $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T(\mathbf{J}^T - \mathbf{J})\mathbf{v}_2$. All components are written out in Appendix B.3; consult it as needed.
+
+The structure of this theorem is remarkably simple. <strong>Integral measured on the global boundary</strong> $=$ <strong>accumulation of local mismatch ($d\omega$) in the interior</strong>. $d$ is the device that <strong>translates</strong> information about $\omega$ on the boundary $\partial S$ into information about $d\omega$ in the interior $S$.
+
+> <strong>Note</strong> (Assumptions used in localization) The tiling explanation here assumes a sufficiently smooth surface and field that can be divided into sufficiently fine coordinate patches. When there are cusps on the boundary, self-intersections, singular points, and the like, patch decomposition and orientation must be handled separately. In this book we treat the smooth cases ordinarily used in physics.
+
+> <strong>Note</strong> (Correspondence with Chapter 3) When we defined surface integrals in Chapter 3 §3.2.1, we fed $dx \wedge dy$ to the surface element $(\mathbf{r}_u\Delta u,\;\mathbf{r}_v\Delta v)$. Here too, we divide the surface into small surface elements, act with the measuring device on each element, and organize the contributions that cancel in the interior.
+
+> <strong>Checkpoint</strong>
+> - If we tile a surface $S$ with infinitesimal loops, interior edges cancel and only the contribution from the boundary $\partial S$ remains.
+> - $\int_{\partial S} \omega = \int_S d\omega$. A global boundary integral equals an integral of the local exterior derivative.
+> - As with surface integrals in Chapter 3, we divide the surface into small patches, act with the measuring device on each patch, and aggregate.
+
+---

--- a/translation/drafts/ch05-5.7-5.9.md
+++ b/translation/drafts/ch05-5.7-5.9.md
@@ -1,0 +1,165 @@
+### §5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence
+
+#### 5.7.1 A $2$-Form Is a Measuring Device for Surfaces
+
+In Chapter 3 §3.4.2 we wrote a general $2$-form in the form
+
+$$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
+
+This is a "measuring device that measures flux along a surface." As we saw in Chapter 2 §2.4.5, the three basis $2$-forms each measure the area of the projection onto the $yz$, $zx$, and $xy$ planes, respectively.
+
+#### 5.7.2 Measuring on the Faces of a Tiny Rectangular Box
+
+In the same spirit as §5.3, we now integrate $\eta$ over <strong>all six faces</strong> of a tiny rectangular box in space, $[x, x+\Delta x] \times [y, y+\Delta y] \times [z, z+\Delta z]$. We align the orientations outward.
+
+For the term $C\,dx \wedge dy$, consider only the bottom and top faces perpendicular to $z$:
+
+- <strong>Bottom face</strong> ($z$, outward direction is $-z$): evaluate $C(x,y,z)$ with the orientation of $-dx \wedge dy$ → approximately $-C(x,y,z)\,\Delta x\,\Delta y$
+- <strong>Top face</strong> ($z+\Delta z$, outward direction is $+z$): $C(x,y,z+\Delta z) \approx C + \frac{\partial C}{\partial z}\Delta z$ → approximately $(C + \frac{\partial C}{\partial z}\Delta z)\,\Delta x\,\Delta y$
+
+Summing, the $C\Delta x\Delta y$ terms cancel and $\frac{\partial C}{\partial z}\,\Delta x\,\Delta y\,\Delta z$ remains. The term $A\,dy \wedge dz$ contributes $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$ from the faces perpendicular to $x$, and the term $B\,dz \wedge dx$ contributes $\frac{\partial B}{\partial y}\,\Delta x\,\Delta y\,\Delta z$ from the faces perpendicular to $y$.
+
+The total over all six faces is:
+
+$$\iint_{\partial (\text{box})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$
+
+Here too the structure is the same—<strong>the leading term of the mismatch measured on the surface is proportional to the enclosed volume</strong>. The proportionality constant $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ represents the "outflow per unit volume."
+
+#### 5.7.3 Definition of $d\eta$ and Algebraic Derivation
+
+As a $3$-form that eats the three edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ of the box:
+
+$$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+This formula can also be derived from the algebraic rules of §5.5.2. First, as we did in §5.5.2, let us confirm for the term $A\,dy \wedge dz$ that the geometric result is consistent with the Leibniz rule.
+
+According to the geometric calculation in §5.7.2, the contribution of $A\,dy \wedge dz$ was $\frac{\partial A}{\partial x}\,\Delta x\,\Delta y\,\Delta z$. In the language of $dx \wedge dy \wedge dz$, this is $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$.
+
+On the other hand, applying the Leibniz rule to $d(A\,dy \wedge dz)$ gives:
+
+$$d(A\,dy \wedge dz) = dA \wedge dy \wedge dz + A\,d(dy \wedge dz)$$
+
+Here, as in §5.5.2, using $d(dy)=d(dz)=0$:
+
+$$d(dy \wedge dz) = d(dy) \wedge dz - dy \wedge d(dz) = 0 \wedge dz - dy \wedge 0 = 0$$
+
+so the second term vanishes and only the first remains:
+
+$$dA \wedge dy \wedge dz = (\frac{\partial A}{\partial x}\,dx + \frac{\partial A}{\partial y}\,dy + \frac{\partial A}{\partial z}\,dz) \wedge dy \wedge dz$$
+
+By antisymmetry of $\wedge$ ($dy \wedge dy = 0$, $dz \wedge dz = 0$), the terms with $\frac{\partial A}{\partial y}$ and $\frac{\partial A}{\partial z}$ vanish, leaving only $\frac{\partial A}{\partial x}\,dx \wedge dy \wedge dz$. This <strong>agrees completely</strong> with the geometric calculation in §5.7.2.
+
+The terms $B\,dz \wedge dx$ and $C\,dx \wedge dy$ are similar; adding the three yields:
+
+$$d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+$d$ has accomplished the promotion $2$-form $\to$ $3$-form.
+
+#### 5.7.4 Gauss' Theorem
+
+By the same tiling argument as in §5.6—this time filling the solid $V$ with tiny rectangular boxes—internal faces cancel and only the outer surface $\partial V$ remains:
+
+$$\iint_{\partial V} \eta = \iiint_V d\eta$$
+
+This is <strong>Gauss' theorem</strong>. It has <strong>exactly the same form</strong> as Stokes' theorem, only with the dimension shifted by one. Placed side by side, the parallel is obvious: $\omega$ ($1$-form) $\to$ $d\omega$ ($2$-form) $\to$ surface $S$, $\eta$ ($2$-form) $\to$ $d\eta$ ($3$-form) $\to$ solid $V$.
+
+Writing out the components explicitly for $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$:
+
+$$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\bigr) = \iiint_V (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
+
+> <strong>Note</strong> (a guide for readers already familiar with vector calculus) Readers who already know vector analysis may recognize $\frac{\partial A}{\partial x}+\frac{\partial B}{\partial y}+\frac{\partial C}{\partial z}$. In this book we first obtain this quantity as the exterior derivative of a $2$-form, and we keep that order of presentation. The correspondence with names will be organized in a later chapter.
+
+> <strong>Checkpoint so far</strong>
+> - The exterior derivative $d\eta$ of a $2$-form $\eta$ is a $3$-form whose coefficient is $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$.
+> - The derivation can be done mechanically with the same algebraic rules as §5.5 (Leibniz rule $+$ $d(dx)=0$).
+> - $\iint_{\partial V} \eta = \iiint_V d\eta$. Stokes ($1$-form $\to$ surface) and Gauss ($2$-form $\to$ solid) differ only in degree; the structure is the same.
+
+---
+
+### §5.8 $d^2 = 0$ — No Mismatch Survives a Second Application
+
+Before unifying Stokes' theorem and Gauss' theorem in the next section, let us confirm one more basic structure of the exterior derivative. $d$ raises the degree by one, but applying it twice in succession leaves no new mismatch. This fact is also connected to the geometric structure we will see later: "the boundary of a boundary cancels as an oriented sum."
+
+#### 5.8.1 $d(df) = 0$
+
+In §5.1 we defined $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$. Let us apply the exterior derivative once more. Using the formula from §5.5 with $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$:
+
+$$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$
+
+By symmetry of mixed partial derivatives (if $f$ is $C^2$ (twice continuously differentiable), then $\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, etc.; see Chapter 1 §1.2), every coefficient vanishes:
+
+$$d(df) = 0$$
+
+> <strong>Note</strong> ($d^2=0$ in the axiomatic viewpoint and the $C^2$ condition) When we compute concretely in coordinates, we see that $d^2=0$ is inevitable from symmetry of mixed partial derivatives and antisymmetry of the wedge product. From the axiomatic standpoint of differential forms, one may instead read things the other way around: requiring $d^2=0$ (as part of the definition) means we are implicitly working with a class of functions for which symmetry of mixed partial derivatives holds ($C^2$ functions). In this book we first understand it through concrete calculation, as the mechanism that prevents contradictions in the hierarchy of physical laws.
+
+#### 5.8.2 $d(d\omega) = 0$
+
+Apply the formula of §5.7 to the $d\omega$ of §5.5. With $A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$:
+
+$$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$
+
+Expanding and rearranging the expression in parentheses:
+
+$$\left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z}\right) + \left(\frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x}\right) + \left(\frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right)$$
+
+By symmetry of mixed partial derivatives ($\frac{\partial^2 R}{\partial y \partial x}=\frac{\partial^2 R}{\partial x \partial y}$, etc.), the six terms cancel in three pairs and the sum is zero:
+
+$$d(d\omega) = 0$$
+
+> <strong>Checkpoint so far</strong>
+> - $d^2 = 0$: applying the exterior derivative twice always gives zero. Symmetry of mixed partial derivatives and antisymmetry of the wedge produce the cancellation.
+> - Several identities familiar to readers who already know vector calculus—"it vanishes when you differentiate twice"—will be organized in a later chapter as other expressions of this $d^2=0$.
+
+---
+
+### §5.9 Unifying the Exterior Derivative — One Formula, One Rule
+
+#### 5.9.1 Stokes and Gauss Were the Same Formula
+
+Stokes' theorem $\oint_{\partial S}\omega = \iint_S d\omega$ from §5.6 and Gauss' theorem $\iint_{\partial V}\eta = \iiint_V d\eta$ from §5.7. Placed side by side, only the number of integral signs differs—$\oint$, $\iint$, $\iiint$—yet the structure is identical. If $M$ is a curve, we write $\int$ (1-dimensional); if a surface, $\iint$ (2-dimensional); if a solid, $\iiint$ (3-dimensional)—the number of integral signs is determined only by the dimension of $M$.
+
+So, regardless of dimension, we write uniformly:
+
+$$\int_{\partial M} \omega = \int_M d\omega$$
+
+Here $\omega$ is a $k$-form, $M$ is a $(k+1)$-dimensional region, and $\partial M$ is its $k$-dimensional boundary. For $k=0$ this is the fundamental theorem of calculus, $\int_{\partial M} f = f(B)-f(A) = \int_M df$; for $k=1$ it is Stokes' theorem; for $k=2$ it is Gauss' theorem. All are absorbed into this single line.
+
+The power of this unified form stands out even more in combination with $d^2=0$ from §5.8. Replacing $\omega$ by $d\omega$ in $\int_{\partial M} \omega = \int_M d\omega$:
+
+$$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\omega) = 0$$
+
+That is, <strong>"the boundary of a boundary is zero as an oriented sum"</strong> ($\partial^2 M = 0$) and <strong>$d^2=0$</strong> correspond to each other. This does not mean that the second boundary is always empty as a set. For example, if we subdivide the boundary of a polygon further into boundary pieces, vertices appear—but counted with orientation, contributions from adjacent edges cancel. $d^2=0$ is the algebraic portrait of this topological cancellation.
+
+> <strong>Note</strong> (three dimensions suffice) Because the stage of this book is three-dimensional space, the dimension of $M$ is 1, 2, or 3, and $\omega$ is a $0$-form, $1$-form, or $2$-form. We do not enter $k=3$ ($M$ four-dimensional). Still, it does no harm to keep in the back of your mind that this formula holds regardless of $k$.
+
+#### 5.9.2 Exterior Derivative of a General $k$-Form
+
+Likewise, the action of $d$ collapses into one pattern regardless of degree. When an arbitrary $k$-form $\omega$ is written as a sum of coefficients $a_{i_1\cdots i_k}$ and basis elements $dx_{i_1}\wedge\cdots\wedge dx_{i_k}$:
+
+$$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x_j}\,dx_j \Bigr) \wedge dx_{i_1}\wedge\cdots\wedge dx_{i_k}$$
+
+For this book we need only the three cases $k=0,1,2$, written out concretely in §5.1 ($df$), §5.5 ($d\omega$), and §5.7 ($d\eta$). The general form above is only confirmation that "at every degree, take the total differential of the coefficients and attach with the wedge"—a single principle.
+
+#### 5.9.3 Summary of Computational Rules
+
+All computations of the exterior derivative $d$ built in this chapter are summarized in the following four rules:
+
+1. <strong>Action on a $0$-form</strong>: $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$ (the definition since Chapter 1 §1.2)
+2. <strong>Linearity</strong>: $d(\omega_1 + \omega_2) = d\omega_1 + d\omega_2$
+3. <strong>Graded Leibniz rule</strong>: $d(f\,\omega) = df \wedge \omega + f\,d\omega$
+4. <strong>Exterior derivative of coordinate bases is zero</strong>: $d(dx) = d(dy) = d(dz) = 0$
+
+Rule 4 reflects the geometric fact that the coordinate bases $dx, dy, dz$ themselves have no coefficients that vary with position, so measuring them on a tiny loop produces no local mismatch. It is also consistent with $d^2=0$ in §5.8.
+
+With only these four rules, the exterior derivative of any form from $0$-form to $3$-form can be computed mechanically. In fact, every calculation treated in this chapter is nothing but a combination of these rules.
+
+> <strong>Note</strong> (commutativity with pullback—payoff of a Chapter 4 foreshadowing) As foreshadowed in Chapter 4, between pullback $\Phi^*$ and exterior derivative $d$ there holds the commutation relation
+> $$\Phi^*(d\omega) = d(\Phi^*\omega)$$
+> "differentiate then pull back" and "pull back then differentiate" give the same result. This property cannot be derived directly from the four rules above, but if we recall that $d$ is the operation that "measures local mismatch" and $\Phi^*$ is the operation that "relabels coordinates," it is natural—the structure of local mismatch does not depend on how coordinates are chosen. This fact will be an important footing when we consider differential forms on general manifolds in Chapter 11.
+
+> <strong>Checkpoint so far</strong>
+> - A single line $\int_{\partial M} \omega = \int_M d\omega$ unifies the fundamental theorem of calculus, Stokes' theorem, and Gauss' theorem.
+> - Computation of $d$ is summarized in four rules ($df$, linearity, Leibniz rule, $d(dx)=0$).
+> - $d^2=0$ and $\partial^2 M=0$ echo each other as algebraic truth and geometric truth.
+
+---

--- a/translation/drafts/ch05-appendix-BC.md
+++ b/translation/drafts/ch05-appendix-BC.md
@@ -1,0 +1,354 @@
+## Appendix B: Matrix Representation of the Exterior Derivative
+
+The main text of this chapter proceeded with the basis $dx, dy, dz$ and the algebra of the wedge product. Here we rewrite the exterior derivative in the language of matrix representations, following the book's convention since Chapter 2 — <strong>arranging every component without exception into matrices</strong>.
+
+### B.1 $0$-form: the $1 \times 3$ row vector of $df$
+
+For $f = f(x,y,z)$, as defined in Chapter 1 §1.2:
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
+
+As a row vector ($1 \times 3$ matrix):
+
+$$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+### B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients
+
+For $\omega = P\,dx + Q\,dy + R\,dz$, the $3 \times 3$ matrix that arranges <strong>all</strong> partial derivatives of the coefficients $(P,Q,R)$ is:
+
+$$\mathbf{J} := \begin{pmatrix}
+\frac{\partial P}{\partial x} & \frac{\partial P}{\partial y} & \frac{\partial P}{\partial z} \\
+\frac{\partial Q}{\partial x} & \frac{\partial Q}{\partial y} & \frac{\partial Q}{\partial z} \\
+\frac{\partial R}{\partial x} & \frac{\partial R}{\partial y} & \frac{\partial R}{\partial z}
+\end{pmatrix}$$
+
+This is the Jacobian matrix of the vector field obtained by stacking $(P,Q,R)$ as a column. The reason §5.1 said that "a mere matrix of partial derivatives is not enough" is precisely that this $\mathbf{J}$ is not antisymmetric.
+
+### B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$
+
+The result of §5.5 is:
+
+$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+Following the convention of Chapter 2 §2.4.4, we seek the antisymmetric matrix $\mathbf{M}$ such that $(d\omega)(\mathbf{v}_1, \mathbf{v}_2) = \mathbf{v}_1^T \mathbf{M} \mathbf{v}_2$ for arbitrary column vectors $\mathbf{v}_1, \mathbf{v}_2$.
+
+Writing out the entries of $\mathbf{J}^T - \mathbf{J}$:
+
+$$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
+0 & \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y} & \frac{\partial R}{\partial x} - \frac{\partial P}{\partial z} \\
+\frac{\partial P}{\partial y} - \frac{\partial Q}{\partial x} & 0 & \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z} \\
+\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x} & \frac{\partial Q}{\partial z} - \frac{\partial R}{\partial y} & 0
+\end{pmatrix}$$
+
+That is, comparing with the matrix representation of a $2$-form found in Chapter 2:
+
+$$d\omega = \mathbf{J}^T - \mathbf{J}$$
+
+Thus, <strong>the matrix representation of the exterior derivative $d\omega$ is the antisymmetric matrix obtained by subtracting the Jacobian matrix of the coefficients from its transpose.</strong>
+
+### B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix
+
+For $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$, let the Jacobian matrix of the coefficients $(A,B,C)$ be:
+
+$$\mathbf{J}_\eta := \begin{pmatrix}
+\frac{\partial A}{\partial x} & \frac{\partial A}{\partial y} & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial x} & \frac{\partial B}{\partial y} & \frac{\partial B}{\partial z} \\
+\frac{\partial C}{\partial x} & \frac{\partial C}{\partial y} & \frac{\partial C}{\partial z}
+\end{pmatrix}$$
+
+Then the coefficient in the result of §5.7, $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$, agrees with the <strong>trace</strong> (sum of diagonal entries) of $\mathbf{J}_\eta$:
+
+$$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$
+
+#### B.4.1 The 27 components of $d\eta$ — expanded into three matrices
+
+The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (the others are sign reversals or $0$). Write the components of $d\eta$ as $(d\eta)_{abc} = \partial_a \eta_{bc}$, where $\partial_x=\frac{\partial}{\partial x}$, $\partial_y=\frac{\partial}{\partial y}$, $\partial_z=\frac{\partial}{\partial z}$, and $a,b,c \in \{x,y,z\}$, so there are $3^3=27$ components. Arranging them into three $3 \times 3$ matrices with $a$ fixed gives:
+
+$$
+\begin{aligned}
+d\eta_{x,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial x} & -\frac{\partial B}{\partial x} \\
+-\frac{\partial C}{\partial x} & 0 & \frac{\partial A}{\partial x} \\
+\frac{\partial B}{\partial x} & -\frac{\partial A}{\partial x} & 0
+\end{pmatrix}, \\
+d\eta_{y,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial y} & -\frac{\partial B}{\partial y} \\
+-\frac{\partial C}{\partial y} & 0 & \frac{\partial A}{\partial y} \\
+\frac{\partial B}{\partial y} & -\frac{\partial A}{\partial y} & 0
+\end{pmatrix}, \\
+d\eta_{z,\cdot,\cdot}
+&= \begin{pmatrix}
+0 & \frac{\partial C}{\partial z} & -\frac{\partial B}{\partial z} \\
+-\frac{\partial C}{\partial z} & 0 & \frac{\partial A}{\partial z} \\
+\frac{\partial B}{\partial z} & -\frac{\partial A}{\partial z} & 0
+\end{pmatrix}
+\end{aligned}
+$$
+
+When these $27$ components are contracted with the corresponding basis wedge products of $1$-forms (for example, if $a=x,\;b=y,\;c=z$, then $dx \wedge dy \wedge dz$), terms with repeated indices (diagonal entries, $b=c$, and so on) vanish because $dx \wedge dx = 0$, and only the $6$ terms with all of $a,b,c$ distinct (permutations of $3!$) survive. Each is summed with its sign. Because each component is antisymmetrized and arranged in a matrix here, we are double-counting; as in Chapter 2 §2.4.4 and Appendix D, a factor of $\frac{1}{2}$ enters:
+
+$$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} \right) dx \wedge dy \wedge dz$$
+
+In other words, of the $27$ components of $d\eta$, $6$ survive and pair up to converge to the trace of $\mathbf{J}_\eta$.
+
+A $3$-form has only the single basis element $dx \wedge dy \wedge dz$, so as a matrix it degenerates to a scalar coefficient.
+
+### B.5 $d^2 f = 0$ and the Hessian
+
+The Hessian of a $0$-form $f$:
+
+$$\mathbf{H}_f := \begin{pmatrix}
+\frac{\partial^2 f}{\partial x^2} & \frac{\partial^2 f}{\partial x \partial y} & \frac{\partial^2 f}{\partial x \partial z} \\
+\frac{\partial^2 f}{\partial y \partial x} & \frac{\partial^2 f}{\partial y^2} & \frac{\partial^2 f}{\partial y \partial z} \\
+\frac{\partial^2 f}{\partial z \partial x} & \frac{\partial^2 f}{\partial z \partial y} & \frac{\partial^2 f}{\partial z^2}
+\end{pmatrix}$$
+
+arranges the second partial derivatives of $f$. If $f$ is $C^2$, then $\mathbf{H}_f$ is a symmetric matrix ($\frac{\partial^2 f}{\partial x \partial y} = \frac{\partial^2 f}{\partial y \partial x}$, and so on).
+
+$d(df) = 0$ is the §5.5 formula for $d\omega$ with $(P,Q,R) = (\frac{\partial f}{\partial x}, \frac{\partial f}{\partial y}, \frac{\partial f}{\partial z})$. We have $\mathbf{J} = \mathbf{H}_f$, and because $\mathbf{H}_f$ is symmetric, $\mathbf{J}^T - \mathbf{J} = 0$; hence $d(df) = 0$. In the language of matrices, this is rephrased as "the antisymmetric part of the Hessian is zero."
+
+## Appendix C: Integral Forms of Electromagnetism and Differential Forms
+
+This appendix verifies, in component form, the passage from the integral forms of the four fundamental equations of electromagnetism to their local forms. What we use here are the exterior derivative $d$ and the degree of a differential form. The metric of space does not appear in this localization itself.
+
+### C.1 Degrees of physical quantities
+
+Quantities measured along a line are placed as $1$-forms, quantities measured through a surface as $2$-forms, and quantities measured over a volume as $3$-forms. In components:
+
+$$
+E = E_x\,dx+E_y\,dy+E_z\,dz,
+\qquad
+H = H_x\,dx+H_y\,dy+H_z\,dz
+$$
+
+$$D = D_x\,dy\wedge dz + D_y\,dz\wedge dx + D_z\,dx\wedge dy$$
+
+$$B = B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$
+
+$$J = J_x\,dy\wedge dz + J_y\,dz\wedge dx + J_z\,dx\wedge dy$$
+
+$$
+\rho = \rho\,dx\wedge dy\wedge dz
+$$
+
+To keep the notation simple, we write both the coefficient representing charge density and the $3$-form obtained by multiplying it by the volume form with the same symbol $\rho$.
+
+$E$ and $H$ are $1$-forms measured along a line; $D$, $B$, and $J$ are $2$-forms measured through a surface; $\rho$ is a $3$-form measured over a volume.
+
+### C.2 Gauss's law for charge
+
+The integral form is:
+
+$$
+\int_{\partial V}D=\int_V\rho
+$$
+
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_{\partial V}D=\int_V dD
+$$
+
+Therefore, if
+
+$$
+\int_V dD=\int_V\rho
+$$
+
+holds for every region $V$, the local form is:
+
+$$
+dD=\rho
+$$
+
+Expanding in components:
+
+$$
+dD
+=
+\left(\frac{\partial D_x}{\partial x}
+{}+\frac{\partial D_y}{\partial y}
+{}+\frac{\partial D_z}{\partial z}\right)
+dx\wedge dy\wedge dz
+$$
+
+Hence:
+
+$$
+\frac{\partial D_x}{\partial x}
+{}+\frac{\partial D_y}{\partial y}
+{}+\frac{\partial D_z}{\partial z}
+=\rho
+$$
+
+### C.3 The law of magnetic flux
+
+The integral form stating that the net magnetic flux through a closed surface is zero is:
+
+$$
+\int_{\partial V}B=0
+$$
+
+By the generalized Stokes' theorem:
+
+$$
+\int_V dB=0
+$$
+
+If this holds for every region $V$, the local form is:
+
+$$
+dB=0
+$$
+
+Expanding in components:
+
+$$
+dB
+=
+\left(\frac{\partial B_x}{\partial x}
+{}+\frac{\partial B_y}{\partial y}
+{}+\frac{\partial B_z}{\partial z}\right)
+dx\wedge dy\wedge dz
+$$
+
+Therefore:
+
+$$
+\frac{\partial B_x}{\partial x}
+{}+\frac{\partial B_y}{\partial y}
+{}+\frac{\partial B_z}{\partial z}
+=0
+$$
+
+### C.4 Faraday's law
+
+The integral form is:
+
+$$
+\int_{\partial S}E
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_S dE
+=
+-\frac{\partial}{\partial t}\int_S B
+$$
+
+If this holds for every surface $S$, the local form is:
+
+$$
+dE=-\frac{\partial B}{\partial t}
+$$
+
+Expanding in components:
+
+$$dE = \left(\frac{\partial E_z}{\partial y}-\frac{\partial E_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial E_x}{\partial z}-\frac{\partial E_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial E_y}{\partial x}-\frac{\partial E_x}{\partial y}\right)dx\wedge dy$$
+
+On the other hand,
+
+$$
+-\frac{\partial B}{\partial t}
+=
+-\frac{\partial B_x}{\partial t}\,dy\wedge dz
+-\frac{\partial B_y}{\partial t}\,dz\wedge dx
+-\frac{\partial B_z}{\partial t}\,dx\wedge dy
+$$
+
+so the components are:
+
+$$
+\frac{\partial E_z}{\partial y}
+-
+\frac{\partial E_y}{\partial z}
+=
+-\frac{\partial B_x}{\partial t}
+$$
+
+$$
+\frac{\partial E_x}{\partial z}
+-
+\frac{\partial E_z}{\partial x}
+=
+-\frac{\partial B_y}{\partial t}
+$$
+
+$$
+\frac{\partial E_y}{\partial x}
+-
+\frac{\partial E_x}{\partial y}
+=
+-\frac{\partial B_z}{\partial t}
+$$
+
+### C.5 Ampère–Maxwell's law
+
+The integral form is:
+
+$$
+\int_{\partial S}H
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+Applying the generalized Stokes' theorem to the left-hand side:
+
+$$
+\int_S dH
+=
+\int_SJ+\frac{\partial}{\partial t}\int_S D
+$$
+
+If this holds for every surface $S$, the local form is:
+
+$$
+dH=J+\frac{\partial D}{\partial t}
+$$
+
+Expanding in components:
+
+$$dH = \left(\frac{\partial H_z}{\partial y}-\frac{\partial H_y}{\partial z}\right)dy\wedge dz + \left(\frac{\partial H_x}{\partial z}-\frac{\partial H_z}{\partial x}\right)dz\wedge dx + \left(\frac{\partial H_y}{\partial x}-\frac{\partial H_x}{\partial y}\right)dx\wedge dy$$
+
+Also,
+
+$$J+\frac{\partial D}{\partial t} = \left(J_x+\frac{\partial D_x}{\partial t}\right)dy\wedge dz + \left(J_y+\frac{\partial D_y}{\partial t}\right)dz\wedge dx + \left(J_z+\frac{\partial D_z}{\partial t}\right)dx\wedge dy$$
+
+so the components are:
+
+$$
+\frac{\partial H_z}{\partial y}
+-
+\frac{\partial H_y}{\partial z}
+=
+J_x+\frac{\partial D_x}{\partial t}
+$$
+
+$$
+\frac{\partial H_x}{\partial z}
+-
+\frac{\partial H_z}{\partial x}
+=
+J_y+\frac{\partial D_y}{\partial t}
+$$
+
+$$
+\frac{\partial H_y}{\partial x}
+-
+\frac{\partial H_x}{\partial y}
+=
+J_z+\frac{\partial D_z}{\partial t}
+$$
+
+### C.6 Where a metric is needed
+
+The four local forms above can be written using only the exterior derivative $d$ and the degree of differential forms. At this stage, no metric for measuring lengths or angles is used.
+
+A metric becomes necessary when relating $E$ to $D$ and $B$ to $H$. It is also needed when pairing $1$-forms with $2$-forms so that the usual three-component fields can be treated as objects of the same kind.
+
+The Hodge star, introduced in the next chapter, is the tool that provides this correspondence.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -149,6 +149,26 @@ Per-section Pass status:
 | `translation/reviews/ch04-pass3.md` | complete |
 | `translation/reviews/ch04-close-reading-polish.md` | complete (#182) |
 
+### English Chapter 5 — `manuscript/en/ch05/ch05.md` (branch `ai/english-translation-ch05`, PR [#166](https://github.com/yokiikoy/nabla-kaitai/pull/166))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 5 (§5.0–§5.11 + App. B–C)** | **1 → 2 → 3** | `ch05-pass2.md`, `ch05-pass3.md`; old YAML draft replaced |
+
+| Section / appendix | Pass | Review |
+|--------------------|------|--------|
+| §5.0–§5.3 | **3** | `ch05-5.0-5.3-review.md` |
+| §5.4–§5.6 | **3** | `ch05-5.4-5.6-review.md` |
+| §5.7–§5.9 | **3** | `ch05-5.7-5.9-review.md` |
+| §5.10–§5.11 | **3** | `ch05-5.10-5.11-review.md` |
+| Appendices B–C | **3** | `ch05-appendix-BC-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch05-*.md` | integrated into `ch05.md` |
+| `translation/reviews/ch05-pass2.md` | complete |
+| `translation/reviews/ch05-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -168,6 +168,7 @@ Per-section Pass status:
 | `translation/drafts/ch05-*.md` | integrated into `ch05.md` |
 | `translation/reviews/ch05-pass2.md` | complete |
 | `translation/reviews/ch05-pass3.md` | complete |
+| `translation/reviews/ch05-close-reading-polish.md` | complete (#183) |
 
 ---
 

--- a/translation/reviews/ch05-5.0-5.3-review.md
+++ b/translation/reviews/ch05-5.0-5.3-review.md
@@ -1,0 +1,7 @@
+# Review: Chapter 5 §5.0–§5.3
+
+Branch: `ai/english-translation-ch05` · Pass 1 **passed** · Pass 2/3 in `ch05-pass{2,3}.md`
+
+Covers §5.0 bridge, §5.1 $df$ revisit, §5.2 closed-loop mismatch, §5.3 tiny-loop dissection. Source fidelity 5; terminology (measuring device, mismatch, row vector) 5.
+
+Integrated from `translation/drafts/ch05-5.0-5.3.md`.

--- a/translation/reviews/ch05-5.10-5.11-review.md
+++ b/translation/reviews/ch05-5.10-5.11-review.md
@@ -1,0 +1,7 @@
+# Review: Chapter 5 §5.10–§5.11
+
+Branch: `ai/english-translation-ch05` · Pass 1 **passed** · Pass 2/3 in `ch05-pass{2,3}.md`
+
+Covers integral→local laws, EM examples, Hodge star foreshadow, Chapter 5 checkpoint.
+
+Integrated from `translation/drafts/ch05-5.10-5.11.md`.

--- a/translation/reviews/ch05-5.4-5.6-review.md
+++ b/translation/reviews/ch05-5.4-5.6-review.md
@@ -1,0 +1,7 @@
+# Review: Chapter 5 §5.4–§5.6
+
+Branch: `ai/english-translation-ch05` · Pass 1 **passed** · Pass 2/3 in `ch05-pass{2,3}.md`
+
+Covers $d$ definition, general $1$-form exterior derivative, Stokes' theorem tile argument. Math and wedge-product linkage preserved.
+
+Integrated from `translation/drafts/ch05-5.4-5.6.md`.

--- a/translation/reviews/ch05-5.7-5.9-review.md
+++ b/translation/reviews/ch05-5.7-5.9-review.md
@@ -1,0 +1,7 @@
+# Review: Chapter 5 §5.7–§5.9
+
+Branch: `ai/english-translation-ch05` · Pass 1 **passed** · Pass 2/3 in `ch05-pass{2,3}.md`
+
+Covers $2$-form $d\eta$, Gauss' theorem, $d^2=0$, unified Stokes $\int_{\partial M}\omega=\int_M d\omega$.
+
+Integrated from `translation/drafts/ch05-5.7-5.9.md`.

--- a/translation/reviews/ch05-appendix-BC-review.md
+++ b/translation/reviews/ch05-appendix-BC-review.md
@@ -1,0 +1,7 @@
+# Review: Chapter 5 Appendices B–C
+
+Branch: `ai/english-translation-ch05` · Pass 1 **passed** · Pass 2/3 in `ch05-pass{2,3}.md`
+
+Appendix B: matrix representation ($\mathbf{J}^T-\mathbf{J}$, trace, Hessian). Appendix C: EM integral forms → local via $d$.
+
+Integrated from `translation/drafts/ch05-appendix-BC.md`.

--- a/translation/reviews/ch05-close-reading-polish.md
+++ b/translation/reviews/ch05-close-reading-polish.md
@@ -1,0 +1,62 @@
+# Close-Reading Polish: Chapter 5
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch05`
+File: `manuscript/en/ch05/ch05.md`
+GitHub issue: #183
+PR context: #166
+
+Scope: publication polish after Pass 3 — Markdown cleanup, mathematical safety in Appendix B.4.1, English naturalness, preservation of mismatch → $d$ → local law arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** Removed duplicate horizontal rules between §5.3/§5.4, §5.6/§5.7, and §5.9/§5.10.
+- **B2** §5.9.1: fixed sentence fragment (`Place Stokes' theorem … side by side`).
+- **B3** Appendix B.4.1: `raw derivative components` before antisymmetrization (not misread as final $d\eta$ components).
+- **B4** Appendix B.4.1: matrix/form factor convention wording (no implied visible missing `1/2`).
+
+### C items (straightforward)
+
+- **C1** §5.1.2: `To first order on each interval`
+- **C2** §5.1.3: closed-curve exact form `xy(\gamma(2\pi))-xy(\gamma(0))=0`
+- **C3** §5.2: measuring device applied along a line
+- **C4** §5.3: higher-order terms sentence after tiny-loop sum
+- **C5** §5.5.2: `we take $d$ to act linearly`
+- **C6** §5.5.3: `guide rail` → `guidepost`
+- **C7** §5.6: matrix $\mathbf{J}$ identified as Jacobian of $(P,Q,R)$
+- **C8** §5.6 checkpoint: $\oint_{\partial S} \omega = \iint_S d\omega$
+- **C9** §5.7.1: measuring device for flux through a surface
+- **C11** §5.9.1: oriented boundary for $k=0$ Stokes case
+- **C13** §5.9.1: `All fit into this single line`
+- **C14** §5.10: note heading capitalization
+- **C17** Appendix B.3: Chapter 2 convention sentence
+- **C18** Appendix B.4.1: `combine into the trace`
+- **C19** Appendix B.4.1: `reduces to a scalar coefficient`
+- **C20** §5.10 / Appendix C: `\int_S J` spacing
+
+### Intentionally unchanged (D items / optional C)
+
+- **C10** §5.8 $d^2=0$ axiomatic note — kept concrete-calculation narrative
+- **C12** §5.9 `does no harm` — preserved looser voice
+- **C15** `Stokes's` — none found; already `Stokes'`
+- **C16** §5.11 Hodge dictionary sentence — kept approachable wording
+- **C24** §5.4 wedge compatibility sentence — kept as-is
+- `mismatch`, `balance the books`, tiny-loop derivation, tiling/cancellation, Kelvin–Stokes naming, full $d(d\omega)$ calculation, general $k$-form formula, pullback commutation note, EM examples / Appendix C, Hodge foreshadow, Appendix B expansions, same-symbol $\rho$, EM current $J$ vs matrix $\mathbf{J}$
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- duplicate `---` blocks — none
+- `Stokes's`, `guide rail`, `measuring device for measuring` — none
+- `Write the components of $d\eta$ as $(d\eta)_{abc} = \partial_a \eta_{bc}` — none
+- `factor of $\frac{1}{2}$ enters`, `converge to the trace`, `degenerates to a scalar coefficient` — none
+- `\int_SJ` — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch05-close-reading-polish.md
+++ b/translation/reviews/ch05-close-reading-polish.md
@@ -44,7 +44,7 @@ Scope: publication polish after Pass 3 — Markdown cleanup, mathematical safety
 - **C12** §5.9 `does no harm` — preserved looser voice
 - **C15** `Stokes's` — none found; already `Stokes'`
 - **C16** §5.11 Hodge dictionary sentence — kept approachable wording
-- **C24** §5.4 wedge compatibility sentence — kept as-is
+- optional §5.4 wedge-compatibility wording — kept as-is
 - `mismatch`, `balance the books`, tiny-loop derivation, tiling/cancellation, Kelvin–Stokes naming, full $d(d\omega)$ calculation, general $k$-form formula, pullback commutation note, EM examples / Appendix C, Hodge foreshadow, Appendix B expansions, same-symbol $\rho$, EM current $J$ vs matrix $\mathbf{J}$
 
 ---

--- a/translation/reviews/ch05-pass2.md
+++ b/translation/reviews/ch05-pass2.md
@@ -1,0 +1,60 @@
+# Pass 2 Review: Chapter 5
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch05`
+File: `manuscript/en/ch05/ch05.md`
+
+Pass 2 scope: English information structure, naturalness, TOC alignment. Math unchanged.
+
+---
+
+## Stage 1: §5.0–§5.3 (complete)
+
+- Replaced outdated YAML draft (wrong chapter: metric $g$).
+- Aligned §5.2–§5.3 headings with `manuscript/en/toc.md`.
+
+**Passed.**
+
+---
+
+## Stage 2: §5.4–§5.6 (complete)
+
+- $d$ birth from tiny-loop mismatch; general $1$-form $d\omega$; Stokes' tile argument preserved.
+- No structural edits beyond terminology scan.
+
+**Passed.**
+
+---
+
+## Stage 3: §5.7–§5.9 (complete)
+
+- $2$-form $d\eta$, Gauss' theorem, $d^2=0$, unified $\int_{\partial M}\omega=\int_M d\omega$.
+- §5.8 heading aligned with TOC.
+
+**Passed.**
+
+---
+
+## Stage 4: §5.10–§5.11 + Appendices B–C (complete)
+
+- EM localization examples; Hodge star foreshadow (no concrete $\ast$ formulas).
+- Appendix B matrix view; Appendix C Maxwell integral → local via $d$.
+
+**Passed.**
+
+---
+
+## Stage 5: Whole chapter (complete)
+
+- `Stokes's` → `Stokes'` (six instances) for consistency.
+- Terminology: measuring device, mismatch, exterior derivative; no rot, no YAML.
+
+**Passed.**
+
+---
+
+# Overall Chapter 5 Pass 2 Result
+
+**Chapter 5 passes Pass 2** on `ai/english-translation-ch05`.
+
+Body: §5.0–§5.11 + Appendices B–C (~1050 lines). Pass 3 in `ch05-pass3.md`.

--- a/translation/reviews/ch05-pass3.md
+++ b/translation/reviews/ch05-pass3.md
@@ -1,0 +1,74 @@
+# Pass 3 Review: Chapter 5
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch05`
+File: `manuscript/en/ch05/ch05.md`
+
+Pass 3 scope: authorial voice, note handling, publication polish. Minimal edits only.
+
+---
+
+## Decisions
+
+### 1. Chapter title and § headings
+
+Decision: **maintain**; Pass 2 aligned §5.2, §5.3, §5.8 with TOC.
+
+### 2. "Mismatch" (ズレ) metaphor
+
+Decision: **keep** throughout §5.2–§5.4 and checkpoints.
+
+Reason: Central pedagogical term for this chapter; do not replace with "curl" prematurely.
+
+### 3. Tiny-loop dissection (§5.3)
+
+Decision: **keep** full $xy$-plane rectangle calculation.
+
+Reason: Geometric origin of $d\omega$; matches Japanese emphasis.
+
+### 4. Kelvin–Stokes naming (§5.6)
+
+Decision: **keep** "Kelvin–Stokes theorem (also called simply Stokes' theorem)."
+
+Reason: Source distinction; English readers benefit.
+
+### 5. EM examples (§5.10.2)
+
+Decision: **keep** form-degree table and localization walkthrough; defer details to Appendix C.
+
+Reason: Architecture matches Japanese; avoids duplicating Appendix C in body.
+
+### 6. Hodge star foreshadow (§5.11)
+
+Decision: **keep** conceptual only; no $\ast$ correspondence formulas.
+
+Reason: Matches preview policy from YAML/recap and ch04 close.
+
+### 7. Appendices B and C
+
+Decision: **keep** in `ch05.md` (not split); full matrix and EM component expansions.
+
+Reason: Japanese source structure; B parallels ch02 Appendix A pattern.
+
+### 8. Minor edits (Pass 2)
+
+| Location | Change | Reason |
+|----------|--------|--------|
+| §5.10+ | `Stokes's` → `Stokes'` | Apostrophe consistency |
+| §5.2–§5.3, §5.8 | Heading TOC alignment | Publication |
+
+### 9. No change
+
+- Leibniz rule derivation (§5.5.2).
+- $27$-component $d\eta$ exposition (Appendix B.4.1).
+- Chapter 5 end checkpoint length.
+
+---
+
+# Overall Chapter 5 Pass 3 Result
+
+**Chapter 5 passes Pass 3** on `ai/english-translation-ch05`.
+
+English Chapter 5 is **Pass 1 + Pass 2 + Pass 3 complete**.
+
+Next: PR with base `ai/english-translation-ch04`; begin Chapter 6.


### PR DESCRIPTION
## Summary
- Replace outdated YAML English ch05 draft (mislabeled as metric $g$) with full exterior derivative chapter from Japanese source.
- Translate §5.0–§5.11 plus Appendices B (matrix $d$) and C (EM integral → local via $d$).
- Pass 2/3: TOC heading alignment, `Stokes's` → `Stokes'` consistency.
- Branch replayed on current `main` after #163 merge; diff is ch05-only.
- Update: close-reading polish from #183 has been applied in `715976e`.

## Scope
| Block | Content |
|-------|---------|
| §5.0–§5.3 | Bridge to $d$; $df$ revisit; closed-loop mismatch; tiny-loop dissection |
| §5.4–§5.6 | Birth of $d$; general $1$-form $d\omega$; Stokes' theorem |
| §5.7–§5.9 | $2$-form $d\eta$; Gauss'; $d^2=0$; unified Stokes |
| §5.10–§5.11 | Integral → local laws; EM; Hodge star foreshadow |
| App. B–C | Matrix representation; Maxwell integral forms |

## Test plan
- [ ] Diff against `manuscript/ja/ch05/ch05.md`
- [ ] Terminology: mismatch, measuring device, curl not rot; no YAML
- [ ] Review records: `ch05-pass2.md`, `ch05-pass3.md`, `ch05-close-reading-polish.md`
- [ ] Merge to `main` (Chapter 4 already on `main` via #163)