### PR TITLE
Fix EN ch03 §3.4.1 PDF display math (Pandoc '+' list marker)

### DIFF
--- a/manuscript/en/ch03/ch03.md
+++ b/manuscript/en/ch03/ch03.md
@@ -504,12 +504,7 @@ Here "equals" means the contraction of the row vector $\omega_{\gamma(t_i)}$ fix
 
 Organize the change in each component in the form "finite ratio $\times \Delta t$":
 
-$$
-\omega_{\gamma(t_i)}(\Delta\mathbf{r}_i)
-= \bigl(P(\gamma(t_i))\frac{\Delta x_i}{\Delta t}
-+ Q(\gamma(t_i))\frac{\Delta y_i}{\Delta t}
-+ R(\gamma(t_i))\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t.
-$$
+$$\omega_{\gamma(t_i)}(\Delta\mathbf{r}_i) = \bigl(P(\gamma(t_i))\frac{\Delta x_i}{\Delta t} + Q(\gamma(t_i))\frac{\Delta y_i}{\Delta t} + R(\gamma(t_i))\frac{\Delta z_i}{\Delta t}\bigr)\,\Delta t$$
 
 Sum over the whole interval and take the limit. Since $\Delta x_i/\Delta t \to x'(t)$, $\Delta y_i/\Delta t \to y'(t)$, and $\Delta z_i/\Delta t \to z'(t)$:
 


### PR DESCRIPTION
## Summary
- Fixes broken block equation in EN ch03 §3.4.1 (*Line Integral of a General 1-Form*) where Pandoc turned `+`-prefixed continuation lines inside `$$...$$` into `\item`, corrupting the PDF layout.
- Collapses the equation to a single-line `$$...$$` block, matching JA ch03 §3.4.1.

Closes #199

## Root cause
```markdown
= \bigl(P(...)\frac{\Delta x_i}{\Delta t}
+ Q(...)\frac{\Delta y_i}{\Delta t}   # Pandoc: markdown list inside display math
```

## Test plan
- [x] `python3 tools/build_pdf.py --lang en` — §3.4.1 Riemann-sum equation renders as one `\[...\]` block in `exports/manuscript-en.tex` (~4013)
- [x] No `\item` / `itemize` inside that equation in generated LaTeX
- [ ] CI build-manuscript workflow passes on PR
- [ ] Spot-check PDF around §3.4.1 after merge

## Note
EN PDF may still log LaTeX errors from ch02 §2.4.4 (#197 / PR #198) until that PR merges.

Made with [Cursor](https://cursor.com)