### PR TITLE
English Chapter 6: §6.0–§6.6 + Appendix D (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch06/ch06.md
+++ b/manuscript/en/ch06/ch06.md
@@ -10,7 +10,7 @@ After all, we are computing on real space $(x,y,z)$—orthogonal Cartesian coord
 
 What is the inner product? We have already met it many times. In Chapter 2, when we obtained an oriented area, we said that if you take the square root of the sum of squares of the three shadow components $A_{yz}, A_{zx}, A_{xy}$, you recover the elementary-school area—that “sum of squares” is precisely the inner product with itself (or its square root). More generally, for column vectors among themselves, or for $1$-forms written as row vectors, the scalar quantity obtained by multiplying corresponding components and adding is what we call the <strong>inner product</strong> here.
 
-……<strong>That is all</strong>. Most readers probably learned the inner product in high-school mathematics and are thinking, “Why state the obvious?” Yet in this book we have, uncomfortably, avoided defining the inner product head-on until now. There is a reason.
+...<strong>That is all</strong>. Most readers probably learned the inner product in high-school mathematics and are thinking, “Why state the obvious?” Yet in this book we have, uncomfortably, avoided defining the inner product head-on until now. There is a reason.
 
 The reason is that if we bring out the inner product too soon, the distinctions we have cared about until now will collapse.
 
@@ -36,7 +36,7 @@ Write two column vectors in real space $(x,y,z)$ in components:
 
 $$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
 
-The operation of multiplying components with the same index and taking the sum we define in this book as the <strong>inner product</strong> (dot product), and denote by the symbol $\cdot$.
+In this book, the <strong>inner product</strong> (dot product), denoted by $\cdot$, is the operation of multiplying components with the same index and adding the results.
 
 $$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
 
@@ -162,7 +162,7 @@ $$J\mathbf{v} = \begin{pmatrix}
 
 The inner product (square of length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed agree. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (unit displacement in the $r$ direction) likewise, $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ agree. In this way $\mathbf{g} = J^T J$ ties the inner products in parameter space and real space without contradiction.
 
-We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$:
+We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$, with $\theta$ taken as the polar angle:
 
 $$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
 
@@ -241,7 +241,7 @@ $$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
 
 In real space ($\mathbf{g}=I$), $|\mathbf{v}|^2 = \Delta x^2 + \Delta y^2 + \Delta z^2$. In the parameter space of cylindrical coordinates, $|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$.
 
-For $k=0$ (zero vectors, i.e. a point), the “size” of a scalar field $f$, which is a $0$-form, is simply its absolute value $|f|$.
+For $k=0$, no displacement vector is fed in; the corresponding size is simply the absolute value of the scalar coefficient $|f|$.
 
 The same holds for $k=2$ (area of the parallelogram spanned by two vectors) and $k=3$ (volume of the parallelepiped spanned by three vectors). As we saw in Chapter 2 §2.4.7, the square root of the sum of squares of the coefficients $A_{xy}, A_{yz}, A_{zx}$ of the three basis $2$-forms $dx \wedge dy, dy \wedge dz, dz \wedge dx$, namely $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$, gives the unsigned area of the parallelogram. In $xyz$ coordinates this calculation needs only the coefficients of the basis $2$-forms; no other information is required.
 
@@ -278,9 +278,7 @@ The diagonal entries of $\mathbf{g}$ express “how much a step along that axis 
 
 ---
 
----
-
-### §6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Methods
+### §6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes
 
 #### 6.3.1 Two Ways to Obtain a Scalar
 
@@ -290,22 +288,22 @@ When we survey the formulas of physics, we notice that there is more than one wa
 
 In other words, at least on the surface, two conventions for obtaining scalars coexist in the notation of physics. In the language of this book, they are the following two:
 
-- <strong>Method ① (differential forms method / d method)</strong>: Prepare a measuring device (row vector: a $1$-form, and so on) and a figure to be measured (column vector: a vector field, and so on), and obtain a scalar by a row $\times$ column computation. What this computation uses is the logic of action and evaluation—a form eats a vector and returns a scalar.
-- <strong>Method ② (vector calculus method / $\nabla$ method)</strong>: Unify all quantities as "arrows of the same kind," and obtain a scalar by an inner product between like vectors (column $\times$ column, or row $\times$ row). In this computation, the metric $g$ is inserted so that like vectors can be compared. Many readers will be familiar with this method from school education.
+- <strong>Route ① (differential-forms route / $d$ route)</strong>: Prepare a measuring device (row vector: a $1$-form, and so on) and a figure to be measured (column vector: a vector field, and so on), and obtain a scalar by a row $\times$ column computation. What this computation uses is the logic of action and evaluation—a form eats a vector and returns a scalar.
+- <strong>Route ② (vector-calculus route / $\nabla$ route)</strong>: Unify all quantities as "arrows of the same kind," and obtain a scalar by an inner product between like vectors (column $\times$ column, or row $\times$ row). In this computation, the metric $g$ is inserted so that like vectors can be compared. Many readers will be familiar with this method from school education.
 
-> <strong>Note</strong> (What to call the two methods—the author's dilemma) The author long wondered what to call these two conventions in a textbook. Calling Method ① the "differential forms method" is natural, but in this book we also write "d method" alongside it. For readers who do not yet know differential forms, the symbol $d$ is more familiar. The author personally also calls it the "topology method." For readers raised in topology or geometry, that name may feel more natural. Likewise, calling Method ② the "vector calculus method" is natural, but in this book we also write "$\nabla$ method" alongside it. The symbol $\nabla$ (nabla) is the most familiar symbol for readers who have studied physics. The author personally also calls it the "inner product method," using that name when emphasizing that the structure of the inner product sits at the core. All of these names refer to the same two conventions.
+> <strong>Note</strong> (What to call the two methods—the author's dilemma) The author long wondered what to call these two conventions in a textbook. Calling Route ① the "differential forms method" is natural, but in this book we also write "d method" alongside it. For readers who do not yet know differential forms, the symbol $d$ is more familiar. The author personally also calls it the "topology method." For readers raised in topology or geometry, that name may feel more natural. Likewise, calling Route ② the "vector calculus method" is natural, but in this book we also write "$\nabla$ method" alongside it. The symbol $\nabla$ (nabla) is the most familiar symbol for readers who have studied physics. The author personally also calls it the "inner product method," using that name when emphasizing that the structure of the inner product sits at the core. All of these names refer to the same two conventions.
 
-> <strong>Note</strong> (Genealogy of the two notations) Method ① lies close to Grassmann's exterior algebra and Élie Cartan's line of development; Method ② lies close to the vector calculus systematized by Gibbs and Heaviside. This is not a matter of one being correct and the other wrong.
+> <strong>Note</strong> (Genealogy of the two notations) Route ① lies close to Grassmann's exterior algebra and Élie Cartan's line of development; Route ② lies close to the vector calculus systematized by Gibbs and Heaviside. This is not a matter of one being correct and the other wrong.
 
 In fact, whichever method we adopt, the physical result we obtain in the end is the same. This is merely a difference of expression.
 
-Yet a practical problem arises here. In the framework of Method ②, quantities that ought to be measured through a "surface" ($2$-forms) and quantities measured along a "line" ($1$-forms) are all treated as the same kind of "three-component arrow." To handle the notions of area and volume from Method ① within the framework of Method ②'s "inner product of arrows," we need a correspondence that links forms of different degrees.
+Yet a practical problem arises here. In the framework of Route ②, quantities that ought to be measured through a "surface" ($2$-forms) and quantities measured along a "line" ($1$-forms) are all treated as the same kind of "three-component arrow." To handle the notions of area and volume from Route ① within the framework of Route ②'s "inner product of arrows," we need a correspondence that links forms of different degrees.
 
 The number of independent components of a $k$-form had a characteristic symmetry. As we saw in Chapter 2 §2.5.9, in three-dimensional space a $0$-form has $1$ component, a $1$-form has $3$, a $2$-form also has $3$, and a $3$-form has $1$—folded at the middle, the pattern $1, 3, 3, 1$ is symmetric left and right. Between a $1$-form and a $2$-form with the same number of independent components, and between a $0$-form and a $3$-form, some correspondence ought to exist. The device that supplies that correspondence is the <strong>Hodge star $\ast$</strong>.
 
 $\ast$ uses the information of the inner product (that is, $g$) to assign to each form the partner that combines with it to make a volume. In the main text we first build this correspondence in the basis of physical space; verification in components is deferred to Appendix D.
 
-> <strong>Note</strong> (Between the two methods) We need not use only one of Method ① and Method ②. The author's ideal is to move freely between both. This book starts from Method ① (differential forms) in order to build a solid foundation that does not depend on distortion of space. On top of that, we want to be able to read the same quantities in the language of Method ② when needed—and $\ast$ is what bridges the two.
+> <strong>Note</strong> (Between the two methods) We need not use only one of Route ① and Route ②. The author's ideal is to move freely between both. This book starts from Route ① (differential forms) in order to build a solid foundation that does not depend on distortion of space. On top of that, we want to be able to read the same quantities in the language of Route ② when needed—and $\ast$ is what bridges the two.
 
 > <strong>Note</strong> (For readers who know vector calculus) Many operations that in ordinary vector calculus are treated as face orientations or cross products can be read anew as the correspondence given by this $\ast$. In this chapter, however, we do not use those as known formulas; we rebuild them from $g$ and the basis $2$-forms of Chapter 2.
 
@@ -385,7 +383,7 @@ $$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx.$$
 In general, in three-dimensional Cartesian physical space, $\ast\ast = \mathrm{id}$ (the identity operator) holds. One application of $\ast$ reverses the degree of a form; two applications return it to the original.
 
 > <strong>Checkpoint so far — §6.3</strong>
-> - There are two ways to obtain a scalar. Method ① obtains a scalar by row $\times$ column action. Method ② reads it as an inner product of like vectors, and the metric $g$ appears there.
+> - There are two ways to obtain a scalar. Route ① obtains a scalar by row $\times$ column action. Route ② reads it as an inner product of like vectors, and the metric $g$ appears there.
 > - The symmetry $1, 3, 3, 1$ seen in Chapter 2 suggests that a correspondence can be set up between $1$-forms and $2$-forms with the same number of independent components.
 > - The Hodge star $\ast$ returns, for a given form, the partner which combines with it to give the positive volume form. The dictionary in physical space includes $\ast dx = dy \wedge dz$, and so on.
 > - This dictionary is not a mere memorization table; once a basis is chosen, it can be written as an array representation of a linear transformation. Details of the array representation are confirmed in Appendix D.
@@ -407,7 +405,7 @@ $$
 (\alpha\cdot\beta)\,dx\wedge dy\wedge dz
 $$
 
-Here $\alpha\cdot\beta$ denotes the inner product of forms of the same degree. For two $1$-forms it is the sum of products of components; for two $2$-forms it is the Frobenius product seen in Appendix D. This formula expresses that $\ast$ links the "scalar obtained by the inner product" with the "$3$-form obtained by the wedge product."
+Here $\alpha\cdot\beta$ denotes the metric-induced inner product of forms of the same degree. For two $1$-forms it is the sum of products of components; for two $2$-forms it is the Frobenius product seen in Appendix D. This formula expresses that $\ast$ links the "scalar obtained by the inner product" with the "$3$-form obtained by the wedge product."
 
 > <strong>Note</strong> (Relation to more advanced definitions) In more advanced textbooks, $\alpha\wedge\ast\beta=(\alpha\cdot\beta)\,dx\wedge dy\wedge dz$ is often adopted as the definition of $\ast$. In this book we first built the dictionary on each basis element and its array representation; that is a concrete realization of this definition in Cartesian coordinates.
 
@@ -440,11 +438,11 @@ The wedge product of a $1$-form and a $2$-form is a $3$-form (a volume density).
 
 Next, see how the same calculation is carried out by <strong>Route ② (dot product of like-kind vectors)</strong>. To take an inner product treating both $E$ and $J$ as if they were $1$-forms, convert $J$, which measures surfaces, into a form that measures lines via $\ast$:
 
-$$\text{vector } J \longleftrightarrow \ast J$$
+$$\text{Route ② display of }J \longleftrightarrow \ast J$$
 
-Now we have two $1$-forms, $E$ and $\ast J$. Take their inner product (dot product). To write the inner product of $1$-forms in the language of differential forms, apply $\ast$ to one side to obtain a $2$-form, wedge to a $3$-form, then apply $\ast$ overall to drop to a $0$-form:
+Now we have two $1$-forms, $E$ and $\ast J$. Take their inner product (dot product). Here $E\cdot J$ is the Route ② display after $J$ has been read through $\ast$ as a like-kind object. To write the inner product of $1$-forms in the language of differential forms, apply $\ast$ to one side to obtain a $2$-form, wedge to a $3$-form, then apply $\ast$ overall to drop to a $0$-form:
 
-$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
+$$\text{Route ② display }E\cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
 
 Here $\ast\ast = \mathrm{id}$, so the inner $\ast(\ast J) = J$:
 
@@ -650,7 +648,7 @@ By now, a substantial part of the structure behind nabla notation has come into 
 
 Readers who know vector analysis may already see the usual $\nabla$ notation rising from here. But this book will not rush. The systematic organization in the usual nabla notation is deferred to later chapters.
 
-In later chapters we will use the $d$, $g$, and $\ast$ obtained here to return to the notation of usual vector analysis. Stokes' theorem, Gauss' divergence theorem, and why formulas grow long in curvilinear coordinates will all be reread from this toolkit.
+In later chapters we will use the $d$, $g$, and $\ast$ obtained here to return to the notation of usual vector analysis. Stokes' theorem, Gauss' theorem, and why formulas grow long in curvilinear coordinates will all be reread from this toolkit.
 
 > <strong>Note</strong> (by flipping just one sign in the metric) This chapter assumed a positive definite metric ($\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$). But on the four-dimensional spacetime stage of special relativity, an indefinite metric appears, such as $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$, with only the time component's sign flipped. This book is fixed on three-dimensional Cartesian physical space, so we do not go further here; but the idea learned in this chapter of "inserting the matrix $\mathbf{g}$" extends directly to four-dimensional spacetime. When that becomes necessary, I hope the reader will return to this chapter.
 
@@ -665,8 +663,6 @@ In later chapters we will use the $d$, $g$, and $\ast$ obtained here to return t
 > - The Joule-heating and helicity examples show that Route ① and Route ② give the same result through $\ast$ and $\ast\ast = \mathrm{id}$.
 > - In Chapter 6 we confirmed that the three types $\mathrm{grad}=d$, $\mathrm{curl}=\ast\,d$, $\mathrm{div}=\ast\,d\,\ast$ appear. The systematic organization in the usual nabla notation is deferred to later chapters.
 > - From $d^2=0$, on the side of forms we get $\mathrm{curl}(\mathrm{grad}\,f)=0$ and $\mathrm{div}(\mathrm{curl}\,\omega)=0$. The meaning in usual vector analysis is treated again in later chapters.
-
----
 
 ---
 
@@ -821,7 +817,7 @@ A\cdot B
 A_{ij}B_{ij}
 $$
 
-> <strong>Note</strong> (trace) $\operatorname{tr}$ is the <strong>trace</strong> of a matrix (the sum of diagonal entries). It appeared when we treated the matrix representation of the exterior derivative in Appendix B. $\operatorname{tr}(A^T B)$ is the three-step operation "transpose $A$, multiply by $B$, and add the diagonal entries." Because it is equivalent to $\frac{1}{2}\sum A_{ij}B_{ij}$, use the latter expression when you want to think in components.
+> <strong>Note</strong> (trace) $\operatorname{tr}$ is the <strong>trace</strong> of a matrix (the sum of diagonal entries). It appeared when we treated the matrix representation of the exterior derivative in Appendix B. $\operatorname{tr}(A^T B)$ is the three-step operation "transpose $A$, multiply by $B$, and add the diagonal entries." Since the product $A\cdot B$ is equivalently $\frac{1}{2}\sum A_{ij}B_{ij}$, use the latter expression when you want to think in components.
 
 This is the same notation as the inner product $\mathbf{v}_1 \cdot \mathbf{v}_2$ between column vectors in §6.2.3. Matrices, too, are "things of the same kind," and we multiply corresponding components and take the sum. Because we contract successively over the two indices $i$ and $j$, this is called the <strong>Frobenius product</strong> or <strong>consecutive contraction</strong>.
 
@@ -902,10 +898,10 @@ $$
 \ast_{2\to1}(\ast_{1\to2}(\omega))
 &=
 \begin{pmatrix}
-E_1\cdot (P E_1+Q E_2+R E_3) \\
-E_2\cdot (P E_1+Q E_2+R E_3) \\
+E_1\cdot (P E_1+Q E_2+R E_3) &
+E_2\cdot (P E_1+Q E_2+R E_3) &
 E_3\cdot (P E_1+Q E_2+R E_3)
-\end{pmatrix}^{T} \\
+\end{pmatrix} \\
 &=
 \begin{pmatrix}
 P & Q & R
@@ -1078,15 +1074,7 @@ That is, $\ast_{3\to0}$ uses the same three antisymmetric matrices. The only dif
 
 If we think of the indices $(i,j,k)$ lined up in a row as a single number, then $\ast_{0\to3}$ is a column vector that spreads one component into $27$ components, and $\ast_{3\to0}$ is a row vector that extracts one component from $27$ components. Apart from the normalization factor $1/3!$, the two are in a transpose relation.
 
-Acting on the $3$-form
-
-$$
-\eta
-=
-\eta_{ijk}
-$$
-
-with $\ast_{3\to0}$ sums over all three indices:
+Let a $3$-form be represented by its completely antisymmetric components $\eta_{ijk}$. Acting with $\ast_{3\to0}$ sums over all three indices:
 
 $$
 \ast_{3\to0}\eta

--- a/manuscript/en/ch06/ch06.md
+++ b/manuscript/en/ch06/ch06.md
@@ -1,431 +1,1199 @@
----
-title: "Chapter 6: Vector Calculus — The True Identity of Nabla"
-series: dx-matrix
-chapter: 6
-order: 60
-assumes:
-  - displacement_vector
-  - dx_as_row_vector
-  - differential
-  - pullback
-  - jacobian
-  - metric
-introduces:
-  cross_product:
-    from: definition
-    to: computation
-  nabla_symbol:
-    from: definition
-    to: computation
-  laplacian:
-    from: definition
-    to: computation
-previews:
-  unified_stokes:
-    max_level: mention
-recap_policy:
-  one_form:
-    max_level: mention
-    max_lines: 3
-  exterior_derivative:
-    max_level: none
-  wedge_product:
-    max_level: none
-  two_form:
-    max_level: none
-  three_form:
-    max_level: none
-  hodge_star:
-    max_level: none
-  nabla_operators:
-    max_level: none
----
+# Chapter 6: The Metric $g$ and the Hodge Star $\ast$ — Summoning the Inner Product and Reversing Degree
 
-# Chapter 6: Vector Calculus — The True Identity of Nabla
+### §6.0 The End of Excuses — Releasing the Inner Product
 
-### §6.0 The Entrance of Nabla
+When, in Chapter 2, we restored the scalar area of a parallelogram as the square root of the sum of squares of three projected areas, and when, in Chapter 3, we measured the surface area $4\pi R^2$ of a sphere and the arc length $2\pi R$ of a circle by the same idea—here we have repeatedly hedged, each time we computed a length or an area, with “we have not yet formally introduced the metric (inner product).”
 
-The title of this book is "Dismantling Nabla." And yet the pretense is that, from Chapter 1 through Chapter 5, we have never once defined nabla $\nabla$ head-on. The words grad, rot, and div themselves only appeared in §5.5 as combinations of $d$ and $\ast$.
+The reader has probably begun to find this tedious by now. To be honest, I have too.
 
-What have we been doing instead? $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as an operator that raises the degree — we have been steadily building up the tools of the "backstage," so to speak. Some readers have probably been wondering, "When on earth is $\nabla$ going to show up?" To be honest, the author, too, has begun to worry that the title is verging on false advertisement.
+After all, we are computing on real space $(x,y,z)$—orthogonal Cartesian coordinates. In this space the Pythagorean theorem holds. Let us stop being shy and start using the <strong>inner product</strong>.
 
-In this chapter, we finally define $\nabla$. And then we lay out standard vector calculus — gradient, divergence, curl, Laplacian, and the various identities — all at once, in a dogmatic fashion. We will not use $d$, $\ast$, or $\wedge$ at all. This is precisely the vector calculus that many readers studied (and probably struggled through) in their first or second year of university.
+What is the inner product? We have already met it many times. In Chapter 2, when we obtained an oriented area, we said that if you take the square root of the sum of squares of the three shadow components $A_{yz}, A_{zx}, A_{xy}$, you recover the elementary-school area—that “sum of squares” is precisely the inner product with itself (or its square root). More generally, for column vectors among themselves, or for $1$-forms written as row vectors, the scalar quantity obtained by multiplying corresponding components and adding is what we call the <strong>inner product</strong> here.
 
-> **Note** (Why now?) The reason we piled up the tools of forms through Chapter 5 is to set up a contrast between this chapter's "formula-ridden vector calculus" and Chapter 7's "world unified by two operators." If, upon finishing this chapter, you feel that "there are too many formulas" — that is exactly right. That discomfort will become the driving force for Part III.
+……<strong>That is all</strong>. Most readers probably learned the inner product in high-school mathematics and are thinking, “Why state the obvious?” Yet in this book we have, uncomfortably, avoided defining the inner product head-on until now. There is a reason.
 
-The tools we use in this chapter are only those we have assembled through Chapter 5 — vertical vectors, horizontal vectors, matrices, inner products, Jacobian matrices, and partial derivatives.
+The reason is that if we bring out the inner product too soon, the distinctions we have cared about until now will collapse.
+
+From a more advanced standpoint, “vector addition and subtraction” and the “inner product” are not inseparable; they can be thought of separately. On that view one distinguishes “spaces with an inner product” from “spaces without one,” and calls the matrix that defines the inner product the “metric tensor.” I respect that distinction too. That is precisely why we have repeatedly hedged that we have not yet formally introduced the metric or the inner product.
+
+What we really want to distinguish here is the operation “row vector × column vector gives a scalar” from the operation “take the inner product between vectors of the same kind.”
+
+> <strong>Note</strong> (Why separate row and column so insistently) There is a standpoint that says one can describe physics quite powerfully even without putting the metric or inner product front and center—for example, elementary integration of $n$-forms and much undergraduate-level physics calculation work well on that view. I respect that standpoint too. On the other hand, the metric viewpoint that uses length, angle, inner product, and the Hodge star $\ast$ is of course also powerful. Personally, I think the ideal is to move back and forth between these two views as the problem demands. And to move back and forth, we must first not confuse “the operation measured by row vector × column vector” with “the operation that takes the inner product between vectors of the same kind.” That is why this book has been so insistent about separating row vectors and column vectors.
+
+Since Chapter 1 we have done mountains of calculations that obtain a scalar from row vector × column vector. So how is that different from the inner product?
+
+The conclusion: <strong>they are completely different things</strong>. Row vector times column vector is a calculation between <strong>vectors of different kinds</strong>—row and column. The inner product, by contrast, is a calculation between <strong>vectors of the same kind</strong>—“row with row” or “column with column.”
+
+Yes—the matter is deeper than the reader may have thought. On the special stage of real space, these two often happen to return the same number, which has encouraged their confusion—and on top of that confusion a vast edifice called vector analysis has been built. The goal of this chapter is to make this distinction clear, then introduce the metric $g$ as the natural generalization of the inner product, and from there expose what the Hodge star $\ast$ really is.
 
 ---
 
-### §6.1 Dot Product and Cross Product
+### §6.1 The Inner Product on Parameter Space — The True Nature of the Metric $g$
 
-#### 6.1.1 Dot Product
+#### 6.1.1 Inner Product in Real Space
 
-The **dot product** (inner product) of two vertical vectors $\mathbf{a} = (a_x, a_y, a_z)^T$, $\mathbf{b} = (b_x, b_y, b_z)^T$ is defined as follows.
+Write two column vectors in real space $(x,y,z)$ in components:
 
-$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
+$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
 
-As we saw in §5.2.3, this equals the inner product $\mathbf{a}^T \mathbf{g} \,\mathbf{b}$ with $\mathbf{g} = I$ in real space $(x,y,z)$. This is an operation we have already used many times in this book as the product of a vertical vector and a horizontal vector.
+The operation of multiplying components with the same index and taking the sum we define in this book as the <strong>inner product</strong> (dot product), and denote by the symbol $\cdot$.
 
-#### 6.1.2 Cross Product
+$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
 
-The **cross product** (vector product) of two vertical vectors $\mathbf{a}, \mathbf{b}$ is defined as follows.
+In $xyz$ coordinates, the inner product is computed simply by multiplying corresponding components and adding.
 
-$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
-a_y b_z - a_z b_y \\
-a_z b_x - a_x b_z \\
-a_x b_y - a_y b_x
+#### 6.1.2 Rereading the Inner Product as a Measuring Device
+
+Here let us reread the same calculation in the language of “measuring devices.” At first glance the inner product looks like an operation of a different lineage from the measuring devices we have handled until now. In fact, however, the inner product can also be read as an operation that “turns something into a measuring device, acts on something else, and yields a scalar.”
+
+The entry point is the transpose. Transposing $\mathbf{v}_1$ turns a column vector into a row vector:
+
+$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$
+
+This is a measuring device that eats the paired column vector $\mathbf{v}_2$ and measures “how large is the inner product with $\mathbf{v}_1$?”
+
+$$\mathbf{v}_1^T\mathbf{v}_2
+= \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
+= x_1x_2 + y_1y_2 + z_1z_2$$
+
+That is, in orthogonal Cartesian coordinates on real space, transposing a column vector $\mathbf{v}_1$ alone yields the row vector—a measuring device—for taking the inner product with that vector.
+
+> <strong>Note</strong> (What raising and lowering indices really are) In tensor analysis there is a convention of distinguishing vector components from measuring-device components by upper and lower indices. One is then told that the metric $g$ is used to raise and lower indices. In the language of this book, the true nature of that is the operation “convert a column vector into a row vector that measures the inner product.” In orthogonal Cartesian coordinates $g=I$, so transpose alone suffices; but in parameter space, as we shall see next, we must insert $\mathbf{g}=J^T J$ along the way.
+
+#### 6.1.3 Taking the Inner Product in Parameter Space
+
+What happens if we carry out the same rereading in parameter space $(r,\theta,z)$?
+
+In orthogonal Cartesian coordinates on real space, $\mathbf{v}_1^T$ was directly the “measuring device for the inner product with $\mathbf{v}_1$.” So in parameter space too we are tempted to use $\mathbf{v}_1^T$ as the measuring device as-is. But that only computes $\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$, which is not the correct inner product in real space. The correspondence between increments in parameter space and displacements in real space varies from place to place.
+
+What, then, must we insert to turn a column vector in parameter space into a row vector that correctly measures the inner product in real space?
+
+In Chapter 4 we saw how the Jacobian matrix of a coordinate change transforms components. Here we use that same matrix $J$ to read a displacement in parameter space as a displacement in real space.
+
+$$J = \begin{pmatrix}
+\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
+\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
+\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
 \end{pmatrix}$$
 
-The result is again a vertical vector. The arrangement of the components of the cross product follows a regular pattern, and can be written concisely using the following antisymmetric matrix.
+From the cylindrical-coordinate formulas $x = r\cos\theta,\; y = r\sin\theta,\; z = z$, computing partial derivatives gives:
 
-$$\mathbf{a} \times = \begin{pmatrix}
-0 & -a_z & a_y \\
-a_z & 0 & -a_x \\
--a_y & a_x & 0
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$
 
-Multiplying this $3\times 3$ matrix on the left by the vector $\mathbf{b}$ yields:
+Write the vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space in components:
 
-$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
-0 & -a_z & a_y \\
-a_z & 0 & -a_x \\
--a_y & a_x & 0
-\end{pmatrix}\begin{pmatrix}
-b_x \\ b_y \\ b_z
-\end{pmatrix} = \begin{pmatrix}
-a_y b_z - a_z b_y \\
-a_z b_x - a_x b_z \\
-a_x b_y - a_y b_x
+$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+
+Read in real space, these become $J\mathbf{v}_1$ and $J\mathbf{v}_2$ respectively. By the reading of the previous subsection, the measuring device for “the inner product with $J\mathbf{v}_1$” in real space is $(J\mathbf{v}_1)^T$. Therefore the inner product we want can be written as
+
+$$\text{inner product} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$
+
+Using the rule for transposes, $(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$, so
+
+$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
+
+Let us actually compute $J^T J$. $J^T$ is $J$ with rows and columns swapped:
+
+$$J^T = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
 \end{pmatrix}$$
 
-We call this $(\mathbf{a} \times)$ the **cross product matrix** of $\mathbf{a}$. It appeared in Chapter 2 §2.4.9 as the matrix representation of a $2$-form, and reappeared in §5.3.2 as the output of $\ast$ — exactly the same matrix. In this chapter, we use it purely as "an operation that takes a vector times a vector and yields a vector."
+Therefore,
 
-The cross product has the following basic properties.
+$$J^T J = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
 
-1. **Anticommutativity**: $\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$
-2. **Cross product with itself is zero**: $\mathbf{a} \times \mathbf{a} = \mathbf{0}$
-3. **Orthogonality**: $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$, $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$
+The algebraic identity $\cos^2\theta + \sin^2\theta = 1$ does all the geometry’s work, leaving $1, r^2, 1$ on the diagonal. We never once thought about arc length in the $\theta$ direction—it is a purely algebraic manipulation using only matrix product and transpose properties.
 
-Property 3 means that the cross product produces a vector orthogonal to both $\mathbf{a}$ and $\mathbf{b}$. This is the true nature of the so-called "right-hand rule."
+<strong>Thus a new measuring device appears.</strong> To build from a column vector $\mathbf{v}_1$ in parameter space a row vector that correctly measures the inner product in real space, we must multiply on the right by $J^T J$, not merely transpose:
 
-> **【Checkpoint — §6.1】**
-> - Dot product $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$. In real space, this equals $\mathbf{a}^T \mathbf{b}$.
-> - The cross product $\mathbf{a}\times\mathbf{b}$ can be written as $(\mathbf{a}\times)\,\mathbf{b}$ using the cross product matrix $(\mathbf{a}\times)$.
-> - The cross product is anticommutative, yields zero with itself, and its result is orthogonal to both vectors.
+$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$
+
+Acting this measuring device on $\mathbf{v}_2$ yields the same value as the inner product in real space.
+
+We call this $J^T J$ the <strong>metric matrix $\mathbf{g}$</strong>:
+
+$$\mathbf{g} = J^T J$$
+
+In $xyz$ coordinates we computed the inner product from the sum of products of components alone, never going through pullback. In parameter space we first read displacements in real space via $J$, then take the sum of products of components. Folding these two stages into matrix form puts $\mathbf{g}=J^T J$ in the middle—and its contents are found mechanically from partial derivatives and matrix products alone, as long as we know the Jacobian matrix $J$. No room remains anywhere for new axioms of geometry.
+
+For safety, let us check with concrete numbers. Consider the point $r=2,\; \theta=\pi/3$. Then $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$, so
+
+$$J = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+In parameter space consider the unit displacement $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ in the $\theta$ direction. We have $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, and since $r=2$ now, $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$. Computing the inner product (square of length) in parameter space:
+
+$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
+
+On the other hand, reading the same $\mathbf{v}$ as a displacement in real space:
+
+$$J\mathbf{v} = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
+
+The inner product (square of length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed agree. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (unit displacement in the $r$ direction) likewise, $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ agree. In this way $\mathbf{g} = J^T J$ ties the inner products in parameter space and real space without contradiction.
+
+We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$:
+
+$$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
+
+The factors $r^2$ and $r^2\sin^2\theta$ on the diagonal are likewise conversion factors derived mechanically from $J$, which lines up the linear coefficients of the coordinate change.
+
+With $g$ as mediator, we can compute inner products (lengths and angles) consistently in any coordinate system. Moreover, the action of the Hodge star $\ast$, treated later, can be read naturally from these rules of inner product.
 
 ---
 
-### §6.2 $\nabla$ and the Gradient
+### §6.2 Converting Between Column Vectors and Row Vectors Using $g$
 
-#### 6.2.1 Definition of $\nabla$
+#### 6.2.1 $\mathbf{v}^T \mathbf{g}$ Is a Row Vector
 
-Nabla $\nabla$ is defined as a formal vector formed by stacking partial differential operators vertically.
+Look once more at the inner-product formula from §6.1, $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$. Matrix products can be executed from the left in order, so this expression can be read as “first compute $\mathbf{v}_1^T \mathbf{g}$, then multiply the result by $\mathbf{v}_2$.”
 
-$$\nabla = \begin{pmatrix}
-\frac{\partial}{\partial x} \\[0.5em]
-\frac{\partial}{\partial y} \\[0.5em]
-\frac{\partial}{\partial z}
-\end{pmatrix}$$
+$\mathbf{v}_1$ is a column vector, but transposed $\mathbf{v}_1^T$ is a row vector. Multiplying a row vector by a square matrix again yields a row vector. So if we extract only the part $\mathbf{v}_1^T \mathbf{g}$,
 
-$\nabla$ is a "vector," but its components are not numbers — they are **differential operators**. $\nabla$ has no meaning by itself; it acquires a value only when it acts on something.
+$$\omega = \mathbf{v}^T \mathbf{g}$$
 
-#### 6.2.2 Gradient
+this is a <strong>row vector</strong> of size $1 \times 3$. The metric $g$ is, arising naturally from the matrix form of the inner product, a <strong>device that converts column vectors into row vectors</strong>.
 
-Applying $\nabla$ to a scalar field $f(x,y,z)$ is called the **gradient**, written $\mathrm{grad}\,f$ or $\nabla f$.
+Let us also write the reverse direction. Suppose a $1$-form given as a row vector
 
-$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
-\frac{\partial f}{\partial x} \\[0.5em]
-\frac{\partial f}{\partial y} \\[0.5em]
-\frac{\partial f}{\partial z}
-\end{pmatrix}$$
+$$
+\omega =
+\begin{pmatrix}
+\omega_1 & \omega_2 & \omega_3
+\end{pmatrix}
+$$
 
-Each component of the gradient is the rate of change of $f$ in the corresponding coordinate direction. Geometrically, $\nabla f$ is a vector field that points in the direction of steepest increase of $f$.
+is given. The corresponding column vector $\mathbf{v}_\omega$ is
 
-> **Note** (Is the gradient a row vector or a column vector?) In §5.5 we wrote $\mathrm{grad}\,f = df$, and $df$ was a row vector of coefficients. In this chapter, we treat $\nabla f$ as a column vector. This is not merely a difference of transposition. $\nabla f$ (column) adopts the perspective of "standing an arrow at each point in space" — the view that real space itself is changing — while $df$ (row) adopts the perspective that "the differential (the form) itself is changing." The starting pictures differ, but when aggregated via line integrals, they yield the same scalar quantity. This agreement is no accident.
+$$
+\mathbf{v}_\omega = \mathbf{g}^{-1}\omega^T
+$$
 
-**Example**: The gradient of $f(x,y,z) = x^2 + y^2 + z^2$.
+> <strong>Note</strong> (Inverse matrix) For a square matrix $A$, the matrix $A^{-1}$ satisfying
+> $$
+> A^{-1}A = AA^{-1} = I
+> $$
+> is called the inverse of $A$. Intuitively, it is the matrix that undoes the transformation by $A$. Here we use $\mathbf{g}^{-1}$ to return a row vector built with $\mathbf{g}$ to the original column vector.
 
-$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$
+In fact, if $\omega = \mathbf{v}^T\mathbf{g}$, transposing gives
 
-This vector field points radially outward from the origin, and grows larger the farther one gets from the origin.
+$$
+\omega^T = \mathbf{g}^T\mathbf{v}
+$$
 
----
+Since $\mathbf{g}$ is symmetric, $\mathbf{g}^T = \mathbf{g}$. Therefore
 
-### §6.3 Divergence
+$$
+\mathbf{v} = \mathbf{g}^{-1}\omega^T
+$$
 
-For a vector field $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)^T$, taking the dot product with $\nabla$ yields the **divergence**.
+returns us to the start.
 
-$$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+In orthogonal Cartesian coordinates on real space, $\mathbf{g}=I$, so this reverse conversion too looks like mere transpose. In a general coordinate system, however, $\mathbf{g}^{-1}$ is needed to return a row vector to a column vector.
 
-Formally this is "the dot product of $\nabla$ and $\mathbf{F}$," but because each component of $\nabla$ is a differential operator, the result is a scalar field.
+> <strong>Note</strong> (What we smuggled in Chapter 2) When we sought a matrix representation of a $2$-form in Chapter 2, we already used the form $\mathbf{v}_1^T M \mathbf{v}_2$. At that time we only said that “laying a column vector on its side is mathematically ill-behaved” and pushed on without going deeper. The $\mathbf{v}^T\mathbf{g}$ we are looking at now is the true nature of the operation we smuggled in then. In real space $\mathbf{g}=I$, so transpose alone makes a column vector look like a row vector. In parameter space, however, to convert a column vector into a row measuring device that reproduces the inner product in real space, we must pass explicitly through the metric $\mathbf{g}$.
 
-The divergence can also be written in the language of matrices. Consider the Jacobian matrix $\mathbf{J}_\mathbf{F}$ of $\mathbf{F}$.
+Consider the meaning of this conversion. Since Chapter 1 we have distinguished “the figure being measured (column vector $\mathbf{v}$)” from “the measuring device (row vector $\omega$).” They were inhabitants of different worlds. But via $g$, a column vector that lived on the figure side changes form to the scale side—the row vector. Even for the same arrow, the “sensitivity as a scale” changes from place to place because $\mathbf{g}$ absorbs all the differences in calibration at each location.
 
-$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
-\frac{\partial F_x}{\partial x} & \frac{\partial F_x}{\partial y} & \frac{\partial F_x}{\partial z} \\[0.3em]
-\frac{\partial F_y}{\partial x} & \frac{\partial F_y}{\partial y} & \frac{\partial F_y}{\partial z} \\[0.3em]
-\frac{\partial F_z}{\partial x} & \frac{\partial F_z}{\partial y} & \frac{\partial F_z}{\partial z}
-\end{pmatrix}$$
+In real space ($\mathbf{g}=I$) we have $\omega = \mathbf{v}^T$, and the components of the column vector become the components of the row vector as-is. In parameter space $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, so $\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$. Only the $\theta$ component is multiplied by $r^2$, reflecting that the $\theta$ direction’s scale is stretched by a factor of $r$.
 
-The **trace** (sum of the diagonal entries) of this matrix coincides with the divergence.
+Without $g$, we cannot convert between “the figure being measured” and “the measuring device” without strain. $g$ is the standard go-between that ties the two together.
 
-$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+#### 6.2.2 What the Metric Gives — Geometric Size of Parallel $k$-Parallelepipeds
 
-Physically, $\mathrm{div}\,\mathbf{F}$ represents the strength of the "source" at that point. Positive means a source, negative means a sink, and zero means there is neither source nor sink at that point.
+The most basic role of the metric $g$ is to define the <strong>actual geometric size</strong> (length, area, volume) of the <strong>parallel $k$-parallelepiped</strong> spanned by $k$ vectors.
 
-**Example**: The divergence of $\mathbf{F} = (x, y, z)^T$.
+In the chapters until now we performed “oriented counting” by feeding $k$ vectors to a $k$-form. $dx(\mathbf{v})$ is the number of the $x$ component of $\mathbf{v}$; $dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ is the oriented area of the parallelogram spanned by $\mathbf{v}_1, \mathbf{v}_2$. But these are measurements of shadows after all; how many meters of segment the vectors span, how many square meters of parallelogram they span under that metric, is determined only once the metric $g$ is given.
 
-$$\nabla \cdot \mathbf{F} = \frac{\partial x}{\partial x} + \frac{\partial y}{\partial y} + \frac{\partial z}{\partial z} = 1 + 1 + 1 = 3$$
+For $k=1$ (the segment spanned by one vector $\mathbf{v}$), the square of its length is defined by the inner product with itself, as we already derived in §6.1:
 
-**Example**: The divergence of $\mathbf{F} = (-y, x, 0)^T$.
+$$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
 
-$$\nabla \cdot \mathbf{F} = \frac{\partial (-y)}{\partial x} + \frac{\partial x}{\partial y} + \frac{\partial 0}{\partial z} = 0 + 0 + 0 = 0$$
+In real space ($\mathbf{g}=I$), $|\mathbf{v}|^2 = \Delta x^2 + \Delta y^2 + \Delta z^2$. In the parameter space of cylindrical coordinates, $|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$.
 
-This field is rotating, but has no source.
+For $k=0$ (zero vectors, i.e. a point), the “size” of a scalar field $f$, which is a $0$-form, is simply its absolute value $|f|$.
 
----
+The same holds for $k=2$ (area of the parallelogram spanned by two vectors) and $k=3$ (volume of the parallelepiped spanned by three vectors). As we saw in Chapter 2 §2.4.7, the square root of the sum of squares of the coefficients $A_{xy}, A_{yz}, A_{zx}$ of the three basis $2$-forms $dx \wedge dy, dy \wedge dz, dz \wedge dx$, namely $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$, gives the unsigned area of the parallelogram. In $xyz$ coordinates this calculation needs only the coefficients of the basis $2$-forms; no other information is required.
 
-### §6.4 Curl
+> <strong>Note</strong> (Why we do not write $k=2$ in vector form) For $k=1$ we wrote length as the inner product $\mathbf{v}^T\mathbf{g}\,\mathbf{v}$ of the column vector $\mathbf{v}$. The analogous inner product for $k=2$—inner product between matrices (the Frobenius product in Appendix D)—we have not yet defined. Moreover, to display the coefficients of a $2$-form as a $3$-component vector requires the Hodge star $\ast$, which changes degree. Here we still treat a face as a face—that is, as coefficients of a $2$-form.
 
-For a vector field $\mathbf{F}$, taking the cross product with $\nabla$ yields the **curl** (rotation).
+The role of the metric $g$ is to generalize this “computation in $xyz$” to coordinate systems with distorted scales, such as parameter space. In every case, <strong>once $g$ is fixed, a consistent geometric size is defined for parallel $k$-parallelepipeds of every degree</strong>—that is the most fundamental role of the metric.
 
-$$\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
-\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.5em]
-\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}
-\end{pmatrix}$$
+#### 6.2.3 Properties of the Inner Product
 
-Using the cross product matrix, it can also be written as follows.
+Just as in Chapter 5 we summarized the properties of the exterior derivative $d$ (linearity, raising degree, $d^2=0$, Leibniz rule), let us organize here the properties of the inner product that emerge from the calculations so far. These do not depend on a particular coordinate system.
 
-$$\mathrm{rot}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
-0 & -\frac{\partial}{\partial z} & \frac{\partial}{\partial y} \\[0.3em]
-\frac{\partial}{\partial z} & 0 & -\frac{\partial}{\partial x} \\[0.3em]
--\frac{\partial}{\partial y} & \frac{\partial}{\partial x} & 0
-\end{pmatrix}\begin{pmatrix}
-F_x \\ F_y \\ F_z
-\end{pmatrix}$$
+1. <strong>Symmetry</strong>: $\mathbf{v}_1 \cdot \mathbf{v}_2 = \mathbf{v}_2 \cdot \mathbf{v}_1$. Apply this to the matrix form derived in §6.1, $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$. We have $\mathbf{v}_2 \cdot \mathbf{v}_1 = \mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1$, but a scalar is unchanged under transpose, so $\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1 = (\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1)^T = \mathbf{v}_1^T \mathbf{g}^T \mathbf{v}_2$. For this to equal $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ we must have $\mathbf{g} = \mathbf{g}^T$. That is, from symmetry of the inner product it follows that $\mathbf{g}$ must be a <strong>symmetric matrix</strong>.
 
-Physically, $\mathrm{rot}\,\mathbf{F}$ represents the strength and direction of the "vortex" at that point. It points in the direction of the vortex axis, with magnitude corresponding to the vortex strength.
+2. <strong>Linearity</strong> (bilinearity): $(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$. Linear in each argument. This is nothing but the distributive law for matrix products, $(a\mathbf{v}_1 + b\mathbf{v}_2)^T \mathbf{g} \,\mathbf{v}_3 = a\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_3 + b\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_3$.
 
-**Example**: The curl of $\mathbf{F} = (-y, x, 0)^T$.
+3. <strong>Positive definiteness</strong>: $\mathbf{v} \cdot \mathbf{v} > 0$ ($\mathbf{v} \neq \mathbf{0}$). This guarantees that “square of length” is positive. In special relativity, where signs are mixed, this need not hold; but on the three-dimensional real space that is the stage of this book it always does.
 
-$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \\[0.3em]
-\frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \\[0.3em]
-\frac{\partial x}{\partial x} - \frac{\partial (-y)}{\partial y}
-\end{pmatrix} = \begin{pmatrix}
-0 - 0 \\ 0 - 0 \\ 1 - (-1)
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$
+> <strong>Note</strong> (Symmetric vs antisymmetric matrices)
+> The fact that the area-measuring device in Chapter 2 required an antisymmetric matrix ($M = -M^T$) and that the inner product here requires a symmetric matrix ($\mathbf{g} = \mathbf{g}^T$) are exactly paired. Antisymmetry governs oriented counting; the symmetric metric governs length and angle, and from there the unsigned area and volume induced.
 
-This field rotates uniformly around the $z$-axis, with vortex strength $2$.
+#### 6.2.4 Letting the Geometry of the Metric Matrix Live in Its Components
 
-**Example**: The curl of $\mathbf{F} = (x, y, z)^T$.
+The diagonal entries of $\mathbf{g}$ express “how much a step along that axis contributes to length”; the off-diagonal entries express “how much steps along different axes interfere with each other.” That $\mathbf{g}$ in cylindrical coordinates was diagonal is because the axes $r,\theta,z$ are mutually orthogonal. In any case, the single matrix $\mathbf{g}$ carries in its components all the “ruler properties” at that location.
 
-$$\nabla \times \mathbf{F} = \begin{pmatrix}
-\frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \\[0.3em]
-\frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \\[0.3em]
-\frac{\partial y}{\partial x} - \frac{\partial x}{\partial y}
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+> <strong>Note</strong> (Axiomatic inner product—reversed order of axioms and matrix) In a standard linear-algebra textbook one first defines the three properties above as axioms, then derives the theorem that any operation satisfying them can be written, in some basis, in the form $\mathbf{v}^T \mathbf{g} \mathbf{w}$ with a symmetric matrix $\mathbf{g}$. The logical order is the reverse of ours. On the axiomatic side the matrix representation is only one representation; on the measuring-device reading of this book, <strong>this matrix $\mathbf{g}$ is the scale of space itself</strong>, the starting point of all measurement. Neither is “correct” in preference to the other. One enters from abstract properties; one enters from concrete symbolic operations of measurement. Only the direction that suits you differs.
 
-A radial field has no vortex — which also matches intuition.
-
-> **【Checkpoint — §6.2–§6.4】**
-> - $\nabla = (\partial_x, \partial_y, \partial_z)^T$ is a formal vector of partial differential operators stacked vertically.
-> - $\mathrm{grad}\,f = \nabla f$ (gradient): scalar field → vector field.
-> - $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}$ (divergence): vector field → scalar field. Equals the trace of the Jacobian matrix.
-> - $\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$ (curl): vector field → vector field. Can be written using the cross product matrix.
+> <strong>Checkpoint so far — §6.0–§6.2</strong>
+> - The inner product is the operation of taking the sum of products of components between vectors of the same kind (row × row, or column × column). It is a different thing from row × column.
+> - The inner product in parameter space is computed by pulling back to real space first. In that process $J^T J$ appears naturally. That is the true nature of the metric $g$.
+> - $g$ converts column vectors to row vectors. Concretely, from a column vector $\mathbf{v}$ the corresponding $1$-form is built by $\omega_{\mathbf{v}} = \mathbf{v}^T\mathbf{g}$.
+> - Conversely, from a $1$-form $\omega$ given as a row vector, the corresponding column vector is $\mathbf{v}_\omega = \mathbf{g}^{-1}\omega^T$. In Cartesian coordinates $\mathbf{g}=I$, so both look like almost nothing but transpose.
+> - With $g$ as mediator, geometric size is defined for parallel $k$-parallelepipeds of every degree.
+> - From the properties of the inner product (symmetry, linearity, positive definiteness) the symmetry of $g$ follows. This pairs with the antisymmetry of the area-measuring device $\wedge$.
 
 ---
 
-### §6.5 Laplacian
+---
 
-Applying the gradient (scalar→vector) followed by the divergence (vector→scalar) in succession yields an operation from a scalar field to a scalar field. This is called the **Laplacian**.
+### §6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Methods
 
-$$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f) = \nabla \cdot (\nabla f) = \frac{\partial^2 f}{\partial x^2} + \frac{\partial^2 f}{\partial y^2} + \frac{\partial^2 f}{\partial z^2}$$
+#### 6.3.1 Two Ways to Obtain a Scalar
 
-The notation $\nabla^2$ is shorthand for $\nabla \cdot \nabla$; some conventions use $\Delta f$ instead.
+By now the true nature of $g = J^T J$ has been revealed, and we can compute inner products in any coordinate system. Let us step back and look at the larger picture.
 
-**Example**: The Laplacian of $f(x,y,z) = x^2 + y^2 + z^2$.
+When we survey the formulas of physics, we notice that there is more than one way to produce a scalar quantity. When we integrate a field along a line or over a surface, a natural notation appears: something that measures acts on something that is measured and returns a number. On the other hand, quantities such as power and energy density are often written as inner products of the same kind of arrow, as in $\mathbf{E}\cdot\mathbf{J}$ or $\mathbf{A}\cdot(\nabla\times\mathbf{A})$.
 
-$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$
+In other words, at least on the surface, two conventions for obtaining scalars coexist in the notation of physics. In the language of this book, they are the following two:
 
-For a vector field $\mathbf{F}$, applying the Laplacian component-wise is called the **vector Laplacian**.
+- <strong>Method ① (differential forms method / d method)</strong>: Prepare a measuring device (row vector: a $1$-form, and so on) and a figure to be measured (column vector: a vector field, and so on), and obtain a scalar by a row $\times$ column computation. What this computation uses is the logic of action and evaluation—a form eats a vector and returns a scalar.
+- <strong>Method ② (vector calculus method / $\nabla$ method)</strong>: Unify all quantities as "arrows of the same kind," and obtain a scalar by an inner product between like vectors (column $\times$ column, or row $\times$ row). In this computation, the metric $g$ is inserted so that like vectors can be compared. Many readers will be familiar with this method from school education.
 
-$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$
+> <strong>Note</strong> (What to call the two methods—the author's dilemma) The author long wondered what to call these two conventions in a textbook. Calling Method ① the "differential forms method" is natural, but in this book we also write "d method" alongside it. For readers who do not yet know differential forms, the symbol $d$ is more familiar. The author personally also calls it the "topology method." For readers raised in topology or geometry, that name may feel more natural. Likewise, calling Method ② the "vector calculus method" is natural, but in this book we also write "$\nabla$ method" alongside it. The symbol $\nabla$ (nabla) is the most familiar symbol for readers who have studied physics. The author personally also calls it the "inner product method," using that name when emphasizing that the structure of the inner product sits at the core. All of these names refer to the same two conventions.
 
-The Laplacian appears everywhere in physics. The heat equation, the wave equation, Poisson's equation — all are equations centered on $\nabla^2$.
+> <strong>Note</strong> (Genealogy of the two notations) Method ① lies close to Grassmann's exterior algebra and Élie Cartan's line of development; Method ② lies close to the vector calculus systematized by Gibbs and Heaviside. This is not a matter of one being correct and the other wrong.
+
+In fact, whichever method we adopt, the physical result we obtain in the end is the same. This is merely a difference of expression.
+
+Yet a practical problem arises here. In the framework of Method ②, quantities that ought to be measured through a "surface" ($2$-forms) and quantities measured along a "line" ($1$-forms) are all treated as the same kind of "three-component arrow." To handle the notions of area and volume from Method ① within the framework of Method ②'s "inner product of arrows," we need a correspondence that links forms of different degrees.
+
+The number of independent components of a $k$-form had a characteristic symmetry. As we saw in Chapter 2 §2.5.9, in three-dimensional space a $0$-form has $1$ component, a $1$-form has $3$, a $2$-form also has $3$, and a $3$-form has $1$—folded at the middle, the pattern $1, 3, 3, 1$ is symmetric left and right. Between a $1$-form and a $2$-form with the same number of independent components, and between a $0$-form and a $3$-form, some correspondence ought to exist. The device that supplies that correspondence is the <strong>Hodge star $\ast$</strong>.
+
+$\ast$ uses the information of the inner product (that is, $g$) to assign to each form the partner that combines with it to make a volume. In the main text we first build this correspondence in the basis of physical space; verification in components is deferred to Appendix D.
+
+> <strong>Note</strong> (Between the two methods) We need not use only one of Method ① and Method ②. The author's ideal is to move freely between both. This book starts from Method ① (differential forms) in order to build a solid foundation that does not depend on distortion of space. On top of that, we want to be able to read the same quantities in the language of Method ② when needed—and $\ast$ is what bridges the two.
+
+> <strong>Note</strong> (For readers who know vector calculus) Many operations that in ordinary vector calculus are treated as face orientations or cross products can be read anew as the correspondence given by this $\ast$. In this chapter, however, we do not use those as known formulas; we rebuild them from $g$ and the basis $2$-forms of Chapter 2.
+
+#### 6.3.2 The $\ast$ Dictionary in Physical Space—Choosing the Partner That Makes a Volume
+
+So how is $\ast$ determined?
+
+Here we first consider orthogonal Cartesian coordinates in physical space $(x,y,z)$. In this space, $dx, dy, dz$ are mutually orthogonal reference measuring devices of length $1$. We also fix the orientation of space so that
+
+$$
+dx \wedge dy \wedge dz
+$$
+
+is the positive volume form.
+
+We may think of $\ast$ as the operation that, given a form, returns the partner which combines with it to yield a volume form.
+
+For example, what $2$-form combines with $dx$ to produce the positive volume form? It is $dy \wedge dz$. Indeed,
+
+$$
+dx \wedge dy \wedge dz
+$$
+
+is obtained. Therefore it is natural to set
+
+$$
+\ast dx = dy \wedge dz.
+$$
+
+Likewise,
+
+$$
+dy \wedge dz \wedge dx = dx \wedge dy \wedge dz,
+$$
+
+so
+
+$$
+\ast dy = dz \wedge dx,
+$$
+
+and
+
+$$
+dz \wedge dx \wedge dy = dx \wedge dy \wedge dz,
+$$
+
+so
+
+$$
+\ast dz = dx \wedge dy.
+$$
+
+In other words, $\ast$ assigns to each line measuring device the surface measuring device that combines with it to give the positive volume form. By the same idea, the scalar $1$ corresponds to the volume form $dx \wedge dy \wedge dz$, and the volume form corresponds to the scalar $1$.
+
+Therefore the $\ast$ dictionary in physical space is as follows.
+
+$$\begin{aligned}
+\ast(1) &= dx \wedge dy \wedge dz, \qquad &\ast(dx \wedge dy \wedge dz) &= 1 \\
+\ast(dx) &= dy \wedge dz, \qquad &\ast(dy \wedge dz) &= dx \\
+\ast(dy) &= dz \wedge dx, \qquad &\ast(dz \wedge dx) &= dy \\
+\ast(dz) &= dx \wedge dy, \qquad &\ast(dx \wedge dy) &= dz
+\end{aligned}$$
+
+At this stage it is enough to read $\ast$ as a "dictionary." However, this correspondence is not a mere memorization table. Once a basis is chosen, $\ast$ can be written as an array representation of a linear transformation that rearranges coefficients. The array representation over all degrees is confirmed in Appendix D.
+
+The meaning of this dictionary is simple. What corresponds to a line segment in the $x$ direction ($dx$) is the face perpendicular to the $x$ axis ($dy \wedge dz$). Likewise $y \leftrightarrow dz \wedge dx$, $z \leftrightarrow dx \wedge dy$. And the scalar $1$ ($0$-form) and the volume $dx \wedge dy \wedge dz$ ($3$-form) correspond to each other. This is precisely the manifestation of the symmetry $1, 3, 3, 1$ of independent component counts that we saw in Chapter 2.
+
+> <strong>Note</strong> (Why this dictionary is the right one) That $\ast dx = dy \wedge dz$ holds is because $dx, dy, dz$ form an orthonormal basis (mutually orthogonal, length $1$) and because we have taken the orientation of space so that $dx \wedge dy \wedge dz$ is positive in a right-handed system. Under these conditions, the dictionary above is determined uniquely. Once parameter space is taken into account, the $\ast$ dictionary depends on the metric $g$ and on how orientation is chosen—in other words, if $g$ is not $I$, the coefficients in the dictionary become more complicated.
+
+#### 6.3.3 $\ast\ast = \mathrm{id}$
+
+As the dictionary above shows immediately, applying $\ast$ twice returns the original:
+
+$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx.$$
+
+In general, in three-dimensional Cartesian physical space, $\ast\ast = \mathrm{id}$ (the identity operator) holds. One application of $\ast$ reverses the degree of a form; two applications return it to the original.
+
+> <strong>Checkpoint so far — §6.3</strong>
+> - There are two ways to obtain a scalar. Method ① obtains a scalar by row $\times$ column action. Method ② reads it as an inner product of like vectors, and the metric $g$ appears there.
+> - The symmetry $1, 3, 3, 1$ seen in Chapter 2 suggests that a correspondence can be set up between $1$-forms and $2$-forms with the same number of independent components.
+> - The Hodge star $\ast$ returns, for a given form, the partner which combines with it to give the positive volume form. The dictionary in physical space includes $\ast dx = dy \wedge dz$, and so on.
+> - This dictionary is not a mere memorization table; once a basis is chosen, it can be written as an array representation of a linear transformation. Details of the array representation are confirmed in Appendix D.
+> - $\ast\ast = \mathrm{id}$ follows immediately from this dictionary.
+
+#### 6.3.4 Properties of $\ast$
+
+Following the pattern of §6.2.3, where we summarized the properties of the inner product, and of Chapter 5, where we summarized the properties of the exterior derivative $d$, let us organize the properties of $\ast$ that emerge from the construction so far.
+
+1. <strong>Reversal of degree</strong>: In three-dimensional space, $\ast$ pairs $0$-forms with $3$-forms and $1$-forms with $2$-forms. In general it sends a $k$-form to a $(3-k)$-form.
+
+2. <strong>Linearity</strong>: $\ast(\omega_1 + \omega_2) = \ast\omega_1 + \ast\omega_2$. $\ast$ is the operation that extends the dictionary on the basis linearly with coefficients; linearity is immediate. Details of the array representation are confirmed in Appendix D.
+
+3. <strong>Correspondence with the inner product</strong>: For forms $\alpha, \beta$ of the same degree, combining $\alpha$ and $\ast\beta$ by the wedge product yields a $3$-form whose coefficient is the inner product of $\alpha$ and $\beta$. In Cartesian coordinates,
+
+$$
+\alpha \wedge \ast\beta
+=
+(\alpha\cdot\beta)\,dx\wedge dy\wedge dz
+$$
+
+Here $\alpha\cdot\beta$ denotes the inner product of forms of the same degree. For two $1$-forms it is the sum of products of components; for two $2$-forms it is the Frobenius product seen in Appendix D. This formula expresses that $\ast$ links the "scalar obtained by the inner product" with the "$3$-form obtained by the wedge product."
+
+> <strong>Note</strong> (Relation to more advanced definitions) In more advanced textbooks, $\alpha\wedge\ast\beta=(\alpha\cdot\beta)\,dx\wedge dy\wedge dz$ is often adopted as the definition of $\ast$. In this book we first built the dictionary on each basis element and its array representation; that is a concrete realization of this definition in Cartesian coordinates.
+
+4. <strong>$\ast\ast = \mathrm{id}$</strong>: Applying it twice returns the original (§6.3.3). This holds under the conditions of an orthonormal basis and a right-handed system; in Appendix D it can also be verified algebraically through antisymmetric matrices and the Frobenius product.
+
+5. <strong>Dependence on the metric $g$</strong>: The $\ast$ dictionary is determined by the metric $g$ of space. In Cartesian coordinates ($g=I$), the concise dictionary of §6.3.2 suffices; in a general coordinate system, the coefficients of $\ast$ become functions of position. We treat the general case in detail in Chapter 9.
+
+These properties show that $\ast$ is not a mere "dictionary" but the very <strong>degree-reversal structure</strong> of a space equipped with a metric and an orientation.
 
 ---
 
-### §6.6 Identities
+### §6.4 Examples of the Correspondence — Differential Forms and Vector Analysis
 
-Two important identities hold among the three operations defined above. Both take the form "applying an operation twice yields zero."
+#### 6.4.1 Joule Heating $P=VI$ — Two Routes
 
-#### 6.6.1 $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$
+Let us verify in actual computation how $\ast$ concretely links differential forms with dot-product representations of like-kind vectors. The purpose of this section is not to learn formulas from electromagnetism or vector analysis. It is to survey, in two examples, how quantities that arise naturally in the language of differential forms can be read in the notation of scalar products and vector analysis.
 
-Taking the gradient to obtain a vector field and then taking its curl always yields the zero vector.
+> <strong>Note</strong> (you need not know electromagnetism or vector analysis) From here on, for the sake of explanation we will use a few symbols from electromagnetism and vector analysis a little ahead of their formal introduction. You need not understand right now what $E$ or $J$ represent, or what $\mathbf{A}\cdot(\nabla\times\mathbf{A})$ means. What we want to see here is a single point: a $3$-form that appears naturally in the language of differential forms can be read, through the Hodge star $\ast$, as a scalar or an inner product. The relation to vector-analytic notation will peek through a little later, but a full systematic treatment is deferred to later chapters.
 
-$$\nabla \times (\nabla f) = \begin{pmatrix}
-\frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \\[0.5em]
-\frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \\[0.5em]
-\frac{\partial}{\partial x}\frac{\partial f}{\partial y} - \frac{\partial}{\partial y}\frac{\partial f}{\partial x}
-\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+Revisit the high-school physics formula "electric power = voltage × current ($P=VI$)" as a phenomenon that occurs at each point in space.
 
-In each component, the terms cancel via commutativity of partial derivatives $\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$. This always holds as long as $f$ is smooth (twice continuously differentiable).
+- The <strong>electric field $E$</strong>, which is the origin of voltage, is a <strong>$1$-form</strong> that counts along line segments.
+- The <strong>current density $J$</strong>, which is the origin of current, is a <strong>$2$-form</strong> that counts charge crossing a surface.
 
-Physical meaning: "A gradient field has no vortex." Gravitational fields and electrostatic fields fall into this category.
+First, let us compute by <strong>Route ① (differential forms)</strong>. Take the wedge product of the $1$-form $E$ and the $2$-form $J$:
 
-#### 6.6.2 $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$
+$$E \wedge J$$
 
-Taking the curl to obtain a vector field and then taking its divergence always yields zero.
+The wedge product of a $1$-form and a $2$-form is a $3$-form (a volume density). This means "power per unit volume (W/m³)." Integrating this over a spatial region ($\int_V E \wedge J$) yields the total power consumed in the region (watts). This route uses only the operation of wedging a $1$-form and a $2$-form into a $3$-form.
 
-$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$
+Next, see how the same calculation is carried out by <strong>Route ② (dot product of like-kind vectors)</strong>. To take an inner product treating both $E$ and $J$ as if they were $1$-forms, convert $J$, which measures surfaces, into a form that measures lines via $\ast$:
 
-Expanding, terms such as $\frac{\partial^2 F_z}{\partial x\partial y}$ and $-\frac{\partial^2 F_z}{\partial y\partial x}$ cancel in pairs, again via commutativity of partial derivatives, and the total sum becomes $0$.
+$$\text{vector } J \longleftrightarrow \ast J$$
 
-Physical meaning: "A vortex field has no source." Magnetic fields fall into this category (the mathematical expression of the nonexistence of magnetic monopoles).
+Now we have two $1$-forms, $E$ and $\ast J$. Take their inner product (dot product). To write the inner product of $1$-forms in the language of differential forms, apply $\ast$ to one side to obtain a $2$-form, wedge to a $3$-form, then apply $\ast$ overall to drop to a $0$-form:
 
-> **【Checkpoint — §6.5–§6.6】**
-> - $\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$ is the Laplacian of a scalar field. It describes heat conduction and waves.
-> - $\mathrm{rot}(\mathrm{grad}\,f) = \mathbf{0}$: A gradient field has no vortex.
-> - $\mathrm{div}(\mathrm{rot}\,\mathbf{F}) = 0$: A vortex field has no source.
-> - Both are natural consequences of commutativity of partial derivatives $\partial_i\partial_j = \partial_j\partial_i$.
+$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
 
----
+Here $\ast\ast = \mathrm{id}$, so the inner $\ast(\ast J) = J$:
 
-### §6.7 Formula Collection for Nabla
+$$\ast(E \wedge J)$$
 
-For practical computation, we collect the product differentiation rules involving $\nabla$ and representative vector identities below. In what follows, $f, g$ are scalar fields and $\mathbf{F}, \mathbf{G}$ are vector fields.
+The bracketed quantity $E \wedge J$ is exactly the same $3$-form obtained in Route ①. The outer $\ast$ strips the volume $dx \wedge dy \wedge dz$ from the $3$-form and extracts a scalar value. The way of writing that multiplies the scalar $E \cdot J$ by a small volume $dV$ and integrates again can be read as restoring afterward the volume that this $3$-form already carried.
 
-#### 6.7.1 Product Differentiation Rules
+<strong>In short, $\ast$ links the $3$-form of Route ① and the scalar display of Route ② without contradiction.</strong> Because $\ast\ast = \mathrm{id}$, either route leads to the same result.
 
-**Product of gradients**:
+#### 6.4.2 Helicity $A \cdot (\nabla \times A)$ — The Round Trip of $\ast$
 
-$$\nabla(fg) = f\,\nabla g + g\,\nabla f$$
+In one more example, let us see further how $\ast$ works. Consider the following $3$-form built from a $1$-form $\alpha$ and its exterior derivative $d\alpha$:
 
-**Product with divergence**:
+$$\alpha \wedge d\alpha$$
 
-$$\nabla \cdot (f\mathbf{F}) = (\nabla f) \cdot \mathbf{F} + f\,(\nabla \cdot \mathbf{F})$$
+In the language of Route ②, this quantity appears as the inner product of a vector field $\mathbf{A}$ with its curl:
 
-**Product with curl**:
+$$\mathbf{A} \cdot (\nabla \times \mathbf{A})$$
 
-$$\nabla \times (f\mathbf{F}) = (\nabla f) \times \mathbf{F} + f\,(\nabla \times \mathbf{F})$$
+Write the $1$-form corresponding to $\mathbf{A}$ as $\alpha$. The $d\alpha$ is first obtained as a $2$-form; in the language of Route ② it corresponds to the $1$-form $\ast d\alpha$.
 
-**Divergence of a cross product**:
+First compute by <strong>Route ①</strong>. The wedge product of the $1$-form $\alpha$ and the $2$-form $d\alpha$:
 
-$$\nabla \cdot (\mathbf{F} \times \mathbf{G}) = (\nabla \times \mathbf{F}) \cdot \mathbf{G} - \mathbf{F} \cdot (\nabla \times \mathbf{G})$$
+$$\alpha \wedge d\alpha$$
 
-#### 6.7.2 Second-Order Identities
+The wedge of a $1$-form and a $2$-form is a $3$-form. On this route, $\alpha$ and $d\alpha$ are combined directly by the wedge product.
 
-The curl of a gradient and the divergence of a curl were derived in §6.6. We restate them here as a formula collection.
+Next look at the internal structure of the same calculation on <strong>Route ②</strong>. To read it as a dot product of like-kind vectors, we cannot leave the $2$-form $d\alpha$ as it is; we assign the corresponding $1$-form $\ast d\alpha$:
 
-**Curl of gradient is zero**:
+$$\nabla \times \mathbf{A} \longleftrightarrow \ast d\alpha$$
 
-$$\nabla \times (\nabla f) = \mathbf{0}$$
+Now we have two $1$-forms, $\alpha$ and $\ast d\alpha$. Take their inner product:
 
-**Divergence of curl is zero**:
+$$\mathbf{A} \cdot (\nabla \times \mathbf{A}) \longleftrightarrow \ast(\alpha \wedge \ast(\ast d\alpha))$$
 
-$$\nabla \cdot (\nabla \times \mathbf{F}) = 0$$
+By $\ast\ast = \mathrm{id}$, the inner $\ast(\ast d\alpha) = d\alpha$. Therefore,
 
-**Curl of curl**:
+$$\ast(\alpha \wedge d\alpha)$$
 
-$$\nabla \times (\nabla \times \mathbf{F}) = \nabla(\nabla \cdot \mathbf{F}) - \nabla^2 \mathbf{F}$$
+The bracketed quantity is the same as the $3$-form $\alpha \wedge d\alpha$ from Route ①. The outer $\ast$ strips the volume and extracts a scalar value.
 
-This decomposes the Laplacian into divergence and curl. The derivation uses the BAC-CAB rule (§6.7.4).
+<strong>What deserves attention here is that $\ast$ appears twice and cancels via $\ast\ast = \mathrm{id}$.</strong> Inside Route ② we use $\ast d\alpha$ as the $1$-form corresponding to $d\alpha$ (a $2$-form), and call on $\ast$ again to take the inner product. This round trip is canceled by $\ast\ast = \mathrm{id}$.
 
-**Divergence of gradient of a scalar field** (= Laplacian):
+> <strong>Note</strong> (why the round trip of $\ast$ occurs) Vector analysis has no concept of the degree of a form and treats everything uniformly as "a three-component arrow." To read a $2$-form as an arrow, one must build the corresponding $1$-form with $\ast$; to take an inner product one must again use $\ast$ to return to the original degree. The Hodge star $\ast$ is the single correspondence that links these two representations.
 
-$$\nabla \cdot (\nabla f) = \nabla^2 f$$
-
-This is the very definition from §6.5.
-
-#### 6.7.3 Scalar Triple Product
-
-The scalar triple product of three vertical vectors $\mathbf{A}, \mathbf{B}, \mathbf{C}$ is defined as the dot product of $\mathbf{A}$ with $\mathbf{B}\times\mathbf{C}$.
-
-$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$
-
-This value equals the signed volume of the parallelepiped spanned by $\mathbf{A}, \mathbf{B}, \mathbf{C}$. It is invariant under cyclic permutation, and swapping any two vectors flips the sign.
-
-$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C}) = \mathbf{B} \cdot (\mathbf{C} \times \mathbf{A}) = \mathbf{C} \cdot (\mathbf{A} \times \mathbf{B})$$
-
-#### 6.7.4 Vector Triple Product (BAC-CAB Rule)
-
-$$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot \mathbf{C}) - \mathbf{C}(\mathbf{A} \cdot \mathbf{B})$$
-
-This appears when the cross product is used twice. The right-hand side consists of scalar multiples of vectors, and is memorized by the mnemonic BAC-CAB.
-
-> **Note** (Why did we list all these formulas?) The formulas collected here are the representative ones that students are forced to memorize for university vector calculus exams. Now, one might ask: if we rewrite them in terms of $d$ and $\ast$, does the number of formulas drop dramatically? Not necessarily. Even on the side of differential forms, rules such as $d(f\omega) = df\wedge\omega + f d\omega$ exist in their own right.
->
-> The true problem of vector calculus is not the number of formulas. It is that **everything looks like the same "three-component arrow."** $\nabla f$, $\nabla \times \mathbf{F}$, $\nabla^2\mathbf{F}$ — they are all just bundles of arrows on the screen. But $\nabla f$ is a gradient (the slope of a potential), while $\nabla \times \mathbf{F}$ is a vortex axis — the geometric meanings of these arrows are entirely different. If one relies on pictures and intuition, the moment a problem becomes complex, these distinctions become impossible to maintain. Differential forms, by explicitly displaying the degree of the measuring device — $0$-form, $1$-form, $2$-form, $3$-form — prevent this confusion in principle. $d$ always raises the degree by $+1$, and $\ast$ always inverts the degree — because type information is carried by a small set of rules, one can tell what is being done from the shape of the expression alone, without looking at arrows. This is the reason we return to the language of forms from Chapter 7 onward.
-
-> **Note** (Just between us) Writing out the correspondences $\mathrm{grad}=d$, $\mathrm{rot}=\ast d$, $\mathrm{div}=\ast d\ast$ is, in truth, something of a compromise for dismantling vector calculus.
->
-> Many popular expositions of differential forms show only the range that can be written beautifully and declare "differential forms are beautiful," sidestepping the real issues. But I believe the reality is different. Consider the vector triple product $\mathbf{A}\times(\mathbf{B}\times\mathbf{C})$ from §6.7.4. If we rewrite this in the framework of forms, we get something like $\ast(\alpha \wedge \ast(\beta \wedge \gamma))$ — nested applications of $\ast$ that end up looking more awkward than vector calculus itself.
->
-> Why, then, do some expositors of differential forms emphasize beauty? If we are to be honest, it is because the world of differential forms originally has no need of $\ast$ at all. Before summoning the "ruler" of a metric, in the world woven from $d$ and $\wedge$ alone — there stretches a landscape of pure exterior differentiation, where no one has yet defined an "inner product." And in that world, one can construct Maxwell's equations without issue.
->
-> And if the reader can think that this "vector calculus via differential forms" computation in this book is ugly and a sidestepping of the real problem — then that is correct. But at that moment, you have already graduated from being a beginner in vector calculus.
+> <strong>Checkpoint so far — §6.4</strong>
+> - In the Joule-heating calculation, Route ① ($E \wedge J$) and Route ② ($E \cdot J = \ast(E \wedge J)$) agree via $\ast$.
+> - In the helicity calculation, $\ast$ is used twice and cancels by $\ast\ast = \mathrm{id}$. Route ① ($\alpha \wedge d\alpha$) and Route ② ($\mathbf{A} \cdot (\nabla \times \mathbf{A})$) give the same result.
+> - $\ast$ is the correspondence linking differential forms and vector analysis; $\ast\ast = \mathrm{id}$ guarantees consistency of the round trip.
 
 ---
 
-### §6.8 Integral Theorems — Stokes, Gauss, Green
+### §6.5 The Types of the Three Operations — grad, curl, div
 
-The most important work of vector calculus is to connect differential operations (grad, div, rot) with integration. Below we present three integral theorems in the language of $\nabla$.
+By now we have the two operators $d$ (Chapter 5) and $\ast$ (this chapter). Combining them yields operations that move the degree of a form in various ways.
 
-#### 6.8.1 Stokes' Theorem
+Among these, three types are especially named in three-dimensional vector analysis:
 
-For a surface $S$ and its boundary, a closed curve $C = \partial S$,
+$$
+0 \to 1,\qquad
+1 \to 2 \to 1,\qquad
+1 \to 2 \to 3 \to 0
+$$
 
-$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+In this book we call them, respectively,
 
-The left-hand side is the line integral (circulation) of $\mathbf{F}$ along the curve $C$; the right-hand side is the surface integral of the normal component of the curl over the surface $S$. It means "the circulation on the boundary equals the sum of the vortices inside." $\mathbf{n}$ is the unit normal vector to the surface, chosen according to the right-hand rule relative to the orientation of $C$.
+$$
+\mathrm{grad},\qquad
+\mathrm{curl},\qquad
+\mathrm{div}
+$$
 
-> **Note** (Green's theorem) When $S$ is a region $D$ in the $xy$-plane and $\mathbf{F} = (P, Q, 0)^T$, Stokes' theorem takes the following form. This is called Green's theorem.
->
-> $$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$
+This chapter stops at naming these three types. The correspondence with the usual $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ is treated again in later chapters.
 
-#### 6.8.2 Gauss's Divergence Theorem
+> <strong>Note</strong> (for readers who know vector analysis) By this point you may already see the usual $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ in the background. This chapter, however, does not formally develop the usual vector-analytic notation. Here we confirm the path: "from combinations of $d$ and $\ast$, extract the three types corresponding to grad, curl, and div." The usual nabla notation, the correspondence with Stokes' theorem, and why formulas grow long in curvilinear coordinates are taken up again in later chapters.
 
-For a solid $V$ and its boundary, a closed surface $S = \partial V$,
+Below, we work first in Cartesian coordinates. Use the $1$-form
 
-$$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+$$
+\omega = P\,dx + Q\,dy + R\,dz
+$$
 
-The left-hand side is the outward flux of $\mathbf{F}$ through the closed surface $S$; the right-hand side is the volume integral of the divergence inside the solid $V$. It means "the total flow through the boundary equals the sum of the sources inside."
+Readers who know vector analysis may read this as the field with components $(P,Q,R)$. A full systematic treatment of this correspondence is deferred to later chapters.
 
-#### 6.8.3 The Common Structure of the Three Theorems
+#### 6.5.1 Gradient $\mathrm{grad}\,f = df$
 
-Lining up Stokes' theorem and Gauss's divergence theorem side by side, a common pattern emerges.
+The exterior derivative $df$ of a $0$-form (scalar field) $f$ is a $1$-form:
 
-| Theorem | Integral on the boundary | Integral in the interior | Differential operation |
+$$
+df = \frac{\partial f}{\partial x}\,dx
+{}+ \frac{\partial f}{\partial y}\,dy
+{}+ \frac{\partial f}{\partial z}\,dz
+$$
+
+In this book we call this the $1$-form representation of the gradient and write
+
+$$
+\mathrm{grad}\,f = df
+$$
+
+The operator $d$ raises the degree from $0 \to 1$. That is the form of the gradient needed in this chapter. The relation to the column-vector display $\nabla f$ of usual vector analysis is organized again in later chapters.
+
+#### 6.5.2 Curl $\mathrm{curl}\,\omega = \ast\,d\,\omega$
+
+For the $1$-form
+
+$$
+\omega = P\,dx + Q\,dy + R\,dz
+$$
+
+applying $d$ yields the $2$-form $d\omega$:
+
+$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+Applying $\ast$ returns the $2$-form to a $1$-form:
+
+$$\ast(d\omega) = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dx + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dy + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dz$$
+
+In this book we call this $1$-form the $1$-form representation of the curl and write
+
+$$\mathrm{curl}\,\omega = \ast\,d\,\omega$$
+
+The composition $\ast\,d$ has the degree transition
+
+$$
+1 \to 2 \to 1
+$$
+
+This structure of "rising once to a surface form, then returning to a line form" corresponds to the curl. The relation to what is written $\nabla\times\mathbf F$ in usual vector analysis is treated again in later chapters.
+
+#### 6.5.3 Divergence $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$
+
+Apply $\ast$ first to the $1$-form $\omega$ to obtain a $2$-form. Apply $d$ to obtain a $3$-form. Apply $\ast$ once more to return to a $0$-form, namely a scalar field:
+
+$$
+\ast d\ast\omega
+$$
+
+Computing in Cartesian coordinates,
+
+$$\ast(d(\ast\omega)) = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$$
+
+In this book we call this $0$-form the divergence and write
+
+$$\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$$
+
+The composition $\ast\,d\,\ast$ has the degree transition
+
+$$
+1 \to 2 \to 3 \to 0
+$$
+
+The relation to what is written $\nabla\cdot\mathbf F$ in usual vector analysis is treated again in later chapters.
+
+#### 6.5.4 The Shadow of $d^2 = 0$
+
+Recall $d^2 = 0$ from Chapter 5. From this single fact, relations arise among the three operations.
+
+First,
+
+$$
+\mathrm{curl}(\mathrm{grad}\,f)
+=
+\ast d(df)
+=
+\ast(d^2 f)
+=
+0
+$$
+
+Also,
+
+$$
+\mathrm{div}(\mathrm{curl}\,\omega)
+=
+\ast d\ast(\ast d\omega)
+=
+\ast d(d\omega)
+=
+\ast(d^2\omega)
+=
+0
+$$
+
+Here we stop at viewing these as identities on the side of forms. Readers who know vector analysis will see the correspondence with the usual identities. In this book, however, the meaning in the usual nabla notation is deferred to later chapters.
+
+---
+### §6.6 Toward Vector Analysis
+
+In Chapter 5 we acquired the exterior derivative $d$; in this chapter, the metric $g$ and the Hodge star $\ast$. With this, the main tools needed to move from the world of forms toward vector analysis are in place.
+
+What we confirmed in this chapter is that from combinations of $d$ and $\ast$, one can extract the three types called grad, curl, and div in three-dimensional vector analysis.
+
+Let us tabulate the correspondences obtained here.
+
+| Operation | Decomposition in this book | Degree transition | Number of uses of $\ast$ |
 |---|---|---|---|
-| Stokes | $\displaystyle\oint_C \mathbf{F}\cdot d\mathbf{r}$ | $\displaystyle\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ | rot |
-| Gauss | $\displaystyle\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS$ | $\displaystyle\iiint_V (\nabla\cdot\mathbf{F})\,dV$ | div |
+| $\mathrm{grad}$ | $d$ | $0 \to 1$ | 0 |
+| $\mathrm{curl}$ | $\ast\,d$ | $1 \to 2 \to 1$ | 1 |
+| $\mathrm{div}$ | $\ast\,d\,\ast$ | $1 \to 2 \to 3 \to 0$ | 2 |
 
-Both take the form "quantity measured on the boundary = sum of differential quantities in the interior." In this framework, the $\mathrm{div}(\mathrm{rot})=0$ of §6.6 reads as: "A vortex field has no source, so even if you enclose it with a closed surface, nothing comes out."
+By now, a substantial part of the structure behind nabla notation has come into view. However, this chapter has not yet formally developed the usual vector analysis.
 
-Yet one dissatisfaction remains. Because Stokes and Gauss use different operators — grad / rot / div — they must be **memorized as separate theorems**. Recall that in Chapter 4, the single equation $\int_{\partial M}\omega = \int_M d\omega$ unified all of these. In Chapter 7, we will complete the dictionary that reinterprets the integral theorems of the $\nabla$ world into this single form.
+Readers who know vector analysis may already see the usual $\nabla$ notation rising from here. But this book will not rush. The systematic organization in the usual nabla notation is deferred to later chapters.
 
-> **【Checkpoint — §6.8】**
-> - Stokes' theorem: $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$
-> - Gauss's divergence theorem: $\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
-> - Green's theorem is the planar version of Stokes' theorem.
-> - The three theorems share the common structure "integral on boundary = integral of differential in interior," but in the language of $\nabla$, they must be treated as separate theorems.
+In later chapters we will use the $d$, $g$, and $\ast$ obtained here to return to the notation of usual vector analysis. Stokes' theorem, Gauss' divergence theorem, and why formulas grow long in curvilinear coordinates will all be reread from this toolkit.
+
+> <strong>Note</strong> (by flipping just one sign in the metric) This chapter assumed a positive definite metric ($\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$). But on the four-dimensional spacetime stage of special relativity, an indefinite metric appears, such as $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$, with only the time component's sign flipped. This book is fixed on three-dimensional Cartesian physical space, so we do not go further here; but the idea learned in this chapter of "inserting the matrix $\mathbf{g}$" extends directly to four-dimensional spacetime. When that becomes necessary, I hope the reader will return to this chapter.
 
 ---
 
-### §6.9 Toward Part III — Don't Look at Arrows, Look at Measuring Devices
+> <strong>Checkpoint so far — Chapter 6 as a whole</strong>
+> - The inner product is an operation taking the product-sum of components between vectors of the same kind (row×row, or column×column). It is a different operation from row×column computation.
+> - In physical space the inner-product matrix is the identity $I$. In parameter space it is determined by the linear coefficients of coordinate transformation as $\mathbf{g}=J^T J$. That is, the metric $g$ is nothing other than the matrix that appears in the middle when one pulls back to physical space and takes the inner product.
+> - $\mathbf{v}^T \mathbf{g}$ converts a column vector into a row vector; $\mathbf{g}^{-1}\omega^T$ returns a row vector to column-vector display. Without $g$, objects and measuring devices cannot convert into each other.
+> - There are two ways to obtain a scalar: Route ① (row×column) and Route ② (inner product of like-kind vectors). The Hodge star $\ast$ is the correspondence linking the two.
+> - $\ast$ returns, for a given form, the partner that combines with it to yield a positive volume form. The dictionary in physical space is $\ast dx = dy \wedge dz$, etc., and it satisfies $\ast\ast = \mathrm{id}$.
+> - The Joule-heating and helicity examples show that Route ① and Route ② give the same result through $\ast$ and $\ast\ast = \mathrm{id}$.
+> - In Chapter 6 we confirmed that the three types $\mathrm{grad}=d$, $\mathrm{curl}=\ast\,d$, $\mathrm{div}=\ast\,d\,\ast$ appear. The systematic organization in the usual nabla notation is deferred to later chapters.
+> - From $d^2=0$, on the side of forms we get $\mathrm{curl}(\mathrm{grad}\,f)=0$ and $\mathrm{div}(\mathrm{curl}\,\omega)=0$. The meaning in usual vector analysis is treated again in later chapters.
 
-In Chapters 4 and 5, we acquired two operators. The exterior derivative $d$ — raises the degree by one, measuring local discrepancies. The Hodge star $\ast$ — inverts the degree based on the metric. In §5.5 we saw that combinations of just these two suffice to write $\mathrm{grad} = d$, $\mathrm{rot} = \ast d$, $\mathrm{div} = \ast d \ast$.
+---
 
-Meanwhile, in this chapter we described the same objects using only $\nabla$, the dot product, and the cross product. $\nabla f$, $\nabla\times\mathbf{F}$, $\nabla\cdot\mathbf{F}$ — on the screen, they are all arrows (or scalars). But the geometric meanings they carry are entirely different. And the more complex the problem, the harder it is to distinguish them just by looking at arrows.
+---
 
-In Part III, we will sort out this situation. We will complete the dictionary that translates $\nabla f$ into $df$, $\nabla\times\mathbf{F}$ into $\ast d\omega$, and $\nabla\cdot\mathbf{F}$ into $\ast d\ast\omega$. Once that is done, the form of an expression itself will tell us "what we are doing right now." Not relying on pictures of arrows, but thinking in the algebra of measuring devices ($n$-forms) — that is the goal of Part III.
+## Appendix D: Array Representation of the Hodge Star
 
-> **【Checkpoint — Entire Chapter 6】**
-> - We defined $\nabla = (\partial_x, \partial_y, \partial_z)^T$ and introduced the gradient, divergence, curl, and Laplacian.
-> - $\mathrm{grad}\,f = \nabla f$, $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$, $\mathrm{rot}\,\mathbf{F} = \nabla \times \mathbf{F}$
-> - $\nabla^2 = \mathrm{div}\,\mathrm{grad}$, $\mathrm{rot}(\mathrm{grad}) = 0$, $\mathrm{div}(\mathrm{rot}) = 0$
-> - Cross product matrix representation and the BAC-CAB rule.
-> - The difficulty of vector calculus lies not so much in the number of formulas as in the fact that everything looks like the same arrow. Differential forms distinguish things by the degree of the measuring device ($n$-form). In Part III, we will link these two languages.
+§6.3.2 gave the dictionary for $\ast$ in real space. This appendix checks how that dictionary looks as array operations. The Hodge star is not an abstract symbol; once a basis is chosen, it is a linear transformation that can be displayed as a concrete array. We first view the $1$-form $\leftrightarrow$ $2$-form correspondence through antisymmetric matrices, and finally view the $0$-form $\leftrightarrow$ $3$-form correspondence through a third-order array.
+
+### D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix
+
+For the $1$-form
+
+$$
+\omega =
+\begin{pmatrix}P & Q & R\end{pmatrix}
+=
+P\,dx + Q\,dy + R\,dz
+$$
+
+apply the dictionary from the main text,
+
+$$
+\ast dx = dy \wedge dz,\qquad
+\ast dy = dz \wedge dx,\qquad
+\ast dz = dx \wedge dy
+$$
+
+to obtain
+
+$$
+\ast\omega
+=
+P\,dy\wedge dz
++
+Q\,dz\wedge dx
++
+R\,dx\wedge dy
+$$
+
+In the antisymmetric matrix representation of Chapter 2, let the matrix representing $dy\wedge dz$ be
+
+$$
+E_1 =
+\begin{pmatrix}
+0 & 0 & 0 \\
+0 & 0 & 1 \\
+0 & -1 & 0
+\end{pmatrix}
+$$
+
+Similarly, let the matrix representing $dz\wedge dx$ be
+
+$$
+E_2 =
+\begin{pmatrix}
+0 & 0 & -1 \\
+0 & 0 & 0 \\
+1 & 0 & 0
+\end{pmatrix}
+$$
+
+and let the matrix representing $dx\wedge dy$ be
+
+$$
+E_3 =
+\begin{pmatrix}
+0 & 1 & 0 \\
+-1 & 0 & 0 \\
+0 & 0 & 0
+\end{pmatrix}
+$$
+
+Therefore,
+
+$$
+\ast_{1\to2}
+=
+\begin{pmatrix}
+E_1\\
+E_2\\
+E_3
+\end{pmatrix}
+$$
+
+can be viewed as a "vertical vector of matrices." Multiplying the $1$-form $\omega=\begin{pmatrix}P&Q&R\end{pmatrix}$ on the left gives
+
+$$
+\omega\,\ast_{1\to2}
+=
+\begin{pmatrix}P&Q&R\end{pmatrix}
+\begin{pmatrix}
+E_1\\
+E_2\\
+E_3
+\end{pmatrix}
+=
+P E_1+Q E_2+R E_3
+$$
+
+Hence
+
+$$
+\ast_{1\to2}(\omega)
+=
+\begin{pmatrix}
+0 & R & -Q \\
+-R & 0 & P \\
+Q & -P & 0
+\end{pmatrix}
+$$
+
+The three coefficients $P,Q,R$ of the $1$-form have been placed into the three independent components of the antisymmetric matrix of the $2$-form. This is the most visible form of $\ast_{1\to2}$.
+
+> <strong>Note</strong> (relation to $\widehat{\epsilon}$ in Chapter 2) These $E_1,E_2,E_3$ are the same matrices written in Appendix A as $\varepsilon_{1,\cdot,\cdot},\varepsilon_{2,\cdot,\cdot},\varepsilon_{3,\cdot,\cdot}$. The essence of $\ast_{1\to2}$ is to place the first index of Einstein's epsilon $\varepsilon_{ijk}$ in the direction of the components of the $1$-form, and the remaining two indices in the directions of the $3\times3$ matrix. The same triple introduced in Chapter 2 as the volume-measuring device $\widehat{\epsilon}$ reappears here as the Hodge star.
+
+### D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product
+
+The reverse map $\ast_{2\to1}$ is the operation that extracts three independent components from an antisymmetric matrix. Looking at matrix entries alone, it suffices to read $A=M_{23}$, $B=M_{31}$, $C=M_{12}$. That is, to return from the antisymmetric matrix
+
+$$
+M=
+\begin{pmatrix}
+0 & C & -B \\
+-C & 0 & A \\
+B & -A & 0
+\end{pmatrix}
+$$
+
+representing the $2$-form
+
+$$
+\eta
+=
+A\,dy\wedge dz
++
+B\,dz\wedge dx
++
+C\,dx\wedge dy
+$$
+
+to $A\,dx+B\,dy+C\,dz$, one need only read these three components. If we stop at this mere "reading," however, the transpose relation with $\ast_{1\to2}$ is hard to see. So we rewrite coefficient extraction itself as an inner product between matrices.
+
+Define the inner product of $3\times3$ matrices $A,B$ by
+
+$$
+A\cdot B
+=
+\frac{1}{2}\operatorname{tr}(A^T B)
+=
+\frac{1}{2}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+A_{ij}B_{ij}
+$$
+
+> <strong>Note</strong> (trace) $\operatorname{tr}$ is the <strong>trace</strong> of a matrix (the sum of diagonal entries). It appeared when we treated the matrix representation of the exterior derivative in Appendix B. $\operatorname{tr}(A^T B)$ is the three-step operation "transpose $A$, multiply by $B$, and add the diagonal entries." Because it is equivalent to $\frac{1}{2}\sum A_{ij}B_{ij}$, use the latter expression when you want to think in components.
+
+This is the same notation as the inner product $\mathbf{v}_1 \cdot \mathbf{v}_2$ between column vectors in §6.2.3. Matrices, too, are "things of the same kind," and we multiply corresponding components and take the sum. Because we contract successively over the two indices $i$ and $j$, this is called the <strong>Frobenius product</strong> or <strong>consecutive contraction</strong>.
+
+> <strong>Note</strong> (the factor $1/2$) Some conventions adopt $\operatorname{tr}(A^T B)$ (without $1/2$) as the Frobenius product. For antisymmetric matrices, however, that picks up both members of a pair such as $M_{23}$ and $M_{32}=-M_{23}$, and the inner product is doubled. In this book we build $1/2$ into the definition. Then the inner product of the $2$-form $M$ with itself, $M\cdot M=M_{23}^2+M_{31}^2+M_{12}^2$, agrees directly with the "squared unsigned area of the parallelogram" in §6.2.2.
+
+> <strong>Note</strong> (the pull of abstraction) §6.2.3 touched on an axiomatic inner product, but once you actually work by hand like this, you can see why that brevity is attractive. For the inner product of column vectors we use $\mathbf{v}_1^T \mathbf{v}_2$; for the inner product of matrices we use $\frac{1}{2}\operatorname{tr}(A^T B)$—redefining the inner product from scratch every time the representation changes is, when you think about it, quite a burden. One notices the urge to lump these together and settle everything with one phrase: "an inner product is an operation satisfying certain axioms." Even so, this book does not abandon its policy of making representations explicit to the end. By this point, that is stubbornness.
+
+The $E_1,E_2,E_3$ of D.1 are orthonormal with respect to this inner product. Indeed, each $E_k$ has only two nonzero components; for the same $E_k$ we get $\frac{1}{2}(1^2+(-1)^2)=1$, and for different $E_i,E_j$ the positions of the nonzero components do not overlap. Therefore,
+
+$$
+E_i\cdot E_j=\delta_{ij}
+$$
+
+Using this orthonormality, the reverse transformation $\ast_{2\to1}$ can be written as inner products with $E_1,E_2,E_3$. Let $M$ be an arbitrary $3\times3$ matrix; when it comes from a $2$-form, $M$ is an antisymmetric matrix.
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+E_1\cdot M & E_2\cdot M & E_3\cdot M
+\end{pmatrix}
+$$
+
+Here $E_k\cdot M=\frac{1}{2}\operatorname{tr}(E_k^T M)$ is the Frobenius product defined above. In components,
+
+$$
+\begin{aligned}
+E_1 \cdot M &= \frac{1}{2}(M_{23}-M_{32}) \\
+E_2 \cdot M &= \frac{1}{2}(M_{31}-M_{13}) \\
+E_3 \cdot M &= \frac{1}{2}(M_{12}-M_{21})
+\end{aligned}
+$$
+
+If $M$ is an antisymmetric matrix, then $M_{32}=-M_{23}$, $M_{13}=-M_{31}$, $M_{21}=-M_{12}$, so
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+M_{23} & M_{31} & M_{12}
+\end{pmatrix}
+$$
+
+Therefore, $\ast_{2\to1}$ is at once the operation that extracts independent components from an antisymmetric matrix and coefficient extraction by the Frobenius product with $E_k$.
+
+Writing out all components, $\ast_{2\to1}$ is the following "horizontal vector of matrices":
+
+$$
+\ast_{2\to1} = \begin{pmatrix}
+\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+\end{pmatrix}
+$$
+
+In $\ast_{1\to2}$ we multiply by coefficients and add; in $\ast_{2\to1}$ we extract coefficients by inner product. Vertical and horizontal, weighted sum and inner-product extraction, correspond to each other.
+
+### D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case
+
+Combining D.1 and D.2, $\ast\ast=\mathrm{id}$ for $1$-forms and $2$-forms appears as orthonormality of arrays.
+
+For
+
+$$
+\omega=P\,dx+Q\,dy+R\,dz
+$$
+
+D.1 gives
+
+$$
+\ast_{1\to2}(\omega)=P E_1+Q E_2+R E_3
+$$
+
+Applying $\ast_{2\to1}$ to this,
+
+$$
+\begin{aligned}
+\ast_{2\to1}(\ast_{1\to2}(\omega))
+&=
+\begin{pmatrix}
+E_1\cdot (P E_1+Q E_2+R E_3) \\
+E_2\cdot (P E_1+Q E_2+R E_3) \\
+E_3\cdot (P E_1+Q E_2+R E_3)
+\end{pmatrix}^{T} \\
+&=
+\begin{pmatrix}
+P & Q & R
+\end{pmatrix}
+=
+\omega
+\end{aligned}
+$$
+
+In the last equality we used $E_i\cdot E_j=\delta_{ij}$. That is, the three coefficients placed into $E_1,E_2,E_3$ by $\ast_{1\to2}$ are recovered unchanged by $\ast_{2\to1}$ through inner products with the same $E_1,E_2,E_3$.
+
+The reverse direction is the same. For the antisymmetric matrix
+
+$$
+M=P E_1+Q E_2+R E_3
+$$
+
+D.2 gives
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+E_1\cdot M & E_2\cdot M & E_3\cdot M
+\end{pmatrix}
+=
+\begin{pmatrix}
+P & Q & R
+\end{pmatrix}
+$$
+
+and applying D.1's $\ast_{1\to2}$,
+
+$$
+\ast_{1\to2}(\ast_{2\to1}(M))
+=
+P E_1+Q E_2+R E_3
+=
+M
+$$
+
+Therefore, in the $1$-form and $2$-form case,
+
+$$
+\ast_{2\to1}(\ast_{1\to2}(\omega))=\omega,
+\qquad
+\ast_{1\to2}(\ast_{2\to1}(M))=M
+$$
+
+hold. $\ast_{1\to2}$ places three coefficients into $E_1,E_2,E_3$; $\ast_{2\to1}$ extracts coefficients by inner product with $E_1,E_2,E_3$. Using the normalized Frobenius product, the transpose relation between the two appears as this correspondence between placement and coefficient extraction.
+
+### D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$
+
+So far we have displayed $\ast_{1\to2}$ and $\ast_{2\to1}$ as transformations that move coefficient arrays. What remains is $\ast_{0\to3}$ and $\ast_{3\to0}$.
+
+A $0$-form has a single coefficient. A $3$-form, viewed purely as an array, is a completely antisymmetric third-order array with three indices. Therefore, $\ast_{0\to3}$ is the transformation that spreads one component into $3\times3\times3$ components, and $\ast_{3\to0}$ is the transformation that extracts one component from $3\times3\times3$ components.
+
+Here we bring $\varepsilon_{ijk}$, which also appeared in Chapter 2, to the fore and look at its form.
+
+> <strong>Note</strong> (what $\varepsilon_{ijk}$ really is) $\varepsilon_{ijk}$ is the completely antisymmetric symbol that appeared in Chapter 2. If the indices $(i,j,k)$ are an even permutation of $(1,2,3)$, it is $+1$; if an odd permutation, $-1$; if the same index appears twice, $0$. In an orthonormal Cartesian basis, it can be read as the component of a completely antisymmetric tensor. In this book we use those components as the representation of the Hodge star.
+
+First, apply $\ast_{0\to3}$ to the $0$-form $f$. The output is a $3$-form, so it can be written in components with three indices. Here we take the components of $\ast_{0\to3}$ itself to be
+
+$$
+(\ast_{0\to3})_{ijk}
+=
+\varepsilon_{ijk}
+$$
+
+Display this as three $3\times3$ matrices with $i$ fixed—that is, for each of $i=1,2,3$, arrange the $(j,k)$ components as a matrix:
+
+$$
+(\ast_{0\to3})_{1jk}
+=
+\begin{pmatrix}
+0&0&0\\
+0&0&1\\
+0&-1&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{0\to3})_{2jk}
+=
+\begin{pmatrix}
+0&0&-1\\
+0&0&0\\
+1&0&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{0\to3})_{3jk}
+=
+\begin{pmatrix}
+0&1&0\\
+-1&0&0\\
+0&0&0
+\end{pmatrix}.
+$$
+
+As you can see, these are exactly the antisymmetric matrices $E_1,E_2,E_3$ used in D.1. That is,
+
+$$
+(\ast_{0\to3})_{1jk}= (E_1)_{jk},
+\qquad
+(\ast_{0\to3})_{2jk}= (E_2)_{jk},
+\qquad
+(\ast_{0\to3})_{3jk}= (E_3)_{jk}
+$$
+
+Almost nothing new happens here. The antisymmetric matrices $E_1,E_2,E_3$ seen in D.1 are now simply arranged as three slices with $i=1,2,3$. In the $1$-form and $2$-form case we read three coefficients as the coefficients of three antisymmetric matrices. In the $0$-form and $3$-form case we build, from one coefficient, the completely antisymmetric third-order array obtained by stacking all three slices at once.
+
+Indeed, acting on the $0$-form $f$,
+
+$$
+(\ast_{0\to3}f)_{ijk}
+=
+(\ast_{0\to3})_{ijk}f
+=
+\varepsilon_{ijk}f
+$$
+
+This is the operation of spreading the coefficient $f$ into a completely antisymmetric third-order array.
+
+Next, consider the reverse map $\ast_{3\to0}$. This is the transformation that takes a third-order array and returns a single coefficient. Its components are
+
+$$
+(\ast_{3\to0})_{ijk}
+=
+\frac{1}{3!}\varepsilon_{ijk}
+$$
+
+Therefore, displayed again as three $3\times3$ matrices with $i$ fixed,
+
+$$
+(\ast_{3\to0})_{1jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&0&0\\
+0&0&1\\
+0&-1&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{3\to0})_{2jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&0&-1\\
+0&0&0\\
+1&0&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{3\to0})_{3jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&1&0\\
+-1&0&0\\
+0&0&0
+\end{pmatrix}.
+$$
+
+That is, $\ast_{3\to0}$ uses the same three antisymmetric matrices. The only difference is that the whole thing is multiplied by $1/3!$.
+
+If we think of the indices $(i,j,k)$ lined up in a row as a single number, then $\ast_{0\to3}$ is a column vector that spreads one component into $27$ components, and $\ast_{3\to0}$ is a row vector that extracts one component from $27$ components. Apart from the normalization factor $1/3!$, the two are in a transpose relation.
+
+Acting on the $3$-form
+
+$$
+\eta
+=
+\eta_{ijk}
+$$
+
+with $\ast_{3\to0}$ sums over all three indices:
+
+$$
+\ast_{3\to0}\eta
+=
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+(\ast_{3\to0})_{ijk}\eta_{ijk}
+$$
+
+Therefore,
+
+$$
+\ast_{3\to0}\eta
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}\eta_{ijk}
+$$
+
+This is a triple contraction that extracts one coefficient from a completely antisymmetric third-order array.
+
+The factor $1/3!$ plays the same role as the $1/2$ that appears in the Frobenius product of D.2. In an antisymmetric matrix, each independent component appears twice, so we multiply by $1/2$ to correct for the duplication. Here, each independent component of a completely antisymmetric third-order array appears $3!=6$ times, so we multiply by $1/3!$ to correct for the duplication.
+
+Let us verify that applying $\ast$ twice returns the original. First, start from the $0$-form $f$:
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}(\ast_{0\to3}f)_{ijk}
+$$
+
+Since $(\ast_{0\to3}f)_{ijk}=\varepsilon_{ijk}f$,
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}\varepsilon_{ijk}f
+$$
+
+Only the $3!=6$ cases in which $(i,j,k)$ is a permutation of $(1,2,3)$ are nonzero; then $\varepsilon_{ijk}\varepsilon_{ijk}=1$, so
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}(3!)f
+=
+f
+$$
+
+Let us also check the reverse direction. An arbitrary $3$-form has only one independent component in three dimensions. Therefore the completely antisymmetric components $\eta_{ijk}$ can be written using some coefficient $h$ as
+
+$$
+\eta_{ijk}
+=
+h\,\varepsilon_{ijk}
+$$
+
+Then
+
+$$
+\ast_{3\to0}\eta
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}(h\varepsilon_{ijk})
+=
+h
+$$
+
+Therefore,
+
+$$
+(\ast_{0\to3}(\ast_{3\to0}\eta))_{ijk}
+=
+(\ast_{0\to3}h)_{ijk}
+=
+h\varepsilon_{ijk}
+=
+\eta_{ijk}
+$$
+
+Thus we have confirmed $\ast\ast=\mathrm{id}$ in the $0$-form and $3$-form case as well, in the array representation.
+
+In the end, what we saw here is the same as in D.1–D.3. In $\ast_{1\to2}$ we distributed three coefficients among three antisymmetric matrices. In $\ast_{0\to3}$ we distributed one coefficient simultaneously among all three antisymmetric matrices. In $\ast_{2\to1}$ we extracted coefficients from an antisymmetric matrix; in $\ast_{3\to0}$ we extracted coefficients by triple contraction with the three antisymmetric matrices. The Hodge star, at every degree, is a linear transformation that can be displayed as a concrete array once a basis is chosen.
+
+### D.5 Summary
+
+> <strong>Checkpoint so far — Appendix D</strong>
+> - $\ast_{1\to2}$ is the linear transformation that places three coefficients into the antisymmetric matrices $E_1,E_2,E_3$.
+> - $\ast_{2\to1}$ is the linear transformation that extracts coefficients from an antisymmetric matrix, and can be written by the Frobenius product with $E_k$.
+> - Using the Frobenius product $A\cdot B=\frac{1}{2}\operatorname{tr}(A^TB)$, we have $E_i\cdot E_j=\delta_{ij}$.
+> - Therefore, in the $1$-form and $2$-form case, $\ast_{2\to1}(\ast_{1\to2}(\omega))=\omega$ and $\ast_{1\to2}(\ast_{2\to1}(M))=M$ hold.
+> - $\ast_{0\to3}$ can be displayed as a third-order array obtained by stacking the three antisymmetric matrices $E_1,E_2,E_3$. In components, $(\ast_{0\to3})_{ijk}=\varepsilon_{ijk}$.
+> - $\ast_{3\to0}$ can be displayed as the same array multiplied by the normalization factor $1/3!$. In components, $(\ast_{3\to0})_{ijk}=\frac{1}{3!}\varepsilon_{ijk}$.
+> - The factors $1/2$ and $1/3!$ correct for duplication of antisymmetric components.
+> - In the $0$-form/$3$-form case as well, $\ast_{3\to0}(\ast_{0\to3}f)=f$ and $\ast_{0\to3}(\ast_{3\to0}\eta)=\eta$ hold.
+> - Therefore, the Hodge star $\ast$, for both $0\leftrightarrow3$ and $1\leftrightarrow2$, is a linear transformation that can be displayed as a concrete array once a basis is chosen.

--- a/translation/drafts/ch06-6.0-6.2.md
+++ b/translation/drafts/ch06-6.0-6.2.md
@@ -1,0 +1,279 @@
+# Chapter 6: The Metric $g$ and the Hodge Star $\ast$ — Summoning the Inner Product and Reversing Degree
+
+### §6.0 The End of Excuses — Releasing the Inner Product
+
+When, in Chapter 2, we restored the scalar area of a parallelogram as the square root of the sum of squares of three projected areas, and when, in Chapter 3, we measured the surface area $4\pi R^2$ of a sphere and the arc length $2\pi R$ of a circle by the same idea—here we have repeatedly hedged, each time we computed a length or an area, with “we have not yet formally introduced the metric (inner product).”
+
+The reader has probably begun to find this tedious by now. To be honest, I have too.
+
+After all, we are computing on real space $(x,y,z)$—orthogonal Cartesian coordinates. In this space the Pythagorean theorem holds. Let us stop being shy and start using the <strong>inner product</strong>.
+
+What is the inner product? We have already met it many times. In Chapter 2, when we obtained an oriented area, we said that if you take the square root of the sum of squares of the three shadow components $A_{yz}, A_{zx}, A_{xy}$, you recover the elementary-school area—that “sum of squares” is precisely the inner product with itself (or its square root). More generally, for column vectors among themselves, or for $1$-forms written as row vectors, the scalar quantity obtained by multiplying corresponding components and adding is what we call the <strong>inner product</strong> here.
+
+……<strong>That is all</strong>. Most readers probably learned the inner product in high-school mathematics and are thinking, “Why state the obvious?” Yet in this book we have, uncomfortably, avoided defining the inner product head-on until now. There is a reason.
+
+The reason is that if we bring out the inner product too soon, the distinctions we have cared about until now will collapse.
+
+From a more advanced standpoint, “vector addition and subtraction” and the “inner product” are not inseparable; they can be thought of separately. On that view one distinguishes “spaces with an inner product” from “spaces without one,” and calls the matrix that defines the inner product the “metric tensor.” I respect that distinction too. That is precisely why we have repeatedly hedged that we have not yet formally introduced the metric or the inner product.
+
+What we really want to distinguish here is the operation “row vector × column vector gives a scalar” from the operation “take the inner product between vectors of the same kind.”
+
+> <strong>Note</strong> (Why separate row and column so insistently) There is a standpoint that says one can describe physics quite powerfully even without putting the metric or inner product front and center—for example, elementary integration of $n$-forms and much undergraduate-level physics calculation work well on that view. I respect that standpoint too. On the other hand, the metric viewpoint that uses length, angle, inner product, and the Hodge star $\ast$ is of course also powerful. Personally, I think the ideal is to move back and forth between these two views as the problem demands. And to move back and forth, we must first not confuse “the operation measured by row vector × column vector” with “the operation that takes the inner product between vectors of the same kind.” That is why this book has been so insistent about separating row vectors and column vectors.
+
+Since Chapter 1 we have done mountains of calculations that obtain a scalar from row vector × column vector. So how is that different from the inner product?
+
+The conclusion: <strong>they are completely different things</strong>. Row vector times column vector is a calculation between <strong>vectors of different kinds</strong>—row and column. The inner product, by contrast, is a calculation between <strong>vectors of the same kind</strong>—“row with row” or “column with column.”
+
+Yes—the matter is deeper than the reader may have thought. On the special stage of real space, these two often happen to return the same number, which has encouraged their confusion—and on top of that confusion a vast edifice called vector analysis has been built. The goal of this chapter is to make this distinction clear, then introduce the metric $g$ as the natural generalization of the inner product, and from there expose what the Hodge star $\ast$ really is.
+
+---
+
+### §6.1 Inner Product in Parameter Space — The True Nature of the Metric $g$
+
+#### 6.1.1 Inner Product in Real Space
+
+Write two column vectors in real space $(x,y,z)$ in components:
+
+$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
+
+The operation of multiplying components with the same index and taking the sum we define in this book as the <strong>inner product</strong> (dot product), and denote by the symbol $\cdot$.
+
+$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
+
+In $xyz$ coordinates, the inner product is computed simply by multiplying corresponding components and adding.
+
+#### 6.1.2 Rereading the Inner Product as a Measuring Device
+
+Here let us reread the same calculation in the language of “measuring devices.” At first glance the inner product looks like an operation of a different lineage from the measuring devices we have handled until now. In fact, however, the inner product can also be read as an operation that “turns something into a measuring device, acts on something else, and yields a scalar.”
+
+The entry point is the transpose. Transposing $\mathbf{v}_1$ turns a column vector into a row vector:
+
+$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$
+
+This is a measuring device that eats the paired column vector $\mathbf{v}_2$ and measures “how large is the inner product with $\mathbf{v}_1$?”
+
+$$\mathbf{v}_1^T\mathbf{v}_2
+= \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
+= x_1x_2 + y_1y_2 + z_1z_2$$
+
+That is, in orthogonal Cartesian coordinates on real space, transposing a column vector $\mathbf{v}_1$ alone yields the row vector—a measuring device—for taking the inner product with that vector.
+
+> <strong>Note</strong> (What raising and lowering indices really are) In tensor analysis there is a convention of distinguishing vector components from measuring-device components by upper and lower indices. One is then told that the metric $g$ is used to raise and lower indices. In the language of this book, the true nature of that is the operation “convert a column vector into a row vector that measures the inner product.” In orthogonal Cartesian coordinates $g=I$, so transpose alone suffices; but in parameter space, as we shall see next, we must insert $\mathbf{g}=J^T J$ along the way.
+
+#### 6.1.3 Taking the Inner Product in Parameter Space
+
+What happens if we carry out the same rereading in parameter space $(r,\theta,z)$?
+
+In orthogonal Cartesian coordinates on real space, $\mathbf{v}_1^T$ was directly the “measuring device for the inner product with $\mathbf{v}_1$.” So in parameter space too we are tempted to use $\mathbf{v}_1^T$ as the measuring device as-is. But that only computes $\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$, which is not the correct inner product in real space. The correspondence between increments in parameter space and displacements in real space varies from place to place.
+
+What, then, must we insert to turn a column vector in parameter space into a row vector that correctly measures the inner product in real space?
+
+In Chapter 4 we saw how the Jacobian matrix of a coordinate change transforms components. Here we use that same matrix $J$ to read a displacement in parameter space as a displacement in real space.
+
+$$J = \begin{pmatrix}
+\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
+\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
+\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
+\end{pmatrix}$$
+
+From the cylindrical-coordinate formulas $x = r\cos\theta,\; y = r\sin\theta,\; z = z$, computing partial derivatives gives:
+
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+Write the vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space in components:
+
+$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+
+Read in real space, these become $J\mathbf{v}_1$ and $J\mathbf{v}_2$ respectively. By the reading of the previous subsection, the measuring device for “the inner product with $J\mathbf{v}_1$” in real space is $(J\mathbf{v}_1)^T$. Therefore the inner product we want can be written as
+
+$$\text{inner product} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$
+
+Using the rule for transposes, $(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$, so
+
+$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
+
+Let us actually compute $J^T J$. $J^T$ is $J$ with rows and columns swapped:
+
+$$J^T = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+Therefore,
+
+$$J^T J = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+The algebraic identity $\cos^2\theta + \sin^2\theta = 1$ does all the geometry’s work, leaving $1, r^2, 1$ on the diagonal. We never once thought about arc length in the $\theta$ direction—it is a purely algebraic manipulation using only matrix product and transpose properties.
+
+<strong>Thus a new measuring device appears.</strong> To build from a column vector $\mathbf{v}_1$ in parameter space a row vector that correctly measures the inner product in real space, we must multiply on the right by $J^T J$, not merely transpose:
+
+$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$
+
+Acting this measuring device on $\mathbf{v}_2$ yields the same value as the inner product in real space.
+
+We call this $J^T J$ the <strong>metric matrix $\mathbf{g}$</strong>:
+
+$$\mathbf{g} = J^T J$$
+
+In $xyz$ coordinates we computed the inner product from the sum of products of components alone, never going through pullback. In parameter space we first read displacements in real space via $J$, then take the sum of products of components. Folding these two stages into matrix form puts $\mathbf{g}=J^T J$ in the middle—and its contents are found mechanically from partial derivatives and matrix products alone, as long as we know the Jacobian matrix $J$. No room remains anywhere for new axioms of geometry.
+
+For safety, let us check with concrete numbers. Consider the point $r=2,\; \theta=\pi/3$. Then $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$, so
+
+$$J = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+In parameter space consider the unit displacement $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ in the $\theta$ direction. We have $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, and since $r=2$ now, $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$. Computing the inner product (square of length) in parameter space:
+
+$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
+
+On the other hand, reading the same $\mathbf{v}$ as a displacement in real space:
+
+$$J\mathbf{v} = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
+
+The inner product (square of length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed agree. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (unit displacement in the $r$ direction) likewise, $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ agree. In this way $\mathbf{g} = J^T J$ ties the inner products in parameter space and real space without contradiction.
+
+We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$:
+
+$$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
+
+The factors $r^2$ and $r^2\sin^2\theta$ on the diagonal are likewise conversion factors derived mechanically from $J$, which lines up the linear coefficients of the coordinate change.
+
+With $g$ as mediator, we can compute inner products (lengths and angles) consistently in any coordinate system. Moreover, the action of the Hodge star $\ast$, treated later, can be read naturally from these rules of inner product.
+
+---
+
+### §6.2 Converting Between Column Vectors and Row Vectors Using $g$
+
+#### 6.2.1 $\mathbf{v}^T \mathbf{g}$ Is a Row Vector
+
+Look once more at the inner-product formula from §6.1, $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$. Matrix products can be executed from the left in order, so this expression can be read as “first compute $\mathbf{v}_1^T \mathbf{g}$, then multiply the result by $\mathbf{v}_2$.”
+
+$\mathbf{v}_1$ is a column vector, but transposed $\mathbf{v}_1^T$ is a row vector. Multiplying a row vector by a square matrix again yields a row vector. So if we extract only the part $\mathbf{v}_1^T \mathbf{g}$,
+
+$$\omega = \mathbf{v}^T \mathbf{g}$$
+
+this is a <strong>row vector</strong> of size $1 \times 3$. The metric $g$ is, arising naturally from the matrix form of the inner product, a <strong>device that converts column vectors into row vectors</strong>.
+
+Let us also write the reverse direction. Suppose a $1$-form given as a row vector
+
+$$
+\omega =
+\begin{pmatrix}
+\omega_1 & \omega_2 & \omega_3
+\end{pmatrix}
+$$
+
+is given. The corresponding column vector $\mathbf{v}_\omega$ is
+
+$$
+\mathbf{v}_\omega = \mathbf{g}^{-1}\omega^T
+$$
+
+> <strong>Note</strong> (Inverse matrix) For a square matrix $A$, the matrix $A^{-1}$ satisfying
+> $$
+> A^{-1}A = AA^{-1} = I
+> $$
+> is called the inverse of $A$. Intuitively, it is the matrix that undoes the transformation by $A$. Here we use $\mathbf{g}^{-1}$ to return a row vector built with $\mathbf{g}$ to the original column vector.
+
+In fact, if $\omega = \mathbf{v}^T\mathbf{g}$, transposing gives
+
+$$
+\omega^T = \mathbf{g}^T\mathbf{v}
+$$
+
+Since $\mathbf{g}$ is symmetric, $\mathbf{g}^T = \mathbf{g}$. Therefore
+
+$$
+\mathbf{v} = \mathbf{g}^{-1}\omega^T
+$$
+
+returns us to the start.
+
+In orthogonal Cartesian coordinates on real space, $\mathbf{g}=I$, so this reverse conversion too looks like mere transpose. In a general coordinate system, however, $\mathbf{g}^{-1}$ is needed to return a row vector to a column vector.
+
+> <strong>Note</strong> (What we smuggled in Chapter 2) When we sought a matrix representation of a $2$-form in Chapter 2, we already used the form $\mathbf{v}_1^T M \mathbf{v}_2$. At that time we only said that “laying a column vector on its side is mathematically ill-behaved” and pushed on without going deeper. The $\mathbf{v}^T\mathbf{g}$ we are looking at now is the true nature of the operation we smuggled in then. In real space $\mathbf{g}=I$, so transpose alone makes a column vector look like a row vector. In parameter space, however, to convert a column vector into a row measuring device that reproduces the inner product in real space, we must pass explicitly through the metric $\mathbf{g}$.
+
+Consider the meaning of this conversion. Since Chapter 1 we have distinguished “the figure being measured (column vector $\mathbf{v}$)” from “the measuring device (row vector $\omega$).” They were inhabitants of different worlds. But via $g$, a column vector that lived on the figure side changes form to the scale side—the row vector. Even for the same arrow, the “sensitivity as a scale” changes from place to place because $\mathbf{g}$ absorbs all the differences in calibration at each location.
+
+In real space ($\mathbf{g}=I$) we have $\omega = \mathbf{v}^T$, and the components of the column vector become the components of the row vector as-is. In parameter space $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, so $\omega = \begin{pmatrix} \Delta r & r^2\Delta\theta & \Delta z \end{pmatrix}$. Only the $\theta$ component is multiplied by $r^2$, reflecting that the $\theta$ direction’s scale is stretched by a factor of $r$.
+
+Without $g$, we cannot convert between “the figure being measured” and “the measuring device” without strain. $g$ is the standard go-between that ties the two together.
+
+#### 6.2.2 What the Metric Gives — Geometric Size of Parallel $k$-Parallelepipeds
+
+The most basic role of the metric $g$ is to define the <strong>actual geometric size</strong> (length, area, volume) of the <strong>parallel $k$-parallelepiped</strong> spanned by $k$ vectors.
+
+In the chapters until now we performed “oriented counting” by feeding $k$ vectors to a $k$-form. $dx(\mathbf{v})$ is the number of the $x$ component of $\mathbf{v}$; $dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ is the oriented area of the parallelogram spanned by $\mathbf{v}_1, \mathbf{v}_2$. But these are measurements of shadows after all; how many meters of segment the vectors span, how many square meters of parallelogram they span under that metric, is determined only once the metric $g$ is given.
+
+For $k=1$ (the segment spanned by one vector $\mathbf{v}$), the square of its length is defined by the inner product with itself, as we already derived in §6.1:
+
+$$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
+
+In real space ($\mathbf{g}=I$), $|\mathbf{v}|^2 = \Delta x^2 + \Delta y^2 + \Delta z^2$. In the parameter space of cylindrical coordinates, $|\mathbf{v}|^2 = \Delta r^2 + r^2\Delta\theta^2 + \Delta z^2$.
+
+For $k=0$ (zero vectors, i.e. a point), the “size” of a scalar field $f$, which is a $0$-form, is simply its absolute value $|f|$.
+
+The same holds for $k=2$ (area of the parallelogram spanned by two vectors) and $k=3$ (volume of the parallelepiped spanned by three vectors). As we saw in Chapter 2 §2.4.7, the square root of the sum of squares of the coefficients $A_{xy}, A_{yz}, A_{zx}$ of the three basis $2$-forms $dx \wedge dy, dy \wedge dz, dz \wedge dx$, namely $\sqrt{A_{yz}^2 + A_{zx}^2 + A_{xy}^2}$, gives the unsigned area of the parallelogram. In $xyz$ coordinates this calculation needs only the coefficients of the basis $2$-forms; no other information is required.
+
+> <strong>Note</strong> (Why we do not write $k=2$ in vector form) For $k=1$ we wrote length as the inner product $\mathbf{v}^T\mathbf{g}\,\mathbf{v}$ of the column vector $\mathbf{v}$. The analogous inner product for $k=2$—inner product between matrices (the Frobenius product in Appendix D)—we have not yet defined. Moreover, to display the coefficients of a $2$-form as a $3$-component vector requires the Hodge star $\ast$, which changes degree. Here we still treat a face as a face—that is, as coefficients of a $2$-form.
+
+The role of the metric $g$ is to generalize this “computation in $xyz$” to coordinate systems with distorted scales, such as parameter space. In every case, <strong>once $g$ is fixed, a consistent geometric size is defined for parallel $k$-parallelepipeds of every degree</strong>—that is the most fundamental role of the metric.
+
+#### 6.2.3 Properties of the Inner Product
+
+Just as in Chapter 5 we summarized the properties of the exterior derivative $d$ (linearity, raising degree, $d^2=0$, Leibniz rule), let us organize here the properties of the inner product that emerge from the calculations so far. These do not depend on a particular coordinate system.
+
+1. <strong>Symmetry</strong>: $\mathbf{v}_1 \cdot \mathbf{v}_2 = \mathbf{v}_2 \cdot \mathbf{v}_1$. Apply this to the matrix form derived in §6.1, $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$. We have $\mathbf{v}_2 \cdot \mathbf{v}_1 = \mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1$, but a scalar is unchanged under transpose, so $\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1 = (\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_1)^T = \mathbf{v}_1^T \mathbf{g}^T \mathbf{v}_2$. For this to equal $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$ we must have $\mathbf{g} = \mathbf{g}^T$. That is, from symmetry of the inner product it follows that $\mathbf{g}$ must be a <strong>symmetric matrix</strong>.
+
+2. <strong>Linearity</strong> (bilinearity): $(a\mathbf{v}_1 + b\mathbf{v}_2) \cdot \mathbf{v}_3 = a(\mathbf{v}_1 \cdot \mathbf{v}_3) + b(\mathbf{v}_2 \cdot \mathbf{v}_3)$. Linear in each argument. This is nothing but the distributive law for matrix products, $(a\mathbf{v}_1 + b\mathbf{v}_2)^T \mathbf{g} \,\mathbf{v}_3 = a\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_3 + b\mathbf{v}_2^T \mathbf{g} \,\mathbf{v}_3$.
+
+3. <strong>Positive definiteness</strong>: $\mathbf{v} \cdot \mathbf{v} > 0$ ($\mathbf{v} \neq \mathbf{0}$). This guarantees that “square of length” is positive. In special relativity, where signs are mixed, this need not hold; but on the three-dimensional real space that is the stage of this book it always does.
+
+> <strong>Note</strong> (Symmetric vs antisymmetric matrices)
+> The fact that the area-measuring device in Chapter 2 required an antisymmetric matrix ($M = -M^T$) and that the inner product here requires a symmetric matrix ($\mathbf{g} = \mathbf{g}^T$) are exactly paired. Antisymmetry governs oriented counting; the symmetric metric governs length and angle, and from there the unsigned area and volume induced.
+
+#### 6.2.4 Letting the Geometry of the Metric Matrix Live in Its Components
+
+The diagonal entries of $\mathbf{g}$ express “how much a step along that axis contributes to length”; the off-diagonal entries express “how much steps along different axes interfere with each other.” That $\mathbf{g}$ in cylindrical coordinates was diagonal is because the axes $r,\theta,z$ are mutually orthogonal. In any case, the single matrix $\mathbf{g}$ carries in its components all the “ruler properties” at that location.
+
+> <strong>Note</strong> (Axiomatic inner product—reversed order of axioms and matrix) In a standard linear-algebra textbook one first defines the three properties above as axioms, then derives the theorem that any operation satisfying them can be written, in some basis, in the form $\mathbf{v}^T \mathbf{g} \mathbf{w}$ with a symmetric matrix $\mathbf{g}$. The logical order is the reverse of ours. On the axiomatic side the matrix representation is only one representation; on the measuring-device reading of this book, <strong>this matrix $\mathbf{g}$ is the scale of space itself</strong>, the starting point of all measurement. Neither is “correct” in preference to the other. One enters from abstract properties; one enters from concrete symbolic operations of measurement. Only the direction that suits you differs.
+
+> <strong>Checkpoint so far — §6.0–§6.2</strong>
+> - The inner product is the operation of taking the sum of products of components between vectors of the same kind (row × row, or column × column). It is a different thing from row × column.
+> - The inner product in parameter space is computed by pulling back to real space first. In that process $J^T J$ appears naturally. That is the true nature of the metric $g$.
+> - $g$ converts column vectors to row vectors. Concretely, from a column vector $\mathbf{v}$ the corresponding $1$-form is built by $\omega_{\mathbf{v}} = \mathbf{v}^T\mathbf{g}$.
+> - Conversely, from a $1$-form $\omega$ given as a row vector, the corresponding column vector is $\mathbf{v}_\omega = \mathbf{g}^{-1}\omega^T$. In Cartesian coordinates $\mathbf{g}=I$, so both look like almost nothing but transpose.
+> - With $g$ as mediator, geometric size is defined for parallel $k$-parallelepipeds of every degree.
+> - From the properties of the inner product (symmetry, linearity, positive definiteness) the symmetry of $g$ follows. This pairs with the antisymmetry of the area-measuring device $\wedge$.
+
+---

--- a/translation/drafts/ch06-6.3.md
+++ b/translation/drafts/ch06-6.3.md
@@ -1,0 +1,136 @@
+### §6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Methods
+
+#### 6.3.1 Two Ways to Obtain a Scalar
+
+By now the true nature of $g = J^T J$ has been revealed, and we can compute inner products in any coordinate system. Let us step back and look at the larger picture.
+
+When we survey the formulas of physics, we notice that there is more than one way to produce a scalar quantity. When we integrate a field along a line or over a surface, a natural notation appears: something that measures acts on something that is measured and returns a number. On the other hand, quantities such as power and energy density are often written as inner products of the same kind of arrow, as in $\mathbf{E}\cdot\mathbf{J}$ or $\mathbf{A}\cdot(\nabla\times\mathbf{A})$.
+
+In other words, at least on the surface, two conventions for obtaining scalars coexist in the notation of physics. In the language of this book, they are the following two:
+
+- <strong>Method ① (differential forms method / d method)</strong>: Prepare a measuring device (row vector: a $1$-form, and so on) and a figure to be measured (column vector: a vector field, and so on), and obtain a scalar by a row $\times$ column computation. What this computation uses is the logic of action and evaluation—a form eats a vector and returns a scalar.
+- <strong>Method ② (vector calculus method / $\nabla$ method)</strong>: Unify all quantities as "arrows of the same kind," and obtain a scalar by an inner product between like vectors (column $\times$ column, or row $\times$ row). In this computation, the metric $g$ is inserted so that like vectors can be compared. Many readers will be familiar with this method from school education.
+
+> <strong>Note</strong> (What to call the two methods—the author's dilemma) The author long wondered what to call these two conventions in a textbook. Calling Method ① the "differential forms method" is natural, but in this book we also write "d method" alongside it. For readers who do not yet know differential forms, the symbol $d$ is more familiar. The author personally also calls it the "topology method." For readers raised in topology or geometry, that name may feel more natural. Likewise, calling Method ② the "vector calculus method" is natural, but in this book we also write "$\nabla$ method" alongside it. The symbol $\nabla$ (nabla) is the most familiar symbol for readers who have studied physics. The author personally also calls it the "inner product method," using that name when emphasizing that the structure of the inner product sits at the core. All of these names refer to the same two conventions.
+
+> <strong>Note</strong> (Genealogy of the two notations) Method ① lies close to Grassmann's exterior algebra and Élie Cartan's line of development; Method ② lies close to the vector calculus systematized by Gibbs and Heaviside. This is not a matter of one being correct and the other wrong.
+
+In fact, whichever method we adopt, the physical result we obtain in the end is the same. This is merely a difference of expression.
+
+Yet a practical problem arises here. In the framework of Method ②, quantities that ought to be measured through a "surface" ($2$-forms) and quantities measured along a "line" ($1$-forms) are all treated as the same kind of "three-component arrow." To handle the notions of area and volume from Method ① within the framework of Method ②'s "inner product of arrows," we need a correspondence that links forms of different degrees.
+
+The number of independent components of a $k$-form had a characteristic symmetry. As we saw in Chapter 2 §2.5.9, in three-dimensional space a $0$-form has $1$ component, a $1$-form has $3$, a $2$-form also has $3$, and a $3$-form has $1$—folded at the middle, the pattern $1, 3, 3, 1$ is symmetric left and right. Between a $1$-form and a $2$-form with the same number of independent components, and between a $0$-form and a $3$-form, some correspondence ought to exist. The device that supplies that correspondence is the <strong>Hodge star $\ast$</strong>.
+
+$\ast$ uses the information of the inner product (that is, $g$) to assign to each form the partner that combines with it to make a volume. In the main text we first build this correspondence in the basis of physical space; verification in components is deferred to Appendix D.
+
+> <strong>Note</strong> (Between the two methods) We need not use only one of Method ① and Method ②. The author's ideal is to move freely between both. This book starts from Method ① (differential forms) in order to build a solid foundation that does not depend on distortion of space. On top of that, we want to be able to read the same quantities in the language of Method ② when needed—and $\ast$ is what bridges the two.
+
+> <strong>Note</strong> (For readers who know vector calculus) Many operations that in ordinary vector calculus are treated as face orientations or cross products can be read anew as the correspondence given by this $\ast$. In this chapter, however, we do not use those as known formulas; we rebuild them from $g$ and the basis $2$-forms of Chapter 2.
+
+#### 6.3.2 The $\ast$ Dictionary in Physical Space—Choosing the Partner That Makes a Volume
+
+So how is $\ast$ determined?
+
+Here we first consider orthogonal Cartesian coordinates in physical space $(x,y,z)$. In this space, $dx, dy, dz$ are mutually orthogonal reference measuring devices of length $1$. We also fix the orientation of space so that
+
+$$
+dx \wedge dy \wedge dz
+$$
+
+is the positive volume form.
+
+We may think of $\ast$ as the operation that, given a form, returns the partner which combines with it to yield a volume form.
+
+For example, what $2$-form combines with $dx$ to produce the positive volume form? It is $dy \wedge dz$. Indeed,
+
+$$
+dx \wedge dy \wedge dz
+$$
+
+is obtained. Therefore it is natural to set
+
+$$
+\ast dx = dy \wedge dz.
+$$
+
+Likewise,
+
+$$
+dy \wedge dz \wedge dx = dx \wedge dy \wedge dz,
+$$
+
+so
+
+$$
+\ast dy = dz \wedge dx,
+$$
+
+and
+
+$$
+dz \wedge dx \wedge dy = dx \wedge dy \wedge dz,
+$$
+
+so
+
+$$
+\ast dz = dx \wedge dy.
+$$
+
+In other words, $\ast$ assigns to each line measuring device the surface measuring device that combines with it to give the positive volume form. By the same idea, the scalar $1$ corresponds to the volume form $dx \wedge dy \wedge dz$, and the volume form corresponds to the scalar $1$.
+
+Therefore the $\ast$ dictionary in physical space is as follows.
+
+$$\begin{aligned}
+\ast(1) &= dx \wedge dy \wedge dz, \qquad &\ast(dx \wedge dy \wedge dz) &= 1 \\
+\ast(dx) &= dy \wedge dz, \qquad &\ast(dy \wedge dz) &= dx \\
+\ast(dy) &= dz \wedge dx, \qquad &\ast(dz \wedge dx) &= dy \\
+\ast(dz) &= dx \wedge dy, \qquad &\ast(dx \wedge dy) &= dz
+\end{aligned}$$
+
+At this stage it is enough to read $\ast$ as a "dictionary." However, this correspondence is not a mere memorization table. Once a basis is chosen, $\ast$ can be written as an array representation of a linear transformation that rearranges coefficients. The array representation over all degrees is confirmed in Appendix D.
+
+The meaning of this dictionary is simple. What corresponds to a line segment in the $x$ direction ($dx$) is the face perpendicular to the $x$ axis ($dy \wedge dz$). Likewise $y \leftrightarrow dz \wedge dx$, $z \leftrightarrow dx \wedge dy$. And the scalar $1$ ($0$-form) and the volume $dx \wedge dy \wedge dz$ ($3$-form) correspond to each other. This is precisely the manifestation of the symmetry $1, 3, 3, 1$ of independent component counts that we saw in Chapter 2.
+
+> <strong>Note</strong> (Why this dictionary is the right one) That $\ast dx = dy \wedge dz$ holds is because $dx, dy, dz$ form an orthonormal basis (mutually orthogonal, length $1$) and because we have taken the orientation of space so that $dx \wedge dy \wedge dz$ is positive in a right-handed system. Under these conditions, the dictionary above is determined uniquely. Once parameter space is taken into account, the $\ast$ dictionary depends on the metric $g$ and on how orientation is chosen—in other words, if $g$ is not $I$, the coefficients in the dictionary become more complicated.
+
+#### 6.3.3 $\ast\ast = \mathrm{id}$
+
+As the dictionary above shows immediately, applying $\ast$ twice returns the original:
+
+$$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx.$$
+
+In general, in three-dimensional Cartesian physical space, $\ast\ast = \mathrm{id}$ (the identity operator) holds. One application of $\ast$ reverses the degree of a form; two applications return it to the original.
+
+> <strong>Checkpoint so far — §6.3</strong>
+> - There are two ways to obtain a scalar. Method ① obtains a scalar by row $\times$ column action. Method ② reads it as an inner product of like vectors, and the metric $g$ appears there.
+> - The symmetry $1, 3, 3, 1$ seen in Chapter 2 suggests that a correspondence can be set up between $1$-forms and $2$-forms with the same number of independent components.
+> - The Hodge star $\ast$ returns, for a given form, the partner which combines with it to give the positive volume form. The dictionary in physical space includes $\ast dx = dy \wedge dz$, and so on.
+> - This dictionary is not a mere memorization table; once a basis is chosen, it can be written as an array representation of a linear transformation. Details of the array representation are confirmed in Appendix D.
+> - $\ast\ast = \mathrm{id}$ follows immediately from this dictionary.
+
+#### 6.3.4 Properties of $\ast$
+
+Following the pattern of §6.2.3, where we summarized the properties of the inner product, and of Chapter 5, where we summarized the properties of the exterior derivative $d$, let us organize the properties of $\ast$ that emerge from the construction so far.
+
+1. <strong>Reversal of degree</strong>: In three-dimensional space, $\ast$ pairs $0$-forms with $3$-forms and $1$-forms with $2$-forms. In general it sends a $k$-form to a $(3-k)$-form.
+
+2. <strong>Linearity</strong>: $\ast(\omega_1 + \omega_2) = \ast\omega_1 + \ast\omega_2$. $\ast$ is the operation that extends the dictionary on the basis linearly with coefficients; linearity is immediate. Details of the array representation are confirmed in Appendix D.
+
+3. <strong>Correspondence with the inner product</strong>: For forms $\alpha, \beta$ of the same degree, combining $\alpha$ and $\ast\beta$ by the wedge product yields a $3$-form whose coefficient is the inner product of $\alpha$ and $\beta$. In Cartesian coordinates,
+
+$$
+\alpha \wedge \ast\beta
+=
+(\alpha\cdot\beta)\,dx\wedge dy\wedge dz
+$$
+
+Here $\alpha\cdot\beta$ denotes the inner product of forms of the same degree. For two $1$-forms it is the sum of products of components; for two $2$-forms it is the Frobenius product seen in Appendix D. This formula expresses that $\ast$ links the "scalar obtained by the inner product" with the "$3$-form obtained by the wedge product."
+
+> <strong>Note</strong> (Relation to more advanced definitions) In more advanced textbooks, $\alpha\wedge\ast\beta=(\alpha\cdot\beta)\,dx\wedge dy\wedge dz$ is often adopted as the definition of $\ast$. In this book we first built the dictionary on each basis element and its array representation; that is a concrete realization of this definition in Cartesian coordinates.
+
+4. <strong>$\ast\ast = \mathrm{id}$</strong>: Applying it twice returns the original (§6.3.3). This holds under the conditions of an orthonormal basis and a right-handed system; in Appendix D it can also be verified algebraically through antisymmetric matrices and the Frobenius product.
+
+5. <strong>Dependence on the metric $g$</strong>: The $\ast$ dictionary is determined by the metric $g$ of space. In Cartesian coordinates ($g=I$), the concise dictionary of §6.3.2 suffices; in a general coordinate system, the coefficients of $\ast$ become functions of position. We treat the general case in detail in Chapter 9.
+
+These properties show that $\ast$ is not a mere "dictionary" but the very <strong>degree-reversal structure</strong> of a space equipped with a metric and an orientation.

--- a/translation/drafts/ch06-6.4-6.5.md
+++ b/translation/drafts/ch06-6.4-6.5.md
@@ -1,0 +1,213 @@
+### §6.4 Examples of the Correspondence — Differential Forms and Vector Analysis
+
+#### 6.4.1 Joule Heating $P=VI$ — Two Routes
+
+Let us verify in actual computation how $\ast$ concretely links differential forms with dot-product representations of like-kind vectors. The purpose of this section is not to learn formulas from electromagnetism or vector analysis. It is to survey, in two examples, how quantities that arise naturally in the language of differential forms can be read in the notation of scalar products and vector analysis.
+
+> <strong>Note</strong> (you need not know electromagnetism or vector analysis) From here on, for the sake of explanation we will use a few symbols from electromagnetism and vector analysis a little ahead of their formal introduction. You need not understand right now what $E$ or $J$ represent, or what $\mathbf{A}\cdot(\nabla\times\mathbf{A})$ means. What we want to see here is a single point: a $3$-form that appears naturally in the language of differential forms can be read, through the Hodge star $\ast$, as a scalar or an inner product. The relation to vector-analytic notation will peek through a little later, but a full systematic treatment is deferred to later chapters.
+
+Revisit the high-school physics formula "electric power = voltage × current ($P=VI$)" as a phenomenon that occurs at each point in space.
+
+- The <strong>electric field $E$</strong>, which is the origin of voltage, is a <strong>$1$-form</strong> that counts along line segments.
+- The <strong>current density $J$</strong>, which is the origin of current, is a <strong>$2$-form</strong> that counts charge crossing a surface.
+
+First, let us compute by <strong>Route ① (differential forms)</strong>. Take the wedge product of the $1$-form $E$ and the $2$-form $J$:
+
+$$E \wedge J$$
+
+The wedge product of a $1$-form and a $2$-form is a $3$-form (a volume density). This means "power per unit volume (W/m³)." Integrating this over a spatial region ($\int_V E \wedge J$) yields the total power consumed in the region (watts). This route uses only the operation of wedging a $1$-form and a $2$-form into a $3$-form.
+
+Next, see how the same calculation is carried out by <strong>Route ② (dot product of like-kind vectors)</strong>. To take an inner product treating both $E$ and $J$ as if they were $1$-forms, convert $J$, which measures surfaces, into a form that measures lines via $\ast$:
+
+$$\text{vector } J \longleftrightarrow \ast J$$
+
+Now we have two $1$-forms, $E$ and $\ast J$. Take their inner product (dot product). To write the inner product of $1$-forms in the language of differential forms, apply $\ast$ to one side to obtain a $2$-form, wedge to a $3$-form, then apply $\ast$ overall to drop to a $0$-form:
+
+$$E \cdot J \longleftrightarrow \ast(E \wedge \ast(\ast J))$$
+
+Here $\ast\ast = \mathrm{id}$, so the inner $\ast(\ast J) = J$:
+
+$$\ast(E \wedge J)$$
+
+The bracketed quantity $E \wedge J$ is exactly the same $3$-form obtained in Route ①. The outer $\ast$ strips the volume $dx \wedge dy \wedge dz$ from the $3$-form and extracts a scalar value. The way of writing that multiplies the scalar $E \cdot J$ by a small volume $dV$ and integrates again can be read as restoring afterward the volume that this $3$-form already carried.
+
+<strong>In short, $\ast$ links the $3$-form of Route ① and the scalar display of Route ② without contradiction.</strong> Because $\ast\ast = \mathrm{id}$, either route leads to the same result.
+
+#### 6.4.2 Helicity $A \cdot (\nabla \times A)$ — The Round Trip of $\ast$
+
+In one more example, let us see further how $\ast$ works. Consider the following $3$-form built from a $1$-form $\alpha$ and its exterior derivative $d\alpha$:
+
+$$\alpha \wedge d\alpha$$
+
+In the language of Route ②, this quantity appears as the inner product of a vector field $\mathbf{A}$ with its curl:
+
+$$\mathbf{A} \cdot (\nabla \times \mathbf{A})$$
+
+Write the $1$-form corresponding to $\mathbf{A}$ as $\alpha$. The $d\alpha$ is first obtained as a $2$-form; in the language of Route ② it corresponds to the $1$-form $\ast d\alpha$.
+
+First compute by <strong>Route ①</strong>. The wedge product of the $1$-form $\alpha$ and the $2$-form $d\alpha$:
+
+$$\alpha \wedge d\alpha$$
+
+The wedge of a $1$-form and a $2$-form is a $3$-form. On this route, $\alpha$ and $d\alpha$ are combined directly by the wedge product.
+
+Next look at the internal structure of the same calculation on <strong>Route ②</strong>. To read it as a dot product of like-kind vectors, we cannot leave the $2$-form $d\alpha$ as it is; we assign the corresponding $1$-form $\ast d\alpha$:
+
+$$\nabla \times \mathbf{A} \longleftrightarrow \ast d\alpha$$
+
+Now we have two $1$-forms, $\alpha$ and $\ast d\alpha$. Take their inner product:
+
+$$\mathbf{A} \cdot (\nabla \times \mathbf{A}) \longleftrightarrow \ast(\alpha \wedge \ast(\ast d\alpha))$$
+
+By $\ast\ast = \mathrm{id}$, the inner $\ast(\ast d\alpha) = d\alpha$. Therefore,
+
+$$\ast(\alpha \wedge d\alpha)$$
+
+The bracketed quantity is the same as the $3$-form $\alpha \wedge d\alpha$ from Route ①. The outer $\ast$ strips the volume and extracts a scalar value.
+
+<strong>What deserves attention here is that $\ast$ appears twice and cancels via $\ast\ast = \mathrm{id}$.</strong> Inside Route ② we use $\ast d\alpha$ as the $1$-form corresponding to $d\alpha$ (a $2$-form), and call on $\ast$ again to take the inner product. This round trip is canceled by $\ast\ast = \mathrm{id}$.
+
+> <strong>Note</strong> (why the round trip of $\ast$ occurs) Vector analysis has no concept of the degree of a form and treats everything uniformly as "a three-component arrow." To read a $2$-form as an arrow, one must build the corresponding $1$-form with $\ast$; to take an inner product one must again use $\ast$ to return to the original degree. The Hodge star $\ast$ is the single correspondence that links these two representations.
+
+> <strong>Checkpoint so far — §6.4</strong>
+> - In the Joule-heating calculation, Route ① ($E \wedge J$) and Route ② ($E \cdot J = \ast(E \wedge J)$) agree via $\ast$.
+> - In the helicity calculation, $\ast$ is used twice and cancels by $\ast\ast = \mathrm{id}$. Route ① ($\alpha \wedge d\alpha$) and Route ② ($\mathbf{A} \cdot (\nabla \times \mathbf{A})$) give the same result.
+> - $\ast$ is the correspondence linking differential forms and vector analysis; $\ast\ast = \mathrm{id}$ guarantees consistency of the round trip.
+
+---
+
+### §6.5 The Types of the Three Operations — grad, curl, div
+
+By now we have the two operators $d$ (Chapter 5) and $\ast$ (this chapter). Combining them yields operations that move the degree of a form in various ways.
+
+Among these, three types are especially named in three-dimensional vector analysis:
+
+$$
+0 \to 1,\qquad
+1 \to 2 \to 1,\qquad
+1 \to 2 \to 3 \to 0
+$$
+
+In this book we call them, respectively,
+
+$$
+\mathrm{grad},\qquad
+\mathrm{curl},\qquad
+\mathrm{div}
+$$
+
+This chapter stops at naming these three types. The correspondence with the usual $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ is treated again in later chapters.
+
+> <strong>Note</strong> (for readers who know vector analysis) By this point you may already see the usual $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ in the background. This chapter, however, does not formally develop the usual vector-analytic notation. Here we confirm the path: "from combinations of $d$ and $\ast$, extract the three types corresponding to grad, curl, and div." The usual nabla notation, the correspondence with Stokes' theorem, and why formulas grow long in curvilinear coordinates are taken up again in later chapters.
+
+Below, we work first in Cartesian coordinates. Use the $1$-form
+
+$$
+\omega = P\,dx + Q\,dy + R\,dz
+$$
+
+Readers who know vector analysis may read this as the field with components $(P,Q,R)$. A full systematic treatment of this correspondence is deferred to later chapters.
+
+#### 6.5.1 Gradient $\mathrm{grad}\,f = df$
+
+The exterior derivative $df$ of a $0$-form (scalar field) $f$ is a $1$-form:
+
+$$
+df = \frac{\partial f}{\partial x}\,dx
+{}+ \frac{\partial f}{\partial y}\,dy
+{}+ \frac{\partial f}{\partial z}\,dz
+$$
+
+In this book we call this the $1$-form representation of the gradient and write
+
+$$
+\mathrm{grad}\,f = df
+$$
+
+The operator $d$ raises the degree from $0 \to 1$. That is the form of the gradient needed in this chapter. The relation to the column-vector display $\nabla f$ of usual vector analysis is organized again in later chapters.
+
+#### 6.5.2 Curl $\mathrm{curl}\,\omega = \ast\,d\,\omega$
+
+For the $1$-form
+
+$$
+\omega = P\,dx + Q\,dy + R\,dz
+$$
+
+applying $d$ yields the $2$-form $d\omega$:
+
+$$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
+
+Applying $\ast$ returns the $2$-form to a $1$-form:
+
+$$\ast(d\omega) = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dx + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dy + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dz$$
+
+In this book we call this $1$-form the $1$-form representation of the curl and write
+
+$$\mathrm{curl}\,\omega = \ast\,d\,\omega$$
+
+The composition $\ast\,d$ has the degree transition
+
+$$
+1 \to 2 \to 1
+$$
+
+This structure of "rising once to a surface form, then returning to a line form" corresponds to the curl. The relation to what is written $\nabla\times\mathbf F$ in usual vector analysis is treated again in later chapters.
+
+#### 6.5.3 Divergence $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$
+
+Apply $\ast$ first to the $1$-form $\omega$ to obtain a $2$-form. Apply $d$ to obtain a $3$-form. Apply $\ast$ once more to return to a $0$-form, namely a scalar field:
+
+$$
+\ast d\ast\omega
+$$
+
+Computing in Cartesian coordinates,
+
+$$\ast(d(\ast\omega)) = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$$
+
+In this book we call this $0$-form the divergence and write
+
+$$\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$$
+
+The composition $\ast\,d\,\ast$ has the degree transition
+
+$$
+1 \to 2 \to 3 \to 0
+$$
+
+The relation to what is written $\nabla\cdot\mathbf F$ in usual vector analysis is treated again in later chapters.
+
+#### 6.5.4 The Shadow of $d^2 = 0$
+
+Recall $d^2 = 0$ from Chapter 5. From this single fact, relations arise among the three operations.
+
+First,
+
+$$
+\mathrm{curl}(\mathrm{grad}\,f)
+=
+\ast d(df)
+=
+\ast(d^2 f)
+=
+0
+$$
+
+Also,
+
+$$
+\mathrm{div}(\mathrm{curl}\,\omega)
+=
+\ast d\ast(\ast d\omega)
+=
+\ast d(d\omega)
+=
+\ast(d^2\omega)
+=
+0
+$$
+
+Here we stop at viewing these as identities on the side of forms. Readers who know vector analysis will see the correspondence with the usual identities. In this book, however, the meaning in the usual nabla notation is deferred to later chapters.
+
+---

--- a/translation/drafts/ch06-6.6.md
+++ b/translation/drafts/ch06-6.6.md
@@ -1,0 +1,35 @@
+### §6.6 Toward Vector Analysis
+
+In Chapter 5 we acquired the exterior derivative $d$; in this chapter, the metric $g$ and the Hodge star $\ast$. With this, the main tools needed to move from the world of forms toward vector analysis are in place.
+
+What we confirmed in this chapter is that from combinations of $d$ and $\ast$, one can extract the three types called grad, curl, and div in three-dimensional vector analysis.
+
+Let us tabulate the correspondences obtained here.
+
+| Operation | Decomposition in this book | Degree transition | Number of uses of $\ast$ |
+|---|---|---|---|
+| $\mathrm{grad}$ | $d$ | $0 \to 1$ | 0 |
+| $\mathrm{curl}$ | $\ast\,d$ | $1 \to 2 \to 1$ | 1 |
+| $\mathrm{div}$ | $\ast\,d\,\ast$ | $1 \to 2 \to 3 \to 0$ | 2 |
+
+By now, a substantial part of the structure behind nabla notation has come into view. However, this chapter has not yet formally developed the usual vector analysis.
+
+Readers who know vector analysis may already see the usual $\nabla$ notation rising from here. But this book will not rush. The systematic organization in the usual nabla notation is deferred to later chapters.
+
+In later chapters we will use the $d$, $g$, and $\ast$ obtained here to return to the notation of usual vector analysis. Stokes' theorem, Gauss's divergence theorem, and why formulas grow long in curvilinear coordinates will all be reread from this toolkit.
+
+> <strong>Note</strong> (by flipping just one sign in the metric) This chapter assumed a positive definite metric ($\mathbf{v}^T \mathbf{g} \,\mathbf{v} > 0$ for $\mathbf{v} \neq 0$). But on the four-dimensional spacetime stage of special relativity, an indefinite metric appears, such as $\mathbf{g} = \begin{pmatrix} -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 1 \end{pmatrix}$, with only the time component's sign flipped. This book is fixed on three-dimensional Cartesian physical space, so we do not go further here; but the idea learned in this chapter of "inserting the matrix $\mathbf{g}$" extends directly to four-dimensional spacetime. When that becomes necessary, I hope the reader will return to this chapter.
+
+---
+
+> <strong>Checkpoint so far — Chapter 6 as a whole</strong>
+> - The inner product is an operation taking the product-sum of components between vectors of the same kind (row×row, or column×column). It is a different operation from row×column computation.
+> - In physical space the inner-product matrix is the identity $I$. In parameter space it is determined by the linear coefficients of coordinate transformation as $\mathbf{g}=J^T J$. That is, the metric $g$ is nothing other than the matrix that appears in the middle when one pulls back to physical space and takes the inner product.
+> - $\mathbf{v}^T \mathbf{g}$ converts a column vector into a row vector; $\mathbf{g}^{-1}\omega^T$ returns a row vector to column-vector display. Without $g$, objects and measuring devices cannot convert into each other.
+> - There are two ways to obtain a scalar: Route ① (row×column) and Route ② (inner product of like-kind vectors). The Hodge star $\ast$ is the correspondence linking the two.
+> - $\ast$ returns, for a given form, the partner that combines with it to yield a positive volume form. The dictionary in physical space is $\ast dx = dy \wedge dz$, etc., and it satisfies $\ast\ast = \mathrm{id}$.
+> - The Joule-heating and helicity examples show that Route ① and Route ② give the same result through $\ast$ and $\ast\ast = \mathrm{id}$.
+> - In Chapter 6 we confirmed that the three types $\mathrm{grad}=d$, $\mathrm{curl}=\ast\,d$, $\mathrm{div}=\ast\,d\,\ast$ appear. The systematic organization in the usual nabla notation is deferred to later chapters.
+> - From $d^2=0$, on the side of forms we get $\mathrm{curl}(\mathrm{grad}\,f)=0$ and $\mathrm{div}(\mathrm{curl}\,\omega)=0$. The meaning in usual vector analysis is treated again in later chapters.
+
+---

--- a/translation/drafts/ch06-appendix-D.md
+++ b/translation/drafts/ch06-appendix-D.md
@@ -1,0 +1,527 @@
+## Appendix D: Array Representation of the Hodge Star
+
+§6.3.2 gave the dictionary for $\ast$ in real space. This appendix checks how that dictionary looks as array operations. The Hodge star is not an abstract symbol; once a basis is chosen, it is a linear transformation that can be displayed as a concrete array. We first view the $1$-form $\leftrightarrow$ $2$-form correspondence through antisymmetric matrices, and finally view the $0$-form $\leftrightarrow$ $3$-form correspondence through a third-order array.
+
+### D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix
+
+For the $1$-form
+
+$$
+\omega =
+\begin{pmatrix}P & Q & R\end{pmatrix}
+=
+P\,dx + Q\,dy + R\,dz
+$$
+
+apply the dictionary from the main text,
+
+$$
+\ast dx = dy \wedge dz,\qquad
+\ast dy = dz \wedge dx,\qquad
+\ast dz = dx \wedge dy
+$$
+
+to obtain
+
+$$
+\ast\omega
+=
+P\,dy\wedge dz
++
+Q\,dz\wedge dx
++
+R\,dx\wedge dy
+$$
+
+In the antisymmetric matrix representation of Chapter 2, let the matrix representing $dy\wedge dz$ be
+
+$$
+E_1 =
+\begin{pmatrix}
+0 & 0 & 0 \\
+0 & 0 & 1 \\
+0 & -1 & 0
+\end{pmatrix}
+$$
+
+Similarly, let the matrix representing $dz\wedge dx$ be
+
+$$
+E_2 =
+\begin{pmatrix}
+0 & 0 & -1 \\
+0 & 0 & 0 \\
+1 & 0 & 0
+\end{pmatrix}
+$$
+
+and let the matrix representing $dx\wedge dy$ be
+
+$$
+E_3 =
+\begin{pmatrix}
+0 & 1 & 0 \\
+-1 & 0 & 0 \\
+0 & 0 & 0
+\end{pmatrix}
+$$
+
+Therefore,
+
+$$
+\ast_{1\to2}
+=
+\begin{pmatrix}
+E_1\\
+E_2\\
+E_3
+\end{pmatrix}
+$$
+
+can be viewed as a "vertical vector of matrices." Multiplying the $1$-form $\omega=\begin{pmatrix}P&Q&R\end{pmatrix}$ on the left gives
+
+$$
+\omega\,\ast_{1\to2}
+=
+\begin{pmatrix}P&Q&R\end{pmatrix}
+\begin{pmatrix}
+E_1\\
+E_2\\
+E_3
+\end{pmatrix}
+=
+P E_1+Q E_2+R E_3
+$$
+
+Hence
+
+$$
+\ast_{1\to2}(\omega)
+=
+\begin{pmatrix}
+0 & R & -Q \\
+-R & 0 & P \\
+Q & -P & 0
+\end{pmatrix}
+$$
+
+The three coefficients $P,Q,R$ of the $1$-form have been placed into the three independent components of the antisymmetric matrix of the $2$-form. This is the most visible form of $\ast_{1\to2}$.
+
+> <strong>Note</strong> (relation to $\widehat{\epsilon}$ in Chapter 2) These $E_1,E_2,E_3$ are the same matrices written in Appendix A as $\varepsilon_{1,\cdot,\cdot},\varepsilon_{2,\cdot,\cdot},\varepsilon_{3,\cdot,\cdot}$. The essence of $\ast_{1\to2}$ is to place the first index of Einstein's epsilon $\varepsilon_{ijk}$ in the direction of the components of the $1$-form, and the remaining two indices in the directions of the $3\times3$ matrix. The same triple introduced in Chapter 2 as the volume-measuring device $\widehat{\epsilon}$ reappears here as the Hodge star.
+
+### D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product
+
+The reverse map $\ast_{2\to1}$ is the operation that extracts three independent components from an antisymmetric matrix. Looking at matrix entries alone, it suffices to read $A=M_{23}$, $B=M_{31}$, $C=M_{12}$. That is, to return from the antisymmetric matrix
+
+$$
+M=
+\begin{pmatrix}
+0 & C & -B \\
+-C & 0 & A \\
+B & -A & 0
+\end{pmatrix}
+$$
+
+representing the $2$-form
+
+$$
+\eta
+=
+A\,dy\wedge dz
++
+B\,dz\wedge dx
++
+C\,dx\wedge dy
+$$
+
+to $A\,dx+B\,dy+C\,dz$, one need only read these three components. If we stop at this mere "reading," however, the transpose relation with $\ast_{1\to2}$ is hard to see. So we rewrite coefficient extraction itself as an inner product between matrices.
+
+Define the inner product of $3\times3$ matrices $A,B$ by
+
+$$
+A\cdot B
+=
+\frac{1}{2}\operatorname{tr}(A^T B)
+=
+\frac{1}{2}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+A_{ij}B_{ij}
+$$
+
+> <strong>Note</strong> (trace) $\operatorname{tr}$ is the <strong>trace</strong> of a matrix (the sum of diagonal entries). It appeared when we treated the matrix representation of the exterior derivative in Appendix B. $\operatorname{tr}(A^T B)$ is the three-step operation "transpose $A$, multiply by $B$, and add the diagonal entries." Because it is equivalent to $\frac{1}{2}\sum A_{ij}B_{ij}$, use the latter expression when you want to think in components.
+
+This is the same notation as the inner product $\mathbf{v}_1 \cdot \mathbf{v}_2$ between column vectors in §6.2.3. Matrices, too, are "things of the same kind," and we multiply corresponding components and take the sum. Because we contract successively over the two indices $i$ and $j$, this is called the <strong>Frobenius product</strong> or <strong>consecutive contraction</strong>.
+
+> <strong>Note</strong> (the factor $1/2$) Some conventions adopt $\operatorname{tr}(A^T B)$ (without $1/2$) as the Frobenius product. For antisymmetric matrices, however, that picks up both members of a pair such as $M_{23}$ and $M_{32}=-M_{23}$, and the inner product is doubled. In this book we build $1/2$ into the definition. Then the inner product of the $2$-form $M$ with itself, $M\cdot M=M_{23}^2+M_{31}^2+M_{12}^2$, agrees directly with the "squared unsigned area of the parallelogram" in §6.2.2.
+
+> <strong>Note</strong> (the pull of abstraction) §6.2.3 touched on an axiomatic inner product, but once you actually work by hand like this, you can see why that brevity is attractive. For the inner product of column vectors we use $\mathbf{v}_1^T \mathbf{v}_2$; for the inner product of matrices we use $\frac{1}{2}\operatorname{tr}(A^T B)$—redefining the inner product from scratch every time the representation changes is, when you think about it, quite a burden. One notices the urge to lump these together and settle everything with one phrase: "an inner product is an operation satisfying certain axioms." Even so, this book does not abandon its policy of making representations explicit to the end. By this point, that is stubbornness.
+
+The $E_1,E_2,E_3$ of D.1 are orthonormal with respect to this inner product. Indeed, each $E_k$ has only two nonzero components; for the same $E_k$ we get $\frac{1}{2}(1^2+(-1)^2)=1$, and for different $E_i,E_j$ the positions of the nonzero components do not overlap. Therefore,
+
+$$
+E_i\cdot E_j=\delta_{ij}
+$$
+
+Using this orthonormality, the reverse transformation $\ast_{2\to1}$ can be written as inner products with $E_1,E_2,E_3$. Let $M$ be an arbitrary $3\times3$ matrix; when it comes from a $2$-form, $M$ is an antisymmetric matrix.
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+E_1\cdot M & E_2\cdot M & E_3\cdot M
+\end{pmatrix}
+$$
+
+Here $E_k\cdot M=\frac{1}{2}\operatorname{tr}(E_k^T M)$ is the Frobenius product defined above. In components,
+
+$$
+\begin{aligned}
+E_1 \cdot M &= \frac{1}{2}(M_{23}-M_{32}) \\
+E_2 \cdot M &= \frac{1}{2}(M_{31}-M_{13}) \\
+E_3 \cdot M &= \frac{1}{2}(M_{12}-M_{21})
+\end{aligned}
+$$
+
+If $M$ is an antisymmetric matrix, then $M_{32}=-M_{23}$, $M_{13}=-M_{31}$, $M_{21}=-M_{12}$, so
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+M_{23} & M_{31} & M_{12}
+\end{pmatrix}
+$$
+
+Therefore, $\ast_{2\to1}$ is at once the operation that extracts independent components from an antisymmetric matrix and coefficient extraction by the Frobenius product with $E_k$.
+
+Writing out all components, $\ast_{2\to1}$ is the following "horizontal vector of matrices":
+
+$$
+\ast_{2\to1} = \begin{pmatrix}
+\begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & -1 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 0 & -1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{pmatrix} &
+\begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+\end{pmatrix}
+$$
+
+In $\ast_{1\to2}$ we multiply by coefficients and add; in $\ast_{2\to1}$ we extract coefficients by inner product. Vertical and horizontal, weighted sum and inner-product extraction, correspond to each other.
+
+### D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case
+
+Combining D.1 and D.2, $\ast\ast=\mathrm{id}$ for $1$-forms and $2$-forms appears as orthonormality of arrays.
+
+For
+
+$$
+\omega=P\,dx+Q\,dy+R\,dz
+$$
+
+D.1 gives
+
+$$
+\ast_{1\to2}(\omega)=P E_1+Q E_2+R E_3
+$$
+
+Applying $\ast_{2\to1}$ to this,
+
+$$
+\begin{aligned}
+\ast_{2\to1}(\ast_{1\to2}(\omega))
+&=
+\begin{pmatrix}
+E_1\cdot (P E_1+Q E_2+R E_3) \\
+E_2\cdot (P E_1+Q E_2+R E_3) \\
+E_3\cdot (P E_1+Q E_2+R E_3)
+\end{pmatrix}^{T} \\
+&=
+\begin{pmatrix}
+P & Q & R
+\end{pmatrix}
+=
+\omega
+\end{aligned}
+$$
+
+In the last equality we used $E_i\cdot E_j=\delta_{ij}$. That is, the three coefficients placed into $E_1,E_2,E_3$ by $\ast_{1\to2}$ are recovered unchanged by $\ast_{2\to1}$ through inner products with the same $E_1,E_2,E_3$.
+
+The reverse direction is the same. For the antisymmetric matrix
+
+$$
+M=P E_1+Q E_2+R E_3
+$$
+
+D.2 gives
+
+$$
+\ast_{2\to1}(M)
+=
+\begin{pmatrix}
+E_1\cdot M & E_2\cdot M & E_3\cdot M
+\end{pmatrix}
+=
+\begin{pmatrix}
+P & Q & R
+\end{pmatrix}
+$$
+
+and applying D.1's $\ast_{1\to2}$,
+
+$$
+\ast_{1\to2}(\ast_{2\to1}(M))
+=
+P E_1+Q E_2+R E_3
+=
+M
+$$
+
+Therefore, in the $1$-form and $2$-form case,
+
+$$
+\ast_{2\to1}(\ast_{1\to2}(\omega))=\omega,
+\qquad
+\ast_{1\to2}(\ast_{2\to1}(M))=M
+$$
+
+hold. $\ast_{1\to2}$ places three coefficients into $E_1,E_2,E_3$; $\ast_{2\to1}$ extracts coefficients by inner product with $E_1,E_2,E_3$. Using the normalized Frobenius product, the transpose relation between the two appears as this correspondence between placement and coefficient extraction.
+
+### D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$
+
+So far we have displayed $\ast_{1\to2}$ and $\ast_{2\to1}$ as transformations that move coefficient arrays. What remains is $\ast_{0\to3}$ and $\ast_{3\to0}$.
+
+A $0$-form has a single coefficient. A $3$-form, viewed purely as an array, is a completely antisymmetric third-order array with three indices. Therefore, $\ast_{0\to3}$ is the transformation that spreads one component into $3\times3\times3$ components, and $\ast_{3\to0}$ is the transformation that extracts one component from $3\times3\times3$ components.
+
+Here we bring $\varepsilon_{ijk}$, which also appeared in Chapter 2, to the fore and look at its form.
+
+> <strong>Note</strong> (what $\varepsilon_{ijk}$ really is) $\varepsilon_{ijk}$ is the completely antisymmetric symbol that appeared in Chapter 2. If the indices $(i,j,k)$ are an even permutation of $(1,2,3)$, it is $+1$; if an odd permutation, $-1$; if the same index appears twice, $0$. In an orthonormal Cartesian basis, it can be read as the component of a completely antisymmetric tensor. In this book we use those components as the representation of the Hodge star.
+
+First, apply $\ast_{0\to3}$ to the $0$-form $f$. The output is a $3$-form, so it can be written in components with three indices. Here we take the components of $\ast_{0\to3}$ itself to be
+
+$$
+(\ast_{0\to3})_{ijk}
+=
+\varepsilon_{ijk}
+$$
+
+Display this as three $3\times3$ matrices with $i$ fixed—that is, for each of $i=1,2,3$, arrange the $(j,k)$ components as a matrix:
+
+$$
+(\ast_{0\to3})_{1jk}
+=
+\begin{pmatrix}
+0&0&0\\
+0&0&1\\
+0&-1&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{0\to3})_{2jk}
+=
+\begin{pmatrix}
+0&0&-1\\
+0&0&0\\
+1&0&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{0\to3})_{3jk}
+=
+\begin{pmatrix}
+0&1&0\\
+-1&0&0\\
+0&0&0
+\end{pmatrix}.
+$$
+
+As you can see, these are exactly the antisymmetric matrices $E_1,E_2,E_3$ used in D.1. That is,
+
+$$
+(\ast_{0\to3})_{1jk}= (E_1)_{jk},
+\qquad
+(\ast_{0\to3})_{2jk}= (E_2)_{jk},
+\qquad
+(\ast_{0\to3})_{3jk}= (E_3)_{jk}
+$$
+
+Almost nothing new happens here. The antisymmetric matrices $E_1,E_2,E_3$ seen in D.1 are now simply arranged as three slices with $i=1,2,3$. In the $1$-form and $2$-form case we read three coefficients as the coefficients of three antisymmetric matrices. In the $0$-form and $3$-form case we build, from one coefficient, the completely antisymmetric third-order array obtained by stacking all three slices at once.
+
+Indeed, acting on the $0$-form $f$,
+
+$$
+(\ast_{0\to3}f)_{ijk}
+=
+(\ast_{0\to3})_{ijk}f
+=
+\varepsilon_{ijk}f
+$$
+
+This is the operation of spreading the coefficient $f$ into a completely antisymmetric third-order array.
+
+Next, consider the reverse map $\ast_{3\to0}$. This is the transformation that takes a third-order array and returns a single coefficient. Its components are
+
+$$
+(\ast_{3\to0})_{ijk}
+=
+\frac{1}{3!}\varepsilon_{ijk}
+$$
+
+Therefore, displayed again as three $3\times3$ matrices with $i$ fixed,
+
+$$
+(\ast_{3\to0})_{1jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&0&0\\
+0&0&1\\
+0&-1&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{3\to0})_{2jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&0&-1\\
+0&0&0\\
+1&0&0
+\end{pmatrix},
+$$
+
+$$
+(\ast_{3\to0})_{3jk}
+=
+\frac{1}{3!}
+\begin{pmatrix}
+0&1&0\\
+-1&0&0\\
+0&0&0
+\end{pmatrix}.
+$$
+
+That is, $\ast_{3\to0}$ uses the same three antisymmetric matrices. The only difference is that the whole thing is multiplied by $1/3!$.
+
+If we think of the indices $(i,j,k)$ lined up in a row as a single number, then $\ast_{0\to3}$ is a column vector that spreads one component into $27$ components, and $\ast_{3\to0}$ is a row vector that extracts one component from $27$ components. Apart from the normalization factor $1/3!$, the two are in a transpose relation.
+
+Acting on the $3$-form
+
+$$
+\eta
+=
+\eta_{ijk}
+$$
+
+with $\ast_{3\to0}$ sums over all three indices:
+
+$$
+\ast_{3\to0}\eta
+=
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+(\ast_{3\to0})_{ijk}\eta_{ijk}
+$$
+
+Therefore,
+
+$$
+\ast_{3\to0}\eta
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}\eta_{ijk}
+$$
+
+This is a triple contraction that extracts one coefficient from a completely antisymmetric third-order array.
+
+The factor $1/3!$ plays the same role as the $1/2$ that appears in the Frobenius product of D.2. In an antisymmetric matrix, each independent component appears twice, so we multiply by $1/2$ to correct for the duplication. Here, each independent component of a completely antisymmetric third-order array appears $3!=6$ times, so we multiply by $1/3!$ to correct for the duplication.
+
+Let us verify that applying $\ast$ twice returns the original. First, start from the $0$-form $f$:
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}(\ast_{0\to3}f)_{ijk}
+$$
+
+Since $(\ast_{0\to3}f)_{ijk}=\varepsilon_{ijk}f$,
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}\varepsilon_{ijk}f
+$$
+
+Only the $3!=6$ cases in which $(i,j,k)$ is a permutation of $(1,2,3)$ are nonzero; then $\varepsilon_{ijk}\varepsilon_{ijk}=1$, so
+
+$$
+\ast_{3\to0}(\ast_{0\to3}f)
+=
+\frac{1}{3!}(3!)f
+=
+f
+$$
+
+Let us also check the reverse direction. An arbitrary $3$-form has only one independent component in three dimensions. Therefore the completely antisymmetric components $\eta_{ijk}$ can be written using some coefficient $h$ as
+
+$$
+\eta_{ijk}
+=
+h\,\varepsilon_{ijk}
+$$
+
+Then
+
+$$
+\ast_{3\to0}\eta
+=
+\frac{1}{3!}
+\sum_{i=1}^{3}
+\sum_{j=1}^{3}
+\sum_{k=1}^{3}
+\varepsilon_{ijk}(h\varepsilon_{ijk})
+=
+h
+$$
+
+Therefore,
+
+$$
+(\ast_{0\to3}(\ast_{3\to0}\eta))_{ijk}
+=
+(\ast_{0\to3}h)_{ijk}
+=
+h\varepsilon_{ijk}
+=
+\eta_{ijk}
+$$
+
+Thus we have confirmed $\ast\ast=\mathrm{id}$ in the $0$-form and $3$-form case as well, in the array representation.
+
+In the end, what we saw here is the same as in D.1–D.3. In $\ast_{1\to2}$ we distributed three coefficients among three antisymmetric matrices. In $\ast_{0\to3}$ we distributed one coefficient simultaneously among all three antisymmetric matrices. In $\ast_{2\to1}$ we extracted coefficients from an antisymmetric matrix; in $\ast_{3\to0}$ we extracted coefficients by triple contraction with the three antisymmetric matrices. The Hodge star, at every degree, is a linear transformation that can be displayed as a concrete array once a basis is chosen.
+
+### D.5 Summary
+
+> <strong>Checkpoint so far — Appendix D</strong>
+> - $\ast_{1\to2}$ is the linear transformation that places three coefficients into the antisymmetric matrices $E_1,E_2,E_3$.
+> - $\ast_{2\to1}$ is the linear transformation that extracts coefficients from an antisymmetric matrix, and can be written by the Frobenius product with $E_k$.
+> - Using the Frobenius product $A\cdot B=\frac{1}{2}\operatorname{tr}(A^TB)$, we have $E_i\cdot E_j=\delta_{ij}$.
+> - Therefore, in the $1$-form and $2$-form case, $\ast_{2\to1}(\ast_{1\to2}(\omega))=\omega$ and $\ast_{1\to2}(\ast_{2\to1}(M))=M$ hold.
+> - $\ast_{0\to3}$ can be displayed as a third-order array obtained by stacking the three antisymmetric matrices $E_1,E_2,E_3$. In components, $(\ast_{0\to3})_{ijk}=\varepsilon_{ijk}$.
+> - $\ast_{3\to0}$ can be displayed as the same array multiplied by the normalization factor $1/3!$. In components, $(\ast_{3\to0})_{ijk}=\frac{1}{3!}\varepsilon_{ijk}$.
+> - The factors $1/2$ and $1/3!$ correct for duplication of antisymmetric components.
+> - In the $0$-form/$3$-form case as well, $\ast_{3\to0}(\ast_{0\to3}f)=f$ and $\ast_{0\to3}(\ast_{3\to0}\eta)=\eta$ hold.
+> - Therefore, the Hodge star $\ast$, for both $0\leftrightarrow3$ and $1\leftrightarrow2$, is a linear transformation that can be displayed as a concrete array once a basis is chosen.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -170,6 +170,26 @@ Per-section Pass status:
 | `translation/reviews/ch05-pass3.md` | complete |
 | `translation/reviews/ch05-close-reading-polish.md` | complete (#183) |
 
+### English Chapter 6 — `manuscript/en/ch06/ch06.md` (branch `ai/english-translation-ch06`, PR [#167](https://github.com/yokiikoy/nabla-kaitai/pull/167))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 6 (§6.0–§6.6 + App. D)** | **1 → 2 → 3** | `ch06-pass2.md`, `ch06-pass3.md`; old YAML draft replaced |
+
+| Block | Pass | Review |
+|-------|------|--------|
+| §6.0–§6.2 | **3** | `ch06-6.0-6.2-review.md` |
+| §6.3 | **3** | `ch06-6.3-review.md` |
+| §6.4–§6.5 | **3** | `ch06-6.4-6.5-review.md` |
+| §6.6 | **3** | `ch06-6.6-review.md` |
+| Appendix D | **3** | `ch06-appendix-D-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch06-*.md` | integrated into `ch06.md` |
+| `translation/reviews/ch06-pass2.md` | complete |
+| `translation/reviews/ch06-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -189,6 +189,7 @@ Per-section Pass status:
 | `translation/drafts/ch06-*.md` | integrated into `ch06.md` |
 | `translation/reviews/ch06-pass2.md` | complete |
 | `translation/reviews/ch06-pass3.md` | complete |
+| `translation/reviews/ch06-close-reading-polish.md` | complete (#184) |
 
 ---
 

--- a/translation/reviews/ch06-6.0-6.2-review.md
+++ b/translation/reviews/ch06-6.0-6.2-review.md
@@ -1,0 +1,5 @@
+# Review: Chapter 6 §6.0–§6.2
+
+Branch: `ai/english-translation-ch06` · Pass 1 **passed**. Metric $g$, pullback $\mathbf{g}=J^T J$, row/column conversion.
+
+From `translation/drafts/ch06-6.0-6.2.md`.

--- a/translation/reviews/ch06-6.3-review.md
+++ b/translation/reviews/ch06-6.3-review.md
@@ -1,0 +1,5 @@
+# Review: Chapter 6 §6.3
+
+Branch: `ai/english-translation-ch06` · Pass 1 **passed**. Hodge star dictionary, $\ast\ast=\mathrm{id}$, properties.
+
+From `translation/drafts/ch06-6.3.md`.

--- a/translation/reviews/ch06-6.4-6.5-review.md
+++ b/translation/reviews/ch06-6.4-6.5-review.md
@@ -1,0 +1,5 @@
+# Review: Chapter 6 §6.4–§6.5
+
+Branch: `ai/english-translation-ch06` · Pass 1 **passed**. Joule/helicity; grad/curl/div (**curl not rot**).
+
+From `translation/drafts/ch06-6.4-6.5.md`.

--- a/translation/reviews/ch06-6.6-review.md
+++ b/translation/reviews/ch06-6.6-review.md
@@ -1,0 +1,5 @@
+# Review: Chapter 6 §6.6
+
+Branch: `ai/english-translation-ch06` · Pass 1 **passed**. Chapter 6 checkpoint; toward nabla in ch7.
+
+From `translation/drafts/ch06-6.6.md`.

--- a/translation/reviews/ch06-appendix-D-review.md
+++ b/translation/reviews/ch06-appendix-D-review.md
@@ -1,0 +1,5 @@
+# Review: Chapter 6 Appendix D
+
+Branch: `ai/english-translation-ch06` · Pass 1 **passed**. $\ast_{1\leftrightarrow2}$, Frobenius product, $\ast_{0\leftrightarrow3}$ arrays.
+
+From `translation/drafts/ch06-appendix-D.md`.

--- a/translation/reviews/ch06-close-reading-polish.md
+++ b/translation/reviews/ch06-close-reading-polish.md
@@ -1,0 +1,57 @@
+# Close-Reading Polish: Chapter 6
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch06`
+File: `manuscript/en/ch06/ch06.md`
+GitHub issue: #184
+PR context: #167
+
+Scope: publication polish after Pass 3 — inner-product grammar, Route ①/② consistency, Hodge-star array safety, Markdown cleanup, preservation of $g$ / $\ast$ discovery arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** §6.1.1: inner-product definition grammar
+- **B2** Removed duplicate horizontal rules between §6.2/§6.3 and §6.6/Appendix D
+- **B3** Normalized `Method ①/②` → `Route ①/②` throughout Chapter 6 (§6.3–checkpoint)
+
+### C items (straightforward)
+
+- **C2** §6.0: `……` → `...`
+- **C3** §6.1: spherical $\mathbf{g}$ — `with $\theta$ taken as the polar angle`
+- **C4** §6.2.2: $k=0$ size sentence
+- **C6** §6.3: metric-induced inner product of forms
+- **C7** §6.4.1: Route ② display clarification for $E\cdot J$
+- **C8** §6.4.1: `Route ② display of $J$`
+- **C10** §6.6: `Gauss' theorem` (matches Chapter 5)
+- **C12** Appendix D.2: $A\cdot B$ vs $\operatorname{tr}(A^T B)$ factor convention
+- **C13** Appendix D.3: row-vector display for $\ast_{2\to1}(\ast_{1\to2}(\omega))$
+- **C14** Appendix D.4: $\eta_{ijk}$ as components, not $\eta=\eta_{ijk}$
+
+### Intentionally unchanged (D items / optional C)
+
+- **C1** §6.0 opening long sentence — preserved rhythm
+- **C5** §6.3 `same kind of arrow` — preserved authorial phrase
+- **C9** §6.5 divergence input reminder — defer language sufficient
+- **C11** §6.6 relativity aside — kept light
+- **C16** §6.11 Hodge dictionary sentence — kept approachable wording
+- “The End of Excuses”, row/column insistence, Chapter 2 smuggled note, arc-length avoidance, Route framing, Hodge basis dictionary, $\ast\ast=\mathrm{id}$, Joule/helicity examples, `grad=d` / `curl=*d` / `div=*d*`, nabla defer, relativity aside, Appendix D expansions, $\widehat{\epsilon}$ / $E_k$, normalized Frobenius $1/2$, $1/3!$ normalization
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- duplicate `---` blocks — none
+- `Method ①`, `Method ②` — none
+- `rot` — none
+- `Gauss' divergence theorem` — none
+- `\eta = \eta_{ijk}` display — none
+- `Because it is equivalent to $\frac{1}{2}\sum` — none
+- old inner-product definition fragment — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch06-pass2.md
+++ b/translation/reviews/ch06-pass2.md
@@ -1,0 +1,20 @@
+# Pass 2 Review: Chapter 6
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch06`
+File: `manuscript/en/ch06/ch06.md`
+
+---
+
+## Stages
+
+| Stage | Scope | Edits |
+|-------|--------|-------|
+| 1 | §6.0–§6.2 | Replaced YAML draft (wrong: vector calculus/nabla); §6.1 heading → TOC |
+| 2 | §6.3–§6.5 | Hodge star dictionary; **curl** not rot throughout §6.5 |
+| 3 | §6.6 + App. D | `Gauss's` → `Gauss'`; Frobenius product appendix preserved |
+| 4 | Whole chapter | No rot, no area meter, no YAML |
+
+**Chapter 6 passes Pass 2.**
+
+Body ~1200 lines. Pass 3 in `ch06-pass3.md`.

--- a/translation/reviews/ch06-pass3.md
+++ b/translation/reviews/ch06-pass3.md
@@ -1,0 +1,29 @@
+# Pass 3 Review: Chapter 6
+
+Review date: 2026-05-22
+Branch: `ai/english-translation-ch06`
+File: `manuscript/en/ch06/ch06.md`
+
+Approach: keep voice; minimal edits only.
+
+---
+
+## Decisions
+
+### Keep
+- Route ①/② two-scalar-path framing (§6.3)
+- Joule heat and helicity examples (§6.4)
+- Authorial Note on abstraction vs explicit displays (Appendix D.2)
+- Special relativity metric aside (§6.6)
+- grad/curl/div as $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$ (curl not rot)
+
+### Pass 2 edits recorded
+- §6.1 TOC heading; `Gauss's` → `Gauss'`
+
+### No change
+- Long Appendix D array expansions
+- $\widehat{\epsilon}$ / $E_1,E_2,E_3$ cross-reference to ch02 Appendix A
+
+---
+
+**Chapter 6 passes Pass 3.** Next: PR base `ai/english-translation-ch05`.


### PR DESCRIPTION
## Summary
- Replace outdated YAML English ch06 draft (mislabeled as vector calculus/nabla) with metric $g$ and Hodge star chapter.
- §6.0–§6.6 + Appendix D (array representation of $\ast$).
- **curl not rot** in §6.5; Pass 2 TOC/apostrophe fixes.
- Branch replayed on current `main` after #166 merge; diff is ch06-only.

## Scope
| Block | Content |
|-------|---------|
| §6.0–§6.2 | Metric $g$; Route ①②; Hodge star definition |
| §6.3 | grad / div / curl via $\ast$ and $d$ |
| §6.4–§6.5 | Laplacian; EM in form language |
| §6.6 | Chapter summary |
| Appendix D | Array representation of $\ast$ |

## Test plan
- [ ] Diff against `manuscript/ja/ch06/ch06.md`
- [ ] curl not rot; measuring device / Route ①② preserved
- [ ] Review records: `ch06-pass2.md`, `ch06-pass3.md`
- [ ] Merge to `main` (Chapter 5 already on `main` via #166)