### PR TITLE
English Chapter 8: §8.0–§8.6 (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch08/ch08.md
+++ b/manuscript/en/ch08/ch08.md
@@ -1,0 +1,370 @@
+# Chapter 8: Two Languages — Differentiating Measuring Devices and Differentiating Fields
+
+### §8.0 The Highlight of This Book
+
+It has been a long road. In Chapter 1 we defined $dx$ as a row vector; in Chapter 2 we built area-measuring devices and volume-measuring devices; in Chapter 3 we rebuilt integration; in Chapter 5 we obtained the exterior derivative $d$; in Chapter 6 we acquired the metric $g$ and the Hodge star $\ast$; and in Chapter 7 we finally defined $\nabla$ head-on and unfolded vector analysis all at once.
+
+From here on, there is no holding back. $d$, $\ast$, and $\nabla$—all the tools are in hand. We no longer need to warn, “for readers who already know vector analysis,” whenever we invoke the vocabulary of vector analysis. $\nabla$ became a proper resident of this book in Chapter 7.
+
+This chapter is the <strong>highlight</strong> of the book. The central translation itself is surprisingly short. At the end, however, to move on to the practical chapter that follows, we will take a single look at how this dictionary behaves in curvilinear coordinates. The painstaking preparation from Chapters 1 through 7—matrices, wedge products, the exterior derivative, the metric, the Hodge star, and vector analysis—was all for that purpose. Because all these tools are now assembled, in this chapter we need only “translate,” and two worlds fit into one picture. We have acquired two languages—the differential of measuring devices ($d$) and the differential of fields ($\nabla$). These two do fundamentally different things. Yet when they are linked through integration, they give exactly the same results. We will now dig thoroughly into how that works.
+
+---
+
+### §8.1 Two Differentials, Two Worlds
+
+#### 8.1.1 Differentiating measuring devices—the standpoint of $d$
+
+Since Chapter 1 we have treated $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ as row-vector measuring devices. When you feed them a column vector (a displacement), they return the displacement in that direction as a scalar.
+
+The exterior derivative $d$ is the operation of <strong>differentiating this measuring device</strong>.
+
+When $f(x,y,z)$ is a scalar field, $df$ is a new measuring device that measures changes in $f$. It becomes a row vector whose components are the partial derivatives.
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+When $\omega = P\,dx + Q\,dy + R\,dz$ is a $1$-form, $d\omega$ is a $2$-form (antisymmetric matrix) that measures the local mismatch of $\omega$.
+
+$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$
+
+When $\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ is a $2$-form, $d\eta$ is a $3$-form (third-order antisymmetric tensor).
+
+$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
+
+In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>the field stays as it is; it is the measuring-device side that changes</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
+
+#### 8.1.2 The formal differential operator stays the same; new fields are what we consider—the standpoint of $\nabla$
+
+Meanwhile, in the world of
+
+$$
+\nabla
+=
+\begin{pmatrix}
+\frac{\partial}{\partial x}\\[0.3em]
+\frac{\partial}{\partial y}\\[0.3em]
+\frac{\partial}{\partial z}
+\end{pmatrix}
+$$
+
+introduced in Chapter 7, <strong>the formal differential operator stays the same; depending on what it acts on, new fields are born</strong>. $\nabla$ is always the same operator, but acting on a scalar field $f$ yields a vector field $\nabla f$; acting on a vector field $\mathbf{F}$ yields a scalar field $\nabla\cdot\mathbf{F}$ or a vector field $\nabla\times\mathbf{F}$.
+
+Applying $\nabla$ to a scalar field $f(x,y,z)$ gives a column-vector field whose components are the rates of change in each direction.
+
+$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+This is an arrow standing at each point in space; it is no longer a measuring device. It represents the direction of steepest increase of $f$ and the strength of that increase.
+
+Applying $\nabla\cdot$ to a vector field $\mathbf{F}$ with components $F_x,F_y,F_z$ gives a scalar field.
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+It returns the sum of the rates of change in each direction—the strength of outflow.
+
+Applying $\nabla\times$ to the same $\mathbf{F}$ gives a column-vector field again.
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$
+
+It represents the axis and strength of the local rotation.
+
+In the world of $\nabla$, the result is always returned as an arrow or a scalar in real space. Both $\nabla f$ and $\nabla\times\mathbf{F}$ look like the same kind of “arrow” on the page; there is no distinction by type.
+
+> <strong>Checkpoint so far — §8.1</strong>
+> - Standpoint of $d$: the field stays as it is; the measuring-device side changes. New measuring devices are born.
+> - Standpoint of $\nabla$: the formal differential operator stays the same; new fields are born.
+
+---
+
+---
+
+### §8.2 Completing the Translation Dictionary
+
+In Chapter 6 §6.5 we introduced the correspondences $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$. Here we align this dictionary with the language of $\nabla$ and organize it in complete form. What we complete here is the translation dictionary used within three-dimensional Euclidean space and the matrix representation of this book.
+
+In the dictionary below, the $1$-form corresponding to a vector field
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+F_x\\
+F_y\\
+F_z
+\end{pmatrix}
+$$
+
+is read using the metric $g$ as
+
+$$
+\omega=\mathbf{F}^T g
+$$
+
+In Cartesian coordinates $g=I$, so
+
+$$
+\omega
+=
+\begin{pmatrix}
+F_x & F_y & F_z
+\end{pmatrix}
+=
+F_x\,dx+F_y\,dy+F_z\,dz
+$$
+
+In orthogonal Cartesian coordinates the components look the same, but this does not mean they are the same object. A vector field is a column vector; a $1$-form is a row vector; and the correspondence between them involves the metric $g$.
+
+#### 8.2.1 Gradient
+
+$$
+\mathrm{grad}\,f = \nabla f
+\quad\longleftrightarrow\quad
+df = \frac{\partial f}{\partial x}dx + \frac{\partial f}{\partial y}dy + \frac{\partial f}{\partial z}dz
+$$
+
+$\nabla f$ is a <strong>column vector</strong>; $df$ is a <strong>row vector</strong>. In Cartesian coordinates the components look the same, but the types differ. In the notation of Chapter 6, to read $df$ as the corresponding column vector we use $g^{-1}(df)^T$. In Cartesian coordinates $g=I$, so its components agree with the usual $\nabla f$.
+
+#### 8.2.2 Curl
+
+$$
+\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}
+\quad\longleftrightarrow\quad
+\ast d\omega
+$$
+
+$\nabla\times\mathbf{F}$ is a <strong>column vector</strong>; $d\omega$ is a <strong>$2$-form (antisymmetric matrix)</strong>; and $\ast d\omega$ is a <strong>$1$-form (row vector)</strong>. Curl is a two-stage operation: "raise the degree by the exterior derivative, then bring the degree back down with the Hodge star."
+
+The $x$-component $\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}$ of $\nabla\times\mathbf{F}$ agrees with the coefficient of $dx$ in $\ast d\omega$. This is exactly the correspondence confirmed in Chapter 6.
+
+#### 8.2.3 Divergence
+
+$$
+\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}
+\quad\longleftrightarrow\quad
+\ast d \ast \omega
+$$
+
+$\nabla\cdot\mathbf{F}$ is a <strong>scalar field</strong>; $\ast d\ast\omega$ is also a <strong>$0$-form (scalar field)</strong>. Divergence is a three-stage operation: "turn it into a $2$-form with the Hodge star, raise it to a $3$-form by the exterior derivative, then drop it back to a scalar with the Hodge star again."
+
+#### 8.2.4 Summary Table of the Dictionary
+
+| Operation | Vector analysis side | Differential forms (measuring device) side | To read back as a vector field |
+|:---:|:---:|:---:|:---:|
+| Gradient | $\mathrm{grad}\,f$ | $df$ | $g^{-1}(df)^T$ |
+| Curl | $\mathrm{curl}\,\mathbf{F}$ | $\ast d\omega$ | $g^{-1}(\ast d\omega)^T$ |
+| Divergence | $\mathrm{div}\,\mathbf{F}$ | $\ast d\ast\omega$ | as-is $0$-form |
+
+The more times $\ast$ is used, the higher the "translation cost" between $\nabla$ notation and $d,\ast$ notation.
+Here $\omega=\mathbf{F}^Tg$. For the gradient, $\ast$ appears zero times, but converting $df$ to the usual gradient vector requires the metric conversion $g^{-1}(df)^T$. For curl, $\ast$ appears once; for divergence, twice. This translation dictionary built from the metric $g$ and $\ast$ was the reason we felt in Chapter 7 §7.7 that "differential forms are dirtier."
+
+> <strong>Checkpoint so far — §8.2</strong>
+> - $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$.
+> - Number of $\ast$ uses: gradient $0$, curl $1$, divergence $2$. This translation cost is the real source of the impression that "differential forms are messy."
+
+---
+
+
+### §8.3 Translating Stokes' Theorem
+
+In Chapter 5 §5.6 we already derived Stokes' theorem in the form $\int_{\partial S}\omega = \int_S d\omega$. In Chapter 7 §7.8.1 we wrote the same theorem in the language of $\nabla$ as $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$. We now confirm that these two are the same thing, using the dictionary of §8.2.
+
+#### 8.3.1 From $\nabla$ to $d$
+
+Take the Stokes' theorem in $\nabla$ notation as the starting point.
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+
+The left-hand side $\oint_C \mathbf{F}\cdot d\mathbf{r}$ is the line integral of the vector field $\mathbf{F}$ along the curve $C$. If we let the $1$-form corresponding to $\mathbf{F}$ be $\omega = F_x\,dx + F_y\,dy + F_z\,dz$, then by the definition of Chapter 3 this equals $\int_C \omega$.
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \int_{\partial S} \omega$$
+
+The right-hand side $\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ is the surface integral of the normal component of the curl. Here we read a surface integral of the normal component of a vector field as the surface integral of the corresponding $2$-form. Using the dictionary $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $(\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ corresponds to the surface integral of the $2$-form $\ast(\ast d\omega) = d\omega$ (the $\ast$'s cancel by $\ast\ast = \mathrm{id}$).
+
+$$\iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS = \int_S d\omega$$
+
+Therefore,
+
+$$\int_{\partial S} \omega = \int_S d\omega$$
+
+This is exactly the formula obtained in Chapter 5 §5.6. Stokes' theorem in the world of $\nabla$, once translated through the dictionary into the language of $d$, becomes nothing but $\int_{\partial M}\omega = \int_M d\omega$.
+
+#### 8.3.2 Round-Trip Translation — Either Direction Works
+
+The reverse direction works too. Apply the dictionary in reverse to an expression written in the language of $d$, and we return to the language of $\nabla$. That this bidirectional translation is free is precisely the greatest achievement of introducing $\ast$ in Chapter 6.
+
+> <strong>Note</strong> (Which language should you think in?) The short answer: it depends on the problem. When the boundary shape is simple and the field has high symmetry, $\nabla$ notation gives better visibility. On the other hand, when coordinates are distorted or you want to keep the "type" of the field clearly separated, $d,\ast$ notation has the advantage. What matters is being able to use both languages.
+
+> <strong>Aside</strong> (My honest opinion) In the main text I wrote that "one should use the two languages as the problem demands." That is the public line for the reader. Personally, I think in the language of $d,\ast$ whenever I can. The reason is that $\nabla$ notation is convenient for calculation, but it collapses the type differences among gradient, curl, and divergence into the same arrows and scalars. The aim of this book is not to ban vector analysis, but to bring the type conversions that go on implicitly behind it out into the open.
+
+---
+
+
+---
+
+### §8.4 Translating Gauss' Theorem
+
+Gauss' divergence theorem from Chapter 7 §7.8.2 can likewise be translated.
+
+$$\oiint_{\partial V} \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+
+The surface integral on the left can be written as $\int_{\partial V} \ast\omega$ using the $1$-form $\omega$ corresponding to $\mathbf{F}$ ($\ast\omega$ is a $2$-form and is the object of the surface integral on a closed surface).
+
+The volume integral of the divergence on the right reads as $\int_V \ast d\ast\omega$ by the dictionary $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$. However, a scalar field itself is not yet a $3$-form to be integrated. In the convention of this book, the object of a volume integral is a $3$-form. Therefore, to integrate $\ast d\ast\omega$ as a volume integral, we apply $\ast$ once more and read it as the $3$-form $d\ast\omega$. That is, $\int_V d\ast\omega$.
+
+In the end, Gauss' theorem is translated into the following form.
+
+$$\int_{\partial V} \ast\omega = \int_V d\ast\omega$$
+
+Setting $\eta = \ast\omega$ ($2$-form),
+
+$$\int_{\partial V} \eta = \int_V d\eta$$
+
+This is exactly the expression of Gauss' theorem obtained in Chapter 5 §5.7 written in the language of $d$. And this formula is already consolidated in §5.9.1 as the $k=2$ case of $\int_{\partial M}\omega = \int_M d\omega$.
+
+#### 8.4.1 Three Theorems, One Formula
+
+The three integral theorems arranged separately in Chapter 7—Green, Stokes, and Gauss—indeed had different faces in the language of $\nabla$. But translated into the language of $d$, all become the same formula, with only the value of $k$ differing in $\int_{\partial M}\omega = \int_M d\omega$.
+
+| $k$ | $\partial M$ | $M$ | Theorem |
+|---|---|---|---|
+| $0$ | $B-A$ (two points) | curve | fundamental theorem of calculus |
+| $1$ | closed curve | surface | Stokes (including Green) |
+| $2$ | closed surface | solid | Gauss |
+
+$k$ is all that differs. There is no longer any reason to memorize three theorems separately. Remember only $\int_{\partial M}\omega = \int_M d\omega$, and then apply it according to the dimension of $M$.
+
+> <strong>Checkpoint so far — §8.3–§8.4</strong>
+> - Stokes' theorem in $\nabla$ notation reduces to $\int_{\partial S}\omega = \int_S d\omega$ once the dictionary is applied.
+> - Gauss' theorem in $\nabla$ notation reduces to $\int_{\partial V}\eta = \int_V d\eta$ once the dictionary is applied.
+> - Both are merely the same $\int_{\partial M}\omega = \int_M d\omega$ with different $k$. The three theorems are different manifestations of one formula.
+
+---
+
+
+### §8.5 Why the Two Languages Agree
+
+In Chapter 6 §6.3.1 we introduced two ways to obtain scalars. In §8.1 we contrasted them as the world of $d$ and the world of $\nabla$. Here we do not repeat that explanation. Building on the translations seen in §8.2–§8.4, we organize why the two languages give the same values upon integration.
+
+#### 8.5.1 The Difference Between the Two Methods
+
+As seen in §8.1, $d$ and $\nabla$ are not doing the same thing. $d$ raises the degree of measuring devices, moving among $0$-forms, $1$-forms, $2$-forms, and $3$-forms. On the other hand, $\nabla$ produces scalar fields or column-vector fields from the same formal differential operator.
+
+That is, in the world of $d$ "what kind of measuring device is being measured" changes, and in the world of $\nabla$ "what kind of field is produced" changes. This difference is the true nature of the problem seen in Chapter 7—that "everything looks like the same arrow."
+
+#### 8.5.2 Why They Agree
+
+Methods ① and ② are <strong>fundamentally different</strong> in what they do. One replaces measuring devices; the other creates new fields. The operations differ, and so do the kinds of objects that appear.
+
+Yet they agree upon integration. For example, when line-integrating the change of a scalar field $f$, whether we use $df$ (a row-vector measuring device) or $\nabla f$ (a column-vector arrow), the result in both cases is $f(B)-f(A)$.
+
+$$\int_C df = \int_C \nabla f \cdot d\mathbf{r} = f(B) - f(A)$$
+
+Why? Because the metric $g$ and $\ast$ connect the two. An "arrow" like $\nabla f$ and a "measuring device" like $df$ are different types. In Cartesian coordinates $g=I$, so they look like the same components, but in general they are paired via the row/column conversion induced by $g$. Passing through this conversion guarantees that $\nabla f$ and $df$, $\nabla\times\mathbf{F}$ and $\ast d\omega$, $\nabla\cdot\mathbf{F}$ and $\ast d\ast\omega$ give the same results at the level of integration.
+
+And because $\ast\ast = \mathrm{id}$, no information is lost no matter how many times we go back and forth through the conversion. This freedom of round-trip translation is precisely the power of being able to speak both languages.
+
+> <strong>Remark</strong> (Choosing between the two methods — my position) I go back and forth between both methods according to the problem. In highly symmetric systems I use $\nabla$ for clarity; in systems where coordinates are distorted or field types are entangled, I translate into $d,\ast$ to check type consistency. There is no need to fixate on one or the other. What matters is keeping the translation dictionary in mind.
+
+> <strong>Checkpoint so far — §8.5</strong>
+>
+> | | <strong>Language of $d$</strong> | <strong>Language of $\nabla$</strong> |
+> |:---|:---|:---|
+> | <strong>Operation</strong> | exterior derivative $d$ | nabla $\nabla$ |
+> | <strong>Change</strong> | the degree of measuring devices changes | new fields arise from the same formal differential operator |
+> | <strong>Result</strong> | measuring devices such as $1$-forms, $2$-forms, $3$-forms | scalar fields and column-vector fields |
+>
+> What supports agreement upon integration is the translation dictionary built from the metric $g$ and $\ast$. Round-trip translation is free thanks to $\ast\ast=\mathrm{id}$.
+
+---
+
+
+---
+
+### §8.6 Curvilinear Coordinates and the Two Methods
+
+From here on is the gateway to the practical part of Chapter 9. The full computational exercises come in the next chapter, but first we confirm once that the dictionary can be built mechanically even when it leaves Cartesian coordinates.
+
+The dictionary of §8.2 assumed Cartesian coordinates $(x,y,z)$ with $\mathbf{g}=I$. In a general coordinate system the metric $g = J^T J$ is no longer the identity matrix, and the $\ast$ dictionary changes as well. Here we use cylindrical coordinates as an example to see how the dictionary changes, and then run through the difference between the two languages organized in §8.5.
+
+#### 8.6.1 The Dictionary Changes with the Metric
+
+In Chapter 6 §6.1.3 we derived the metric for cylindrical coordinates.
+
+$$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$$
+
+How does this $\mathbf{g} \neq I$ affect the $\ast$ dictionary? In Cartesian coordinates we had $\ast(dx) = dy \wedge dz$. Taking the basis $1$-forms of cylindrical coordinates as $(dr, d\theta, dz)$, the $\ast$ dictionary changes as follows:
+
+$$\begin{aligned}
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
+\end{aligned}$$
+
+The coefficients $r$ and $1/r$ are determined from the diagonal components $1, r^2, 1$ of $\mathbf{g} = J^T J$. The $\ast$ dictionary carries location-dependent coefficients that reflect the metric at each point.
+
+#### 8.6.2 Trying Out the Two Methods
+
+That the dictionary changes means the difference between the two methods contrasted in §8.1 shows up in concrete calculations. Here we actually solve the same problem by both methods. The problem is "find the divergence at a point in the plane."
+
+> <strong>Note</strong> (Thinking in two dimensions) Since Chapter 1, whenever we treated two-dimensional problems we stated $z=0$. By now, readers who have come this far probably no longer need such a disclaimer. Below we proceed using only the plane $(x,y)$ and its polar coordinates $(r,\theta)$.
+
+<strong>Method ①—keep the field as it is; change the measuring device.</strong>
+
+Prepare parameter space $(r,\theta)$ and physical space $(x,y)$—two sheets of Cartesian coordinate paper. On the parameter-space sheet, an identical square grid is laid out everywhere. On this square grid we perform our measurements.
+
+A vector field $\mathbf{F}$ with components $F_x,F_y$ lives in physical space. We <strong>pull back</strong> its measuring device $\omega = F_x\,dx + F_y\,dy$ onto the parameter-space sheet. Pullback is the operation of recasting a physical-space measuring device into the language of parameter space. It goes opposite to the map $\phi: (r,\theta) \to (x,y)$ that sends into physical space—bringing the measuring device back. Using $dx = \cos\theta\,dr - r\sin\theta\,d\theta$, $dy = \sin\theta\,dr + r\cos\theta\,d\theta$,
+
+$$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
+
+is obtained.
+
+> <strong>Note</strong> (Orthonormal components and form coefficients) In vector analysis, $\mathbf{F}$ is expressed by components $(F_r, F_\theta)$ with respect to unit arrows. But the natural basis of differential forms is the coordinate differentials $(dr, d\theta)$, and the tick spacing in the $d\theta$ direction differs by a factor of $r$ from place to place. Hereafter in this section, when we write $F_\theta$ we mean the component in the orthonormal direction used in vector analysis—not the coefficient on $d\theta$ itself. When we write $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$, the form coefficient $\tilde{F}_\theta$ is $r F_\theta$, which differs in both dimension and value from the vector-analysis component $F_\theta$. This difference is what produces the visual gap between the formulas of Method ① and Method ②.
+
+From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are—there is no need anywhere along the way to insert factors such as $\frac{1}{r}$.
+
+$$\begin{aligned}
+\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
+\ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
+\end{aligned}$$
+
+The $\frac{1}{r}$ appeared only in the single place $\ast(dr\wedge d\theta) = \frac{1}{r}$ at the end. The $r$ and $\frac{1}{r}$ in the middle cancel—the $r$ attached to the $d\theta$ coefficient and the $\frac{1}{r}$ in $\ast(d\theta)$. $\ast$ takes on all the metric information at once, and $d$ is responsible purely for partial differentiation—this division of labor is the greatest strength of Method ①.
+
+In parameter space we can keep thinking of the measurement grid as uniform. Differences in conversion factors from place to place are woven in by the pullback, and $\ast$ sorts them out. Limit operations can be carried out all at once at the end.
+
+<strong>Method ②—keep the same formal operator; consider a new field.</strong>
+
+This time use a single sheet of graph paper in physical space. On polar coordinates $(r,\theta)$, draw a small area element centered at the point $(r,\theta)$ directly. It is a small piece with width $\Delta r$ in the $r$ direction and $\Delta\theta$ in the $\theta$ direction. Here <strong>$\Delta r$ and $\Delta\theta$ must be infinitesimal</strong>—because of the angle, a finite $\Delta\theta$ would make the radial edges non-parallel, so the piece would not be a simple rectangle.
+
+This small piece is part of a sector. The length of the inner edge in the $\theta$ direction is $r\Delta\theta$, the outer edge is $(r+\Delta r)\Delta\theta$, and the edges grow longer as $r$ grows larger. A vector field $\mathbf{F}$ with components $F_r,F_\theta$ passes through the four sides of this piece; we account for the flux through each side one by one.
+
+$r$ direction: from the inner edge $-F_r(r,\theta) \cdot r\Delta\theta$ flows in, from the outer edge $+F_r(r+\Delta r,\theta) \cdot (r+\Delta r)\Delta\theta$ flows out. Dividing the difference by $\Delta r$ and then by the area $r\Delta r\Delta\theta$ and taking the limit yields $\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$.
+
+$\theta$ direction: from the $\theta$ side $-F_\theta(r,\theta) \cdot \Delta r$ flows in, from the $\theta+\Delta\theta$ side $+F_\theta(r,\theta+\Delta\theta) \cdot \Delta r$ flows out. Processing similarly yields $\frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$.
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}$$
+
+Draw the small piece directly in physical space and count the flow through the walls—the picture is intuitive. But whenever the coordinate system changes, the shape of the small piece changes and we are forced into a different accounting each time. The $\frac{1}{r}$ in $\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$ appears because we divide by the sector area $r\Delta r\Delta\theta$, but this term did not appear when we did the same calculation in Cartesian coordinates.
+
+<strong>Neither is superior</strong>
+
+Method ① measures on a uniform square grid; Method ② draws a sector piece and counts flow. What they do is completely different. Yet the answer is the same: $\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$. And this agreement is not limited to divergence. Gradient, curl, and Laplacian—all differential operators can be built by these two methods. For a simple coordinate change, Method ② may be faster, but when the coordinate system is distorted or the types of fields become intertwined, switch to Method ①.
+
+#### 8.6.3 Divergence and Curl in Curvilinear Coordinates
+
+Combining the dictionary of §8.6.1 with Method ① of §8.6.2, the formulas for divergence and curl in cylindrical coordinates can be derived mechanically. Here $F_r,F_\theta,F_z$ are the orthonormal components in cylindrical coordinates. We show only the results.
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
+\frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
+\end{pmatrix}$$
+
+Memorizing these formulas is exhausting. But if we think in terms of the combination of $d$ and $\ast$ in $\ast d\ast\omega$, we can derive the $\ast$ dictionary on the spot from $g = J^T J$ and compute mechanically. In Chapter 9 we put this technique of "building the dictionary on the spot" into practice.
+
+> <strong>Checkpoint so far — Chapter 8 as a whole</strong>
+> - $d$ and $\nabla$ stand on fundamentally different worldviews, but they agree in integration. $d$ changes the degree of measuring devices; $\nabla$ builds scalar fields and column vector fields from the same formal differential operator.
+> - Through the dictionary $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$, the two can be translated freely.
+> - With the single formula $\int_{\partial M}\omega = \int_M d\omega$, we can unify the fundamental theorem of calculus, Stokes, and Gauss.
+> - The $\ast$ dictionary depends on the metric $g = J^T J$; in curvilinear coordinates, coefficients such as $r$ and $1/r$ appear.
+> - What matters is not clinging to one language but using the two languages as the problem demands. You already have the dictionary for that. In Chapter 9 we build this dictionary on the spot and apply it to real problems.

--- a/manuscript/en/ch08/ch08.md
+++ b/manuscript/en/ch08/ch08.md
@@ -16,7 +16,7 @@ This chapter is the <strong>highlight</strong> of the book. The central translat
 
 Since Chapter 1 we have treated $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ as row-vector measuring devices. When you feed them a column vector (a displacement), they return the displacement in that direction as a scalar.
 
-The exterior derivative $d$ is the operation of <strong>differentiating this measuring device</strong>.
+The exterior derivative $d$ is the operation that differentiates the coefficients and produces the next measuring device.
 
 When $f(x,y,z)$ is a scalar field, $df$ is a new measuring device that measures changes in $f$. It becomes a row vector whose components are the partial derivatives.
 
@@ -30,7 +30,7 @@ When $\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ is a $2$-form, $d
 
 $$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
 
-In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>the field stays as it is; it is the measuring-device side that changes</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
+In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>$d$ does not produce a new arrow field in the sense of vector analysis; it differentiates the coefficients and changes the measuring-device side</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
 
 #### 8.1.2 The formal differential operator stays the same; new fields are what we consider—the standpoint of $\nabla$
 
@@ -69,10 +69,8 @@ It represents the axis and strength of the local rotation.
 In the world of $\nabla$, the result is always returned as an arrow or a scalar in real space. Both $\nabla f$ and $\nabla\times\mathbf{F}$ look like the same kind of “arrow” on the page; there is no distinction by type.
 
 > <strong>Checkpoint so far — §8.1</strong>
-> - Standpoint of $d$: the field stays as it is; the measuring-device side changes. New measuring devices are born.
+> - Standpoint of $d$: $d$ does not produce a new arrow field; the measuring-device side changes. New measuring devices are born.
 > - Standpoint of $\nabla$: the formal differential operator stays the same; new fields are born.
-
----
 
 ---
 
@@ -130,7 +128,7 @@ $$
 \ast d\omega
 $$
 
-$\nabla\times\mathbf{F}$ is a <strong>column vector</strong>; $d\omega$ is a <strong>$2$-form (antisymmetric matrix)</strong>; and $\ast d\omega$ is a <strong>$1$-form (row vector)</strong>. Curl is a two-stage operation: "raise the degree by the exterior derivative, then bring the degree back down with the Hodge star."
+$\nabla\times\mathbf{F}$ is a <strong>column vector</strong>; $d\omega$ is a <strong>$2$-form (antisymmetric matrix)</strong>; and $\ast d\omega$ is a <strong>$1$-form (row vector)</strong>. To compare it directly with the column-vector display of $\nabla\times\mathbf F$, we again read the $1$-form $\ast d\omega$ back through the metric as $g^{-1}(\ast d\omega)^T$. Curl is a two-stage operation: "raise the degree by the exterior derivative, then bring the degree back down with the Hodge star."
 
 The $x$-component $\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}$ of $\nabla\times\mathbf{F}$ agrees with the coefficient of $dx$ in $\ast d\omega$. This is exactly the correspondence confirmed in Chapter 6.
 
@@ -153,7 +151,7 @@ $\nabla\cdot\mathbf{F}$ is a <strong>scalar field</strong>; $\ast d\ast\omega$ i
 | Divergence | $\mathrm{div}\,\mathbf{F}$ | $\ast d\ast\omega$ | as-is $0$-form |
 
 The more times $\ast$ is used, the higher the "translation cost" between $\nabla$ notation and $d,\ast$ notation.
-Here $\omega=\mathbf{F}^Tg$. For the gradient, $\ast$ appears zero times, but converting $df$ to the usual gradient vector requires the metric conversion $g^{-1}(df)^T$. For curl, $\ast$ appears once; for divergence, twice. This translation dictionary built from the metric $g$ and $\ast$ was the reason we felt in Chapter 7 §7.7 that "differential forms are dirtier."
+Here $\omega=\mathbf{F}^Tg$. For the gradient, $\ast$ appears zero times, but converting $df$ to the usual gradient vector requires the metric conversion $g^{-1}(df)^T$. For curl, $\ast$ appears once; for divergence, twice. This translation dictionary built from the metric $g$ and $\ast$ was the reason we felt in Chapter 7 §7.7 that "differential forms are messy."
 
 > <strong>Checkpoint so far — §8.2</strong>
 > - $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$.
@@ -168,7 +166,7 @@ In Chapter 5 §5.6 we already derived Stokes' theorem in the form $\int_{\partia
 
 #### 8.3.1 From $\nabla$ to $d$
 
-Take the Stokes' theorem in $\nabla$ notation as the starting point.
+Start with Stokes' theorem in $\nabla$ notation.
 
 $$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
 
@@ -196,18 +194,15 @@ The reverse direction works too. Apply the dictionary in reverse to an expressio
 
 ---
 
-
----
-
 ### §8.4 Translating Gauss' Theorem
 
-Gauss' divergence theorem from Chapter 7 §7.8.2 can likewise be translated.
+Gauss' theorem from Chapter 7 §7.8.2 can likewise be translated.
 
 $$\oiint_{\partial V} \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
 
 The surface integral on the left can be written as $\int_{\partial V} \ast\omega$ using the $1$-form $\omega$ corresponding to $\mathbf{F}$ ($\ast\omega$ is a $2$-form and is the object of the surface integral on a closed surface).
 
-The volume integral of the divergence on the right reads as $\int_V \ast d\ast\omega$ by the dictionary $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$. However, a scalar field itself is not yet a $3$-form to be integrated. In the convention of this book, the object of a volume integral is a $3$-form. Therefore, to integrate $\ast d\ast\omega$ as a volume integral, we apply $\ast$ once more and read it as the $3$-form $d\ast\omega$. That is, $\int_V d\ast\omega$.
+By the dictionary, the divergence itself corresponds to the $0$-form $\ast d\ast\omega$. To integrate it over $V$, we must read this scalar as the corresponding $3$-form. Applying $\ast$ once more gives $d\ast\omega$, so the volume integral is $\int_V d\ast\omega$.
 
 In the end, Gauss' theorem is translated into the following form.
 
@@ -243,25 +238,27 @@ $k$ is all that differs. There is no longer any reason to memorize three theorem
 
 In Chapter 6 §6.3.1 we introduced two ways to obtain scalars. In §8.1 we contrasted them as the world of $d$ and the world of $\nabla$. Here we do not repeat that explanation. Building on the translations seen in §8.2–§8.4, we organize why the two languages give the same values upon integration.
 
-#### 8.5.1 The Difference Between the Two Methods
+#### 8.5.1 The Difference Between the Two Routes
 
 As seen in §8.1, $d$ and $\nabla$ are not doing the same thing. $d$ raises the degree of measuring devices, moving among $0$-forms, $1$-forms, $2$-forms, and $3$-forms. On the other hand, $\nabla$ produces scalar fields or column-vector fields from the same formal differential operator.
 
-That is, in the world of $d$ "what kind of measuring device is being measured" changes, and in the world of $\nabla$ "what kind of field is produced" changes. This difference is the true nature of the problem seen in Chapter 7—that "everything looks like the same arrow."
+That is, in the world of $d$, the degree of the measuring device changes, and in the world of $\nabla$ "what kind of field is produced" changes. This difference is the true nature of the problem seen in Chapter 7—that "everything looks like the same arrow."
 
 #### 8.5.2 Why They Agree
 
-Methods ① and ② are <strong>fundamentally different</strong> in what they do. One replaces measuring devices; the other creates new fields. The operations differ, and so do the kinds of objects that appear.
+Routes ① and ② are <strong>fundamentally different</strong> in what they do. One changes the measuring-device side; the other creates new fields. The operations differ, and so do the kinds of objects that appear.
 
 Yet they agree upon integration. For example, when line-integrating the change of a scalar field $f$, whether we use $df$ (a row-vector measuring device) or $\nabla f$ (a column-vector arrow), the result in both cases is $f(B)-f(A)$.
 
 $$\int_C df = \int_C \nabla f \cdot d\mathbf{r} = f(B) - f(A)$$
 
-Why? Because the metric $g$ and $\ast$ connect the two. An "arrow" like $\nabla f$ and a "measuring device" like $df$ are different types. In Cartesian coordinates $g=I$, so they look like the same components, but in general they are paired via the row/column conversion induced by $g$. Passing through this conversion guarantees that $\nabla f$ and $df$, $\nabla\times\mathbf{F}$ and $\ast d\omega$, $\nabla\cdot\mathbf{F}$ and $\ast d\ast\omega$ give the same results at the level of integration.
+The middle equality uses the metric identification between $df$ and $\nabla f$ discussed in §8.2.
+
+Why? Because the metric $g$ and $\ast$ connect the two. An "arrow" like $\nabla f$ and a "measuring device" like $df$ are different types. In Cartesian coordinates $g=I$, so they look like the same components, but in general they are paired via the row/column conversion induced by $g$. Passing through this conversion is what makes the corresponding integral quantities agree.
 
 And because $\ast\ast = \mathrm{id}$, no information is lost no matter how many times we go back and forth through the conversion. This freedom of round-trip translation is precisely the power of being able to speak both languages.
 
-> <strong>Remark</strong> (Choosing between the two methods — my position) I go back and forth between both methods according to the problem. In highly symmetric systems I use $\nabla$ for clarity; in systems where coordinates are distorted or field types are entangled, I translate into $d,\ast$ to check type consistency. There is no need to fixate on one or the other. What matters is keeping the translation dictionary in mind.
+> <strong>Remark</strong> (Choosing between the two routes — my position) I go back and forth between both routes according to the problem. In highly symmetric systems I use $\nabla$ for clarity; in systems where coordinates are distorted or field types are entangled, I translate into $d,\ast$ to check type consistency. There is no need to fixate on one or the other. What matters is keeping the translation dictionary in mind.
 
 > <strong>Checkpoint so far — §8.5</strong>
 >
@@ -275,14 +272,11 @@ And because $\ast\ast = \mathrm{id}$, no information is lost no matter how many 
 
 ---
 
-
----
-
-### §8.6 Curvilinear Coordinates and the Two Methods
+### §8.6 Curvilinear Coordinates and the Two Routes
 
 From here on is the gateway to the practical part of Chapter 9. The full computational exercises come in the next chapter, but first we confirm once that the dictionary can be built mechanically even when it leaves Cartesian coordinates.
 
-The dictionary of §8.2 assumed Cartesian coordinates $(x,y,z)$ with $\mathbf{g}=I$. In a general coordinate system the metric $g = J^T J$ is no longer the identity matrix, and the $\ast$ dictionary changes as well. Here we use cylindrical coordinates as an example to see how the dictionary changes, and then run through the difference between the two languages organized in §8.5.
+The dictionary of §8.2 assumed Cartesian coordinates $(x,y,z)$ with $\mathbf{g}=I$. In a general coordinate system the metric $g = J^T J$ is no longer the identity matrix, and the $\ast$ dictionary changes as well. Here we use cylindrical coordinates as an example to see how the dictionary changes, and then run through the difference between the two languages organized in §8.5. We first state the three-dimensional cylindrical dictionary, then restrict to the two-dimensional polar plane for the worked divergence example.
 
 #### 8.6.1 The Dictionary Changes with the Metric
 
@@ -300,13 +294,13 @@ $$\begin{aligned}
 
 The coefficients $r$ and $1/r$ are determined from the diagonal components $1, r^2, 1$ of $\mathbf{g} = J^T J$. The $\ast$ dictionary carries location-dependent coefficients that reflect the metric at each point.
 
-#### 8.6.2 Trying Out the Two Methods
+#### 8.6.2 Trying Out the Two Routes
 
-That the dictionary changes means the difference between the two methods contrasted in §8.1 shows up in concrete calculations. Here we actually solve the same problem by both methods. The problem is "find the divergence at a point in the plane."
+That the dictionary changes means the difference between the two routes contrasted in §8.1 shows up in concrete calculations. Here we actually solve the same problem by both routes. The problem is "find the divergence at a point in the plane."
 
 > <strong>Note</strong> (Thinking in two dimensions) Since Chapter 1, whenever we treated two-dimensional problems we stated $z=0$. By now, readers who have come this far probably no longer need such a disclaimer. Below we proceed using only the plane $(x,y)$ and its polar coordinates $(r,\theta)$.
 
-<strong>Method ①—keep the field as it is; change the measuring device.</strong>
+<strong>Route ①—pull back the measuring device and let the form side carry the coordinate change.</strong>
 
 Prepare parameter space $(r,\theta)$ and physical space $(x,y)$—two sheets of Cartesian coordinate paper. On the parameter-space sheet, an identical square grid is laid out everywhere. On this square grid we perform our measurements.
 
@@ -316,9 +310,9 @@ $$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
 
 is obtained.
 
-> <strong>Note</strong> (Orthonormal components and form coefficients) In vector analysis, $\mathbf{F}$ is expressed by components $(F_r, F_\theta)$ with respect to unit arrows. But the natural basis of differential forms is the coordinate differentials $(dr, d\theta)$, and the tick spacing in the $d\theta$ direction differs by a factor of $r$ from place to place. Hereafter in this section, when we write $F_\theta$ we mean the component in the orthonormal direction used in vector analysis—not the coefficient on $d\theta$ itself. When we write $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$, the form coefficient $\tilde{F}_\theta$ is $r F_\theta$, which differs in both dimension and value from the vector-analysis component $F_\theta$. This difference is what produces the visual gap between the formulas of Method ① and Method ②.
+> <strong>Note</strong> (Orthonormal components and form coefficients) In vector analysis, $\mathbf{F}$ is expressed by components $(F_r, F_\theta)$ with respect to unit arrows. But the natural basis of differential forms is the coordinate differentials $(dr, d\theta)$, and the tick spacing in the $d\theta$ direction differs by a factor of $r$ from place to place. Hereafter in this section, when we write $F_\theta$ we mean the component in the orthonormal direction used in vector analysis—not the coefficient on $d\theta$ itself. When we write $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$, the form coefficient $\tilde{F}_\theta$ is $r F_\theta$, which differs in both dimension and value from the vector-analysis component $F_\theta$. This difference is what produces the visual gap between the formulas of Route ① and Route ②.
 
-From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are—there is no need anywhere along the way to insert factors such as $\frac{1}{r}$.
+From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are; the metric factors are handled by $\ast$, not inserted into $d$ by hand.
 
 $$\begin{aligned}
 \ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
@@ -326,11 +320,11 @@ d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$
 
-The $\frac{1}{r}$ appeared only in the single place $\ast(dr\wedge d\theta) = \frac{1}{r}$ at the end. The $r$ and $\frac{1}{r}$ in the middle cancel—the $r$ attached to the $d\theta$ coefficient and the $\frac{1}{r}$ in $\ast(d\theta)$. $\ast$ takes on all the metric information at once, and $d$ is responsible purely for partial differentiation—this division of labor is the greatest strength of Method ①.
+The $\frac{1}{r}$ appeared only in the single place $\ast(dr\wedge d\theta) = \frac{1}{r}$ at the end. The $r$ and $\frac{1}{r}$ in the middle cancel—the $r$ attached to the $d\theta$ coefficient and the $\frac{1}{r}$ in $\ast(d\theta)$. $\ast$ takes on all the metric information at once, and $d$ is responsible purely for partial differentiation—this division of labor is the greatest strength of Route ①.
 
 In parameter space we can keep thinking of the measurement grid as uniform. Differences in conversion factors from place to place are woven in by the pullback, and $\ast$ sorts them out. Limit operations can be carried out all at once at the end.
 
-<strong>Method ②—keep the same formal operator; consider a new field.</strong>
+<strong>Route ②—draw the physical infinitesimal piece and count flux directly.</strong>
 
 This time use a single sheet of graph paper in physical space. On polar coordinates $(r,\theta)$, draw a small area element centered at the point $(r,\theta)$ directly. It is a small piece with width $\Delta r$ in the $r$ direction and $\Delta\theta$ in the $\theta$ direction. Here <strong>$\Delta r$ and $\Delta\theta$ must be infinitesimal</strong>—because of the angle, a finite $\Delta\theta$ would make the radial edges non-parallel, so the piece would not be a simple rectangle.
 
@@ -346,11 +340,11 @@ Draw the small piece directly in physical space and count the flow through the w
 
 <strong>Neither is superior</strong>
 
-Method ① measures on a uniform square grid; Method ② draws a sector piece and counts flow. What they do is completely different. Yet the answer is the same: $\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$. And this agreement is not limited to divergence. Gradient, curl, and Laplacian—all differential operators can be built by these two methods. For a simple coordinate change, Method ② may be faster, but when the coordinate system is distorted or the types of fields become intertwined, switch to Method ①.
+Route ① measures on a uniform square grid; Route ② draws a sector piece and counts flow. What they do is completely different. Yet the answer is the same: $\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$. And this agreement is not limited to divergence. Gradient, curl, and Laplacian—all differential operators can be built by these two routes. For a simple coordinate change, Route ② may be faster, but when the coordinate system is distorted or the types of fields become intertwined, switch to Route ①.
 
 #### 8.6.3 Divergence and Curl in Curvilinear Coordinates
 
-Combining the dictionary of §8.6.1 with Method ① of §8.6.2, the formulas for divergence and curl in cylindrical coordinates can be derived mechanically. Here $F_r,F_\theta,F_z$ are the orthonormal components in cylindrical coordinates. We show only the results.
+Combining the dictionary of §8.6.1 with Route ① of §8.6.2, the formulas for divergence and curl in cylindrical coordinates can be derived mechanically. Here $F_r,F_\theta,F_z$ are the orthonormal components in cylindrical coordinates. We show only the results.
 
 $$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$
 

--- a/translation/drafts/ch08-8.0-8.1.md
+++ b/translation/drafts/ch08-8.0-8.1.md
@@ -1,0 +1,75 @@
+# Chapter 8: Two Languages — Differentiating Measuring Devices and Differentiating Fields
+
+### §8.0 The Highlight of This Book
+
+It has been a long road. In Chapter 1 we defined $dx$ as a row vector; in Chapter 2 we built area-measuring devices and volume-measuring devices; in Chapter 3 we rebuilt integration; in Chapter 5 we obtained the exterior derivative $d$; in Chapter 6 we acquired the metric $g$ and the Hodge star $\ast$; and in Chapter 7 we finally defined $\nabla$ head-on and unfolded vector analysis all at once.
+
+From here on, there is no holding back. $d$, $\ast$, and $\nabla$—all the tools are in hand. We no longer need to warn, “for readers who already know vector analysis,” whenever we invoke the vocabulary of vector analysis. $\nabla$ became a proper resident of this book in Chapter 7.
+
+This chapter is the <strong>highlight</strong> of the book. The central translation itself is surprisingly short. At the end, however, to move on to the practical chapter that follows, we will take a single look at how this dictionary behaves in curvilinear coordinates. The painstaking preparation from Chapters 1 through 7—matrices, wedge products, the exterior derivative, the metric, the Hodge star, and vector analysis—was all for that purpose. Because all these tools are now assembled, in this chapter we need only “translate,” and two worlds fit into one picture. We have acquired two languages—the differential of measuring devices ($d$) and the differential of fields ($\nabla$). These two do fundamentally different things. Yet when they are linked through integration, they give exactly the same results. We will now dig thoroughly into how that works.
+
+---
+
+### §8.1 Two Differentials, Two Worlds
+
+#### 8.1.1 Differentiating measuring devices—the standpoint of $d$
+
+Since Chapter 1 we have treated $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ as row-vector measuring devices. When you feed them a column vector (a displacement), they return the displacement in that direction as a scalar.
+
+The exterior derivative $d$ is the operation of <strong>differentiating this measuring device</strong>.
+
+When $f(x,y,z)$ is a scalar field, $df$ is a new measuring device that measures changes in $f$. It becomes a row vector whose components are the partial derivatives.
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+When $\omega = P\,dx + Q\,dy + R\,dz$ is a $1$-form, $d\omega$ is a $2$-form (antisymmetric matrix) that measures the local mismatch of $\omega$.
+
+$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$
+
+When $\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ is a $2$-form, $d\eta$ is a $3$-form (third-order antisymmetric tensor).
+
+$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
+
+In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>the field stays as it is; it is the measuring-device side that changes</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
+
+#### 8.1.2 The formal differential operator stays the same; new fields are what we consider—the standpoint of $\nabla$
+
+Meanwhile, in the world of
+
+$$
+\nabla
+=
+\begin{pmatrix}
+\frac{\partial}{\partial x}\\[0.3em]
+\frac{\partial}{\partial y}\\[0.3em]
+\frac{\partial}{\partial z}
+\end{pmatrix}
+$$
+
+introduced in Chapter 7, <strong>the formal differential operator stays the same; depending on what it acts on, new fields are born</strong>. $\nabla$ is always the same operator, but acting on a scalar field $f$ yields a vector field $\nabla f$; acting on a vector field $\mathbf{F}$ yields a scalar field $\nabla\cdot\mathbf{F}$ or a vector field $\nabla\times\mathbf{F}$.
+
+Applying $\nabla$ to a scalar field $f(x,y,z)$ gives a column-vector field whose components are the rates of change in each direction.
+
+$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+This is an arrow standing at each point in space; it is no longer a measuring device. It represents the direction of steepest increase of $f$ and the strength of that increase.
+
+Applying $\nabla\cdot$ to a vector field $\mathbf{F}$ with components $F_x,F_y,F_z$ gives a scalar field.
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+It returns the sum of the rates of change in each direction—the strength of outflow.
+
+Applying $\nabla\times$ to the same $\mathbf{F}$ gives a column-vector field again.
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$
+
+It represents the axis and strength of the local rotation.
+
+In the world of $\nabla$, the result is always returned as an arrow or a scalar in real space. Both $\nabla f$ and $\nabla\times\mathbf{F}$ look like the same kind of “arrow” on the page; there is no distinction by type.
+
+> <strong>Checkpoint so far — §8.1</strong>
+> - Standpoint of $d$: the field stays as it is; the measuring-device side changes. New measuring devices are born.
+> - Standpoint of $\nabla$: the formal differential operator stays the same; new fields are born.
+
+---

--- a/translation/drafts/ch08-8.2-8.3.md
+++ b/translation/drafts/ch08-8.2-8.3.md
@@ -1,0 +1,119 @@
+### §8.2 Completing the Translation Dictionary
+
+In Chapter 6 §6.5 we introduced the correspondences $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$. Here we align this dictionary with the language of $\nabla$ and organize it in complete form. What we complete here is the translation dictionary used within three-dimensional Euclidean space and the matrix representation of this book.
+
+In the dictionary below, the $1$-form corresponding to a vector field
+
+$$
+\mathbf{F}
+=
+\begin{pmatrix}
+F_x\\
+F_y\\
+F_z
+\end{pmatrix}
+$$
+
+is read using the metric $g$ as
+
+$$
+\omega=\mathbf{F}^T g
+$$
+
+In Cartesian coordinates $g=I$, so
+
+$$
+\omega
+=
+\begin{pmatrix}
+F_x & F_y & F_z
+\end{pmatrix}
+=
+F_x\,dx+F_y\,dy+F_z\,dz
+$$
+
+In orthogonal Cartesian coordinates the components look the same, but this does not mean they are the same object. A vector field is a column vector; a $1$-form is a row vector; and the correspondence between them involves the metric $g$.
+
+#### 8.2.1 Gradient
+
+$$
+\mathrm{grad}\,f = \nabla f
+\quad\longleftrightarrow\quad
+df = \frac{\partial f}{\partial x}dx + \frac{\partial f}{\partial y}dy + \frac{\partial f}{\partial z}dz
+$$
+
+$\nabla f$ is a <strong>column vector</strong>; $df$ is a <strong>row vector</strong>. In Cartesian coordinates the components look the same, but the types differ. In the notation of Chapter 6, to read $df$ as the corresponding column vector we use $g^{-1}(df)^T$. In Cartesian coordinates $g=I$, so its components agree with the usual $\nabla f$.
+
+#### 8.2.2 Curl
+
+$$
+\mathrm{curl}\,\mathbf{F} = \nabla \times \mathbf{F}
+\quad\longleftrightarrow\quad
+\ast d\omega
+$$
+
+$\nabla\times\mathbf{F}$ is a <strong>column vector</strong>; $d\omega$ is a <strong>$2$-form (antisymmetric matrix)</strong>; and $\ast d\omega$ is a <strong>$1$-form (row vector)</strong>. Curl is a two-stage operation: "raise the degree by the exterior derivative, then bring the degree back down with the Hodge star."
+
+The $x$-component $\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}$ of $\nabla\times\mathbf{F}$ agrees with the coefficient of $dx$ in $\ast d\omega$. This is exactly the correspondence confirmed in Chapter 6.
+
+#### 8.2.3 Divergence
+
+$$
+\mathrm{div}\,\mathbf{F} = \nabla \cdot \mathbf{F}
+\quad\longleftrightarrow\quad
+\ast d \ast \omega
+$$
+
+$\nabla\cdot\mathbf{F}$ is a <strong>scalar field</strong>; $\ast d\ast\omega$ is also a <strong>$0$-form (scalar field)</strong>. Divergence is a three-stage operation: "turn it into a $2$-form with the Hodge star, raise it to a $3$-form by the exterior derivative, then drop it back to a scalar with the Hodge star again."
+
+#### 8.2.4 Summary Table of the Dictionary
+
+| Operation | Vector analysis side | Differential forms (measuring device) side | To read back as a vector field |
+|:---:|:---:|:---:|:---:|
+| Gradient | $\mathrm{grad}\,f$ | $df$ | $g^{-1}(df)^T$ |
+| Curl | $\mathrm{curl}\,\mathbf{F}$ | $\ast d\omega$ | $g^{-1}(\ast d\omega)^T$ |
+| Divergence | $\mathrm{div}\,\mathbf{F}$ | $\ast d\ast\omega$ | as-is $0$-form |
+
+The more times $\ast$ is used, the higher the "translation cost" between $\nabla$ notation and $d,\ast$ notation.
+Here $\omega=\mathbf{F}^Tg$. For the gradient, $\ast$ appears zero times, but converting $df$ to the usual gradient vector requires the metric conversion $g^{-1}(df)^T$. For curl, $\ast$ appears once; for divergence, twice. This translation dictionary built from the metric $g$ and $\ast$ was the reason we felt in Chapter 7 §7.7 that "differential forms are dirtier."
+
+> <strong>Checkpoint so far — §8.2</strong>
+> - $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$.
+> - Number of $\ast$ uses: gradient $0$, curl $1$, divergence $2$. This translation cost is the real source of the impression that "differential forms are messy."
+
+---
+
+
+### §8.3 Translating Stokes' Theorem
+
+In Chapter 5 §5.6 we already derived Stokes' theorem in the form $\int_{\partial S}\omega = \int_S d\omega$. In Chapter 7 §7.8.1 we wrote the same theorem in the language of $\nabla$ as $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$. We now confirm that these two are the same thing, using the dictionary of §8.2.
+
+#### 8.3.1 From $\nabla$ to $d$
+
+Take the Stokes' theorem in $\nabla$ notation as the starting point.
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$
+
+The left-hand side $\oint_C \mathbf{F}\cdot d\mathbf{r}$ is the line integral of the vector field $\mathbf{F}$ along the curve $C$. If we let the $1$-form corresponding to $\mathbf{F}$ be $\omega = F_x\,dx + F_y\,dy + F_z\,dz$, then by the definition of Chapter 3 this equals $\int_C \omega$.
+
+$$\oint_C \mathbf{F} \cdot d\mathbf{r} = \int_{\partial S} \omega$$
+
+The right-hand side $\iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ is the surface integral of the normal component of the curl. Here we read a surface integral of the normal component of a vector field as the surface integral of the corresponding $2$-form. Using the dictionary $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $(\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$ corresponds to the surface integral of the $2$-form $\ast(\ast d\omega) = d\omega$ (the $\ast$'s cancel by $\ast\ast = \mathrm{id}$).
+
+$$\iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS = \int_S d\omega$$
+
+Therefore,
+
+$$\int_{\partial S} \omega = \int_S d\omega$$
+
+This is exactly the formula obtained in Chapter 5 §5.6. Stokes' theorem in the world of $\nabla$, once translated through the dictionary into the language of $d$, becomes nothing but $\int_{\partial M}\omega = \int_M d\omega$.
+
+#### 8.3.2 Round-Trip Translation — Either Direction Works
+
+The reverse direction works too. Apply the dictionary in reverse to an expression written in the language of $d$, and we return to the language of $\nabla$. That this bidirectional translation is free is precisely the greatest achievement of introducing $\ast$ in Chapter 6.
+
+> <strong>Note</strong> (Which language should you think in?) The short answer: it depends on the problem. When the boundary shape is simple and the field has high symmetry, $\nabla$ notation gives better visibility. On the other hand, when coordinates are distorted or you want to keep the "type" of the field clearly separated, $d,\ast$ notation has the advantage. What matters is being able to use both languages.
+
+> <strong>Aside</strong> (My honest opinion) In the main text I wrote that "one should use the two languages as the problem demands." That is the public line for the reader. Personally, I think in the language of $d,\ast$ whenever I can. The reason is that $\nabla$ notation is convenient for calculation, but it collapses the type differences among gradient, curl, and divergence into the same arrows and scalars. The aim of this book is not to ban vector analysis, but to bring the type conversions that go on implicitly behind it out into the open.
+
+---

--- a/translation/drafts/ch08-8.4-8.5.md
+++ b/translation/drafts/ch08-8.4-8.5.md
@@ -1,0 +1,75 @@
+### §8.4 Translating Gauss' Theorem
+
+Gauss' divergence theorem from Chapter 7 §7.8.2 can likewise be translated.
+
+$$\oiint_{\partial V} \mathbf{F} \cdot \mathbf{n}\,dS = \iiint_V (\nabla \cdot \mathbf{F})\,dV$$
+
+The surface integral on the left can be written as $\int_{\partial V} \ast\omega$ using the $1$-form $\omega$ corresponding to $\mathbf{F}$ ($\ast\omega$ is a $2$-form and is the object of the surface integral on a closed surface).
+
+The volume integral of the divergence on the right reads as $\int_V \ast d\ast\omega$ by the dictionary $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$. However, a scalar field itself is not yet a $3$-form to be integrated. In the convention of this book, the object of a volume integral is a $3$-form. Therefore, to integrate $\ast d\ast\omega$ as a volume integral, we apply $\ast$ once more and read it as the $3$-form $d\ast\omega$. That is, $\int_V d\ast\omega$.
+
+In the end, Gauss' theorem is translated into the following form.
+
+$$\int_{\partial V} \ast\omega = \int_V d\ast\omega$$
+
+Setting $\eta = \ast\omega$ ($2$-form),
+
+$$\int_{\partial V} \eta = \int_V d\eta$$
+
+This is exactly the expression of Gauss' theorem obtained in Chapter 5 §5.7 written in the language of $d$. And this formula is already consolidated in §5.9.1 as the $k=2$ case of $\int_{\partial M}\omega = \int_M d\omega$.
+
+#### 8.4.1 Three Theorems, One Formula
+
+The three integral theorems arranged separately in Chapter 7—Green, Stokes, and Gauss—indeed had different faces in the language of $\nabla$. But translated into the language of $d$, all become the same formula, with only the value of $k$ differing in $\int_{\partial M}\omega = \int_M d\omega$.
+
+| $k$ | $\partial M$ | $M$ | Theorem |
+|---|---|---|---|
+| $0$ | $B-A$ (two points) | curve | fundamental theorem of calculus |
+| $1$ | closed curve | surface | Stokes (including Green) |
+| $2$ | closed surface | solid | Gauss |
+
+$k$ is all that differs. There is no longer any reason to memorize three theorems separately. Remember only $\int_{\partial M}\omega = \int_M d\omega$, and then apply it according to the dimension of $M$.
+
+> <strong>Checkpoint so far — §8.3–§8.4</strong>
+> - Stokes' theorem in $\nabla$ notation reduces to $\int_{\partial S}\omega = \int_S d\omega$ once the dictionary is applied.
+> - Gauss' theorem in $\nabla$ notation reduces to $\int_{\partial V}\eta = \int_V d\eta$ once the dictionary is applied.
+> - Both are merely the same $\int_{\partial M}\omega = \int_M d\omega$ with different $k$. The three theorems are different manifestations of one formula.
+
+---
+
+
+### §8.5 Why the Two Languages Agree
+
+In Chapter 6 §6.3.1 we introduced two ways to obtain scalars. In §8.1 we contrasted them as the world of $d$ and the world of $\nabla$. Here we do not repeat that explanation. Building on the translations seen in §8.2–§8.4, we organize why the two languages give the same values upon integration.
+
+#### 8.5.1 The Difference Between the Two Methods
+
+As seen in §8.1, $d$ and $\nabla$ are not doing the same thing. $d$ raises the degree of measuring devices, moving among $0$-forms, $1$-forms, $2$-forms, and $3$-forms. On the other hand, $\nabla$ produces scalar fields or column-vector fields from the same formal differential operator.
+
+That is, in the world of $d$ "what kind of measuring device is being measured" changes, and in the world of $\nabla$ "what kind of field is produced" changes. This difference is the true nature of the problem seen in Chapter 7—that "everything looks like the same arrow."
+
+#### 8.5.2 Why They Agree
+
+Methods ① and ② are <strong>fundamentally different</strong> in what they do. One replaces measuring devices; the other creates new fields. The operations differ, and so do the kinds of objects that appear.
+
+Yet they agree upon integration. For example, when line-integrating the change of a scalar field $f$, whether we use $df$ (a row-vector measuring device) or $\nabla f$ (a column-vector arrow), the result in both cases is $f(B)-f(A)$.
+
+$$\int_C df = \int_C \nabla f \cdot d\mathbf{r} = f(B) - f(A)$$
+
+Why? Because the metric $g$ and $\ast$ connect the two. An "arrow" like $\nabla f$ and a "measuring device" like $df$ are different types. In Cartesian coordinates $g=I$, so they look like the same components, but in general they are paired via the row/column conversion induced by $g$. Passing through this conversion guarantees that $\nabla f$ and $df$, $\nabla\times\mathbf{F}$ and $\ast d\omega$, $\nabla\cdot\mathbf{F}$ and $\ast d\ast\omega$ give the same results at the level of integration.
+
+And because $\ast\ast = \mathrm{id}$, no information is lost no matter how many times we go back and forth through the conversion. This freedom of round-trip translation is precisely the power of being able to speak both languages.
+
+> <strong>Remark</strong> (Choosing between the two methods — my position) I go back and forth between both methods according to the problem. In highly symmetric systems I use $\nabla$ for clarity; in systems where coordinates are distorted or field types are entangled, I translate into $d,\ast$ to check type consistency. There is no need to fixate on one or the other. What matters is keeping the translation dictionary in mind.
+
+> <strong>Checkpoint so far — §8.5</strong>
+>
+> | | <strong>Language of $d$</strong> | <strong>Language of $\nabla$</strong> |
+> |:---|:---|:---|
+> | <strong>Operation</strong> | exterior derivative $d$ | nabla $\nabla$ |
+> | <strong>Change</strong> | the degree of measuring devices changes | new fields arise from the same formal differential operator |
+> | <strong>Result</strong> | measuring devices such as $1$-forms, $2$-forms, $3$-forms | scalar fields and column-vector fields |
+>
+> What supports agreement upon integration is the translation dictionary built from the metric $g$ and $\ast$. Round-trip translation is free thanks to $\ast\ast=\mathrm{id}$.
+
+---

--- a/translation/drafts/ch08-8.6.md
+++ b/translation/drafts/ch08-8.6.md
@@ -1,0 +1,90 @@
+### §8.6 Curvilinear Coordinates and the Two Methods
+
+From here on is the gateway to the practical part of Chapter 9. The full computational exercises come in the next chapter, but first we confirm once that the dictionary can be built mechanically even when it leaves Cartesian coordinates.
+
+The dictionary of §8.2 assumed Cartesian coordinates $(x,y,z)$ with $\mathbf{g}=I$. In a general coordinate system the metric $g = J^T J$ is no longer the identity matrix, and the $\ast$ dictionary changes as well. Here we use cylindrical coordinates as an example to see how the dictionary changes, and then run through the difference between the two languages organized in §8.5.
+
+#### 8.6.1 The Dictionary Changes with the Metric
+
+In Chapter 6 §6.1.3 we derived the metric for cylindrical coordinates.
+
+$$\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$$
+
+How does this $\mathbf{g} \neq I$ affect the $\ast$ dictionary? In Cartesian coordinates we had $\ast(dx) = dy \wedge dz$. Taking the basis $1$-forms of cylindrical coordinates as $(dr, d\theta, dz)$, the $\ast$ dictionary changes as follows:
+
+$$\begin{aligned}
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
+\end{aligned}$$
+
+The coefficients $r$ and $1/r$ are determined from the diagonal components $1, r^2, 1$ of $\mathbf{g} = J^T J$. The $\ast$ dictionary carries location-dependent coefficients that reflect the metric at each point.
+
+#### 8.6.2 Trying Out the Two Methods
+
+That the dictionary changes means the difference between the two methods contrasted in §8.1 shows up in concrete calculations. Here we actually solve the same problem by both methods. The problem is "find the divergence at a point in the plane."
+
+> <strong>Note</strong> (Thinking in two dimensions) Since Chapter 1, whenever we treated two-dimensional problems we stated $z=0$. By now, readers who have come this far probably no longer need such a disclaimer. Below we proceed using only the plane $(x,y)$ and its polar coordinates $(r,\theta)$.
+
+<strong>Method ①—keep the field as it is; change the measuring device.</strong>
+
+Prepare parameter space $(r,\theta)$ and physical space $(x,y)$—two sheets of Cartesian coordinate paper. On the parameter-space sheet, an identical square grid is laid out everywhere. On this square grid we perform our measurements.
+
+A vector field $\mathbf{F}$ with components $F_x,F_y$ lives in physical space. We <strong>pull back</strong> its measuring device $\omega = F_x\,dx + F_y\,dy$ onto the parameter-space sheet. Pullback is the operation of recasting a physical-space measuring device into the language of parameter space. It goes opposite to the map $\phi: (r,\theta) \to (x,y)$ that sends into physical space—bringing the measuring device back. Using $dx = \cos\theta\,dr - r\sin\theta\,d\theta$, $dy = \sin\theta\,dr + r\cos\theta\,d\theta$,
+
+$$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
+
+is obtained.
+
+> <strong>Note</strong> (Orthonormal components and form coefficients) In vector analysis, $\mathbf{F}$ is expressed by components $(F_r, F_\theta)$ with respect to unit arrows. But the natural basis of differential forms is the coordinate differentials $(dr, d\theta)$, and the tick spacing in the $d\theta$ direction differs by a factor of $r$ from place to place. Hereafter in this section, when we write $F_\theta$ we mean the component in the orthonormal direction used in vector analysis—not the coefficient on $d\theta$ itself. When we write $\tilde{\omega} = F_r\,dr + \tilde{F}_\theta\,d\theta$, the form coefficient $\tilde{F}_\theta$ is $r F_\theta$, which differs in both dimension and value from the vector-analysis component $F_\theta$. This difference is what produces the visual gap between the formulas of Method ① and Method ②.
+
+From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are—there is no need anywhere along the way to insert factors such as $\frac{1}{r}$.
+
+$$\begin{aligned}
+\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
+\ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
+\end{aligned}$$
+
+The $\frac{1}{r}$ appeared only in the single place $\ast(dr\wedge d\theta) = \frac{1}{r}$ at the end. The $r$ and $\frac{1}{r}$ in the middle cancel—the $r$ attached to the $d\theta$ coefficient and the $\frac{1}{r}$ in $\ast(d\theta)$. $\ast$ takes on all the metric information at once, and $d$ is responsible purely for partial differentiation—this division of labor is the greatest strength of Method ①.
+
+In parameter space we can keep thinking of the measurement grid as uniform. Differences in conversion factors from place to place are woven in by the pullback, and $\ast$ sorts them out. Limit operations can be carried out all at once at the end.
+
+<strong>Method ②—keep the same formal operator; consider a new field.</strong>
+
+This time use a single sheet of graph paper in physical space. On polar coordinates $(r,\theta)$, draw a small area element centered at the point $(r,\theta)$ directly. It is a small piece with width $\Delta r$ in the $r$ direction and $\Delta\theta$ in the $\theta$ direction. Here <strong>$\Delta r$ and $\Delta\theta$ must be infinitesimal</strong>—because of the angle, a finite $\Delta\theta$ would make the radial edges non-parallel, so the piece would not be a simple rectangle.
+
+This small piece is part of a sector. The length of the inner edge in the $\theta$ direction is $r\Delta\theta$, the outer edge is $(r+\Delta r)\Delta\theta$, and the edges grow longer as $r$ grows larger. A vector field $\mathbf{F}$ with components $F_r,F_\theta$ passes through the four sides of this piece; we account for the flux through each side one by one.
+
+$r$ direction: from the inner edge $-F_r(r,\theta) \cdot r\Delta\theta$ flows in, from the outer edge $+F_r(r+\Delta r,\theta) \cdot (r+\Delta r)\Delta\theta$ flows out. Dividing the difference by $\Delta r$ and then by the area $r\Delta r\Delta\theta$ and taking the limit yields $\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$.
+
+$\theta$ direction: from the $\theta$ side $-F_\theta(r,\theta) \cdot \Delta r$ flows in, from the $\theta+\Delta\theta$ side $+F_\theta(r,\theta+\Delta\theta) \cdot \Delta r$ flows out. Processing similarly yields $\frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$.
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}$$
+
+Draw the small piece directly in physical space and count the flow through the walls—the picture is intuitive. But whenever the coordinate system changes, the shape of the small piece changes and we are forced into a different accounting each time. The $\frac{1}{r}$ in $\frac{1}{r}\frac{\partial}{\partial r}(rF_r)$ appears because we divide by the sector area $r\Delta r\Delta\theta$, but this term did not appear when we did the same calculation in Cartesian coordinates.
+
+<strong>Neither is superior</strong>
+
+Method ① measures on a uniform square grid; Method ② draws a sector piece and counts flow. What they do is completely different. Yet the answer is the same: $\frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta}$. And this agreement is not limited to divergence. Gradient, curl, and Laplacian—all differential operators can be built by these two methods. For a simple coordinate change, Method ② may be faster, but when the coordinate system is distorted or the types of fields become intertwined, switch to Method ①.
+
+#### 8.6.3 Divergence and Curl in Curvilinear Coordinates
+
+Combining the dictionary of §8.6.1 with Method ① of §8.6.2, the formulas for divergence and curl in cylindrical coordinates can be derived mechanically. Here $F_r,F_\theta,F_z$ are the orthonormal components in cylindrical coordinates. We show only the results.
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta} + \frac{\partial F_z}{\partial z}$$
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
+\frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
+\end{pmatrix}$$
+
+Memorizing these formulas is exhausting. But if we think in terms of the combination of $d$ and $\ast$ in $\ast d\ast\omega$, we can derive the $\ast$ dictionary on the spot from $g = J^T J$ and compute mechanically. In Chapter 9 we put this technique of "building the dictionary on the spot" into practice.
+
+> <strong>Checkpoint so far — Chapter 8 as a whole</strong>
+> - $d$ and $\nabla$ stand on fundamentally different worldviews, but they agree in integration. $d$ changes the degree of measuring devices; $\nabla$ builds scalar fields and column vector fields from the same formal differential operator.
+> - Through the dictionary $\nabla f \leftrightarrow df$, $\nabla\times\mathbf{F} \leftrightarrow \ast d\omega$, $\nabla\cdot\mathbf{F} \leftrightarrow \ast d\ast\omega$, the two can be translated freely.
+> - With the single formula $\int_{\partial M}\omega = \int_M d\omega$, we can unify the fundamental theorem of calculus, Stokes, and Gauss.
+> - The $\ast$ dictionary depends on the metric $g = J^T J$; in curvilinear coordinates, coefficients such as $r$ and $1/r$ appear.
+> - What matters is not clinging to one language but using the two languages as the problem demands. You already have the dictionary for that. In Chapter 9 we build this dictionary on the spot and apply it to real problems.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -229,6 +229,7 @@ Per-section Pass status:
 | `translation/drafts/ch08-*.md` | integrated into `ch08.md` |
 | `translation/reviews/ch08-pass2.md` | complete |
 | `translation/reviews/ch08-pass3.md` | complete |
+| `translation/reviews/ch08-close-reading-polish.md` | complete (#186) |
 
 ---
 

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -211,6 +211,25 @@ Per-section Pass status:
 | `translation/reviews/ch07-pass3.md` | complete |
 | `translation/reviews/ch07-close-reading-polish.md` | complete (#185) |
 
+### English Chapter 8 — `manuscript/en/ch08/ch08.md` (branch `ai/english-translation-ch08`, PR [#169](https://github.com/yokiikoy/nabla-kaitai/pull/169))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 8 (§8.0–§8.6)** | **1 → 2 → 3** | `ch08-pass2.md`, `ch08-pass3.md` |
+
+| Block | Pass | Review |
+|-------|------|--------|
+| §8.0–§8.1 | **3** | `ch08-8.0-8.1-review.md` |
+| §8.2–§8.3 | **3** | `ch08-8.2-8.3-review.md` |
+| §8.4–§8.5 | **3** | `ch08-8.4-8.5-review.md` |
+| §8.6 | **3** | `ch08-8.6-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch08-*.md` | integrated into `ch08.md` |
+| `translation/reviews/ch08-pass2.md` | complete |
+| `translation/reviews/ch08-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/reviews/ch08-8.0-8.1-review.md
+++ b/translation/reviews/ch08-8.0-8.1-review.md
@@ -1,0 +1,3 @@
+# Review: ch08 §8.0–§8.1
+
+Pass 1 **passed**. `ch08-8.0-8.1.md`.

--- a/translation/reviews/ch08-8.2-8.3-review.md
+++ b/translation/reviews/ch08-8.2-8.3-review.md
@@ -1,0 +1,3 @@
+# Review: ch08 §8.2–§8.3
+
+Pass 1 **passed**. Dictionary; Stokes translation. `ch08-8.2-8.3.md`.

--- a/translation/reviews/ch08-8.4-8.5-review.md
+++ b/translation/reviews/ch08-8.4-8.5-review.md
@@ -1,0 +1,3 @@
+# Review: ch08 §8.4–§8.5
+
+Pass 1 **passed**. Gauss translation; why languages agree. `ch08-8.4-8.5.md`.

--- a/translation/reviews/ch08-8.6-review.md
+++ b/translation/reviews/ch08-8.6-review.md
@@ -1,0 +1,3 @@
+# Review: ch08 §8.6
+
+Pass 1 **passed**. Curvilinear coords; ch9 foreshadow. `ch08-8.6.md`.

--- a/translation/reviews/ch08-close-reading-polish.md
+++ b/translation/reviews/ch08-close-reading-polish.md
@@ -1,0 +1,62 @@
+# Close-Reading Polish: Chapter 8
+
+Review date: 2026-05-23
+Branch: `ai/english-translation-ch08`
+File: `manuscript/en/ch08/ch08.md`
+GitHub issue: #186
+PR context: #169
+
+Scope: publication polish after Pass 3 — Route ①/② consistency with Chapter 6, Markdown cleanup, $d$ vs $\nabla$ safety, Gauss terminology alignment, preservation of highlight / translation-dictionary arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** Removed duplicate horizontal rules between §8.1/§8.2, §8.3/§8.4, and §8.5/§8.6
+- **B2** Normalized named `Method ①/②` → `Route ①/②` throughout Chapter 8 (§8.5–§8.6)
+- **B3** §8.1.1: `$d$ does not produce a new arrow field…` (replacing “field stays as it is”)
+
+### C items (straightforward)
+
+- **C1** §8.1.1: `$d$` differentiates coefficients and produces the next measuring device
+- **C2** §8.2.2: metric read-back $g^{-1}(\ast d\omega)^T$ for curl comparison
+- **C3** §8.2.4: `dirtier` → `messy` (consistent with checkpoint)
+- **C4** §8.3.1: `Start with Stokes' theorem…`
+- **C5** §8.4: `Gauss' theorem` (matches Chapters 5–7)
+- **C6** §8.4: scalar-to-3-form step clarified for Gauss translation
+- **C8** §8.5.1: measuring-device degree wording
+- **C9** §8.5.2: “One changes the measuring-device side…”
+- **C10** §8.5.2: metric identification note after $\int_C df = \int_C \nabla f\cdot d\mathbf r$
+- **C11** §8.5.2: `guarantees` → softer agreement wording
+- **C12** §8.6 heading: `Two Routes`
+- **C13** §8.6: 3D cylindrical → 2D polar transition sentence
+- **C14** §8.6.2: `$d$` vs metric factors division of labor
+- **C15** §8.6.2: Route ① subtitle (pullback / form side)
+
+### Intentionally unchanged (D items / optional C)
+
+- **C7** §8.3.2 “public line for the reader” — preserved authorial voice
+- §8.0 highlight framing, two-worldview structure, full dictionary table
+- $\omega=\mathbf F^T g$, Stokes via $\ast(\ast d\omega)=d\omega$, Gauss via $\eta=\ast\omega$
+- Three Theorems One Formula, “Neither is superior”, polar walkthrough
+- Orthonormal vs form-coefficient note, cylindrical results, Chapter 9 foreshadow
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- duplicate `---` blocks — none
+- `Method ①`, `Method ②`, `Methods ①` — none
+- `the field stays as it is` — none
+- `Gauss' divergence theorem` — none
+- `Take the Stokes' theorem` — none
+- `what kind of measuring device is being measured` — none
+- `replaces measuring devices` — none
+- `insert factors such as $\frac{1}{r}$` — none
+- `rot` (as curl synonym) — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch08-pass2.md
+++ b/translation/reviews/ch08-pass2.md
@@ -1,0 +1,7 @@
+# Pass 2 Review: Chapter 8
+
+Branch: `ai/english-translation-ch08` · ~370 lines
+
+New chapter; translation dictionary §8.2; unified Stokes §8.4.1; Method ①/② §8.6. **curl not rot.** No edits beyond integration.
+
+**Passes Pass 2.** See `ch08-pass3.md`.

--- a/translation/reviews/ch08-pass3.md
+++ b/translation/reviews/ch08-pass3.md
@@ -1,0 +1,10 @@
+# Pass 3 Review: Chapter 8
+
+## Keep
+- §8.0 "highlight of this book" framing
+- Two-worldview $d$ vs $\nabla$ (§8.1)
+- Full translation dictionary table (§8.2.4)
+- Method ①/② polar divergence walkthrough (§8.6.2)
+- "Neither method is superior" (§8.6.2)
+
+**Chapter 8 passes Pass 3.**


### PR DESCRIPTION
## Summary
- New English `manuscript/en/ch08/ch08.md`: two languages ($d$ vs $\nabla$), translation dictionary, unified Stokes/Gauss, curvilinear Route ①/②.
- Book highlight chapter; curl not rot; bridge to Chapter 9.
- Branch replayed on current `main`; diff is ch08-only.

## Scope
| Block | Content |
|-------|---------|
| §8.0–§8.1 | Two languages, translation dictionary |
| §8.2–§8.3 | Stokes/Gauss unification, curvilinear coordinates |
| §8.4–§8.5 | Route ①/②, agreement upon integration |
| §8.6 | Chapter summary; Chapter 9 foreshadow |

## Test plan
- [ ] Diff against `manuscript/ja/ch08/ch08.md`
- [ ] curl not rot; Route ①/② consistent with Chapter 6
- [ ] Review records: `ch08-pass2.md`, `ch08-pass3.md`
- [ ] Merge to `main`