### PR TITLE
Add GitHub Actions: build verify (PR) + artifact rebuild (main)

### DIFF
--- a/.github/workflows/build-manuscript.yml
+++ b/.github/workflows/build-manuscript.yml
@@ -67,10 +67,5 @@ jobs:
             exit 0
           fi
 
-          git commit -m "$(cat <<'EOF'
-chore: rebuild release artifacts
-
-Automated rebuild from tools/build_release.py on main.
-EOF
-)"
+          git commit -m "chore: rebuild release artifacts (automated)"
           git push

--- a/.github/workflows/build-manuscript.yml
+++ b/.github/workflows/build-manuscript.yml
@@ -1,0 +1,76 @@
+name: Build manuscript
+
+on:
+  pull_request:
+    paths:
+      - 'manuscript/**'
+      - 'tools/**'
+      - '.github/workflows/build-manuscript.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'manuscript/**'
+      - 'tools/**'
+      - '.github/workflows/build-manuscript.yml'
+
+concurrency:
+  group: build-manuscript-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pandoc \
+            texlive-xetex \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            fonts-ipaexfont
+
+      - name: Build release artifacts
+        run: python3 tools/build_release.py
+
+      - name: Commit rebuilt artifacts to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add \
+            docs/*.html \
+            docs/en/*.html \
+            exports/manuscript.pdf \
+            exports/manuscript-en.pdf \
+            exports/manuscript_combined.md \
+            exports/manuscript-en_combined.md \
+            exports/body.tex \
+            exports/manuscript.tex \
+            exports/manuscript-en.tex \
+            manuscript.pdf
+
+          if git diff --staged --quiet; then
+            echo "No artifact changes to commit."
+            exit 0
+          fi
+
+          git commit -m "$(cat <<'EOF'
+chore: rebuild release artifacts
+
+Automated rebuild from tools/build_release.py on main.
+EOF
+)"
+          git push


### PR DESCRIPTION
## Summary

- Add `.github/workflows/build-manuscript.yml` implementing **A + B**:
  - **A (verify):** on PRs touching `manuscript/**`, `tools/**`, or this workflow, run `python3 tools/build_release.py` (JA+EN HTML + PDF). Fails if the build breaks.
  - **B (rebuild):** on push to `main` with the same path filters, rebuild and auto-commit tracked release artifacts (`docs/`, `docs/en/`, PDFs, combined markdown, LaTeX sources).

## Why now

- #194 merged manuscript-only fixes; `docs/` / PDFs on main are still stale until rebuilt.
- After this workflow lands, the first `main` push will run **B** and commit Wave 4 HTML/PDF updates without a manual rebuild PR.

## CI dependencies

Ubuntu packages: `pandoc`, `texlive-xetex`, `texlive-latex-extra`, `texlive-fonts-recommended`, `fonts-ipaexfont`.

## Branch protection note

Job **B** pushes to `main` with `github-actions[bot]`. If the push step fails, allow the Actions bot to bypass PR requirements (or grant `contents: write` push access under branch rules).

Rebuilt commits only touch `docs/` / `exports/` / `manuscript.pdf`, so they **do not** retrigger this workflow (path filter is manuscript/tools only).

## Test plan

- [ ] PR check runs and completes `Build release artifacts`
- [ ] After merge, verify a follow-up bot commit updates `docs/ch10.html` with `\mathbf{B}^T g_3` notation
- [ ] Confirm no infinite rebuild loop on main


Made with [Cursor](https://cursor.com)