### PR TITLE
English Chapter 7: §7.0–§7.9 (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch07/ch07.md
+++ b/manuscript/en/ch07/ch07.md
@@ -1,0 +1,487 @@
+# Chapter 7: Vector Analysis — Enter Nabla
+
+### §7.0 Enter Nabla
+
+The title of this book is *Unmasking Nabla*—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+
+What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
+
+I have been worrying about false advertising in the title for quite a while myself.
+
+In this chapter we finally define $\nabla$. Then we unfold standard vector analysis—gradient, divergence, curl, the Laplacian, and the various identities—straight from the textbook, all at once. In the calculations in the main text, we set $d$, $\ast$, and $\wedge$ aside for now. This is the very vector analysis that many readers learned (probably while struggling) in their first or second year of university.
+
+> <strong>Note</strong> (Why now) In Chapter 6 we previewed the shapes of grad, curl, and div using $d$ and $\ast$. In this chapter we deliberately unfold the same objects in standard vector-analysis notation, formula after formula. If, when you finish this chapter, you feel that there are too many formulas, that is fine. That discomfort will be the driving force for matching the two notations in the next chapter.
+
+The tools used in this chapter are only those we have already assembled—column vectors, row vectors, matrices, inner products, the Jacobian matrix, and partial derivatives.
+
+---
+
+### §7.1 Dot Products and Cross Products
+
+#### 7.1.1 Dot Product
+
+For two column vectors
+
+$$
+\mathbf{a}
+=
+\begin{pmatrix}
+a_x\\
+a_y\\
+a_z
+\end{pmatrix},
+\qquad
+\mathbf{b}
+=
+\begin{pmatrix}
+b_x\\
+b_y\\
+b_z
+\end{pmatrix}
+$$
+
+we define the <strong>dot product</strong> (inner product) by
+
+$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
+
+As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. This is merely the same matrix product as the “evaluation in which a row vector eats a column vector” from Chapter 1 onward; conceptually, it is the inner product.
+
+#### 7.1.2 Cross Product
+
+For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> (outer product) by
+
+$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+The result is again a column vector. The arrangement of cross-product components follows a regular pattern, and it can be written compactly using the following antisymmetric matrix:
+
+$$\mathbf{a} \times = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}$$
+
+Multiplying this $3\times 3$ matrix on the left by the vector $\mathbf{b}$ gives
+
+$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}\begin{pmatrix}
+b_x \\ b_y \\ b_z
+\end{pmatrix} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+We call this $(\mathbf{a} \times)$ the <strong>cross-product matrix</strong> of $\mathbf{a}$. It appeared in Chapter 2 as the matrix representation of a $2$-form, and in Appendix D of Chapter 6 it reappeared as the array form of the Hodge star—exactly the same shape. In this chapter we use it purely as the operation “multiply a vector by a vector and obtain a vector.”
+
+The cross product has the following basic properties:
+
+1. <strong>Anticommutativity</strong>: $\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$
+2. <strong>Cross product with itself is zero</strong>: $\mathbf{a} \times \mathbf{a} = \mathbf{0}$
+3. <strong>Orthogonality</strong>: $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$, $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$
+
+Property 3 means that the cross product produces a vector orthogonal to both $\mathbf{a}$ and $\mathbf{b}$. That is the real content of the so-called “right-hand rule.”
+
+> <strong>Checkpoint — §7.1</strong>
+> - Dot product: $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$. In real space, transposing the column vector $\mathbf{a}$ gives $\mathbf{a}^T \mathbf{b}$.
+> - Cross product: $\mathbf{a}\times\mathbf{b}$ can be written as $(\mathbf{a}\times)\,\mathbf{b}$ using the cross-product matrix $(\mathbf{a}\times)$.
+> - The cross product is anticommutative, vanishes with itself, and its result is orthogonal to both input vectors.
+
+---
+
+### §7.2 $\nabla$ and the Gradient
+
+#### 7.2.1 Definition of $\nabla$
+
+English textbooks usually call the symbol $\nabla$ <strong>del</strong>; it is also called <strong>nabla</strong>, the name common in Japanese texts. This book is about what div, grad, and curl do—not primarily about what to call the symbol. We define nabla $\nabla$ as a formal column vector whose components are partial-derivative operators:
+
+$$\nabla = \begin{pmatrix}
+\frac{\partial}{\partial x} \\[0.5em]
+\frac{\partial}{\partial y} \\[0.5em]
+\frac{\partial}{\partial z}
+\end{pmatrix}$$
+
+$\nabla$ is a “vector,” but its components are not numbers—they are <strong>differential operators</strong>. $\nabla$ does not ordinarily have a value as a vector quantity on its own; it returns a concrete field only when it acts on something.
+
+#### 7.2.2 Gradient
+
+What we obtain by letting $\nabla$ act on a scalar field $f(x,y,z)$ is called the <strong>gradient</strong>, written $\mathrm{grad}\,f$ or $\nabla f$:
+
+$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
+\frac{\partial f}{\partial x} \\[0.5em]
+\frac{\partial f}{\partial y} \\[0.5em]
+\frac{\partial f}{\partial z}
+\end{pmatrix}$$
+
+Each component of the gradient is the rate of change of $f$ in the corresponding coordinate direction. Geometrically, $\nabla f$ is the vector field pointing in the direction of steepest increase of $f$.
+
+> <strong>Note</strong> (Is the gradient a row vector or a column vector?) In §6.5 we wrote $\mathrm{grad}\,f = df$, and $df$ was a row vector of coefficients. In this chapter we treat $\nabla f$ as a column vector. Using the Euclidean metric introduced in Chapter 6, we read the $1$-form $df$ as the corresponding column vector and obtain $\nabla f$. In §6.5 we stood on the view that “the differential itself (the form) measures properties of space”; in this chapter we adopt the standard vector-analysis view that “at each point an arrow (a vector) stands.” The starting pictures differ, but if we aggregate by line integral we get the same scalar quantity. That agreement is no accident.
+
+<strong>Example</strong>: the gradient of $f(x,y,z) = x^2 + y^2 + z^2$.
+
+$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$
+
+This vector field points radially outward from the origin and grows larger as one moves away from the origin.
+
+---
+
+---
+
+### §7.3 Divergence
+
+For a vector field
+
+$$
+\mathbf{F}(x,y,z)
+=
+\begin{pmatrix}
+F_x\\
+F_y\\
+F_z
+\end{pmatrix}
+$$
+
+we call the dot product with $\nabla$ the <strong>divergence</strong>.
+
+$$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+Formally this is “the dot product of $\nabla$ and $\mathbf{F}$,” but since each component of $\nabla$ is a differential operator, the result is a scalar field.
+
+> <strong>Note</strong> (connection to Chapter 6) In Chapter 6 we defined divergence on a $1$-form as $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$. The $\mathrm{div}\,\mathbf{F}$ above is the same operation, written here in nabla notation for the vector field corresponding to that $1$-form.
+
+Divergence can also be written in the language of matrices. Consider the Jacobian matrix $\mathbf{J}_\mathbf{F}$ of $\mathbf{F}$.
+
+$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
+\frac{\partial F_x}{\partial x} & \frac{\partial F_x}{\partial y} & \frac{\partial F_x}{\partial z} \\[0.3em]
+\frac{\partial F_y}{\partial x} & \frac{\partial F_y}{\partial y} & \frac{\partial F_y}{\partial z} \\[0.3em]
+\frac{\partial F_z}{\partial x} & \frac{\partial F_z}{\partial y} & \frac{\partial F_z}{\partial z}
+\end{pmatrix}$$
+
+The <strong>trace</strong> (sum of the diagonal entries) of this matrix agrees with the divergence.
+
+$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+Physically, $\mathrm{div}\,\mathbf{F}$ measures the strength of outflow at that point. If it is positive, there is outflow; if negative, inflow; if zero, there is neither outflow nor inflow at that point.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+x\\
+y\\
+z
+\end{pmatrix}
+$$
+
+The divergence of this field is
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial x}{\partial x} + \frac{\partial y}{\partial y} + \frac{\partial z}{\partial z} = 1 + 1 + 1 = 3$$
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+-y\\
+x\\
+0
+\end{pmatrix}
+$$
+
+The divergence of this field is
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial (-y)}{\partial x} + \frac{\partial x}{\partial y} + \frac{\partial 0}{\partial z} = 0 + 0 + 0 = 0$$
+
+This field rotates, but there is no outflow or inflow.
+
+---
+
+
+### §7.4 Curl
+
+For a vector field $\mathbf{F}$, we call the cross product with $\nabla$ the <strong>curl</strong>.
+
+$$\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
+\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.5em]
+\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}
+\end{pmatrix}$$
+
+Using the cross-product matrix, we can also write
+
+$$\mathrm{curl}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
+0 & -\frac{\partial}{\partial z} & \frac{\partial}{\partial y} \\[0.3em]
+\frac{\partial}{\partial z} & 0 & -\frac{\partial}{\partial x} \\[0.3em]
+-\frac{\partial}{\partial y} & \frac{\partial}{\partial x} & 0
+\end{pmatrix}\begin{pmatrix}
+F_x \\ F_y \\ F_z
+\end{pmatrix}$$
+
+> <strong>Note</strong> (connection to Chapter 6) Chapter 6 defined curl on a $1$-form as $\mathrm{curl}\,\omega = \ast\,d\,\omega$. The $\mathrm{curl}\,\mathbf{F}$ above is the same operation, written here in nabla notation for the corresponding vector field.
+
+Physically, $\mathrm{curl}\,\mathbf{F}$ represents the strength and direction of the vortex at that point. It points along the axis of the vortex, and its magnitude corresponds to the strength of the vortex.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+-y\\
+x\\
+0
+\end{pmatrix}
+$$
+
+The curl of this field is
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \\[0.3em]
+\frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \\[0.3em]
+\frac{\partial x}{\partial x} - \frac{\partial (-y)}{\partial y}
+\end{pmatrix} = \begin{pmatrix}
+0 - 0 \\ 0 - 0 \\ 1 - (-1)
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$
+
+This field rotates uniformly about the $z$-axis, and the strength of the vortex is $2$.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+x\\
+y\\
+z
+\end{pmatrix}
+$$
+
+The curl of this field is
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \\[0.3em]
+\frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \\[0.3em]
+\frac{\partial y}{\partial x} - \frac{\partial x}{\partial y}
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+
+A radial field has no vortex—consistent with intuition.
+
+> <strong>Checkpoint — §7.2–§7.4</strong>
+> - $\nabla$ is the formal vector obtained by stacking $\partial_x,\partial_y,\partial_z$ vertically.
+> - $\mathrm{grad}\,f = \nabla f$ (gradient): scalar field → vector field.
+> - $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}$ (divergence): vector field → scalar field. Equal to the trace of the Jacobian matrix.
+> - $\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}$ (curl): vector field → vector field. Can be written using the cross-product matrix.
+
+---
+
+
+---
+
+### §7.5 The Laplacian
+
+Applying the gradient (scalar → vector) and then the divergence (vector → scalar) in succession yields an operation from a scalar field to a scalar field. This is called the <strong>Laplacian</strong>.
+
+$$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f) = \nabla \cdot (\nabla f) = \frac{\partial^2 f}{\partial x^2} + \frac{\partial^2 f}{\partial y^2} + \frac{\partial^2 f}{\partial z^2}$$
+
+The notation $\nabla^2$ is shorthand for $\nabla \cdot \nabla$, and some authors write $\Delta f$ instead.
+
+<strong>Example</strong>: The Laplacian of $f(x,y,z) = x^2 + y^2 + z^2$.
+
+$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$
+
+For a vector field $\mathbf{F}$ as well, applying the Laplacian to each component is called the <strong>vector Laplacian</strong>.
+
+$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$
+
+The Laplacian appears everywhere in physics. The heat equation, the wave equation, Poisson's equation—all are equations built around $\nabla^2$.
+
+---
+
+
+### §7.6 Identities
+
+Among the three operations defined so far, two important identities hold. Both take the form "applying twice gives zero."
+
+#### 7.6.1 $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$
+
+If we take a vector field from a gradient and then take its curl, we always get the zero vector.
+
+$$\nabla \times (\nabla f) = \begin{pmatrix}
+\frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \\[0.5em]
+\frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \\[0.5em]
+\frac{\partial}{\partial x}\frac{\partial f}{\partial y} - \frac{\partial}{\partial y}\frac{\partial f}{\partial x}
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+
+In each component, terms cancel by exchanging the order of partial derivatives $\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$. This always holds if $f$ is smooth (twice continuously differentiable).
+
+Physical meaning: "A gradient field has no vortex." Conservative gravitational and electrostatic fields fall into this category.
+
+#### 7.6.2 $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$
+
+If we take a vector field from a curl and then take its divergence, we always get zero.
+
+$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$
+
+When expanded, terms pair up and cancel by exchanging the order of partial derivatives, as in $\frac{\partial^2 F_z}{\partial x\partial y}$ and $-\frac{\partial^2 F_z}{\partial y\partial x}$, so the sum is $0$.
+
+Physical meaning: "A curl field has no outflow or inflow." The magnetic field falls into this category (the mathematical expression that magnetic monopoles do not exist).
+
+> <strong>Checkpoint — §7.5–§7.6</strong>
+> - $\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$ is the Laplacian of a scalar field. It describes heat conduction and waves.
+> - $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$: A gradient field has no vortex.
+> - $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$: A curl field has no outflow or inflow.
+> - All follow from exchanging the order of partial derivatives $\partial_i\partial_j = \partial_j\partial_i$.
+
+---
+
+
+### §7.7 A Formula Collection for Nabla
+
+For practical calculation, we collect product rules involving $\nabla$ and representative vector identities. Below, $f, g$ denote scalar fields and $\mathbf{F}, \mathbf{G}$ denote vector fields.
+
+#### 7.7.1 Product rules
+
+<strong>Gradient of a product</strong>:
+
+$$\nabla(fg) = f\,\nabla g + g\,\nabla f$$
+
+<strong>Divergence of a product</strong>:
+
+$$\nabla \cdot (f\mathbf{F}) = (\nabla f) \cdot \mathbf{F} + f\,(\nabla \cdot \mathbf{F})$$
+
+<strong>Curl of a product</strong>:
+
+$$\nabla \times (f\mathbf{F}) = (\nabla f) \times \mathbf{F} + f\,(\nabla \times \mathbf{F})$$
+
+<strong>Divergence of a cross product</strong>:
+
+$$\nabla \cdot (\mathbf{F} \times \mathbf{G}) = (\nabla \times \mathbf{F}) \cdot \mathbf{G} - \mathbf{F} \cdot (\nabla \times \mathbf{G})$$
+
+#### 7.7.2 Identities for double application
+
+The curl of the gradient of a scalar field and the divergence of the curl of a vector field were derived in §7.6. We restate them here as part of the formula collection.
+
+<strong>Curl of a gradient is zero</strong>:
+
+$$\nabla \times (\nabla f) = \mathbf{0}$$
+
+<strong>Divergence of a curl is zero</strong>:
+
+$$\nabla \cdot (\nabla \times \mathbf{F}) = 0$$
+
+<strong>Curl of a curl</strong>:
+
+$$\nabla \times (\nabla \times \mathbf{F}) = \nabla(\nabla \cdot \mathbf{F}) - \nabla^2 \mathbf{F}$$
+
+This is the formula that decomposes the Laplacian into divergence and curl. The derivation uses the BAC-CAB rule (§7.7.4).
+
+<strong>Divergence of the gradient of a scalar field</strong> (= Laplacian):
+
+$$\nabla \cdot (\nabla f) = \nabla^2 f$$
+
+This is exactly the definition from §7.5.
+
+#### 7.7.3 Scalar triple product
+
+The scalar triple product of three column vectors $\mathbf{A}, \mathbf{B}, \mathbf{C}$ is defined as the dot product of $\mathbf{A}$ with $\mathbf{B}\times\mathbf{C}$.
+
+$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$
+
+This value equals the signed volume of the parallelepiped spanned by $\mathbf{A}, \mathbf{B}, \mathbf{C}$. It is invariant under cyclic permutation, and swapping two vectors reverses the sign.
+
+$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C}) = \mathbf{B} \cdot (\mathbf{C} \times \mathbf{A}) = \mathbf{C} \cdot (\mathbf{A} \times \mathbf{B})$$
+
+#### 7.7.4 Vector triple product (BAC-CAB rule)
+
+$$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot \mathbf{C}) - \mathbf{C}(\mathbf{A} \cdot \mathbf{B})$$
+
+This appears when the cross product is used twice. Each term on the right is a vector scaled by a scalar, and the mnemonic is BAC-CAB.
+
+> <strong>Note</strong> (why we listed the formulas) The formulas listed here are typical of those students are forced to memorize on university vector-analysis exams. One might ask: if we rewrite everything with $d$ and $\ast$, does the number of formulas shrink dramatically? Not necessarily. On the differential-forms side too, there are rules such as $d(f\omega) = df\wedge\omega + f d\omega$ in comparable quantity.
+>
+> The real problem of vector analysis is not the number of formulas. <strong>Everything looks like the same "bundle of three-component arrows."</strong> $\nabla f$, $\nabla \times \mathbf{F}$, and $\nabla^2\mathbf{F}$ all look on the screen like nothing but bundles of arrows. Yet $\nabla f$ is the gradient (the slope of a potential), $\nabla \times \mathbf{F}$ is the axis of a vortex—the geometric meaning of the arrows is entirely different. If you rely on drawing pictures and intuition, the distinction vanishes the moment a problem gets complicated. Differential forms prevent this confusion in principle by making the degree of the measuring instrument explicit: $0$-form, $1$-form, $2$-form, $3$-form. $d$ always raises the degree by $1$, and $\ast$ always reverses the degree—because type information rides on a few rules, you can tell what an expression is doing from its form alone, without looking at arrows. This is why we return to the language of forms from Chapter 8 onward.
+
+
+> <strong>Note</strong> (just between us) Writing down the correspondences $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$ is, in fact, partly a compromise for dismantling vector analysis.
+>
+> In some introductory explanations of differential forms, what can be written neatly is often emphasized. But if you try seriously to translate vector analysis, $\ast$ keeps appearing and the appearance does not necessarily become simpler. For example, if we rewrite the vector triple product $\mathbf{A}\times(\mathbf{B}\times\mathbf{C})$ from §7.7.4 in this framework, nested $\ast$ appear as in $\ast(\alpha \wedge \ast(\beta \wedge \gamma))$, and it exposes a form more awkward than vector analysis itself.
+>
+> Even so, some introductory books emphasize beauty because the world before summoning the "strong constraint" called a metric—that is, the landscape woven only from $d$ and $\wedge$, without $\ast$—is so pure and beautiful. The fact that the skeleton of physical laws such as Maxwell's equations is fixed even before defining a metric (an inner product) is indeed striking.
+>
+> To head toward that "pure world of differential forms," we deliberately carry out once this awkward, $\ast$-covered translation work. That is the aim of this stage of the book. If you find these "vector analysis via differential forms" calculations dirty and unnatural, that reaction is correct. At that moment, you have already graduated from being a beginner in vector analysis.
+
+---
+
+
+---
+
+### §7.8 Integral Theorems — Stokes, Gauss, and Green
+
+The most important job of vector analysis is to connect differential operators (grad, div, curl) with integration. Below we state the three integral theorems in the language of $\nabla$.
+
+#### 7.8.1 Stokes' Theorem
+
+For a surface $S$ and its boundary, the closed curve $C = \partial S$,
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+
+The left-hand side is the line integral (circulation) of $\mathbf{F}$ along the curve $C$; the right-hand side is the surface integral of the normal component of the curl on the surface $S$. It means that "circulation on the boundary equals the total vorticity inside." Here $\mathbf{n}$ is the unit normal vector to the surface, chosen in the right-hand-screw relation to the orientation of $C$.
+
+> <strong>Note</strong> (Green's theorem) When $S$ is a region $D$ in the $xy$ plane and the components of $\mathbf{F}$ are $F_x=P,\;F_y=Q,\;F_z=0$, Stokes' theorem takes the following form. This is called Green's theorem.
+>
+> $$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$
+
+#### 7.8.2 Gauss' Divergence Theorem
+
+For a solid $V$ and its boundary, the closed surface $S = \partial V$,
+
+$$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+
+The left-hand side is the outward flux of $\mathbf{F}$ through the closed surface $S$; the right-hand side is the volume integral of the divergence inside the solid $V$. It means that "the total flow through the boundary equals the total sources inside."
+
+#### 7.8.3 Common Structure of the Integral Theorems
+
+Placed side by side, Stokes' theorem and Gauss' divergence theorem reveal a common pattern.
+
+| Theorem | Integral on the boundary | Integral in the interior | Differential operator |
+|---|---|---|---|
+| Stokes | $\displaystyle\oint_C \mathbf{F}\cdot d\mathbf{r}$ | $\displaystyle\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ | curl |
+| Gauss | $\displaystyle\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS$ | $\displaystyle\iiint_V (\nabla\cdot\mathbf{F})\,dV$ | div |
+
+Each has the form "quantity measured on the boundary = sum of differential quantities in the interior." In this framework, §7.6's $\mathrm{div}(\mathrm{curl})=0$ can be read as "a curl field has no divergence, so nothing emerges from a closed surface that encloses it."
+
+Yet one dissatisfaction remains. Because Stokes and Gauss use different operators—grad, curl, and div—they must be <strong>memorized as separate theorems</strong>. Recall that in Chapter 5, a single formula $\int_{\partial M}\omega = \int_M d\omega$ unified all of these. In Chapter 8 we will organize the correspondence that rewrites the integral theorems of the $\nabla$ world into this single form.
+
+> <strong>Checkpoint so far — §7.8</strong>
+> - Stokes' theorem: $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$
+> - Gauss' divergence theorem: $\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
+> - Green's theorem is the planar version of Stokes' theorem.
+> - These integral theorems share the common structure "integral on the boundary = integral of a differential in the interior," but in the language of $\nabla$ they must be treated as separate theorems.
+
+---
+
+
+### §7.9 Toward Chapter 8 — Do Not Look at the Arrows; Look at the Measuring Devices
+
+In Chapter 6 we saw that by combining the exterior derivative $d$ and the Hodge star $\ast$, three types appear: $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$.
+
+In this chapter we rewrote the same objects in the language of standard vector analysis. $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ are convenient, but on the screen they all look like arrows and scalars. Yet the geometric meaning each one carries is entirely different. And the more complex the problem becomes, the harder it is to distinguish them by looking at arrows alone.
+
+In the next chapter we will align the $d$ and $\ast$ types obtained in Chapter 6 with the $\nabla$ notation introduced in this chapter. By reading $\nabla f$ as $df$, $\nabla\times\mathbf F$ as $\ast d\omega$, and $\nabla\cdot\mathbf F$ as $\ast d\ast\omega$, the formulas of standard vector analysis are organized as equations that carry the degree of measuring devices. Think in the algebra of measuring devices, not in pictures of arrows—that viewpoint will be connected to standard vector-analytic notation in the next chapter.
+
+> <strong>Checkpoint so far — Chapter 7</strong>
+> - We defined $\nabla$ as a formal vector with partial-derivative operators stacked vertically, and introduced gradient, divergence, curl, and the Laplacian.
+> - $\mathrm{grad}\,f = \nabla f$, $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$, $\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}$.
+> - $\nabla^2 = \mathrm{div}\,\mathrm{grad}$, $\mathrm{curl}(\mathrm{grad}) = 0$, $\mathrm{div}(\mathrm{curl}) = 0$.
+> - We confirmed the cross product as an exterior-product matrix representation and the BAC-CAB rule.
+> - The difficulty of vector analysis lies not only in the number of formulas but in the fact that everything looks like the same arrow. Differential forms distinguish objects by the degree of measuring devices ($n$-forms). Chapter 8 will connect these two languages.

--- a/manuscript/en/ch07/ch07.md
+++ b/manuscript/en/ch07/ch07.md
@@ -44,11 +44,11 @@ we define the <strong>dot product</strong> (inner product) by
 
 $$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
 
-As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. This is merely the same matrix product as the “evaluation in which a row vector eats a column vector” from Chapter 1 onward; conceptually, it is the inner product.
+As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. In Cartesian coordinates the same numerical computation can be written as the row-column product $\mathbf a^T\mathbf b$; conceptually, however, it is the inner product introduced in Chapter 6.
 
 #### 7.1.2 Cross Product
 
-For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> (outer product) by
+For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> by
 
 $$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
 a_y b_z - a_z b_y \\
@@ -131,8 +131,6 @@ This vector field points radially outward from the origin and grows larger as on
 
 ---
 
----
-
 ### §7.3 Divergence
 
 For a vector field
@@ -147,7 +145,7 @@ F_z
 \end{pmatrix}
 $$
 
-we call the dot product with $\nabla$ the <strong>divergence</strong>.
+we call the operation $\nabla\cdot\mathbf{F}$ the <strong>divergence</strong>.
 
 $$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
 
@@ -208,7 +206,7 @@ This field rotates, but there is no outflow or inflow.
 
 ### §7.4 Curl
 
-For a vector field $\mathbf{F}$, we call the cross product with $\nabla$ the <strong>curl</strong>.
+For a vector field $\mathbf{F}$, the operation $\nabla\times\mathbf{F}$ is called the <strong>curl</strong>.
 
 $$\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
@@ -284,9 +282,6 @@ A radial field has no vortex—consistent with intuition.
 
 ---
 
-
----
-
 ### §7.5 The Laplacian
 
 Applying the gradient (scalar → vector) and then the divergence (vector → scalar) in succession yields an operation from a scalar field to a scalar field. This is called the <strong>Laplacian</strong>.
@@ -334,7 +329,7 @@ $$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\
 
 When expanded, terms pair up and cancel by exchanging the order of partial derivatives, as in $\frac{\partial^2 F_z}{\partial x\partial y}$ and $-\frac{\partial^2 F_z}{\partial y\partial x}$, so the sum is $0$.
 
-Physical meaning: "A curl field has no outflow or inflow." The magnetic field falls into this category (the mathematical expression that magnetic monopoles do not exist).
+Physical meaning: "A curl field has no outflow or inflow." This is the identity reflected in Maxwell's equation $\nabla\cdot\mathbf B=0$, the mathematical expression of the absence of magnetic monopoles.
 
 > <strong>Checkpoint — §7.5–§7.6</strong>
 > - $\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$ is the Laplacian of a scalar field. It describes heat conduction and waves.
@@ -347,7 +342,7 @@ Physical meaning: "A curl field has no outflow or inflow." The magnetic field fa
 
 ### §7.7 A Formula Collection for Nabla
 
-For practical calculation, we collect product rules involving $\nabla$ and representative vector identities. Below, $f, g$ denote scalar fields and $\mathbf{F}, \mathbf{G}$ denote vector fields.
+For practical calculation, we collect product rules involving $\nabla$ and representative vector identities for smooth scalar and vector fields. Below, $f, g$ denote scalar fields and $\mathbf{F}, \mathbf{G}$ denote vector fields.
 
 #### 7.7.1 Product rules
 
@@ -407,7 +402,7 @@ $$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot
 
 This appears when the cross product is used twice. Each term on the right is a vector scaled by a scalar, and the mnemonic is BAC-CAB.
 
-> <strong>Note</strong> (why we listed the formulas) The formulas listed here are typical of those students are forced to memorize on university vector-analysis exams. One might ask: if we rewrite everything with $d$ and $\ast$, does the number of formulas shrink dramatically? Not necessarily. On the differential-forms side too, there are rules such as $d(f\omega) = df\wedge\omega + f d\omega$ in comparable quantity.
+> <strong>Note</strong> (why we listed the formulas) The formulas listed here are typical of the ones students are forced to memorize on university vector-analysis exams. One might ask: if we rewrite everything with $d$ and $\ast$, does the number of formulas shrink dramatically? Not necessarily. On the differential-forms side too, there are rules such as $d(f\omega) = df\wedge\omega + f d\omega$ in comparable quantity.
 >
 > The real problem of vector analysis is not the number of formulas. <strong>Everything looks like the same "bundle of three-component arrows."</strong> $\nabla f$, $\nabla \times \mathbf{F}$, and $\nabla^2\mathbf{F}$ all look on the screen like nothing but bundles of arrows. Yet $\nabla f$ is the gradient (the slope of a potential), $\nabla \times \mathbf{F}$ is the axis of a vortex—the geometric meaning of the arrows is entirely different. If you rely on drawing pictures and intuition, the distinction vanishes the moment a problem gets complicated. Differential forms prevent this confusion in principle by making the degree of the measuring instrument explicit: $0$-form, $1$-form, $2$-form, $3$-form. $d$ always raises the degree by $1$, and $\ast$ always reverses the degree—because type information rides on a few rules, you can tell what an expression is doing from its form alone, without looking at arrows. This is why we return to the language of forms from Chapter 8 onward.
 
@@ -419,9 +414,6 @@ This appears when the cross product is used twice. Each term on the right is a v
 > Even so, some introductory books emphasize beauty because the world before summoning the "strong constraint" called a metric—that is, the landscape woven only from $d$ and $\wedge$, without $\ast$—is so pure and beautiful. The fact that the skeleton of physical laws such as Maxwell's equations is fixed even before defining a metric (an inner product) is indeed striking.
 >
 > To head toward that "pure world of differential forms," we deliberately carry out once this awkward, $\ast$-covered translation work. That is the aim of this stage of the book. If you find these "vector analysis via differential forms" calculations dirty and unnatural, that reaction is correct. At that moment, you have already graduated from being a beginner in vector analysis.
-
----
-
 
 ---
 
@@ -437,11 +429,11 @@ $$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdo
 
 The left-hand side is the line integral (circulation) of $\mathbf{F}$ along the curve $C$; the right-hand side is the surface integral of the normal component of the curl on the surface $S$. It means that "circulation on the boundary equals the total vorticity inside." Here $\mathbf{n}$ is the unit normal vector to the surface, chosen in the right-hand-screw relation to the orientation of $C$.
 
-> <strong>Note</strong> (Green's theorem) When $S$ is a region $D$ in the $xy$ plane and the components of $\mathbf{F}$ are $F_x=P,\;F_y=Q,\;F_z=0$, Stokes' theorem takes the following form. This is called Green's theorem.
+> <strong>Note</strong> (Green's theorem) When $S$ is a region $D$ in the $xy$ plane and the components of $\mathbf{F}$ are $F_x=P,\;F_y=Q,\;F_z=0$, Stokes' theorem takes the following form, with the positive orientation on $\partial D$. This is called Green's theorem.
 >
 > $$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$
 
-#### 7.8.2 Gauss' Divergence Theorem
+#### 7.8.2 Gauss' Theorem
 
 For a solid $V$ and its boundary, the closed surface $S = \partial V$,
 
@@ -451,7 +443,7 @@ The left-hand side is the outward flux of $\mathbf{F}$ through the closed surfac
 
 #### 7.8.3 Common Structure of the Integral Theorems
 
-Placed side by side, Stokes' theorem and Gauss' divergence theorem reveal a common pattern.
+Placed side by side, Stokes' theorem and Gauss' theorem reveal a common pattern.
 
 | Theorem | Integral on the boundary | Integral in the interior | Differential operator |
 |---|---|---|---|
@@ -460,11 +452,11 @@ Placed side by side, Stokes' theorem and Gauss' divergence theorem reveal a comm
 
 Each has the form "quantity measured on the boundary = sum of differential quantities in the interior." In this framework, §7.6's $\mathrm{div}(\mathrm{curl})=0$ can be read as "a curl field has no divergence, so nothing emerges from a closed surface that encloses it."
 
-Yet one dissatisfaction remains. Because Stokes and Gauss use different operators—grad, curl, and div—they must be <strong>memorized as separate theorems</strong>. Recall that in Chapter 5, a single formula $\int_{\partial M}\omega = \int_M d\omega$ unified all of these. In Chapter 8 we will organize the correspondence that rewrites the integral theorems of the $\nabla$ world into this single form.
+Yet one dissatisfaction remains. Because the vector-analysis language splits the same pattern across different operators such as curl and div, these formulas are usually <strong>memorized as separate theorems</strong>. Recall that in Chapter 5, a single formula $\int_{\partial M}\omega = \int_M d\omega$ unified all of these. In Chapter 8 we will organize the correspondence that rewrites the integral theorems of the $\nabla$ world into this single form.
 
 > <strong>Checkpoint so far — §7.8</strong>
 > - Stokes' theorem: $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$
-> - Gauss' divergence theorem: $\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
+> - Gauss' theorem: $\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
 > - Green's theorem is the planar version of Stokes' theorem.
 > - These integral theorems share the common structure "integral on the boundary = integral of a differential in the interior," but in the language of $\nabla$ they must be treated as separate theorems.
 
@@ -477,11 +469,11 @@ In Chapter 6 we saw that by combining the exterior derivative $d$ and the Hodge 
 
 In this chapter we rewrote the same objects in the language of standard vector analysis. $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ are convenient, but on the screen they all look like arrows and scalars. Yet the geometric meaning each one carries is entirely different. And the more complex the problem becomes, the harder it is to distinguish them by looking at arrows alone.
 
-In the next chapter we will align the $d$ and $\ast$ types obtained in Chapter 6 with the $\nabla$ notation introduced in this chapter. By reading $\nabla f$ as $df$, $\nabla\times\mathbf F$ as $\ast d\omega$, and $\nabla\cdot\mathbf F$ as $\ast d\ast\omega$, the formulas of standard vector analysis are organized as equations that carry the degree of measuring devices. Think in the algebra of measuring devices, not in pictures of arrows—that viewpoint will be connected to standard vector-analytic notation in the next chapter.
+In the next chapter we will align the $d$ and $\ast$ types obtained in Chapter 6 with the $\nabla$ notation introduced in this chapter. By reading $\nabla f$ as $df$, and for the $1$-form $\omega$ corresponding to $\mathbf F$, reading $\nabla\times\mathbf F$ as $\ast d\omega$ and $\nabla\cdot\mathbf F$ as $\ast d\ast\omega$, the formulas of standard vector analysis are organized as equations that carry the degree of measuring devices. Think in the algebra of measuring devices, not in pictures of arrows—that viewpoint will be connected to standard vector-analytic notation in the next chapter.
 
 > <strong>Checkpoint so far — Chapter 7</strong>
 > - We defined $\nabla$ as a formal vector with partial-derivative operators stacked vertically, and introduced gradient, divergence, curl, and the Laplacian.
 > - $\mathrm{grad}\,f = \nabla f$, $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$, $\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}$.
 > - $\nabla^2 = \mathrm{div}\,\mathrm{grad}$, $\mathrm{curl}(\mathrm{grad}) = 0$, $\mathrm{div}(\mathrm{curl}) = 0$.
-> - We confirmed the cross product as an exterior-product matrix representation and the BAC-CAB rule.
+> - We confirmed the cross-product matrix as the antisymmetric-matrix representation connected to exterior products, and reviewed the BAC-CAB rule.
 > - The difficulty of vector analysis lies not only in the number of formulas but in the fact that everything looks like the same arrow. Differential forms distinguish objects by the degree of measuring devices ($n$-forms). Chapter 8 will connect these two languages.

--- a/translation/drafts/ch07-7.0-7.2.md
+++ b/translation/drafts/ch07-7.0-7.2.md
@@ -1,0 +1,132 @@
+# Chapter 7: Vector Analysis — Enter Nabla
+
+### §7.0 Enter Nabla
+
+The title of this book is *Unmasking Nabla*—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+
+What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
+
+I have been worrying about false advertising in the title for quite a while myself.
+
+In this chapter we finally define $\nabla$. Then we unfold standard vector analysis—gradient, divergence, curl, the Laplacian, and the various identities—straight from the textbook, all at once. In the calculations in the main text, we set $d$, $\ast$, and $\wedge$ aside for now. This is the very vector analysis that many readers learned (probably while struggling) in their first or second year of university.
+
+> <strong>Note</strong> (Why now) In Chapter 6 we previewed the shapes of grad, curl, and div using $d$ and $\ast$. In this chapter we deliberately unfold the same objects in standard vector-analysis notation, formula after formula. If, when you finish this chapter, you feel that there are too many formulas, that is fine. That discomfort will be the driving force for matching the two notations in the next chapter.
+
+The tools used in this chapter are only those we have already assembled—column vectors, row vectors, matrices, inner products, the Jacobian matrix, and partial derivatives.
+
+---
+
+### §7.1 Dot Product and Cross Product
+
+#### 7.1.1 Dot Product
+
+For two column vectors
+
+$$
+\mathbf{a}
+=
+\begin{pmatrix}
+a_x\\
+a_y\\
+a_z
+\end{pmatrix},
+\qquad
+\mathbf{b}
+=
+\begin{pmatrix}
+b_x\\
+b_y\\
+b_z
+\end{pmatrix}
+$$
+
+we define the <strong>dot product</strong> (inner product) by
+
+$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
+
+As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. This is merely the same matrix product as the “evaluation in which a row vector eats a column vector” from Chapter 1 onward; conceptually, it is the inner product.
+
+#### 7.1.2 Cross Product
+
+For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> (outer product) by
+
+$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+The result is again a column vector. The arrangement of cross-product components follows a regular pattern, and it can be written compactly using the following antisymmetric matrix:
+
+$$\mathbf{a} \times = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}$$
+
+Multiplying this $3\times 3$ matrix on the left by the vector $\mathbf{b}$ gives
+
+$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}\begin{pmatrix}
+b_x \\ b_y \\ b_z
+\end{pmatrix} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+We call this $(\mathbf{a} \times)$ the <strong>cross-product matrix</strong> of $\mathbf{a}$. It appeared in Chapter 2 as the matrix representation of a $2$-form, and in Appendix D of Chapter 6 it reappeared as the array form of the Hodge star—exactly the same shape. In this chapter we use it purely as the operation “multiply a vector by a vector and obtain a vector.”
+
+The cross product has the following basic properties:
+
+1. <strong>Anticommutativity</strong>: $\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$
+2. <strong>Cross product with itself is zero</strong>: $\mathbf{a} \times \mathbf{a} = \mathbf{0}$
+3. <strong>Orthogonality</strong>: $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$, $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$
+
+Property 3 means that the cross product produces a vector orthogonal to both $\mathbf{a}$ and $\mathbf{b}$. That is the real content of the so-called “right-hand rule.”
+
+> <strong>Checkpoint — §7.1</strong>
+> - Dot product: $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$. In real space, transposing the column vector $\mathbf{a}$ gives $\mathbf{a}^T \mathbf{b}$.
+> - Cross product: $\mathbf{a}\times\mathbf{b}$ can be written as $(\mathbf{a}\times)\,\mathbf{b}$ using the cross-product matrix $(\mathbf{a}\times)$.
+> - The cross product is anticommutative, vanishes with itself, and its result is orthogonal to both input vectors.
+
+---
+
+### §7.2 $\nabla$ and the Gradient
+
+#### 7.2.1 Definition of $\nabla$
+
+English textbooks usually call the symbol $\nabla$ <strong>del</strong>; it is also called <strong>nabla</strong>, the name common in Japanese texts. This book is about what div, grad, and curl do—not primarily about what to call the symbol. We define nabla $\nabla$ as a formal column vector whose components are partial-derivative operators:
+
+$$\nabla = \begin{pmatrix}
+\frac{\partial}{\partial x} \\[0.5em]
+\frac{\partial}{\partial y} \\[0.5em]
+\frac{\partial}{\partial z}
+\end{pmatrix}$$
+
+$\nabla$ is a “vector,” but its components are not numbers—they are <strong>differential operators</strong>. $\nabla$ does not ordinarily have a value as a vector quantity on its own; it returns a concrete field only when it acts on something.
+
+#### 7.2.2 Gradient
+
+What we obtain by letting $\nabla$ act on a scalar field $f(x,y,z)$ is called the <strong>gradient</strong>, written $\mathrm{grad}\,f$ or $\nabla f$:
+
+$$\mathrm{grad}\,f = \nabla f = \begin{pmatrix}
+\frac{\partial f}{\partial x} \\[0.5em]
+\frac{\partial f}{\partial y} \\[0.5em]
+\frac{\partial f}{\partial z}
+\end{pmatrix}$$
+
+Each component of the gradient is the rate of change of $f$ in the corresponding coordinate direction. Geometrically, $\nabla f$ is the vector field pointing in the direction of steepest increase of $f$.
+
+> <strong>Note</strong> (Is the gradient a row vector or a column vector?) In §6.5 we wrote $\mathrm{grad}\,f = df$, and $df$ was a row vector of coefficients. In this chapter we treat $\nabla f$ as a column vector. Using the Euclidean metric introduced in Chapter 6, we read the $1$-form $df$ as the corresponding column vector and obtain $\nabla f$. In §6.5 we stood on the view that “the differential itself (the form) measures properties of space”; in this chapter we adopt the standard vector-analysis view that “at each point an arrow (a vector) stands.” The starting pictures differ, but if we aggregate by line integral we get the same scalar quantity. That agreement is no accident.
+
+<strong>Example</strong>: the gradient of $f(x,y,z) = x^2 + y^2 + z^2$.
+
+$$\nabla f = \begin{pmatrix} 2x \\ 2y \\ 2z \end{pmatrix}$$
+
+This vector field points radially outward from the origin and grows larger as one moves away from the origin.
+
+---

--- a/translation/drafts/ch07-7.3-7.4.md
+++ b/translation/drafts/ch07-7.3-7.4.md
@@ -1,0 +1,150 @@
+### §7.3 Divergence
+
+For a vector field
+
+$$
+\mathbf{F}(x,y,z)
+=
+\begin{pmatrix}
+F_x\\
+F_y\\
+F_z
+\end{pmatrix}
+$$
+
+we call the dot product with $\nabla$ the <strong>divergence</strong>.
+
+$$\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+Formally this is “the dot product of $\nabla$ and $\mathbf{F}$,” but since each component of $\nabla$ is a differential operator, the result is a scalar field.
+
+> <strong>Note</strong> (connection to Chapter 6) In Chapter 6 we defined divergence on a $1$-form as $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$. The $\mathrm{div}\,\mathbf{F}$ above is the same operation, written here in nabla notation for the vector field corresponding to that $1$-form.
+
+Divergence can also be written in the language of matrices. Consider the Jacobian matrix $\mathbf{J}_\mathbf{F}$ of $\mathbf{F}$.
+
+$$\mathbf{J}_\mathbf{F} = \begin{pmatrix}
+\frac{\partial F_x}{\partial x} & \frac{\partial F_x}{\partial y} & \frac{\partial F_x}{\partial z} \\[0.3em]
+\frac{\partial F_y}{\partial x} & \frac{\partial F_y}{\partial y} & \frac{\partial F_y}{\partial z} \\[0.3em]
+\frac{\partial F_z}{\partial x} & \frac{\partial F_z}{\partial y} & \frac{\partial F_z}{\partial z}
+\end{pmatrix}$$
+
+The <strong>trace</strong> (sum of the diagonal entries) of this matrix agrees with the divergence.
+
+$$\mathrm{div}\,\mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F}) = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+Physically, $\mathrm{div}\,\mathbf{F}$ measures the strength of outflow at that point. If it is positive, there is outflow; if negative, inflow; if zero, there is neither outflow nor inflow at that point.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+x\\
+y\\
+z
+\end{pmatrix}
+$$
+
+The divergence of this field is
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial x}{\partial x} + \frac{\partial y}{\partial y} + \frac{\partial z}{\partial z} = 1 + 1 + 1 = 3$$
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+-y\\
+x\\
+0
+\end{pmatrix}
+$$
+
+The divergence of this field is
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial (-y)}{\partial x} + \frac{\partial x}{\partial y} + \frac{\partial 0}{\partial z} = 0 + 0 + 0 = 0$$
+
+This field rotates, but there is no outflow or inflow.
+
+---
+
+
+### §7.4 Curl
+
+For a vector field $\mathbf{F}$, we call the cross product with $\nabla$ the <strong>curl</strong>.
+
+$$\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.5em]
+\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.5em]
+\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}
+\end{pmatrix}$$
+
+Using the cross-product matrix, we can also write
+
+$$\mathrm{curl}\,\mathbf{F} = (\nabla \times)\,\mathbf{F} = \begin{pmatrix}
+0 & -\frac{\partial}{\partial z} & \frac{\partial}{\partial y} \\[0.3em]
+\frac{\partial}{\partial z} & 0 & -\frac{\partial}{\partial x} \\[0.3em]
+-\frac{\partial}{\partial y} & \frac{\partial}{\partial x} & 0
+\end{pmatrix}\begin{pmatrix}
+F_x \\ F_y \\ F_z
+\end{pmatrix}$$
+
+> <strong>Note</strong> (connection to Chapter 6) Chapter 6 defined curl on a $1$-form as $\mathrm{curl}\,\omega = \ast\,d\,\omega$. The $\mathrm{curl}\,\mathbf{F}$ above is the same operation, written here in nabla notation for the corresponding vector field.
+
+Physically, $\mathrm{curl}\,\mathbf{F}$ represents the strength and direction of the vortex at that point. It points along the axis of the vortex, and its magnitude corresponds to the strength of the vortex.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+-y\\
+x\\
+0
+\end{pmatrix}
+$$
+
+The curl of this field is
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial 0}{\partial y} - \frac{\partial x}{\partial z} \\[0.3em]
+\frac{\partial (-y)}{\partial z} - \frac{\partial 0}{\partial x} \\[0.3em]
+\frac{\partial x}{\partial x} - \frac{\partial (-y)}{\partial y}
+\end{pmatrix} = \begin{pmatrix}
+0 - 0 \\ 0 - 0 \\ 1 - (-1)
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 2 \end{pmatrix}$$
+
+This field rotates uniformly about the $z$-axis, and the strength of the vortex is $2$.
+
+<strong>Example</strong>:
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+x\\
+y\\
+z
+\end{pmatrix}
+$$
+
+The curl of this field is
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{\partial z}{\partial y} - \frac{\partial y}{\partial z} \\[0.3em]
+\frac{\partial x}{\partial z} - \frac{\partial z}{\partial x} \\[0.3em]
+\frac{\partial y}{\partial x} - \frac{\partial x}{\partial y}
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+
+A radial field has no vortex—consistent with intuition.
+
+> <strong>Checkpoint — §7.2–§7.4</strong>
+> - $\nabla$ is the formal vector obtained by stacking $\partial_x,\partial_y,\partial_z$ vertically.
+> - $\mathrm{grad}\,f = \nabla f$ (gradient): scalar field → vector field.
+> - $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}$ (divergence): vector field → scalar field. Equal to the trace of the Jacobian matrix.
+> - $\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}$ (curl): vector field → vector field. Can be written using the cross-product matrix.
+
+---

--- a/translation/drafts/ch07-7.5-7.7.md
+++ b/translation/drafts/ch07-7.5-7.7.md
@@ -1,0 +1,134 @@
+### §7.5 The Laplacian
+
+Applying the gradient (scalar → vector) and then the divergence (vector → scalar) in succession yields an operation from a scalar field to a scalar field. This is called the <strong>Laplacian</strong>.
+
+$$\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f) = \nabla \cdot (\nabla f) = \frac{\partial^2 f}{\partial x^2} + \frac{\partial^2 f}{\partial y^2} + \frac{\partial^2 f}{\partial z^2}$$
+
+The notation $\nabla^2$ is shorthand for $\nabla \cdot \nabla$, and some authors write $\Delta f$ instead.
+
+<strong>Example</strong>: The Laplacian of $f(x,y,z) = x^2 + y^2 + z^2$.
+
+$$\nabla^2 f = \frac{\partial^2}{\partial x^2}(x^2) + \frac{\partial^2}{\partial y^2}(y^2) + \frac{\partial^2}{\partial z^2}(z^2) = 2 + 2 + 2 = 6$$
+
+For a vector field $\mathbf{F}$ as well, applying the Laplacian to each component is called the <strong>vector Laplacian</strong>.
+
+$$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2 F_z \end{pmatrix}$$
+
+The Laplacian appears everywhere in physics. The heat equation, the wave equation, Poisson's equation—all are equations built around $\nabla^2$.
+
+---
+
+
+### §7.6 Identities
+
+Among the three operations defined so far, two important identities hold. Both take the form "applying twice gives zero."
+
+#### 7.6.1 $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$
+
+If we take a vector field from a gradient and then take its curl, we always get the zero vector.
+
+$$\nabla \times (\nabla f) = \begin{pmatrix}
+\frac{\partial}{\partial y}\frac{\partial f}{\partial z} - \frac{\partial}{\partial z}\frac{\partial f}{\partial y} \\[0.5em]
+\frac{\partial}{\partial z}\frac{\partial f}{\partial x} - \frac{\partial}{\partial x}\frac{\partial f}{\partial z} \\[0.5em]
+\frac{\partial}{\partial x}\frac{\partial f}{\partial y} - \frac{\partial}{\partial y}\frac{\partial f}{\partial x}
+\end{pmatrix} = \begin{pmatrix} 0 \\ 0 \\ 0 \end{pmatrix}$$
+
+In each component, terms cancel by exchanging the order of partial derivatives $\frac{\partial^2 f}{\partial y\partial z} = \frac{\partial^2 f}{\partial z\partial y}$. This always holds if $f$ is smooth (twice continuously differentiable).
+
+Physical meaning: "A gradient field has no vortex." Conservative gravitational and electrostatic fields fall into this category.
+
+#### 7.6.2 $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$
+
+If we take a vector field from a curl and then take its divergence, we always get zero.
+
+$$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$
+
+When expanded, terms pair up and cancel by exchanging the order of partial derivatives, as in $\frac{\partial^2 F_z}{\partial x\partial y}$ and $-\frac{\partial^2 F_z}{\partial y\partial x}$, so the sum is $0$.
+
+Physical meaning: "A curl field has no outflow or inflow." The magnetic field falls into this category (the mathematical expression that magnetic monopoles do not exist).
+
+> <strong>Checkpoint — §7.5–§7.6</strong>
+> - $\nabla^2 f = \mathrm{div}(\mathrm{grad}\,f)$ is the Laplacian of a scalar field. It describes heat conduction and waves.
+> - $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$: A gradient field has no vortex.
+> - $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$: A curl field has no outflow or inflow.
+> - All follow from exchanging the order of partial derivatives $\partial_i\partial_j = \partial_j\partial_i$.
+
+---
+
+
+### §7.7 A Formula Collection for Nabla
+
+For practical calculation, we collect product rules involving $\nabla$ and representative vector identities. Below, $f, g$ denote scalar fields and $\mathbf{F}, \mathbf{G}$ denote vector fields.
+
+#### 7.7.1 Product rules
+
+<strong>Gradient of a product</strong>:
+
+$$\nabla(fg) = f\,\nabla g + g\,\nabla f$$
+
+<strong>Divergence of a product</strong>:
+
+$$\nabla \cdot (f\mathbf{F}) = (\nabla f) \cdot \mathbf{F} + f\,(\nabla \cdot \mathbf{F})$$
+
+<strong>Curl of a product</strong>:
+
+$$\nabla \times (f\mathbf{F}) = (\nabla f) \times \mathbf{F} + f\,(\nabla \times \mathbf{F})$$
+
+<strong>Divergence of a cross product</strong>:
+
+$$\nabla \cdot (\mathbf{F} \times \mathbf{G}) = (\nabla \times \mathbf{F}) \cdot \mathbf{G} - \mathbf{F} \cdot (\nabla \times \mathbf{G})$$
+
+#### 7.7.2 Identities for double application
+
+The curl of the gradient of a scalar field and the divergence of the curl of a vector field were derived in §7.6. We restate them here as part of the formula collection.
+
+<strong>Curl of a gradient is zero</strong>:
+
+$$\nabla \times (\nabla f) = \mathbf{0}$$
+
+<strong>Divergence of a curl is zero</strong>:
+
+$$\nabla \cdot (\nabla \times \mathbf{F}) = 0$$
+
+<strong>Curl of a curl</strong>:
+
+$$\nabla \times (\nabla \times \mathbf{F}) = \nabla(\nabla \cdot \mathbf{F}) - \nabla^2 \mathbf{F}$$
+
+This is the formula that decomposes the Laplacian into divergence and curl. The derivation uses the BAC-CAB rule (§7.7.4).
+
+<strong>Divergence of the gradient of a scalar field</strong> (= Laplacian):
+
+$$\nabla \cdot (\nabla f) = \nabla^2 f$$
+
+This is exactly the definition from §7.5.
+
+#### 7.7.3 Scalar triple product
+
+The scalar triple product of three column vectors $\mathbf{A}, \mathbf{B}, \mathbf{C}$ is defined as the dot product of $\mathbf{A}$ with $\mathbf{B}\times\mathbf{C}$.
+
+$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$
+
+This value equals the signed volume of the parallelepiped spanned by $\mathbf{A}, \mathbf{B}, \mathbf{C}$. It is invariant under cyclic permutation, and swapping two vectors reverses the sign.
+
+$$\mathbf{A} \cdot (\mathbf{B} \times \mathbf{C}) = \mathbf{B} \cdot (\mathbf{C} \times \mathbf{A}) = \mathbf{C} \cdot (\mathbf{A} \times \mathbf{B})$$
+
+#### 7.7.4 Vector triple product (BAC-CAB rule)
+
+$$\mathbf{A} \times (\mathbf{B} \times \mathbf{C}) = \mathbf{B}(\mathbf{A} \cdot \mathbf{C}) - \mathbf{C}(\mathbf{A} \cdot \mathbf{B})$$
+
+This appears when the cross product is used twice. Each term on the right is a vector scaled by a scalar, and the mnemonic is BAC-CAB.
+
+> <strong>Note</strong> (why we listed the formulas) The formulas listed here are typical of those students are forced to memorize on university vector-analysis exams. One might ask: if we rewrite everything with $d$ and $\ast$, does the number of formulas shrink dramatically? Not necessarily. On the differential-forms side too, there are rules such as $d(f\omega) = df\wedge\omega + f d\omega$ in comparable quantity.
+>
+> The real problem of vector analysis is not the number of formulas. <strong>Everything looks like the same "bundle of three-component arrows."</strong> $\nabla f$, $\nabla \times \mathbf{F}$, and $\nabla^2\mathbf{F}$ all look on the screen like nothing but bundles of arrows. Yet $\nabla f$ is the gradient (the slope of a potential), $\nabla \times \mathbf{F}$ is the axis of a vortex—the geometric meaning of the arrows is entirely different. If you rely on drawing pictures and intuition, the distinction vanishes the moment a problem gets complicated. Differential forms prevent this confusion in principle by making the degree of the measuring instrument explicit: $0$-form, $1$-form, $2$-form, $3$-form. $d$ always raises the degree by $1$, and $\ast$ always reverses the degree—because type information rides on a few rules, you can tell what an expression is doing from its form alone, without looking at arrows. This is why we return to the language of forms from Chapter 8 onward.
+
+
+> <strong>Note</strong> (just between us) Writing down the correspondences $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$ is, in fact, partly a compromise for dismantling vector analysis.
+>
+> In some introductory explanations of differential forms, what can be written neatly is often emphasized. But if you try seriously to translate vector analysis, $\ast$ keeps appearing and the appearance does not necessarily become simpler. For example, if we rewrite the vector triple product $\mathbf{A}\times(\mathbf{B}\times\mathbf{C})$ from §7.7.4 in this framework, nested $\ast$ appear as in $\ast(\alpha \wedge \ast(\beta \wedge \gamma))$, and it exposes a form more awkward than vector analysis itself.
+>
+> Even so, some introductory books emphasize beauty because the world before summoning the "strong constraint" called a metric—that is, the landscape woven only from $d$ and $\wedge$, without $\ast$—is so pure and beautiful. The fact that the skeleton of physical laws such as Maxwell's equations is fixed even before defining a metric (an inner product) is indeed striking.
+>
+> To head toward that "pure world of differential forms," we deliberately carry out once this awkward, $\ast$-covered translation work. That is the aim of this stage of the book. If you find these "vector analysis via differential forms" calculations dirty and unnatural, that reaction is correct. At that moment, you have already graduated from being a beginner in vector analysis.
+
+---

--- a/translation/drafts/ch07-7.8-7.9.md
+++ b/translation/drafts/ch07-7.8-7.9.md
@@ -1,0 +1,60 @@
+### §7.8 Integral Theorems — Stokes, Gauss, and Green
+
+The most important job of vector analysis is to connect differential operators (grad, div, curl) with integration. Below we state the three integral theorems in the language of $\nabla$.
+
+#### 7.8.1 Stokes' Theorem
+
+For a surface $S$ and its boundary, the closed curve $C = \partial S$,
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+
+The left-hand side is the line integral (circulation) of $\mathbf{F}$ along the curve $C$; the right-hand side is the surface integral of the normal component of the curl on the surface $S$. It means that "circulation on the boundary equals the total vorticity inside." Here $\mathbf{n}$ is the unit normal vector to the surface, chosen in the right-hand-screw relation to the orientation of $C$.
+
+> <strong>Note</strong> (Green's theorem) When $S$ is a region $D$ in the $xy$ plane and the components of $\mathbf{F}$ are $F_x=P,\;F_y=Q,\;F_z=0$, Stokes' theorem takes the following form. This is called Green's theorem.
+>
+> $$\oint_{\partial D} (P\,dx + Q\,dy) = \iint_D \left(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}\right) dx\,dy$$
+
+#### 7.8.2 Gauss' Divergence Theorem
+
+For a solid $V$ and its boundary, the closed surface $S = \partial V$,
+
+$$\oiint_S \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+
+The left-hand side is the outward flux of $\mathbf{F}$ through the closed surface $S$; the right-hand side is the volume integral of the divergence inside the solid $V$. It means that "the total flow through the boundary equals the total sources inside."
+
+#### 7.8.3 Common Structure of the Integral Theorems
+
+Placed side by side, Stokes' theorem and Gauss' divergence theorem reveal a common pattern.
+
+| Theorem | Integral on the boundary | Integral in the interior | Differential operator |
+|---|---|---|---|
+| Stokes | $\displaystyle\oint_C \mathbf{F}\cdot d\mathbf{r}$ | $\displaystyle\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ | curl |
+| Gauss | $\displaystyle\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS$ | $\displaystyle\iiint_V (\nabla\cdot\mathbf{F})\,dV$ | div |
+
+Each has the form "quantity measured on the boundary = sum of differential quantities in the interior." In this framework, §7.6's $\mathrm{div}(\mathrm{curl})=0$ can be read as "a curl field has no divergence, so nothing emerges from a closed surface that encloses it."
+
+Yet one dissatisfaction remains. Because Stokes and Gauss use different operators—grad, curl, and div—they must be <strong>memorized as separate theorems</strong>. Recall that in Chapter 5, a single formula $\int_{\partial M}\omega = \int_M d\omega$ unified all of these. In Chapter 8 we will organize the correspondence that rewrites the integral theorems of the $\nabla$ world into this single form.
+
+> <strong>Checkpoint so far — §7.8</strong>
+> - Stokes' theorem: $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$
+> - Gauss' divergence theorem: $\oiint_S \mathbf{F}\cdot\mathbf{n}\,dS = \iiint_V (\nabla\cdot\mathbf{F})\,dV$
+> - Green's theorem is the planar version of Stokes' theorem.
+> - These integral theorems share the common structure "integral on the boundary = integral of a differential in the interior," but in the language of $\nabla$ they must be treated as separate theorems.
+
+---
+
+
+### §7.9 Toward Chapter 8 — Do Not Look at the Arrows; Look at the Measuring Devices
+
+In Chapter 6 we saw that by combining the exterior derivative $d$ and the Hodge star $\ast$, three types appear: $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$.
+
+In this chapter we rewrote the same objects in the language of standard vector analysis. $\nabla f$, $\nabla\times\mathbf F$, and $\nabla\cdot\mathbf F$ are convenient, but on the screen they all look like arrows and scalars. Yet the geometric meaning each one carries is entirely different. And the more complex the problem becomes, the harder it is to distinguish them by looking at arrows alone.
+
+In the next chapter we will align the $d$ and $\ast$ types obtained in Chapter 6 with the $\nabla$ notation introduced in this chapter. By reading $\nabla f$ as $df$, $\nabla\times\mathbf F$ as $\ast d\omega$, and $\nabla\cdot\mathbf F$ as $\ast d\ast\omega$, the formulas of standard vector analysis are organized as equations that carry the degree of measuring devices. Think in the algebra of measuring devices, not in pictures of arrows—that viewpoint will be connected to standard vector-analytic notation in the next chapter.
+
+> <strong>Checkpoint so far — Chapter 7</strong>
+> - We defined $\nabla$ as a formal vector with partial-derivative operators stacked vertically, and introduced gradient, divergence, curl, and the Laplacian.
+> - $\mathrm{grad}\,f = \nabla f$, $\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F} = \operatorname{tr}(\mathbf{J}_\mathbf{F})$, $\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}$.
+> - $\nabla^2 = \mathrm{div}\,\mathrm{grad}$, $\mathrm{curl}(\mathrm{grad}) = 0$, $\mathrm{div}(\mathrm{curl}) = 0$.
+> - We confirmed the cross product as an exterior-product matrix representation and the BAC-CAB rule.
+> - The difficulty of vector analysis lies not only in the number of formulas but in the fact that everything looks like the same arrow. Differential forms distinguish objects by the degree of measuring devices ($n$-forms). Chapter 8 will connect these two languages.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -191,6 +191,25 @@ Per-section Pass status:
 | `translation/reviews/ch06-pass3.md` | complete |
 | `translation/reviews/ch06-close-reading-polish.md` | complete (#184) |
 
+### English Chapter 7 — `manuscript/en/ch07/ch07.md` (branch `ai/english-translation-ch07`, PR [#168](https://github.com/yokiikoy/nabla-kaitai/pull/168))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 7 (§7.0–§7.9)** | **1 → 2 → 3** | `ch07-pass2.md`, `ch07-pass3.md`; new file |
+
+| Block | Pass | Review |
+|-------|------|--------|
+| §7.0–§7.2 | **3** | `ch07-7.0-7.2-review.md` |
+| §7.3–§7.4 | **3** | `ch07-7.3-7.4-review.md` |
+| §7.5–§7.7 | **3** | `ch07-7.5-7.7-review.md` |
+| §7.8–§7.9 | **3** | `ch07-7.8-7.9-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch07-*.md` | integrated into `ch07.md` |
+| `translation/reviews/ch07-pass2.md` | complete |
+| `translation/reviews/ch07-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -209,6 +209,7 @@ Per-section Pass status:
 | `translation/drafts/ch07-*.md` | integrated into `ch07.md` |
 | `translation/reviews/ch07-pass2.md` | complete |
 | `translation/reviews/ch07-pass3.md` | complete |
+| `translation/reviews/ch07-close-reading-polish.md` | complete (#185) |
 
 ---
 

--- a/translation/reviews/ch07-7.0-7.2-review.md
+++ b/translation/reviews/ch07-7.0-7.2-review.md
@@ -1,0 +1,3 @@
+# Review: Chapter 7 §7.0–§7.2
+
+Pass 1 **passed**. nabla/del, dot/cross product, gradient. `ch07-7.0-7.2.md`.

--- a/translation/reviews/ch07-7.3-7.4-review.md
+++ b/translation/reviews/ch07-7.3-7.4-review.md
@@ -1,0 +1,3 @@
+# Review: Chapter 7 §7.3–§7.4
+
+Pass 1 **passed**. Divergence, curl, ch6 correspondence. `ch07-7.3-7.4.md`.

--- a/translation/reviews/ch07-7.5-7.7-review.md
+++ b/translation/reviews/ch07-7.5-7.7-review.md
@@ -1,0 +1,3 @@
+# Review: Chapter 7 §7.5–§7.7
+
+Pass 1 **passed**. Laplacian, identities, nabla formula collection. `ch07-7.5-7.7.md`.

--- a/translation/reviews/ch07-7.8-7.9-review.md
+++ b/translation/reviews/ch07-7.8-7.9-review.md
@@ -1,0 +1,3 @@
+# Review: Chapter 7 §7.8–§7.9
+
+Pass 1 **passed**. Integral theorems; Chapter 7 checkpoint; ch8 bridge. `ch07-7.8-7.9.md`.

--- a/translation/reviews/ch07-close-reading-polish.md
+++ b/translation/reviews/ch07-close-reading-polish.md
@@ -1,0 +1,60 @@
+# Close-Reading Polish: Chapter 7
+
+Review date: 2026-05-23
+Branch: `ai/english-translation-ch07`
+File: `manuscript/en/ch07/ch07.md`
+GitHub issue: #185
+PR context: #168
+
+Scope: publication polish after Pass 3 — cross-product terminology, Markdown cleanup, row-column safety, Gauss terminology alignment with Chapters 5–6, Chapter 8 bridge clarity, preservation of vector-analysis discomfort arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** §7.1.2: removed `(outer product)` gloss from cross-product definition
+- **B2** Removed duplicate horizontal rules between §7.2/§7.3, §7.4/§7.5, and §7.7/§7.8
+
+### C items (straightforward)
+
+- **C1** §7.1.1: dot product / row-column distinction — inner product from Chapter 6
+- **C2** §7.3: divergence as operation $\nabla\cdot\mathbf F$
+- **C3** §7.4: curl as operation $\nabla\times\mathbf F$
+- **C4** §7.7: smoothness premise for product rules
+- **C5** §7.6.2: Maxwell $\nabla\cdot\mathbf B=0$ / magnetic monopole sentence
+- **C6** §7.7: formula-list note grammar (`typical of the ones`)
+- **C7** §7.8: `Gauss' divergence theorem` → `Gauss' theorem` (matches Chapters 5–6)
+- **C8** §7.8: Green's theorem — positive orientation on $\partial D$
+- **C9** §7.8.3: common-structure sentence (curl/div, not grad list)
+- **C10** §7.9: Chapter 8 bridge — explicit $1$-form $\omega$ for $\mathbf F$
+- **C11** Final checkpoint: cross-product matrix wording
+
+### Intentionally unchanged (D items / optional C)
+
+- **C12** §7.0 title joke / nabla entry framing
+- **C13** §7.7 `dirty and unnatural` note
+- Chapter 6 preview → standard vector analysis transition
+- Cross-product matrix and Chapter 2 / Chapter 6 back-links
+- Chapter 6 back-links for div/curl ($\ast d\ast$, $\ast d$)
+- Trace reading of divergence, BAC-CAB, physical examples
+- Formula collection, “bundle of three-component arrows” theme
+- “Just between us” note, standard theorem statements
+- Chapter 5 unified Stokes recall, §7.9 measuring-devices transition
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- duplicate `---` blocks — none
+- `outer product` — none
+- `Gauss' divergence theorem` — none
+- `typical of those students are forced to memorize` — none
+- `Because Stokes and Gauss use different operators—grad, curl, and div` — none
+- `exterior-product matrix representation` — none
+- `rot` (as curl synonym) — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch07-pass2.md
+++ b/translation/reviews/ch07-pass2.md
@@ -1,0 +1,9 @@
+# Pass 2 Review: Chapter 7
+
+Branch: `ai/english-translation-ch07` · File: `manuscript/en/ch07/ch07.md`
+
+- New chapter (no old draft). §7.1 heading aligned with TOC (Dot Products).
+- **curl not rot** throughout; del/nabla explained §7.2.1.
+- Stokes'/Gauss' apostrophe consistent.
+
+**Chapter 7 passes Pass 2.** Pass 3 in `ch07-pass3.md`. ~487 lines.

--- a/translation/reviews/ch07-pass3.md
+++ b/translation/reviews/ch07-pass3.md
@@ -1,0 +1,14 @@
+# Pass 3 Review: Chapter 7
+
+Branch: `ai/english-translation-ch07`
+
+## Keep
+- §7.0 title joke / nabla entry framing
+- Cross product matrix and BAC-CAB (§7.7.4)
+- "All arrows look the same" difficulty theme (§7.9)
+- ch6 back-links for div/curl as $\ast d\ast$, $\ast d$
+
+## Pass 2
+- §7.1 TOC heading only
+
+**Chapter 7 passes Pass 3.**


### PR DESCRIPTION
## Summary
- New English `manuscript/en/ch07/ch07.md` from Japanese source (no prior draft).
- nabla, grad/curl/div, identities, integral theorems, Chapter 8 foreshadow.
- **curl not rot**; del explained at §7.2.1.
- Branch replayed on current `main`; diff is ch07-only.

## Scope
| Block | Content |
|-------|---------|
| §7.0–§7.2 | nabla, grad/curl/div, del note |
| §7.3–§7.4 | Vector identities |
| §7.5–§7.7 | Integral theorems in vector form |
| §7.8–§7.9 | Chapter summary; Chapter 8 foreshadow |

## Test plan
- [ ] Diff against `manuscript/ja/ch07/ch07.md`
- [ ] curl not rot; measuring-device bridge to Chapter 8
- [ ] Review records: `ch07-pass2.md`, `ch07-pass3.md`
- [ ] Merge to `main` (after prior chapters land via their PRs)