### PR TITLE
Unify English book title; fix ch07 Unmasking Nabla reference

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -12,7 +12,7 @@
 
 - 日本語: **ナブラ解体新書**
 - サブタイトル: 行列表示の微分形式によるベクトル解析の抜け道
-- 英語: **Unmasking Div Grad Curl: An Elementary Matrix Bypass via Exterior Forms**
+- 英語: **Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms**
 
 ## 2. ターゲットと4部構成
 

--- a/docs/en/ch07.html
+++ b/docs/en/ch07.html
@@ -129,7 +129,7 @@
     <article class="markdown-body">
 <h1 id="Chapter-7:-Vector-Analysis-—-Enter-Nabla">Chapter 7: Vector Analysis — Enter Nabla</h1>
 <h3 id="§7.0-Enter-Nabla">§7.0 Enter Nabla</h3>
-<p>The title of this book is <em>Unmasking Nabla</em>—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+<p>The title of this book is <em>Unmasking Div, Grad, and Curl</em> (or <em>Unmasking Nabla</em>, as the Japanese title suggests)—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
 </p>
 <p>What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
 </p>

--- a/manuscript/en/ch07/ch07.md
+++ b/manuscript/en/ch07/ch07.md
@@ -2,7 +2,7 @@
 
 ### §7.0 Enter Nabla
 
-The title of this book is *Unmasking Nabla*—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+The title of this book is *Unmasking Div, Grad, and Curl* (or *Unmasking Nabla*, as the Japanese title suggests)—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
 
 What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
 

--- a/manuscript/en/toc.md
+++ b/manuscript/en/toc.md
@@ -1,13 +1,13 @@
 ---
 title: "Table of Contents"
-series: "Unmasking Div, Grad, and Curl: A Heuristic Matrix Route from Differential Forms to Vector Analysis"
+series: "Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms"
 chapter: NA
 order: 0
 ---
 
 # Table of Contents
 
-## *Unmasking Div, Grad, and Curl: A Heuristic Matrix Route from Differential Forms to Vector Analysis*
+## *Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms*
 
 ---
 

--- a/manuscript/ja/toc.md
+++ b/manuscript/ja/toc.md
@@ -9,7 +9,7 @@ order: 0
 
 ## 『ナブラ解体新書 —— 行列表示の微分形式によるベクトル解析の抜け道 ——』
 
-<strong>Unmasking Div, Grad, and Curl: A Heuristic Matrix Route from Differential Forms to Vector Analysis</strong>
+<strong>Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms</strong>
 
 ---
 

--- a/translation/drafts/ch07-7.0-7.2.md
+++ b/translation/drafts/ch07-7.0-7.2.md
@@ -2,7 +2,7 @@
 
 ### §7.0 Enter Nabla
 
-The title of this book is *Unmasking Nabla*—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+The title of this book is *Unmasking Div, Grad, and Curl* (or *Unmasking Nabla*, as the Japanese title suggests)—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
 
 What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
 

--- a/translation/evaluation-rubric.md
+++ b/translation/evaluation-rubric.md
@@ -1,6 +1,6 @@
 # English Translation Evaluation Rubric v0.1
 
-This rubric is used to evaluate each English translation draft of *Unmasking Div, Grad, and Curl*.
+This rubric is used to evaluate each English translation draft of *Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms*.
 
 The goal is not merely to produce grammatically correct English. The goal is to produce an English mathematical text that preserves the author’s argument, tone, and pedagogical strategy while reading naturally as English.
 

--- a/translation/style-guide.md
+++ b/translation/style-guide.md
@@ -2,7 +2,17 @@
 
 ## Title
 
-*Unmasking Div, Grad, and Curl: A Heuristic Matrix Route from Differential Forms to Vector Analysis*
+**Full title (metadata, toc, PDF subtitle block):**
+
+*Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms*
+
+Use a hyphen in `Matrix-Represented` in prose, metadata, URLs, and GitHub. Typography-only contexts (e.g. a print cover) may use a figure dash if desired.
+
+**Short title (HTML sidebar, page `<title>` suffix):**
+
+*Unmasking Div, Grad, and Curl*
+
+**Chapter 7 §7.0:** refer to the full English title, then note the Japanese parallel *Unmasking Nabla* / ナブラ解体新書.
 
 ## Basic Policy
 


### PR DESCRIPTION
## Summary

- Adopt canonical English full title: **Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms** (hyphen in `Matrix-Represented` for metadata/prose).
- **ch07 §7.0:** cite the formal English title, then *Unmasking Nabla* as the Japanese-title parallel (preserves the “title fraud” joke).
- Replace obsolete **Heuristic Matrix Route** / old REQUIREMENTS wording in `toc.md`, `ja/toc.md`, style guide, and evaluation rubric.
- Rebuild `docs/en/ch07.html`.

## Canonical titles (documented in `translation/style-guide.md`)

| Role | Title |
|------|-------|
| Full | Unmasking Div, Grad, and Curl: A Shortcut to Vector Analysis through Matrix-Represented Differential Forms |
| Short | Unmasking Div, Grad, and Curl (HTML/PDF main title; already in `locale.py`) |

## Test plan

- [ ] ch07 §7.0 reads naturally with dual title reference
- [ ] `manuscript/en/toc.md` series YAML matches style guide
- [ ] GitHub Pages ch07 shows updated paragraph after merge + CI rebuild
- [ ] PDF subtitle block unchanged (already matched in `locale.py`)


Made with [Cursor](https://cursor.com)