### PR TITLE
English Chapter 9: §9.0–§9.6 (Pass 1–3 complete)

### DIFF
--- a/manuscript/en/ch09/ch09.md
+++ b/manuscript/en/ch09/ch09.md
@@ -2,13 +2,13 @@
 
 ### §9.0 The Central Tools of This Book Are Now in Place
 
-In §8.0 of Chapter 8 we declared that this chapter is the highlight of the book, and we actually translated between the two languages, unified the integral theorems, and contrasted the two methodologies. The central tools of this book are now largely in place.
+In Chapter 8 §8.0 we called that chapter the highlight of the book, and there we translated between the two languages, unified the integral theorems, and contrasted the two routes. The central tools of this book are now largely in place.
 
 But it would be a waste to assemble all these tools and never use them. In this chapter we apply the dictionary built so far to actual problems and show how to solve hard problems in vector analysis mechanically. Theory is sufficient through Chapter 8—what follows is <strong>exercise</strong>.
 
 The reader may simply watch the calculations below—or follow along by hand. Either way, what we show here is a demonstration of the fact that you need not memorize formulas; if you have the dictionary, everything can be derived.
 
-> <strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $\ast d\ast$ and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while managing factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ by hand on $\nabla$. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.
+> <strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $d$, $\ast d$, or $\ast d\ast$ as appropriate, and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while manually attaching factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ to the $\nabla$ formulas. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.
 
 ---
 
@@ -30,8 +30,6 @@ Also, in curvilinear coordinates, the orthonormal vector components used in vect
 > In curvilinear coordinates you must distinguish the coordinate-associated $1$-forms from the $1$-forms that measure actual length in units of 1. For example, in polar coordinates, the angular scale $d\theta$ itself differs from the unit-length scale $r\,d\theta$. The dictionary of the Hodge star absorbs all of this scale-factor information. That is what lets us carry out "straight computation" on a "distorted coordinate system."
 
 Below, we demonstrate this procedure in cylindrical and spherical coordinates. Keep in mind the flow: compute first as $1$-forms and $2$-forms, then convert back to orthonormal vector components at the end.
-
----
 
 ---
 
@@ -99,7 +97,7 @@ The factor $\frac{1}{r}$ on the $\theta$ component appears because $\nabla f$ gi
 
 #### 9.2.3 Divergence
 
-For a vector field $\mathbf{F}$ with orthonormal components $F_r,F_\theta,F_z$, the corresponding $1$-form is $\omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$, following the convention stated below: "make the coefficients as $1$-forms explicit through the scale factors that appear in the formulas."
+For a vector field $\mathbf{F}$ with orthonormal components $F_r,F_\theta,F_z$, the corresponding $1$-form is $\omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$, following the convention that we always write the scale factors explicitly in the $1$-form coefficients.
 
 > <strong>Note</strong> (About the tilde on $\tilde{\omega}$)
 > In Chapter 8 §8.6.2, we used the notation $\tilde{\omega}$ to distinguish the orthonormal component $F_\theta$ from the coefficient as a $1$-form, $rF_\theta$. In this chapter we lighten the notation and write $\omega$ without a tilde below. However, $F_r,F_\theta,F_z$ always denote orthonormal vector components. The corresponding $1$-form is made explicit on each occasion by including the scale factors. In cylindrical coordinates,
@@ -129,7 +127,7 @@ $$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\
 
 $$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + r\!\left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right)\! d\theta + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! dz$$
 
-Reading off the coefficients of $dr, d\theta, dz$ from the $1$-form and converting back to orthonormal components, the $d\theta$ coefficient is further divided by $\frac{1}{r}$. In the end,
+Reading off the coefficients of $dr, d\theta, dz$ from the $1$-form and converting back to orthonormal components, the coefficient of $d\theta$ is divided by the scale factor $r$. In the end,
 
 $$\nabla \times \mathbf{F} = \begin{pmatrix}
 \frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
@@ -138,8 +136,6 @@ $$\nabla \times \mathbf{F} = \begin{pmatrix}
 \end{pmatrix}$$
 
 The structure in which $r$ appears both inside and outside $\frac{\partial}{\partial r}$ has exactly the same origin as the $\frac{1}{r}$ that appeared when we counted the area element of a sector in the previous chapter.
-
----
 
 ---
 
@@ -160,7 +156,7 @@ $$J = \begin{pmatrix}
 0 & 0 & \rho^2\sin^2\theta
 \end{pmatrix}$$
 
-The dictionary for $\ast$ is determined from the diagonal components $\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$, namely $1, \rho, \rho\sin\theta$.
+The scale factors $1, \rho, \rho\sin\theta$ derived from the diagonal metric components determine the coefficients in the $\ast$ dictionary.
 
 $$\begin{aligned}
 \ast(d\rho) &= \rho^2\sin\theta\; d\theta \wedge d\phi \\
@@ -209,9 +205,6 @@ $$\nabla \times \mathbf{F} = \begin{pmatrix}
 
 ---
 
-
----
-
 ### §9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates
 
 The vector Laplacian $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ is known as one of the longest formulas in the vector-analysis handbook. Here we show that every component falls out mechanically from the dictionary.
@@ -222,7 +215,7 @@ The strategy is simply to use the Chapter 8 dictionary as is.
 
 Therefore, viewing the result as a $1$-form,
 
-$$\nabla^2\mathbf{F} \leftrightarrow d\ast d\ast\omega - \ast d\ast d\omega$$
+$$\nabla^2\mathbf{F} \leftrightarrow d\bigl(\ast d\ast\omega\bigr)-\ast d\bigl(\ast d\omega\bigr)$$
 
 Starting from $\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$ in spherical coordinates, we compute $d\ast d\ast\omega$ and $\ast d\ast d\omega$ separately and take their difference.
 
@@ -268,7 +261,9 @@ Substituting the expressions for $S$ and $C_\theta, C_\phi$, expanding partial d
 
 $$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
 
-Here $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$.
+Here $\nabla^2 F_\rho$ denotes the scalar Laplacian applied to the scalar component $F_\rho$:
+
+$$\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$$
 
 Similarly, for the $\theta$ and $\phi$ components,
 
@@ -276,8 +271,9 @@ $$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2
 
 $$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$
 
-This completes the derivation of all components. Deriving from scratch in the usual vector-analysis style would easily exceed a page of computation, but via the dictionary each step is nothing more than partial differentiation and multiplication by coefficients. There is no need to memorize individual formulas by rote—given the single identity $d\ast d\ast\omega - \ast d\ast d\omega$ and the $\ast$ dictionary of §9.3, everything can be reconstructed on the spot.
+This completes the derivation of all components. Deriving from scratch in the usual vector-analysis style would easily exceed a page of computation, but via the dictionary each step is nothing more than partial differentiation and multiplication by coefficients. There is no need to memorize individual formulas by rote—given the single identity $d(\ast d\ast\omega)-\ast d(\ast d\omega)$ and the $\ast$ dictionary of §9.3, everything can be reconstructed on the spot.
 
+---
 
 ### §9.5 A Hard Problem in Electromagnetism — Divergence of the Point-Charge Electric Field
 
@@ -301,12 +297,11 @@ The second term vanishes because $d\theta\wedge d\theta = 0$; the third term lik
 
 $$d\ast\omega = 0 \quad (\rho \neq 0)$$
 
-So $\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$. The $\rho^2$ in $E_\rho$ cancels the $\rho^2$ in $\ast(d\rho)$, and the exterior derivative of the remaining $\sin\theta\,d\theta\wedge d\phi$ is zero—that alone shows zero divergence away from the origin.
+So $\ast d\ast\omega = 0$, which corresponds to $\nabla\cdot\mathbf{E}=0$ away from the origin. The $\rho^2$ in $E_\rho$ cancels the $\rho^2$ in $\ast(d\rho)$, and the exterior derivative of the remaining $\sin\theta\,d\theta\wedge d\phi$ is zero—that alone shows zero divergence away from the origin.
 
 > <strong>Note</strong> (What about the origin?) At $\rho = 0$, $\omega$ is not defined. To treat all of space including the origin, one must represent the point charge by distributions ($\delta$ functions) or in integral form rather than by ordinary divergence as a function. This book does not go there; we restrict ourselves to computation on the region excluding the origin. In Chapter 10, where charge density is treated, we write charge density as $\rho_{\mathrm e}$ so as not to confuse it with the radial coordinate $\rho$, and handle the form in which $\rho_{\mathrm e}/\varepsilon_0$ appears on the right-hand side.
 
 ---
-
 
 ### §9.6 The Dictionary Ends; the Journey Continues
 

--- a/manuscript/en/ch09/ch09.md
+++ b/manuscript/en/ch09/ch09.md
@@ -1,0 +1,325 @@
+# Chapter 9: In Practice — Build the Dictionary and Solve Hard Problems
+
+### §9.0 The Central Tools of This Book Are Now in Place
+
+In §8.0 of Chapter 8 we declared that this chapter is the highlight of the book, and we actually translated between the two languages, unified the integral theorems, and contrasted the two methodologies. The central tools of this book are now largely in place.
+
+But it would be a waste to assemble all these tools and never use them. In this chapter we apply the dictionary built so far to actual problems and show how to solve hard problems in vector analysis mechanically. Theory is sufficient through Chapter 8—what follows is <strong>exercise</strong>.
+
+The reader may simply watch the calculations below—or follow along by hand. Either way, what we show here is a demonstration of the fact that you need not memorize formulas; if you have the dictionary, everything can be derived.
+
+> <strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $\ast d\ast$ and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while managing factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ by hand on $\nabla$. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.
+
+---
+
+### §9.1 Building the Dictionary on the Spot — A Mechanical Procedure
+
+The procedure for deriving the formulas for $\mathrm{grad}$, $\mathrm{div}$, and $\mathrm{curl}$ in orthogonal curvilinear coordinates boils down to the following three steps.
+
+1. <strong>Write the Jacobian matrix $J$</strong>. From the coordinate transformation $x = x(q_1,q_2,q_3)$, $y = y(q_1,q_2,q_3)$, $z = z(q_1,q_2,q_3)$, arrange the partial derivatives. Each column of $J$ represents how a single step along one axis in parameter space moves in physical space.
+
+2. <strong>Compute the metric $\mathbf{g} = J^T J$</strong>. This is the procedure we have followed since Chapter 6 §6.1.3. The diagonal entries of $\mathbf{g}$ are the squares of the scales along each axis; the off-diagonal entries represent how orthogonal the axes are to one another.
+
+3. <strong>From $\mathbf{g}$, derive the dictionary for the Hodge star $\ast$, and combine it with $d$</strong>. Substitute the dictionary for $\ast$ in that coordinate system into each formula $\mathrm{grad} = d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$, and the desired formulas are obtained mechanically.
+
+However, the usual $\mathrm{grad}$ and $\mathrm{curl}$ of vector analysis return vector fields as arrows. By contrast, this book's $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$ are read first as formulas on the measuring-device side. To read a $1$-form obtained on the differential-forms side as a column vector, first use the metric $\mathbf{g}$ to convert it back to the form $\mathbf{g}^{-1}(\cdot)^T$. These are the column components corresponding to the coordinates. To read them as orthonormal vector components as used in vector analysis, you must also account for the scale factor in each direction.
+
+Also, in curvilinear coordinates, the orthonormal vector components used in vector analysis generally do not agree with the coefficients relative to the coordinate-associated $1$-forms. Because the calculation is carried out on the $1$-form side, first convert the vector field to the corresponding $1$-form. Then the coefficients of $d\theta$ and $d\phi$ pick up scale factors.
+
+> <strong>Note</strong> (vector components and $1$-form coefficients)
+> In curvilinear coordinates you must distinguish the coordinate-associated $1$-forms from the $1$-forms that measure actual length in units of 1. For example, in polar coordinates, the angular scale $d\theta$ itself differs from the unit-length scale $r\,d\theta$. The dictionary of the Hodge star absorbs all of this scale-factor information. That is what lets us carry out "straight computation" on a "distorted coordinate system."
+
+Below, we demonstrate this procedure in cylindrical and spherical coordinates. Keep in mind the flow: compute first as $1$-forms and $2$-forms, then convert back to orthonormal vector components at the end.
+
+---
+
+---
+
+### §9.2 Cylindrical Coordinates $(r,\theta,z)$
+
+#### 9.2.1 Deriving the Dictionary
+
+The coordinate transformation to cylindrical coordinates is $x = r\cos\theta$, $y = r\sin\theta$, $z = z$.
+
+> <strong>Note</strong> (Domain and singular points)
+> Below we compute on the coordinate patch where $r > 0$. At $r = 0$, $\theta$ is not defined and cylindrical coordinates themselves become singular. Also, since $\theta$ is an angular coordinate with period $2\pi$, strictly speaking it should be treated as a local coordinate (for example $0 < \theta < 2\pi$). The formulas in this section are intended for use in regions that do not include this singular axis.
+
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}, \qquad
+\mathbf{g} = J^T J = \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+From $\mathbf{g}$ we derive the $\ast$ dictionary. By the same principle as the $\ast$ dictionary in Cartesian coordinates seen in Chapter 6, the square roots of the diagonal components of $\mathbf{g}$ appear as coefficients in $\ast$.
+
+$$\begin{aligned}
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
+\end{aligned}$$
+
+Also $\ast(1) = r\,dr\wedge d\theta\wedge dz$, $\ast(dr\wedge d\theta\wedge dz) = 1/r$.
+
+> <strong>Note</strong> (Four things to distinguish in cylindrical coordinates)
+> To treat vector fields correctly as differential forms, let us distinguish the following four layers:
+>
+> | Name | Concrete example in cylindrical coordinates |
+> | :--- | :--- |
+> | <strong>Coordinate $1$-forms</strong> | $dr, d\theta, dz$ |
+> | <strong>$1$-forms corresponding to unit-length ticks</strong> | $dr, r\,d\theta, dz$ |
+> | <strong>Components used in vector analysis</strong> | $F_r, F_\theta, F_z$ |
+> | <strong>Coefficients as $1$-forms</strong> | $F_r, rF_\theta, F_z$ |
+>
+> If we write the components in the unit-vector directions used in vector analysis as $F_r,F_\theta,F_z$, the corresponding $1$-form is $F_r dr + F_\theta (r d\theta) + F_z dz$—that is, the coefficients as $1$-forms are $F_r,rF_\theta,F_z$. Throughout this chapter, $F_\theta$ always refers to the "components used in vector analysis."
+
+#### 9.2.2 Gradient
+
+$\mathrm{grad}\,f = df$ does not use $\ast$. It simply places the partial-derivative coefficients on the basis $1$-forms.
+
+$$df = \frac{\partial f}{\partial r}\,dr + \frac{\partial f}{\partial \theta}\,d\theta + \frac{\partial f}{\partial z}\,dz$$
+
+In the notation of vector analysis (as a column vector),
+
+$$
+\nabla f
+=
+\begin{pmatrix}
+\frac{\partial f}{\partial r}\\[0.4em]
+\frac{1}{r}\frac{\partial f}{\partial \theta}\\[0.4em]
+\frac{\partial f}{\partial z}
+\end{pmatrix}
+$$
+
+The factor $\frac{1}{r}$ on the $\theta$ component appears because $\nabla f$ gives components with respect to an orthonormal basis. The coefficient of $d\theta$ in $df$, namely $\frac{\partial f}{\partial\theta}$, is the "rate of change per unit angle," whereas the $\mathbf{e}_\theta$ component of $\nabla f$ is the "rate of change per unit length." The conversion $\frac{1}{r}$ is needed because $d\theta$ corresponds to arc length $r\,d\theta$.
+
+#### 9.2.3 Divergence
+
+For a vector field $\mathbf{F}$ with orthonormal components $F_r,F_\theta,F_z$, the corresponding $1$-form is $\omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$, following the convention stated below: "make the coefficients as $1$-forms explicit through the scale factors that appear in the formulas."
+
+> <strong>Note</strong> (About the tilde on $\tilde{\omega}$)
+> In Chapter 8 §8.6.2, we used the notation $\tilde{\omega}$ to distinguish the orthonormal component $F_\theta$ from the coefficient as a $1$-form, $rF_\theta$. In this chapter we lighten the notation and write $\omega$ without a tilde below. However, $F_r,F_\theta,F_z$ always denote orthonormal vector components. The corresponding $1$-form is made explicit on each occasion by including the scale factors. In cylindrical coordinates,
+> $$
+> \omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz
+> $$
+> and in spherical coordinates,
+> $$
+> \omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi
+> $$
+> Read with the convention that the coefficients as $1$-forms are made explicit through the scale factors appearing in the formulas—not inferred by the reader from context.
+
+$$\begin{aligned}
+\ast\omega &= F_r(r\,d\theta\wedge dz) + rF_\theta\!\left(\frac{1}{r}\,dz\wedge dr\right) + F_z(r\,dr\wedge d\theta) \\
+&= rF_r\,d\theta\wedge dz + F_\theta\,dz\wedge dr + rF_z\,dr\wedge d\theta \\[0.3em]
+d\ast\omega &= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta}{\partial\theta} + \frac{\partial}{\partial z}(rF_z)\right) dr\wedge d\theta\wedge dz \\[0.3em]
+\ast d\ast\omega &= \frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta} + \frac{\partial F_z}{\partial z}
+\end{aligned}$$
+
+This is the formula for divergence in cylindrical coordinates.
+
+#### 9.2.4 Curl
+
+Curl is $\mathrm{curl}\,\mathbf{F} \leftrightarrow \ast d\omega$.
+
+$$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right) dr\wedge d\theta + \left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right) d\theta\wedge dz + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz\wedge dr$$
+
+$$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + r\!\left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right)\! d\theta + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! dz$$
+
+Reading off the coefficients of $dr, d\theta, dz$ from the $1$-form and converting back to orthonormal components, the $d\theta$ coefficient is further divided by $\frac{1}{r}$. In the end,
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
+\frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
+\end{pmatrix}$$
+
+The structure in which $r$ appears both inside and outside $\frac{\partial}{\partial r}$ has exactly the same origin as the $\frac{1}{r}$ that appeared when we counted the area element of a sector in the previous chapter.
+
+---
+
+---
+
+### §9.3 Spherical Coordinates $(\rho,\theta,\phi)$
+
+#### 9.3.1 Deriving the Dictionary
+
+The conversion to spherical coordinates is $x = \rho\sin\theta\cos\phi$, $y = \rho\sin\theta\sin\phi$, $z = \rho\cos\theta$ ($\theta$ is the angle from the $z$-axis, $\phi$ is the azimuthal angle in the $xy$ plane).
+
+$$J = \begin{pmatrix}
+\sin\theta\cos\phi & \rho\cos\theta\cos\phi & -\rho\sin\theta\sin\phi \\
+\sin\theta\sin\phi & \rho\cos\theta\sin\phi & \rho\sin\theta\cos\phi \\
+\cos\theta & -\rho\sin\theta & 0
+\end{pmatrix},\qquad
+\mathbf{g} = J^T J = \begin{pmatrix}
+1 & 0 & 0 \\
+0 & \rho^2 & 0 \\
+0 & 0 & \rho^2\sin^2\theta
+\end{pmatrix}$$
+
+The dictionary for $\ast$ is determined from the diagonal components $\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$, namely $1, \rho, \rho\sin\theta$.
+
+$$\begin{aligned}
+\ast(d\rho) &= \rho^2\sin\theta\; d\theta \wedge d\phi \\
+\ast(d\theta) &= \sin\theta\; d\phi \wedge d\rho \\
+\ast(d\phi) &= \frac{1}{\sin\theta}\; d\rho \wedge d\theta
+\end{aligned}$$
+
+> <strong>Note</strong> (Four things to distinguish in spherical coordinates)
+>
+> | Name | Concrete example in spherical coordinates |
+> | :--- | :--- |
+> | <strong>Coordinate $1$-forms</strong> | $d\rho, d\theta, d\phi$ |
+> | <strong>$1$-forms for unit-length scales</strong> | $d\rho, \rho\,d\theta, \rho\sin\theta\,d\phi$ |
+> | <strong>Components used in vector analysis</strong> | $F_\rho, F_\theta, F_\phi$ |
+> | <strong>Coefficients as $1$-forms</strong> | $F_\rho, \rho F_\theta, \rho\sin\theta F_\phi$ |
+>
+> The $1$-form for orthonormal components $F_\rho,F_\theta,F_\phi$ is $\omega = F_\rho d\rho + \rho F_\theta d\theta + \rho\sin\theta F_\phi d\phi$.
+
+Here we compute on the coordinate patch $\rho>0$ and $0<\theta<\pi$. At the origin $\rho=0$ and on the polar axis $\sin\theta=0$, spherical coordinates themselves become singular, and formulas containing $1/\rho$ or $1/\sin\theta$ cannot be used as written. For problems spanning singular points, use a different coordinate patch, or compute in a region excluding the singularities and then treat them via boundary conditions.
+
+#### 9.3.2 Divergence
+
+When converting a vector field $\mathbf{F}$ with orthonormal components $F_\rho,F_\theta,F_\phi$ to a $1$-form, the coefficient of $d\rho$ is $F_\rho$ ($\rho$ already carries length), the coefficient of $d\theta$ is $\rho F_\theta$, and the coefficient of $d\phi$ is $\rho\sin\theta\,F_\phi$ (corresponding respectively to arc lengths $\rho\,d\theta$, $\rho\sin\theta\,d\phi$).
+
+$$\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$$
+
+Compute $\ast d\ast\omega$.
+
+$$\ast\omega = \rho^2\sin\theta\,F_\rho\,d\theta\wedge d\phi + \rho\sin\theta\,F_\theta\,d\phi\wedge d\rho + \rho\,F_\phi\,d\rho\wedge d\theta$$
+
+$$d\ast\omega = \left(\frac{\partial}{\partial\rho}(\rho^2\sin\theta\,F_\rho) + \frac{\partial}{\partial\theta}(\rho\sin\theta\,F_\theta) + \frac{\partial}{\partial\phi}(\rho\,F_\phi)\right) d\rho\wedge d\theta\wedge d\phi$$
+
+From $\ast(d\rho\wedge d\theta\wedge d\phi) = 1/(\rho^2\sin\theta)$,
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+#### 9.3.3 Curl
+
+Similarly, from $\ast d\omega$,
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+\frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
+\frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
+\end{pmatrix}$$
+
+---
+
+
+---
+
+### §9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates
+
+The vector Laplacian $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ is known as one of the longest formulas in the vector-analysis handbook. Here we show that every component falls out mechanically from the dictionary.
+
+The strategy is simply to use the Chapter 8 dictionary as is.
+- $\nabla(\nabla\cdot\mathbf{F}) \leftrightarrow d(\ast d\ast\omega)$
+- $\nabla\times(\nabla\times\mathbf{F}) \leftrightarrow \ast d(\ast d\omega)$
+
+Therefore, viewing the result as a $1$-form,
+
+$$\nabla^2\mathbf{F} \leftrightarrow d\ast d\ast\omega - \ast d\ast d\omega$$
+
+Starting from $\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$ in spherical coordinates, we compute $d\ast d\ast\omega$ and $\ast d\ast d\omega$ separately and take their difference.
+
+#### 9.4.1 The First Term — Gradient of the Divergence
+
+From §9.3.2, the divergence is
+
+$$\ast d\ast\omega = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+Denote this by $S$. Since $S$ is a scalar field, its gradient is $dS = \frac{\partial S}{\partial\rho}\,d\rho + \frac{\partial S}{\partial\theta}\,d\theta + \frac{\partial S}{\partial\phi}\,d\phi$. Converting to orthonormal components,
+
+$$\nabla(\nabla\cdot\mathbf{F}) = \begin{pmatrix}
+\frac{\partial S}{\partial\rho} \\[0.5em]
+\frac{1}{\rho}\frac{\partial S}{\partial\theta} \\[0.5em]
+\frac{1}{\rho\sin\theta}\frac{\partial S}{\partial\phi}
+\end{pmatrix}$$
+
+#### 9.4.2 The Second Term — Curl of the Curl
+
+Write the curl from §9.3.3 as $C_\rho, C_\theta, C_\phi$.
+
+$$\begin{aligned}
+C_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+C_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
+C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
+\end{aligned}$$
+
+To apply $\nabla\times$ again to $\mathbf{C} = \nabla\times\mathbf{F}$, substitute $C_\rho, C_\theta, C_\phi$ into the formula of §9.3.3 in place of $F_\rho, F_\theta, F_\phi$.
+
+$$\begin{aligned}
+(\nabla\times(\nabla\times\mathbf{F}))_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi} \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial C_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\phi) \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\theta) - \frac{1}{\rho}\frac{\partial C_\rho}{\partial\theta}
+\end{aligned}$$
+
+#### 9.4.3 Take the Difference — The Vector Laplacian
+
+Since $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$, each component is obtained by subtracting the second term from the first. Expand the $\rho$ component.
+
+$$(\nabla^2\mathbf{F})_\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$
+
+Substituting the expressions for $S$ and $C_\theta, C_\phi$, expanding partial derivatives, and collecting terms yields the following. The expansion is long, so here we show only the result after substitution and like-term collection.
+
+$$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+Here $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$.
+
+Similarly, for the $\theta$ and $\phi$ components,
+
+$$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+$$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$
+
+This completes the derivation of all components. Deriving from scratch in the usual vector-analysis style would easily exceed a page of computation, but via the dictionary each step is nothing more than partial differentiation and multiplication by coefficients. There is no need to memorize individual formulas by rote—given the single identity $d\ast d\ast\omega - \ast d\ast d\omega$ and the $\ast$ dictionary of §9.3, everything can be reconstructed on the spot.
+
+
+### §9.5 A Hard Problem in Electromagnetism — Divergence of the Point-Charge Electric Field
+
+Finally, one example from electromagnetism. It also serves as a bridge to Chapter 10.
+
+> <strong>Note</strong> (For readers who have not studied electromagnetism) The terms "electric field" and "point charge" below need not be fully understood. Please read them simply as the calculation of "a vector field proportional to $\frac{1}{\rho^2}$." Chapter 10 does not dig deeply into electromagnetism itself either. It only shows that Maxwell's equations become terrifyingly concise when written in differential forms—and that we will actually write out in full what happens when one drops them all the way down to matrices, even though most textbooks stop at saying how beautiful they are.
+
+When a point charge $q$ sits at the origin, the electric field is $\mathbf{E} = \frac{q}{4\pi\varepsilon_0}\frac{\hat{\boldsymbol{\rho}}}{\rho^2}$ ($\hat{\boldsymbol{\rho}}$ is the radial unit vector). In vector analysis one shows $\nabla\cdot\mathbf{E} = 0$ (away from the origin) by plugging into the spherical divergence formula, but it is clearer to work directly with the $1$-form corresponding to $\mathbf{E}$.
+
+The $\rho$ component of $\mathbf{E}$ is $E_\rho = \frac{k}{\rho^2}$ ($k = q/4\pi\varepsilon_0$); the $\theta$ and $\phi$ components are zero. The corresponding $1$-form is
+
+$$\omega = \frac{k}{\rho^2}\,d\rho$$
+
+Compute $d\ast\omega$. In spherical coordinates $\ast(d\rho) = \rho^2\sin\theta\,d\theta\wedge d\phi$ (§9.3.1), so
+
+$$\ast\omega = \frac{k}{\rho^2} \cdot \rho^2\sin\theta\,d\theta\wedge d\phi = k\sin\theta\,d\theta\wedge d\phi$$
+
+$$d\ast\omega = \frac{\partial}{\partial\rho}(k\sin\theta)\,d\rho\wedge d\theta\wedge d\phi + \frac{\partial}{\partial\theta}(k\sin\theta)\,d\theta\wedge d\theta\wedge d\phi + \cdots$$
+
+The second term vanishes because $d\theta\wedge d\theta = 0$; the third term likewise. The first term has $\frac{\partial}{\partial\rho}(k\sin\theta) = 0$ (no dependence on $\rho$). Therefore
+
+$$d\ast\omega = 0 \quad (\rho \neq 0)$$
+
+So $\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$. The $\rho^2$ in $E_\rho$ cancels the $\rho^2$ in $\ast(d\rho)$, and the exterior derivative of the remaining $\sin\theta\,d\theta\wedge d\phi$ is zero—that alone shows zero divergence away from the origin.
+
+> <strong>Note</strong> (What about the origin?) At $\rho = 0$, $\omega$ is not defined. To treat all of space including the origin, one must represent the point charge by distributions ($\delta$ functions) or in integral form rather than by ordinary divergence as a function. This book does not go there; we restrict ourselves to computation on the region excluding the origin. In Chapter 10, where charge density is treated, we write charge density as $\rho_{\mathrm e}$ so as not to confuse it with the radial coordinate $\rho$, and handle the form in which $\rho_{\mathrm e}/\varepsilon_0$ appears on the right-hand side.
+
+---
+
+
+### §9.6 The Dictionary Ends; the Journey Continues
+
+In this chapter we used the dictionary built through Chapter 8 to derive vector-analysis formulas mechanically and to solve hard problems from calculus and electromagnetism. What matters is that every calculation required not "recalling a formula" but only "looking up the dictionary and tracing the procedure."
+
+There is no longer any need to memorize the divergence and curl formulas for cylindrical or spherical coordinates by rote. Remember this single path: $J \to g = J^T J \to \ast$ dictionary $\to$ combinations of $d$ and $\ast$—and you can reconstruct the formulas for orthogonal curvilinear coordinates on the spot. The same principle holds for non-orthogonal coordinates, but note that the $\ast$ dictionary then acquires mixed terms from the off-diagonal metric, so the tables in this chapter with scale factors alone no longer suffice.
+
+In Chapter 10 we apply this toolkit to Maxwell's equations.
+The four fundamental equations of vector analysis collapse to two in differential-form language. Many textbooks stop here with "how beautiful," but we go further. We write Maxwell's equations in differential forms and actually carry out the full component expansion—showing what it looks like when done. Having worked through the calculations of this chapter, that translation should no longer be difficult.
+
+> <strong>Checkpoint — Chapter 9 as a whole</strong>
+> - Deriving formulas in orthogonal curvilinear coordinates proceeds by $J \to g = J^T J \to \ast$ dictionary $\to$ combinations of $d$ and $\ast$.
+> - We derived the $\ast$ dictionary and the divergence and curl formulas in cylindrical and spherical coordinates.
+> - Even hard problems such as the vector Laplacian $\nabla^2\mathbf{F}$ can be solved mechanically by combining the dictionary with identities.
+> - Zero divergence of the point-charge electric field follows from the simple cancellation of $\ast(d\rho)$ with the $\rho^2$ in $E_\rho$.
+> - Formulas need not be memorized by rote. Given the dictionary—and even that dictionary can be reconstructed on the spot—everything can be rebuilt when needed.

--- a/translation/drafts/ch09-9.0-9.1.md
+++ b/translation/drafts/ch09-9.0-9.1.md
@@ -1,0 +1,34 @@
+# Chapter 9: In Practice — Build the Dictionary and Solve Hard Problems
+
+### §9.0 The Central Tools of This Book Are Now in Place
+
+In §8.0 of Chapter 8 we declared that this chapter is the highlight of the book, and we actually translated between the two languages, unified the integral theorems, and contrasted the two methodologies. The central tools of this book are now largely in place.
+
+But it would be a waste to assemble all these tools and never use them. In this chapter we apply the dictionary built so far to actual problems and show how to solve hard problems in vector analysis mechanically. Theory is sufficient through Chapter 8—what follows is <strong>exercise</strong>.
+
+The reader may simply watch the calculations below—or follow along by hand. Either way, what we show here is a demonstration of the fact that you need not memorize formulas; if you have the dictionary, everything can be derived.
+
+> <strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $\ast d\ast$ and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while managing factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ by hand on $\nabla$. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.
+
+---
+
+### §9.1 Building the Dictionary on the Spot — A Mechanical Procedure
+
+The procedure for deriving the formulas for $\mathrm{grad}$, $\mathrm{div}$, and $\mathrm{curl}$ in orthogonal curvilinear coordinates boils down to the following three steps.
+
+1. <strong>Write the Jacobian matrix $J$</strong>. From the coordinate transformation $x = x(q_1,q_2,q_3)$, $y = y(q_1,q_2,q_3)$, $z = z(q_1,q_2,q_3)$, arrange the partial derivatives. Each column of $J$ represents how a single step along one axis in parameter space moves in physical space.
+
+2. <strong>Compute the metric $\mathbf{g} = J^T J$</strong>. This is the procedure we have followed since Chapter 6 §6.1.3. The diagonal entries of $\mathbf{g}$ are the squares of the scales along each axis; the off-diagonal entries represent how orthogonal the axes are to one another.
+
+3. <strong>From $\mathbf{g}$, derive the dictionary for the Hodge star $\ast$, and combine it with $d$</strong>. Substitute the dictionary for $\ast$ in that coordinate system into each formula $\mathrm{grad} = d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$, and the desired formulas are obtained mechanically.
+
+However, the usual $\mathrm{grad}$ and $\mathrm{curl}$ of vector analysis return vector fields as arrows. By contrast, this book's $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$ are read first as formulas on the measuring-device side. To read a $1$-form obtained on the differential-forms side as a column vector, first use the metric $\mathbf{g}$ to convert it back to the form $\mathbf{g}^{-1}(\cdot)^T$. These are the column components corresponding to the coordinates. To read them as orthonormal vector components as used in vector analysis, you must also account for the scale factor in each direction.
+
+Also, in curvilinear coordinates, the orthonormal vector components used in vector analysis generally do not agree with the coefficients relative to the coordinate-associated $1$-forms. Because the calculation is carried out on the $1$-form side, first convert the vector field to the corresponding $1$-form. Then the coefficients of $d\theta$ and $d\phi$ pick up scale factors.
+
+> <strong>Note</strong> (vector components and $1$-form coefficients)
+> In curvilinear coordinates you must distinguish the coordinate-associated $1$-forms from the $1$-forms that measure actual length in units of 1. For example, in polar coordinates, the angular scale $d\theta$ itself differs from the unit-length scale $r\,d\theta$. The dictionary of the Hodge star absorbs all of this scale-factor information. That is what lets us carry out "straight computation" on a "distorted coordinate system."
+
+Below, we demonstrate this procedure in cylindrical and spherical coordinates. Keep in mind the flow: compute first as $1$-forms and $2$-forms, then convert back to orthonormal vector components at the end.
+
+---

--- a/translation/drafts/ch09-9.2.md
+++ b/translation/drafts/ch09-9.2.md
@@ -1,0 +1,105 @@
+### §9.2 Cylindrical Coordinates $(r,\theta,z)$
+
+#### 9.2.1 Deriving the Dictionary
+
+The coordinate transformation to cylindrical coordinates is $x = r\cos\theta$, $y = r\sin\theta$, $z = z$.
+
+> <strong>Note</strong> (Domain and singular points)
+> Below we compute on the coordinate patch where $r > 0$. At $r = 0$, $\theta$ is not defined and cylindrical coordinates themselves become singular. Also, since $\theta$ is an angular coordinate with period $2\pi$, strictly speaking it should be treated as a local coordinate (for example $0 < \theta < 2\pi$). The formulas in this section are intended for use in regions that do not include this singular axis.
+
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}, \qquad
+\mathbf{g} = J^T J = \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+From $\mathbf{g}$ we derive the $\ast$ dictionary. By the same principle as the $\ast$ dictionary in Cartesian coordinates seen in Chapter 6, the square roots of the diagonal components of $\mathbf{g}$ appear as coefficients in $\ast$.
+
+$$\begin{aligned}
+\ast(dr) &= r\,d\theta \wedge dz \\
+\ast(d\theta) &= \frac{1}{r}\,dz \wedge dr \\
+\ast(dz) &= r\,dr \wedge d\theta
+\end{aligned}$$
+
+Also $\ast(1) = r\,dr\wedge d\theta\wedge dz$, $\ast(dr\wedge d\theta\wedge dz) = 1/r$.
+
+> <strong>Note</strong> (Four things to distinguish in cylindrical coordinates)
+> To treat vector fields correctly as differential forms, let us distinguish the following four layers:
+>
+> | Name | Concrete example in cylindrical coordinates |
+> | :--- | :--- |
+> | <strong>Coordinate $1$-forms</strong> | $dr, d\theta, dz$ |
+> | <strong>$1$-forms corresponding to unit-length ticks</strong> | $dr, r\,d\theta, dz$ |
+> | <strong>Components used in vector analysis</strong> | $F_r, F_\theta, F_z$ |
+> | <strong>Coefficients as $1$-forms</strong> | $F_r, rF_\theta, F_z$ |
+>
+> If we write the components in the unit-vector directions used in vector analysis as $F_r,F_\theta,F_z$, the corresponding $1$-form is $F_r dr + F_\theta (r d\theta) + F_z dz$—that is, the coefficients as $1$-forms are $F_r,rF_\theta,F_z$. Throughout this chapter, $F_\theta$ always refers to the "components used in vector analysis."
+
+#### 9.2.2 Gradient
+
+$\mathrm{grad}\,f = df$ does not use $\ast$. It simply places the partial-derivative coefficients on the basis $1$-forms.
+
+$$df = \frac{\partial f}{\partial r}\,dr + \frac{\partial f}{\partial \theta}\,d\theta + \frac{\partial f}{\partial z}\,dz$$
+
+In the notation of vector analysis (as a column vector),
+
+$$
+\nabla f
+=
+\begin{pmatrix}
+\frac{\partial f}{\partial r}\\[0.4em]
+\frac{1}{r}\frac{\partial f}{\partial \theta}\\[0.4em]
+\frac{\partial f}{\partial z}
+\end{pmatrix}
+$$
+
+The factor $\frac{1}{r}$ on the $\theta$ component appears because $\nabla f$ gives components with respect to an orthonormal basis. The coefficient of $d\theta$ in $df$, namely $\frac{\partial f}{\partial\theta}$, is the "rate of change per unit angle," whereas the $\mathbf{e}_\theta$ component of $\nabla f$ is the "rate of change per unit length." The conversion $\frac{1}{r}$ is needed because $d\theta$ corresponds to arc length $r\,d\theta$.
+
+#### 9.2.3 Divergence
+
+For a vector field $\mathbf{F}$ with orthonormal components $F_r,F_\theta,F_z$, the corresponding $1$-form is $\omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz$, following the convention stated below: "make the coefficients as $1$-forms explicit through the scale factors that appear in the formulas."
+
+> <strong>Note</strong> (About the tilde on $\tilde{\omega}$)
+> In Chapter 8 §8.6.2, we used the notation $\tilde{\omega}$ to distinguish the orthonormal component $F_\theta$ from the coefficient as a $1$-form, $rF_\theta$. In this chapter we lighten the notation and write $\omega$ without a tilde below. However, $F_r,F_\theta,F_z$ always denote orthonormal vector components. The corresponding $1$-form is made explicit on each occasion by including the scale factors. In cylindrical coordinates,
+> $$
+> \omega = F_r\,dr + rF_\theta\,d\theta + F_z\,dz
+> $$
+> and in spherical coordinates,
+> $$
+> \omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi
+> $$
+> Read with the convention that the coefficients as $1$-forms are made explicit through the scale factors appearing in the formulas—not inferred by the reader from context.
+
+$$\begin{aligned}
+\ast\omega &= F_r(r\,d\theta\wedge dz) + rF_\theta\!\left(\frac{1}{r}\,dz\wedge dr\right) + F_z(r\,dr\wedge d\theta) \\
+&= rF_r\,d\theta\wedge dz + F_\theta\,dz\wedge dr + rF_z\,dr\wedge d\theta \\[0.3em]
+d\ast\omega &= \left(\frac{\partial}{\partial r}(rF_r) + \frac{\partial F_\theta}{\partial\theta} + \frac{\partial}{\partial z}(rF_z)\right) dr\wedge d\theta\wedge dz \\[0.3em]
+\ast d\ast\omega &= \frac{1}{r}\frac{\partial}{\partial r}(rF_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial\theta} + \frac{\partial F_z}{\partial z}
+\end{aligned}$$
+
+This is the formula for divergence in cylindrical coordinates.
+
+#### 9.2.4 Curl
+
+Curl is $\mathrm{curl}\,\mathbf{F} \leftrightarrow \ast d\omega$.
+
+$$d\omega = \left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right) dr\wedge d\theta + \left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right) d\theta\wedge dz + \left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right) dz\wedge dr$$
+
+$$\ast d\omega = \frac{1}{r}\!\left(\frac{\partial F_z}{\partial\theta} - \frac{\partial}{\partial z}(rF_\theta)\right)\! dr + r\!\left(\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r}\right)\! d\theta + \frac{1}{r}\!\left(\frac{\partial}{\partial r}(rF_\theta) - \frac{\partial F_r}{\partial\theta}\right)\! dz$$
+
+Reading off the coefficients of $dr, d\theta, dz$ from the $1$-form and converting back to orthonormal components, the $d\theta$ coefficient is further divided by $\frac{1}{r}$. In the end,
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{r}\frac{\partial F_z}{\partial \theta} - \frac{\partial F_\theta}{\partial z} \\[0.3em]
+\frac{\partial F_r}{\partial z} - \frac{\partial F_z}{\partial r} \\[0.3em]
+\frac{1}{r}\frac{\partial}{\partial r}(r F_\theta) - \frac{1}{r}\frac{\partial F_r}{\partial \theta}
+\end{pmatrix}$$
+
+The structure in which $r$ appears both inside and outside $\frac{\partial}{\partial r}$ has exactly the same origin as the $\frac{1}{r}$ that appeared when we counted the area element of a sector in the previous chapter.
+
+---

--- a/translation/drafts/ch09-9.3.md
+++ b/translation/drafts/ch09-9.3.md
@@ -1,0 +1,65 @@
+### §9.3 Spherical Coordinates $(\rho,\theta,\phi)$
+
+#### 9.3.1 Deriving the Dictionary
+
+The conversion to spherical coordinates is $x = \rho\sin\theta\cos\phi$, $y = \rho\sin\theta\sin\phi$, $z = \rho\cos\theta$ ($\theta$ is the angle from the $z$-axis, $\phi$ is the azimuthal angle in the $xy$ plane).
+
+$$J = \begin{pmatrix}
+\sin\theta\cos\phi & \rho\cos\theta\cos\phi & -\rho\sin\theta\sin\phi \\
+\sin\theta\sin\phi & \rho\cos\theta\sin\phi & \rho\sin\theta\cos\phi \\
+\cos\theta & -\rho\sin\theta & 0
+\end{pmatrix},\qquad
+\mathbf{g} = J^T J = \begin{pmatrix}
+1 & 0 & 0 \\
+0 & \rho^2 & 0 \\
+0 & 0 & \rho^2\sin^2\theta
+\end{pmatrix}$$
+
+The dictionary for $\ast$ is determined from the diagonal components $\sqrt{1}, \sqrt{\rho^2}, \sqrt{\rho^2\sin^2\theta}$, namely $1, \rho, \rho\sin\theta$.
+
+$$\begin{aligned}
+\ast(d\rho) &= \rho^2\sin\theta\; d\theta \wedge d\phi \\
+\ast(d\theta) &= \sin\theta\; d\phi \wedge d\rho \\
+\ast(d\phi) &= \frac{1}{\sin\theta}\; d\rho \wedge d\theta
+\end{aligned}$$
+
+> <strong>Note</strong> (Four things to distinguish in spherical coordinates)
+>
+> | Name | Concrete example in spherical coordinates |
+> | :--- | :--- |
+> | <strong>Coordinate $1$-forms</strong> | $d\rho, d\theta, d\phi$ |
+> | <strong>$1$-forms for unit-length scales</strong> | $d\rho, \rho\,d\theta, \rho\sin\theta\,d\phi$ |
+> | <strong>Components used in vector analysis</strong> | $F_\rho, F_\theta, F_\phi$ |
+> | <strong>Coefficients as $1$-forms</strong> | $F_\rho, \rho F_\theta, \rho\sin\theta F_\phi$ |
+>
+> The $1$-form for orthonormal components $F_\rho,F_\theta,F_\phi$ is $\omega = F_\rho d\rho + \rho F_\theta d\theta + \rho\sin\theta F_\phi d\phi$.
+
+Here we compute on the coordinate patch $\rho>0$ and $0<\theta<\pi$. At the origin $\rho=0$ and on the polar axis $\sin\theta=0$, spherical coordinates themselves become singular, and formulas containing $1/\rho$ or $1/\sin\theta$ cannot be used as written. For problems spanning singular points, use a different coordinate patch, or compute in a region excluding the singularities and then treat them via boundary conditions.
+
+#### 9.3.2 Divergence
+
+When converting a vector field $\mathbf{F}$ with orthonormal components $F_\rho,F_\theta,F_\phi$ to a $1$-form, the coefficient of $d\rho$ is $F_\rho$ ($\rho$ already carries length), the coefficient of $d\theta$ is $\rho F_\theta$, and the coefficient of $d\phi$ is $\rho\sin\theta\,F_\phi$ (corresponding respectively to arc lengths $\rho\,d\theta$, $\rho\sin\theta\,d\phi$).
+
+$$\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$$
+
+Compute $\ast d\ast\omega$.
+
+$$\ast\omega = \rho^2\sin\theta\,F_\rho\,d\theta\wedge d\phi + \rho\sin\theta\,F_\theta\,d\phi\wedge d\rho + \rho\,F_\phi\,d\rho\wedge d\theta$$
+
+$$d\ast\omega = \left(\frac{\partial}{\partial\rho}(\rho^2\sin\theta\,F_\rho) + \frac{\partial}{\partial\theta}(\rho\sin\theta\,F_\theta) + \frac{\partial}{\partial\phi}(\rho\,F_\phi)\right) d\rho\wedge d\theta\wedge d\phi$$
+
+From $\ast(d\rho\wedge d\theta\wedge d\phi) = 1/(\rho^2\sin\theta)$,
+
+$$\nabla \cdot \mathbf{F} = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+#### 9.3.3 Curl
+
+Similarly, from $\ast d\omega$,
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix}
+\frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+\frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
+\frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
+\end{pmatrix}$$
+
+---

--- a/translation/drafts/ch09-9.4-9.6.md
+++ b/translation/drafts/ch09-9.4-9.6.md
@@ -1,0 +1,111 @@
+### §9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates
+
+The vector Laplacian $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$ is known as one of the longest formulas in the vector-analysis handbook. Here we show that every component falls out mechanically from the dictionary.
+
+The strategy is simply to use the Chapter 8 dictionary as is.
+- $\nabla(\nabla\cdot\mathbf{F}) \leftrightarrow d(\ast d\ast\omega)$
+- $\nabla\times(\nabla\times\mathbf{F}) \leftrightarrow \ast d(\ast d\omega)$
+
+Therefore, viewing the result as a $1$-form,
+
+$$\nabla^2\mathbf{F} \leftrightarrow d\ast d\ast\omega - \ast d\ast d\omega$$
+
+Starting from $\omega = F_\rho\,d\rho + \rho F_\theta\,d\theta + \rho\sin\theta\,F_\phi\,d\phi$ in spherical coordinates, we compute $d\ast d\ast\omega$ and $\ast d\ast d\omega$ separately and take their difference.
+
+#### 9.4.1 The First Term — Gradient of the Divergence
+
+From §9.3.2, the divergence is
+
+$$\ast d\ast\omega = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}(\rho^2 F_\rho) + \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) + \frac{1}{\rho\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+Denote this by $S$. Since $S$ is a scalar field, its gradient is $dS = \frac{\partial S}{\partial\rho}\,d\rho + \frac{\partial S}{\partial\theta}\,d\theta + \frac{\partial S}{\partial\phi}\,d\phi$. Converting to orthonormal components,
+
+$$\nabla(\nabla\cdot\mathbf{F}) = \begin{pmatrix}
+\frac{\partial S}{\partial\rho} \\[0.5em]
+\frac{1}{\rho}\frac{\partial S}{\partial\theta} \\[0.5em]
+\frac{1}{\rho\sin\theta}\frac{\partial S}{\partial\phi}
+\end{pmatrix}$$
+
+#### 9.4.2 The Second Term — Curl of the Curl
+
+Write the curl from §9.3.3 as $C_\rho, C_\theta, C_\phi$.
+
+$$\begin{aligned}
+C_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial F_\theta}{\partial\phi} \\[0.3em]
+C_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial F_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\phi) \\[0.3em]
+C_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho F_\theta) - \frac{1}{\rho}\frac{\partial F_\rho}{\partial\theta}
+\end{aligned}$$
+
+To apply $\nabla\times$ again to $\mathbf{C} = \nabla\times\mathbf{F}$, substitute $C_\rho, C_\theta, C_\phi$ into the formula of §9.3.3 in place of $F_\rho, F_\theta, F_\phi$.
+
+$$\begin{aligned}
+(\nabla\times(\nabla\times\mathbf{F}))_\rho &= \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) - \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi} \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\theta &= \frac{1}{\rho\sin\theta}\frac{\partial C_\rho}{\partial\phi} - \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\phi) \\[0.5em]
+(\nabla\times(\nabla\times\mathbf{F}))_\phi &= \frac{1}{\rho}\frac{\partial}{\partial\rho}(\rho C_\theta) - \frac{1}{\rho}\frac{\partial C_\rho}{\partial\theta}
+\end{aligned}$$
+
+#### 9.4.3 Take the Difference — The Vector Laplacian
+
+Since $\nabla^2\mathbf{F} = \nabla(\nabla\cdot\mathbf{F}) - \nabla\times(\nabla\times\mathbf{F})$, each component is obtained by subtracting the second term from the first. Expand the $\rho$ component.
+
+$$(\nabla^2\mathbf{F})_\rho = \frac{\partial S}{\partial\rho} - \frac{1}{\rho\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,C_\phi) + \frac{1}{\rho\sin\theta}\frac{\partial C_\theta}{\partial\phi}$$
+
+Substituting the expressions for $S$ and $C_\theta, C_\phi$, expanding partial derivatives, and collecting terms yields the following. The expansion is long, so here we show only the result after substitution and like-term collection.
+
+$$(\nabla^2\mathbf{F})_\rho = \nabla^2 F_\rho - \frac{2F_\rho}{\rho^2} - \frac{2}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}(\sin\theta\,F_\theta) - \frac{2}{\rho^2\sin\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+Here $\nabla^2 F_\rho = \frac{1}{\rho^2}\frac{\partial}{\partial\rho}\!\left(\rho^2\frac{\partial F_\rho}{\partial\rho}\right) + \frac{1}{\rho^2\sin\theta}\frac{\partial}{\partial\theta}\!\left(\sin\theta\frac{\partial F_\rho}{\partial\theta}\right) + \frac{1}{\rho^2\sin^2\theta}\frac{\partial^2 F_\rho}{\partial\phi^2}$.
+
+Similarly, for the $\theta$ and $\phi$ components,
+
+$$(\nabla^2\mathbf{F})_\theta = \nabla^2 F_\theta - \frac{F_\theta}{\rho^2\sin^2\theta} + \frac{2}{\rho^2}\frac{\partial F_\rho}{\partial\theta} - \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\phi}{\partial\phi}$$
+
+$$(\nabla^2\mathbf{F})_\phi = \nabla^2 F_\phi - \frac{F_\phi}{\rho^2\sin^2\theta} + \frac{2}{\rho^2\sin\theta}\frac{\partial F_\rho}{\partial\phi} + \frac{2\cos\theta}{\rho^2\sin^2\theta}\frac{\partial F_\theta}{\partial\phi}$$
+
+This completes the derivation of all components. Deriving from scratch in the usual vector-analysis style would easily exceed a page of computation, but via the dictionary each step is nothing more than partial differentiation and multiplication by coefficients. There is no need to memorize individual formulas by rote—given the single identity $d\ast d\ast\omega - \ast d\ast d\omega$ and the $\ast$ dictionary of §9.3, everything can be reconstructed on the spot.
+
+
+### §9.5 A Hard Problem in Electromagnetism — Divergence of the Point-Charge Electric Field
+
+Finally, one example from electromagnetism. It also serves as a bridge to Chapter 10.
+
+> <strong>Note</strong> (For readers who have not studied electromagnetism) The terms "electric field" and "point charge" below need not be fully understood. Please read them simply as the calculation of "a vector field proportional to $\frac{1}{\rho^2}$." Chapter 10 does not dig deeply into electromagnetism itself either. It only shows that Maxwell's equations become terrifyingly concise when written in differential forms—and that we will actually write out in full what happens when one drops them all the way down to matrices, even though most textbooks stop at saying how beautiful they are.
+
+When a point charge $q$ sits at the origin, the electric field is $\mathbf{E} = \frac{q}{4\pi\varepsilon_0}\frac{\hat{\boldsymbol{\rho}}}{\rho^2}$ ($\hat{\boldsymbol{\rho}}$ is the radial unit vector). In vector analysis one shows $\nabla\cdot\mathbf{E} = 0$ (away from the origin) by plugging into the spherical divergence formula, but it is clearer to work directly with the $1$-form corresponding to $\mathbf{E}$.
+
+The $\rho$ component of $\mathbf{E}$ is $E_\rho = \frac{k}{\rho^2}$ ($k = q/4\pi\varepsilon_0$); the $\theta$ and $\phi$ components are zero. The corresponding $1$-form is
+
+$$\omega = \frac{k}{\rho^2}\,d\rho$$
+
+Compute $d\ast\omega$. In spherical coordinates $\ast(d\rho) = \rho^2\sin\theta\,d\theta\wedge d\phi$ (§9.3.1), so
+
+$$\ast\omega = \frac{k}{\rho^2} \cdot \rho^2\sin\theta\,d\theta\wedge d\phi = k\sin\theta\,d\theta\wedge d\phi$$
+
+$$d\ast\omega = \frac{\partial}{\partial\rho}(k\sin\theta)\,d\rho\wedge d\theta\wedge d\phi + \frac{\partial}{\partial\theta}(k\sin\theta)\,d\theta\wedge d\theta\wedge d\phi + \cdots$$
+
+The second term vanishes because $d\theta\wedge d\theta = 0$; the third term likewise. The first term has $\frac{\partial}{\partial\rho}(k\sin\theta) = 0$ (no dependence on $\rho$). Therefore
+
+$$d\ast\omega = 0 \quad (\rho \neq 0)$$
+
+So $\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$. The $\rho^2$ in $E_\rho$ cancels the $\rho^2$ in $\ast(d\rho)$, and the exterior derivative of the remaining $\sin\theta\,d\theta\wedge d\phi$ is zero—that alone shows zero divergence away from the origin.
+
+> <strong>Note</strong> (What about the origin?) At $\rho = 0$, $\omega$ is not defined. To treat all of space including the origin, one must represent the point charge by distributions ($\delta$ functions) or in integral form rather than by ordinary divergence as a function. This book does not go there; we restrict ourselves to computation on the region excluding the origin. In Chapter 10, where charge density is treated, we write charge density as $\rho_{\mathrm e}$ so as not to confuse it with the radial coordinate $\rho$, and handle the form in which $\rho_{\mathrm e}/\varepsilon_0$ appears on the right-hand side.
+
+---
+
+
+### §9.6 The Dictionary Ends; the Journey Continues
+
+In this chapter we used the dictionary built through Chapter 8 to derive vector-analysis formulas mechanically and to solve hard problems from calculus and electromagnetism. What matters is that every calculation required not "recalling a formula" but only "looking up the dictionary and tracing the procedure."
+
+There is no longer any need to memorize the divergence and curl formulas for cylindrical or spherical coordinates by rote. Remember this single path: $J \to g = J^T J \to \ast$ dictionary $\to$ combinations of $d$ and $\ast$—and you can reconstruct the formulas for orthogonal curvilinear coordinates on the spot. The same principle holds for non-orthogonal coordinates, but note that the $\ast$ dictionary then acquires mixed terms from the off-diagonal metric, so the tables in this chapter with scale factors alone no longer suffice.
+
+In Chapter 10 we apply this toolkit to Maxwell's equations.
+The four fundamental equations of vector analysis collapse to two in differential-form language. Many textbooks stop here with "how beautiful," but we go further. We write Maxwell's equations in differential forms and actually carry out the full component expansion—showing what it looks like when done. Having worked through the calculations of this chapter, that translation should no longer be difficult.
+
+> <strong>Checkpoint — Chapter 9 as a whole</strong>
+> - Deriving formulas in orthogonal curvilinear coordinates proceeds by $J \to g = J^T J \to \ast$ dictionary $\to$ combinations of $d$ and $\ast$.
+> - We derived the $\ast$ dictionary and the divergence and curl formulas in cylindrical and spherical coordinates.
+> - Even hard problems such as the vector Laplacian $\nabla^2\mathbf{F}$ can be solved mechanically by combining the dictionary with identities.
+> - Zero divergence of the point-charge electric field follows from the simple cancellation of $\ast(d\rho)$ with the $\rho^2$ in $E_\rho$.
+> - Formulas need not be memorized by rote. Given the dictionary—and even that dictionary can be reconstructed on the spot—everything can be rebuilt when needed.

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -249,6 +249,7 @@ Per-section Pass status:
 | `translation/drafts/ch09-*.md` | integrated into `ch09.md` |
 | `translation/reviews/ch09-pass2.md` | complete |
 | `translation/reviews/ch09-pass3.md` | complete |
+| `translation/reviews/ch09-close-reading-polish.md` | complete (#187) |
 
 ---
 

--- a/translation/progress.md
+++ b/translation/progress.md
@@ -231,6 +231,25 @@ Per-section Pass status:
 | `translation/reviews/ch08-pass3.md` | complete |
 | `translation/reviews/ch08-close-reading-polish.md` | complete (#186) |
 
+### English Chapter 9 — `manuscript/en/ch09/ch09.md` (branch `ai/english-translation-ch09`, PR [#170](https://github.com/yokiikoy/nabla-kaitai/pull/170))
+
+| Scope | Pass | Notes |
+|-------|------|-------|
+| **Chapter 9 (§9.0–§9.6)** | **1 → 2 → 3** | `ch09-pass2.md`, `ch09-pass3.md` |
+
+| Block | Pass | Review |
+|-------|------|--------|
+| §9.0–§9.1 | **3** | `ch09-9.0-9.1-review.md` |
+| §9.2 | **3** | `ch09-9.2-review.md` |
+| §9.3 | **3** | `ch09-9.3-review.md` |
+| §9.4–§9.6 | **3** | `ch09-9.4-9.6-review.md` |
+
+| Artifact | Status |
+|----------|--------|
+| `translation/drafts/ch09-*.md` | integrated into `ch09.md` |
+| `translation/reviews/ch09-pass2.md` | complete |
+| `translation/reviews/ch09-pass3.md` | complete |
+
 ---
 
 ## History (closed issues on this branch)

--- a/translation/reviews/ch09-9.0-9.1-review.md
+++ b/translation/reviews/ch09-9.0-9.1-review.md
@@ -1,0 +1,3 @@
+# Review: ch09 §9.0–§9.1
+
+Pass 1 **passed**. `ch09-9.0-9.1.md`.

--- a/translation/reviews/ch09-9.2-review.md
+++ b/translation/reviews/ch09-9.2-review.md
@@ -1,0 +1,3 @@
+# Review: ch09 §9.2
+
+Pass 1 **passed**. Cylindrical coords. `ch09-9.2.md`.

--- a/translation/reviews/ch09-9.3-review.md
+++ b/translation/reviews/ch09-9.3-review.md
@@ -1,0 +1,3 @@
+# Review: ch09 §9.3
+
+Pass 1 **passed**. Spherical coords. `ch09-9.3.md`.

--- a/translation/reviews/ch09-9.4-9.6-review.md
+++ b/translation/reviews/ch09-9.4-9.6-review.md
@@ -1,0 +1,3 @@
+# Review: ch09 §9.4–§9.6
+
+Pass 1 **passed**. Laplacian, point charge, ch10 foreshadow. `ch09-9.4-9.6.md`.

--- a/translation/reviews/ch09-close-reading-polish.md
+++ b/translation/reviews/ch09-close-reading-polish.md
@@ -1,0 +1,56 @@
+# Close-Reading Polish: Chapter 9
+
+Review date: 2026-05-23
+Branch: `ai/english-translation-ch09`
+File: `manuscript/en/ch09/ch09.md`
+GitHub issue: #187
+PR context: #170
+
+Scope: publication polish after Pass 3 — curvilinear dictionary safety, orthonormal vs form-coefficient read-back, Markdown cleanup, preservation of “build the dictionary on the spot” arc.
+
+---
+
+## Applied
+
+### B items
+
+- **B1** Removed duplicate horizontal rules between §9.1/§9.2, §9.2/§9.3, and §9.3/§9.4
+- **B2** §9.2.4: cylindrical curl read-back — $d\theta$ coefficient divided by scale factor $r$ (not $1/r$)
+
+### C items (straightforward)
+
+- **C1** §9.0: Chapter 8 highlight referent (`that chapter` / `routes`)
+- **C2** §9.0 note: `$d$`, `$\ast d$`, or `$\ast d\ast$` as appropriate
+- **C3** §9.0 note: manually attaching factors to `$\nabla$` formulas
+- **C4** §9.2.3: scale-factor convention sentence
+- **C5** §9.3.1: Hodge-star coefficients from scale factors
+- **C7** §9.4: vector Laplacian identity with explicit parentheses
+- **C8** §9.4: `$\nabla^2 F_\rho$` as scalar Laplacian on component
+- **C9** §9.4/§9.5: single horizontal rule between major sections
+- **C10** §9.5: point-charge divergence correspondence wording
+- **C11** §9.5/§9.6: extra blank lines cleaned
+
+### Intentionally unchanged (D items / optional C)
+
+- **C6** §9.3.3 “Similarly, from `$\ast d\omega$`” — kept for brevity
+- Three-step `J -> g -> *` recipe, “no memorizing formulas”
+- Vector components vs $1$-form coefficients, four-layer tables
+- Cylindrical/spherical final formulas, vector Laplacian decomposition
+- Point-charge calculation, origin note, `$\rho_{\mathrm e}$` foreshadow
+- Non-orthogonal caveat, Chapter 10 Maxwell bridge
+
+---
+
+## Verification
+
+Post-edit searches (expected: no matches):
+
+- duplicate `---` blocks — none
+- `this chapter is the highlight` — none
+- `Substitute the dictionary into $\ast d\ast$` — none
+- `divided by $\frac{1}{r}$` (curl read-back) — none
+- `diagonal components $\sqrt{1}` — none
+- `$\ast d\ast\omega = \nabla\cdot\mathbf{E} = 0$` — none
+- `rot` — none
+
+`git diff --check` passes.

--- a/translation/reviews/ch09-pass2.md
+++ b/translation/reviews/ch09-pass2.md
@@ -1,0 +1,7 @@
+# Pass 2 Review: Chapter 9
+
+Branch: `ai/english-translation-ch09` · ~325 lines
+
+Mechanical dictionary procedure; cylindrical/spherical worked examples; vector Laplacian; point charge. **curl not rot**; $\rho_{\mathrm e}$ for charge density. No structural edits.
+
+**Passes Pass 2.**

--- a/translation/reviews/ch09-pass3.md
+++ b/translation/reviews/ch09-pass3.md
@@ -1,0 +1,10 @@
+# Pass 3 Review: Chapter 9
+
+## Keep
+- Three-step recipe $J \to g \to \ast$ (§9.1)
+- Four-layer table (§9.2.1)
+- Vector Laplacian decomposition (§9.4)
+- Origin Note with $\rho_{\mathrm e}$ foreshadow (§9.5)
+- "No memorizing formulas" closing (§9.6)
+
+**Chapter 9 passes Pass 3.**


### PR DESCRIPTION
## Summary
- New English `manuscript/en/ch09/ch09.md`: practical dictionary-building in cylindrical/spherical coordinates, vector Laplacian, point-charge divergence.
- curl not rot; $\rho_e$ for charge density; bridge to Chapter 10.
- Branch replayed on current `main`; diff is ch09-only.

## Scope
| Block | Content |
|-------|---------|
| §9.0–§9.1 | Dictionary on the spot, cylindrical setup |
| §9.2 | Cylindrical grad/div/curl/Laplacian |
| §9.3 | Spherical coordinates dictionary |
| §9.4–§9.6 | Spherical operators, point charge, summary |

## Test plan
- [ ] Diff against `manuscript/ja/ch09/ch09.md`
- [ ] curl not rot; Route ①/② consistent with Chapter 8
- [ ] Review records: `ch09-pass2.md`, `ch09-pass3.md`
- [ ] Merge to `main`