### PR TITLE
Fix EN build dropping first section per chapter (YAML '---' false positive)

### DIFF
--- a/docs/en/appendix.html
+++ b/docs/en/appendix.html
@@ -121,7 +121,7 @@
 <li class="level-1"><a href="ch12.html" id="link-ch12.html">Chapter 12</a></li>
 <li class="level-1"><a href="postscript.html" id="link-postscript.html">Afterword</a></li>
 <li class="level-1"><a href="refs.html" id="link-refs.html">References (with Comments from the Author)</a></li>
-<li class="level-1"><a href="appendix.html" class="active" id="link-appendix.html">Appendix</a><ul class="sub-toc"><li class="level-2"><a href="#II.-On-Methodological-Choices-and-Limits-of-Application">II. On Methodological Choices and Limits of Application</a></li><li class="level-2"><a href="#III.-On-Physical-Definitions-and-Pedagogical-Choices">III. On Physical Definitions and Pedagogical Choices</a></li></ul></li>
+<li class="level-1"><a href="appendix.html" class="active" id="link-appendix.html">Appendix</a><ul class="sub-toc"><li class="level-2"><a href="#I.-On-the-Theoretical-Framework-and-Rigor">I. On the Theoretical Framework and Rigor</a></li><li class="level-2"><a href="#II.-On-Methodological-Choices-and-Limits-of-Application">II. On Methodological Choices and Limits of Application</a></li><li class="level-2"><a href="#III.-On-Physical-Definitions-and-Pedagogical-Choices">III. On Physical Definitions and Pedagogical Choices</a></li></ul></li>
 </ul>
     </div>
   </nav>
@@ -156,6 +156,49 @@
 <p><strong>Note</strong> (will the day come when I am not fooled?)</p>
 <p>They say one stands at thirty; when I actually reached that milestone, I was still getting angry at formulas rather than standing upright. I have started making dad jokes.</p>
 </blockquote>
+<hr />
+<h2 id="I.-On-the-Theoretical-Framework-and-Rigor">I. On the Theoretical Framework and Rigor</h2>
+<ul>
+<li><strong>Introducing the exterior derivative $d$ without mathematical definitions of manifolds, atlases, tangent spaces, and so on is inaccurate</strong></li>
+<p>  → This book is not a textbook of differential forms on general manifolds; it is an introductory book for reaching vector analysis on three-dimensional Euclidean space. Chapter 11 gives signposts for moving to general manifolds.
+</p>
+</ul>
+<ul>
+<li><strong>Contravariant and covariant vectors (dual spaces) should be distinguished clearly from the start</strong></li>
+<p>  → Chapter 1 §1.1.6 introduces the distinction between "column vectors (displacements)" and "row vectors (measuring devices)," which is a concrete representation of the dual-space idea. A more abstract formulation of dual spaces is connected in Chapter 6 and Chapter 11.
+</p>
+</ul>
+<ul>
+<li><strong>Treating $dx$ as a row vector is not standard notation in mathematics books</strong></li>
+<p>  → An intentional choice. Defined in Chapter 1 §1.1 and used consistently throughout. The aim is to translate the abstract idea "1-form = function that eats vectors" into "matrix multiplication" that the reader already knows. Correspondence with standard differential-form notation is shown in Chapter 11.
+</p>
+</ul>
+<ul>
+<li><strong>The exterior derivative $d$ should be defined generally from axioms (Leibniz rule, $d^2=0$)</strong></li>
+<p>  → This book does not start from axioms; in Chapter 5 §5.3 it discovery-style derives $d$ from the physical intuition of "mismatch when traversing an infinitesimal loop." $d^2=0$ is understood in Chapter 5 §5.8 as a consequence of symmetry of mixed partial derivatives. The axiomatic definition is supplemented in Chapter 11.
+</p>
+</ul>
+<ul>
+<li><strong>A complete proof of Stokes' theorem on general $n$-dimensional manifolds is not given</strong></li>
+<p>  → This book derives the concrete cases in three-dimensional Euclidean space (Gauss, Stokes, Green) directly from the definition of integration (Chapters 5 and 8). Proof of Stokes' theorem in general dimension is outside the book's scope; Chapter 11 gives signposts only.
+</p>
+</ul>
+<ul>
+<li><strong>The axiomatic approach via universal properties of exterior algebra is not used in defining the wedge product</strong></li>
+<p>  → In §2.4 this book builds the wedge product as antisymmetrization of the tensor product. That is a concrete entry point toward the axiomatic approach, chosen so the reader can work by hand with matrix subtraction. The more standard abstract viewpoint is signposted in Chapter 11.
+</p>
+</ul>
+<ul>
+<li><strong>The book relies too much on component representations even though geometric objects have no absolute coordinate representation</strong></li>
+<p>  → An intentional choice. The subject of this book is "how to use differential forms," not the philosophy of "differential forms as coordinate-independent geometric entities." Like standard vector-analysis textbooks, it adopts component representations as a practical computational tool. The coordinate-invariant viewpoint is connected in Chapter 11.
+</p>
+</ul>
+<ul>
+<li><strong>Avoiding standard notation makes the book look like it claims a private school</strong></li>
+<p>  → The notation is chosen with top priority on "beginners can work by hand with matrix calculations." Why standard notation (index contraction, $\partial_\mu$, and so on) is deliberately avoided is explained in Chapter 11. This policy itself is widely seen in numerical computation and similar fields; the author does not especially claim anything new. There simply seemed to be no Japanese book in this style, so the author wrote one.
+</p>
+</ul>
+<hr />
 <h2 id="II.-On-Methodological-Choices-and-Limits-of-Application">II. On Methodological Choices and Limits of Application</h2>
 <ul>
 <li><strong>Einstein summation (tensor analysis) would allow the same calculations without bundles of matrices</strong></li>

--- a/docs/en/ch01.html
+++ b/docs/en/ch01.html
@@ -107,7 +107,7 @@
 <li class="level-1"><a href="index.html" id="link-index.html">Preface</a></li>
 <li class="level-1"><a href="intro.html" id="link-intro.html">Introduction</a></li>
 <li class="level-1"><a href="portal.html" id="link-portal.html">Portal Site and a Small Experiment</a></li>
-<li class="level-1"><a href="ch01.html" class="active" id="link-ch01.html">Chapter 1</a><ul class="sub-toc"><li class="level-3"><a href="#§1.0-The-Mathematician’s-One-Dimension,-the-Physicist’s-One-Dimension">§1.0 The Mathematician’s One Dimension, the Physicist’s One Dimension</a></li><li class="level-3"><a href="#§1.2-The-Total-Differential-$df$-—-An-Operator-That-Packs-Rates-of-Change-into-a-Matrix">§1.2 The Total Differential $df$ — An Operator That Packs Rates of Change into a Matrix</a></li><li class="level-3"><a href="#§1.3-Leibniz-Notation-and-Algebraic-Intuition">§1.3 Leibniz Notation and Algebraic Intuition</a></li><li class="level-3"><a href="#§1.4-Coordinate-Transformations-—-Rebuilding-Measuring-Devices-in-New-Coordinates">§1.4 Coordinate Transformations — Rebuilding Measuring Devices in New Coordinates</a></li><li class="level-3"><a href="#§1.5-Writing-in-Another-Coordinate-System-—-Exercises">§1.5 Writing in Another Coordinate System — Exercises</a></li><li class="level-3"><a href="#§1.6-Summary-of-This-Chapter-and-Outlook-Toward-the-Next">§1.6 Summary of This Chapter and Outlook Toward the Next</a></li></ul></li>
+<li class="level-1"><a href="ch01.html" class="active" id="link-ch01.html">Chapter 1</a><ul class="sub-toc"><li class="level-3"><a href="#§1.0-The-Mathematician’s-One-Dimension,-the-Physicist’s-One-Dimension">§1.0 The Mathematician’s One Dimension, the Physicist’s One Dimension</a></li><li class="level-3"><a href="#§1.1-Riemann-Sums-and-Matrix-Products">§1.1 Riemann Sums and Matrix Products</a></li><li class="level-3"><a href="#§1.2-The-Total-Differential-$df$-—-An-Operator-That-Packs-Rates-of-Change-into-a-Matrix">§1.2 The Total Differential $df$ — An Operator That Packs Rates of Change into a Matrix</a></li><li class="level-3"><a href="#§1.3-Leibniz-Notation-and-Algebraic-Intuition">§1.3 Leibniz Notation and Algebraic Intuition</a></li><li class="level-3"><a href="#§1.4-Coordinate-Transformations-—-Rebuilding-Measuring-Devices-in-New-Coordinates">§1.4 Coordinate Transformations — Rebuilding Measuring Devices in New Coordinates</a></li><li class="level-3"><a href="#§1.5-Writing-in-Another-Coordinate-System-—-Exercises">§1.5 Writing in Another Coordinate System — Exercises</a></li><li class="level-3"><a href="#§1.6-Summary-of-This-Chapter-and-Outlook-Toward-the-Next">§1.6 Summary of This Chapter and Outlook Toward the Next</a></li></ul></li>
 <li class="level-1"><a href="ch02.html" id="link-ch02.html">Chapter 2</a></li>
 <li class="level-1"><a href="ch03.html" id="link-ch03.html">Chapter 3</a></li>
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
@@ -127,7 +127,7 @@
   </nav>
   <main class="main-content">
     <article class="markdown-body">
-<h1 id="Chapter-1:-What-Is-__MATH_BLOCK_65__?-—-A-Measuring-Device-That-Eats-Vectors,-or-a-Row-Vector">Chapter 1: What Is $dx$? — A Measuring Device That Eats Vectors, or a Row Vector</h1>
+<h1 id="Chapter-1:-What-Is-__MATH_BLOCK_85__?-—-A-Measuring-Device-That-Eats-Vectors,-or-a-Row-Vector">Chapter 1: What Is $dx$? — A Measuring Device That Eats Vectors, or a Row Vector</h1>
 <h3 id="§1.0-The-Mathematician’s-One-Dimension,-the-Physicist’s-One-Dimension">§1.0 The Mathematician’s One Dimension, the Physicist’s One Dimension</h3>
 <p>When we first learn the one-dimensional integral $\int f(x)\,dx$ in high school, the textbook places before us a single line: the $x$-axis. For a mathematics textbook, that is perfectly reasonable. A <strong>mathematician</strong> assumes a self-contained abstract world called one-dimensional space $\mathbb{R}^1$, and builds the logic there. A point is a real number $x$, a displacement is a real number $\Delta x$, and an integral is defined as the limit of “function times tiny width.” Everything is self-contained.
 </p>
@@ -186,6 +186,255 @@ $$
 <p><strong>Note</strong> (extensions in Part III)</p>
 <p>In Part III, however, we will touch on curvilinear coordinates and extensions to higher dimensions as needed.</p>
 </blockquote>
+<hr />
+<h3 id="§1.1-Riemann-Sums-and-Matrix-Products">§1.1 Riemann Sums and Matrix Products</h3>
+<p>In the previous section, we reinterpreted a physical infinitesimal displacement as the column vector $\mathbf{v}$. As in §1.0,
+</p>
+$$
+\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}.
+$$
+<p>With that picture in place, let us rewrite the familiar Riemann integral and see what perspective “$dx$ as a matrix” gives us.
+</p>
+<blockquote>
+<p><strong>Note</strong> (on transpose notation)</p>
+<p>In mathematics and in other books, a column vector is sometimes laid sideways on the page and marked with a superscript ${}^T$, as in $(\Delta x,\Delta y,\Delta z)^T$. In this book, I avoid this kind of space-saving transpose notation as much as possible. Column vectors are written as columns, and row vectors as rows. If ${}^T$ appears exceptionally, read it as an intentional transpose operation.</p>
+</blockquote>
+<h4 id="1.1.1-The-Standard-Construction-of-a-Riemann-Sum-(Review)">1.1.1 The Standard Construction of a Riemann Sum (Review)</h4>
+<p>The definite integral of a function $f(x)$ over the interval $[a,b]$ is defined as follows. In high-school language, this is the method of exhaustion by subdivision.
+</p>
+<blockquote>
+<p><strong>Note</strong> (closed intervals)</p>
+<p>The notation $[a,b]$ denotes the <strong>closed interval</strong> containing both endpoints $a$ and $b$: the set of real numbers $x$ such that $a \le x \le b$.</p>
+</blockquote>
+<ol>
+<li>Divide the interval into $n$ subintervals: $a=x_0<x_1<\cdots<x_n=b$.</li>
+<li>Let the width of the small interval be $\Delta x_i=x_i-x_{i-1}$.</li>
+<li>Choose one representative point $\xi_i$ <strong>inside</strong> each subinterval $[x_{i-1},x_i]$.</li>
+<li>Form the Riemann sum $R_n:=\sum_{i=1}^n f(\xi_i)\Delta x_i$. We write the sum for this particular $n$-fold partition as $R_n$.</li>
+<li>Take the limit as the partition becomes finer. Strictly speaking, the <strong>maximum</strong> width of the subintervals approaches $0$. Merely increasing the number of pieces $n$ can still leave a large interval somewhere, so more advanced mathematics emphasizes this condition. In what follows, $\lim_{n\to\infty}R_n$ assumes partitions satisfying this condition:</li>
+</ol>
+$$
+\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n.
+$$
+<p>In the usual textbook explanation, you read $dx$ as what the “tiny width $\Delta x_i$” becomes in the limit. Here we go one step deeper.
+</p>
+<h4 id="1.1.2-Displacement-on-Each-Subinterval">1.1.2 Displacement on Each Subinterval</h4>
+<p>For the $i$-th subinterval $[x_{i-1},x_i]$, we write the displacement vector from §1.0, adjusted to the width of that interval, as
+</p>
+$$
+\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}.
+$$
+<p>The subscript $i$ only means “for the $i$-th subinterval.” The object $\mathbf{v}_i$ is still a displacement vector. Since we are currently considering straight-line motion, the $y$ and $z$ components are zero. But that is not a condition imposed in advance; rather, in this particular situation, those components simply come out to be zero.
+</p>
+<p><!-- pagebreak -->
+</p>
+<h4 id="1.1.3-The-Appearance-of-__MATH_BLOCK_136__-—-The-Defining-Assertion-of-This-Book">1.1.3 The Appearance of $dx$ — The Defining Assertion of This Book</h4>
+<p>Now we give the symbol $dx$ the following meaning. <strong>This may look bold, even strange, but it is also the defining feature of this book</strong>: here, we <strong>declare</strong> that $dx$ is the following $1\times3$ matrix.
+</p>
+<p>That is, we <strong>define</strong> $dx$ as the following <strong>row vector</strong>, with its components written horizontally as a $1\times3$ matrix:
+</p>
+$$
+dx := \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}.
+$$
+<p>This is not, in fact, a private notation detached from the standard point of view. The same object already appears in standard linear algebra, tensor analysis, and manifold theory. What I am doing here is fixing standard coordinates on $\mathbb{R}^3$ and writing it out as a matrix from the beginning. I spell this out in the note below.
+</p>
+<p>For readers familiar with more advanced mathematics: this is the matrix representation of the linear operator that takes an input column vector and returns only its $x$-component. It is the representation of $dx$ in the standard coordinates of $\mathbb{R}^3$.
+</p>
+<blockquote>
+<p><strong>Note</strong> ($dx=(1\ 0\ 0)$ and its relation to textbooks)</p>
+<p>This notation is not often brought to the foreground in ordinary textbooks, but it is already there implicitly.</p>
+<p><strong>For readers who have studied vector analysis</strong></p>
+<p>For a scalar-valued function $f:\mathbb{R}^3\to\mathbb{R}$, the gradient is</p>
+$$
+\nabla f = \begin{pmatrix}
+\frac{\partial f}{\partial x} \\
+\frac{\partial f}{\partial y} \\
+\frac{\partial f}{\partial z}
+\end{pmatrix}.
+$$
+<p>Its transpose</p>
+$$
+(\nabla f)^T=
+\begin{pmatrix}
+\frac{\partial f}{\partial x} &
+\frac{\partial f}{\partial y} &
+\frac{\partial f}{\partial z}
+\end{pmatrix}
+$$
+<p>is a $1\times3$ row vector. If we set $f=x$, then $(\nabla x)^T=(1\ 0\ 0)$. In the Cartesian coordinates and matrix convention used in this book, this transpose of the gradient is precisely the row-vector representation of $dx$.</p>
+<p><strong>For readers who have studied tensor analysis</strong></p>
+<p>The symbols $dx^i$ are the dual basis to the coordinate basis $\frac{\partial}{\partial x^j}$, so</p>
+$$
+dx^i\!\left(\frac{\partial}{\partial x^j}\right)=\delta^i_j.
+$$
+<p>Therefore, in Cartesian coordinates, their row-vector representations are</p>
+$$
+dx^1=(1\ 0\ 0),\qquad dx^2=(0\ 1\ 0),\qquad dx^3=(0\ 0\ 1).
+$$
+<p><strong>For readers familiar with manifold theory</strong></p>
+<p>We have $df_p:T_p\mathbb{R}^3\to\mathbb{R}$, $df_p(v)=v(f)$, and $dx^i_p(v)=v(x^i)$. In standard coordinates, if</p>
+$$
+v=v^i\frac{\partial}{\partial x^i}
+\longmapsto
+\begin{pmatrix}v^1\\v^2\\v^3\end{pmatrix},
+$$
+<p>then $dx^1_p(v)=v^1$, $dx^2_p(v)=v^2$, and $dx^3_p(v)=v^3$. Thus, in standard coordinate representation,</p>
+$$
+dx^1_p\longmapsto(1\ 0\ 0),\qquad
+dx^2_p\longmapsto(0\ 1\ 0),\qquad
+dx^3_p\longmapsto(0\ 0\ 1).
+$$
+</blockquote>
+<p>Now multiply the displacement vector $\mathbf{v}_i$ on the left by the row vector $dx$:
+</p>
+$$
+dx\,\mathbf{v}_i
+=
+\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}
+\begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}
+=
+\Delta x_i.
+$$
+<p>Here we write the image that “$dx$ eats the displacement vector $\mathbf{v}_i$ and spits out the scalar $\Delta x_i$” <strong>as if it were a function value</strong>:
+</p>
+$$
+dx(\mathbf{v}_i)
+:=
+dx\,\mathbf{v}_i
+=
+\Delta x_i.
+$$
+<p>In this book, I will often emphasize this form $dx(\mathbf{v})$: the row vector $dx$ acts on the column vector $\mathbf{v}$. This point cannot be emphasized too often.
+</p>
+<blockquote>
+<p><strong>Note</strong> (operator, functional, function, or map?)</p>
+<p>Different books use different words for this $dx(\mathbf{v})$: <strong>operator</strong>, <strong>functional</strong>, <strong>function</strong>, or <strong>map</strong>. I prefer to call it an <strong>operator</strong>, so that is the word I will often use from here on.</p>
+</blockquote>
+<p>The $\Delta x_i$ that appears in the Riemann sum is not a “mysterious one-dimensional infinitesimal quantity.” It is <strong>the result of applying the matrix $dx$ above to the displacement vector $\mathbf{v}_i$ in three-dimensional space and extracting only its $x$-component</strong>.
+</p>
+<p>In other words,
+</p>
+$$
+\Delta x_i = dx(\mathbf{v}_i).
+$$
+<p><strong>This is the decisive moment</strong>:
+</p>
+<ul>
+<li>Left-hand side: $dx(\mathbf{v}_i)$ is the algebraic operation in which the matrix $dx$ acts on the <strong>displacement vector</strong> $\mathbf{v}_i$.</li>
+<li>Right-hand side: the “small interval width $\Delta x_i$” that appears in the conventional Riemann sum.</li>
+</ul>
+<p>Thus $\Delta x_i$ is <strong>not a mysterious one-dimensional infinitesimal displacement, but $dx(\mathbf{v}_i)$, obtained by extracting only the $x$-direction component from the three-dimensional infinitesimal displacement $\mathbf{v}_i$</strong>.
+</p>
+<blockquote>
+<p><strong>Note</strong> (component-order convention)</p>
+<p>For row vectors and abbreviated row components, I write $(1\ 0\ 0)$, with <strong>no commas</strong>, separating components only by spaces. I use notation with <strong>commas followed by spaces</strong>, such as $(1, 0, 0)$, when emphasizing <strong>coordinates</strong>, such as the position of a point. I do <strong>not</strong> use that notation for abbreviated matrices or row vectors.</p>
+</blockquote>
+<p>Once this one line lands, the $dx$ at the end of the integral sign starts to look different. Next, let us rewrite the ordinary Riemann sum in this notation.
+</p>
+<h4 id="1.1.4-Vector-Reinterpretation-of-the-Riemann-Sum-and-the-Integral-Sign">1.1.4 Vector Reinterpretation of the Riemann Sum and the Integral Sign</h4>
+<p>From this point of view, the Riemann sum becomes
+</p>
+$$
+R_n
+=
+\sum_{i=1}^n f(\xi_i)\,dx(\mathbf{v}_i).
+$$
+<p>Since
+</p>
+$$
+dx(\mathbf{v}_i)=\Delta x_i,
+$$
+<p>this is the same as the ordinary Riemann sum
+</p>
+$$
+R_n
+=
+\sum_{i=1}^n f(\xi_i)\,\Delta x_i.
+$$
+<p>But the same notation admits a second reading. On each subinterval, consider the row vector obtained by multiplying the measuring device $dx$ by the function value $f(\xi_i)$:
+</p>
+$$
+\bigl(f(\xi_i)\,dx\bigr)
+:=
+f(\xi_i)\,dx
+=
+\begin{pmatrix}
+f(\xi_i) & 0 & 0
+\end{pmatrix}.
+$$
+<p>If this row vector acts on the displacement vector $\mathbf{v}_i$, then
+</p>
+$$
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)
+=
+f(\xi_i)\,dx(\mathbf{v}_i)
+=
+f(\xi_i)\,\Delta x_i.
+$$
+<p>In other words, we obtain the individual terms of the Riemann sum themselves.
+</p>
+<p>Therefore, the Riemann sum can also be read as
+</p>
+$$
+R_n
+=
+\sum_{i=1}^n
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i).
+$$
+<p>In the limit where the partition becomes infinitely fine, that is, in the limit where the maximum width tends to $0$, the definition of the Riemann integral gives
+</p>
+$$
+\int_a^b f(x)\,dx
+=
+\lim_{n\to\infty} R_n
+=
+\lim_{n\to\infty}
+\sum_{i=1}^n
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i).
+$$
+<p>The left-hand side, $\int_a^b f(x)\,dx$, is the familiar integral notation we have known since high school. It is the same quantity as $\lim_{n\to\infty}R_n$ in the construction above.
+</p>
+<p>The right-hand side is another face of the same integral: <strong>the limit of the sum, over subintervals, of the values obtained when the measuring device $f(\xi_i)\,dx$ acts on the displacement vector $\mathbf{v}_i$</strong>.
+</p>
+<p>Thus the $dx$ at the end of the integral sign is not a mere decoration. At least in this reading, it works as a measuring device that extracts the $x$-direction width from the displacement vector on each subinterval. And $f(x)\,dx$ can be read as a new row vector obtained by multiplying that measuring device by the value of the function.
+</p>
+<blockquote>
+<p><strong>Note</strong> (work integrals)</p>
+<p>The work integral $W=\int F(x)\,dx$ from mechanics can be read in the same way. On each subinterval, the row vector $F(\xi_i)\,dx$ eats the displacement vector $\mathbf{v}_i$ and returns $F(\xi_i)\Delta x_i$. The limit of the sum is the work.</p>
+</blockquote>
+<h4 id="1.1.5-Linear-Forms-(__MATH_BLOCK_199__-Forms)">1.1.5 Linear Forms ($1$-Forms)</h4>
+<p>So far, we have defined $dx$ as a row vector that acts on a displacement vector, extracts a specified component, and returns a scalar, that is, a real number. A <strong>linear</strong> measuring device of this kind, one that eats a vector and spits out a scalar, is technically called a <strong>linear form</strong>, or a <strong>$1$-form</strong>. What we have been calling “$dx$ as a matrix” is precisely this $1$-form.
+</p>
+<blockquote>
+<p><strong>Note</strong> (the term “covector”)</p>
+<p>Mathematicians also often use the term <strong>covector</strong> as another name for a <strong>linear form</strong>, or <strong>$1$-form</strong>. Keep it in the corner of your mind as a dictionary entry for reading other books.</p>
+</blockquote>
+<p>The origin of the name is simple:
+</p>
+<ul>
+<li><strong>“linear”</strong>: because it processes the displacement vector <strong>linearly</strong>;</li>
+<li><strong>“form”</strong>: for now, think of it as a fixed pattern of measurement or action.</li>
+</ul>
+<p>From here on, I will call this measuring device a “matrix,” a “linear form ($1$-form),” or an operator. These all refer to the same object.
+</p>
+<blockquote>
+<p><strong>Note</strong> (matrix, linear form, measuring device)</p>
+<p>To repeat: from the standpoint of this book, these are represented by the same array. Throughout the book, I will call the same object a “matrix,” a “linear form,” or a “measuring device,” depending on what needs to be emphasized.</p>
+</blockquote>
+<h4 id="1.1.6-The-Notational-Contract-of-This-Book">1.1.6 The Notational Contract of This Book</h4>
+<p>In this book, <strong>we do not use a standalone $dx$ to mean an “infinitesimal displacement” or an “infinitesimal change.”</strong> To avoid confusing the width of a displacement with the measuring device, the row vector, we make the following agreement. For the magnitude of an infinitesimal displacement in the $x$ direction, we use $\Delta x$, or we explicitly write the displacement vector $\mathbf{v}$ and write $dx(\mathbf{v})$.
+</p>
+<p>On the other hand, a <strong>standalone $dx$</strong> means the operator, the row vector or $1$-form, that <strong>extracts the $x$-component</strong>. A $dx$ appearing in an expression such as $df=f'(x)\,dx$ is also <strong>always read as an operator</strong>. <strong>Keep this distinction clear. Everything that follows depends on it.</strong>
+</p>
+<p>From here on, the $dx$ at the end of the integral sign $\int_a^b f(x)\,dx$ will remain as <strong>conventional notation</strong> inherited from high school. But outside the integral sign, we will always write it in the form $dx(\mathbf{v})$ when the action is being shown explicitly. In the main text, when speaking about displacements and infinitesimal widths, we will use $\Delta x$ or $dx(\mathbf{v})$, and we will not attach the image of width or amount of change to a bare $dx$.
+</p>
+<blockquote>
+<p><strong>Note</strong> (usage of $dx$ in the literature)</p>
+<p>Physicists often use the convention of writing the displacement component itself as $dx$. But once you get used to the notation of this book, it becomes easier to read by separating <strong>$dx$ as a measuring device</strong> from the scalar of displacement. In more advanced books, that distinction will matter directly.</p>
+</blockquote>
+<p>In the next section, we extend this point of view to the differential of a function and define the total differential $df$ as a matrix.
+</p>
+<hr />
 <blockquote>
 <p><strong>Checkpoint so far</strong></p>
 <p>- An infinitesimal displacement is a column vector $\mathbf{v}$. The symbol $\Delta x$ is a scalar width, while a standalone $dx$ is an operator, a row vector or $1$-form.</p>
@@ -194,7 +443,7 @@ $$
 <p>- The $dx$ at the end of the integral sign $\int_a^b f(x)\,dx$ is conventional notation. The displacement itself is written as $\Delta x$ or $dx(\mathbf{v})$, according to the contract in §1.1.6.</p>
 </blockquote>
 <hr />
-<h3 id="§1.2-The-Total-Differential-__MATH_BLOCK_101__-—-An-Operator-That-Packs-Rates-of-Change-into-a-Matrix">§1.2 The Total Differential $df$ — An Operator That Packs Rates of Change into a Matrix</h3>
+<h3 id="§1.2-The-Total-Differential-__MATH_BLOCK_243__-—-An-Operator-That-Packs-Rates-of-Change-into-a-Matrix">§1.2 The Total Differential $df$ — An Operator That Packs Rates of Change into a Matrix</h3>
 <p>In the previous section, we dismantled the Riemann integral as “the limit of sums of the action of the matrix $f(x)\,dx$ on displacement vectors.” In this section, we extend that idea to the differential of the function itself and <strong>define the total differential $df$ as a row vector, or matrix</strong>. A “differential” is not merely a numerical rate of change. We treat it as an <strong>operator that produces the linear part of the change only after it is multiplied by a displacement vector</strong>.
 </p>
 <h4 id="1.2.1-Matrix-Representation-of-Differentiability">1.2.1 Matrix Representation of Differentiability</h4>
@@ -214,7 +463,7 @@ $$
 $$
 <p>Then the change $\Delta f$ of the function can be regarded as the effect caused by this $\mathbf{v}$.
 </p>
-<h4 id="1.2.2-Defining-__MATH_BLOCK_115__-as-a-Matrix-and-Reading-__MATH_BLOCK_116__">1.2.2 Defining $df$ as a Matrix and Reading $df(\mathbf{v})$</h4>
+<h4 id="1.2.2-Defining-__MATH_BLOCK_257__-as-a-Matrix-and-Reading-__MATH_BLOCK_258__">1.2.2 Defining $df$ as a Matrix and Reading $df(\mathbf{v})$</h4>
 <p>At the point $x$, define the <strong>total differential</strong> $df$ of the function $f$ as the following $1\times3$ row vector:
 </p>
 $$
@@ -240,7 +489,7 @@ $$
 <p><strong>Note</strong> ($df$ is an operator; $df(\mathbf{v})$ is the linear part of the change)</p>
 <p>This is the same distinction as the notational contract in §1.1.6, stated once again. It may feel repetitive, but <strong>if you misread this point, everything that follows will shift out of alignment</strong>. The repetition is worth it.</p>
 </blockquote>
-<h4 id="1.2.3-The-Measuring-Devices-__MATH_BLOCK_132__-and-__MATH_BLOCK_133__-in-the-__MATH_BLOCK_134__-and-__MATH_BLOCK_135__-Directions">1.2.3 The Measuring Devices $dy$ and $dz$ in the $y$ and $z$ Directions</h4>
+<h4 id="1.2.3-The-Measuring-Devices-__MATH_BLOCK_274__-and-__MATH_BLOCK_275__-in-the-__MATH_BLOCK_276__-and-__MATH_BLOCK_277__-Directions">1.2.3 The Measuring Devices $dy$ and $dz$ in the $y$ and $z$ Directions</h4>
 <p>The strength of this viewpoint shows up when we return to the mechanics example from §1.1.5: it extends naturally to the general case where the force has a component in the $y$ direction as well. With the $dy$ we now define, two-dimensional work can be treated uniformly in the form $F_x\,dx+F_y\,dy$.
 </p>
 <p>Just as $dx$ extracts the $x$-component, we define $dy$ in physical space as the row vector, or $1$-form, that extracts the $y$-component, and $dz$ as the one that extracts the $z$-component. Their matrix representations are
@@ -264,7 +513,7 @@ $$
 </p>
 <p>We have now supplemented the one-variable expression $df=f'(x)\,dx$ with $dy$ and $dz$ as measuring devices of the same type. In the concrete example below and in the extension to three dimensions in §1.2.6, we will see how all three devices come into play.
 </p>
-<h4 id="1.2.4-Example:-__MATH_BLOCK_168__">1.2.4 Example: $f(x)=x^2$</h4>
+<h4 id="1.2.4-Example:-__MATH_BLOCK_310__">1.2.4 Example: $f(x)=x^2$</h4>
 <p>Let $f(x)=x^2$. Then $f'(x)=2x$.
 </p>
 <p>For example, at $x=3$, the total differential is written explicitly as a row vector. Placing the row vector and column vector side by side,
@@ -532,7 +781,7 @@ z=z.
 $$
 <p>The question is: what kind of measuring device does the physical-space $dx$ become on the parameter-space side?
 </p>
-<h4 id="1.4.2-Map-a-Small-Step-and-Measure-It-with-__MATH_BLOCK_271__">1.4.2 Map a Small Step and Measure It with $dx$</h4>
+<h4 id="1.4.2-Map-a-Small-Step-and-Measure-It-with-__MATH_BLOCK_413__">1.4.2 Map a Small Step and Measure It with $dx$</h4>
 <p>Consider a small step
 </p>
 $$

--- a/docs/en/ch02.html
+++ b/docs/en/ch02.html
@@ -108,7 +108,7 @@
 <li class="level-1"><a href="intro.html" id="link-intro.html">Introduction</a></li>
 <li class="level-1"><a href="portal.html" id="link-portal.html">Portal Site and a Small Experiment</a></li>
 <li class="level-1"><a href="ch01.html" id="link-ch01.html">Chapter 1</a></li>
-<li class="level-1"><a href="ch02.html" class="active" id="link-ch02.html">Chapter 2</a><ul class="sub-toc"><li class="level-3"><a href="#§2.0-Measuring-Devices,-Area,-Volume,-and-Length">§2.0 Measuring Devices, Area, Volume, and Length</a></li><li class="level-3"><a href="#§2.2-The-Three-Rules-an-Area-Measuring-Device-Must-Satisfy">§2.2 The Three Rules an Area-Measuring Device Must Satisfy</a></li><li class="level-3"><a href="#§2.3-An-Area-Measuring-Device-Is-an-"Antisymmetric-Matrix"">§2.3 An Area-Measuring Device Is an "Antisymmetric Matrix"</a></li><li class="level-3"><a href="#§2.4-Internal-Structure-of-the-Area-Measuring-Device">§2.4 Internal Structure of the Area-Measuring Device</a></li><li class="level-3"><a href="#§2.5-Volume-Measuring-Devices-and-Determinants">§2.5 Volume-Measuring Devices and Determinants</a></li><li class="level-3"><a href="#§2.6-Summary-of-This-Chapter-and-Outlook-Toward-Chapter-3">§2.6 Summary of This Chapter and Outlook Toward Chapter 3</a></li><li class="level-2"><a href="#Appendix-A:-Tensor-Product-Representation-of-the-Volume-Measuring-Device-—-Full-Component-Calculation">Appendix A: Tensor-Product Representation of the Volume-Measuring Device — Full Component Calculation</a></li></ul></li>
+<li class="level-1"><a href="ch02.html" class="active" id="link-ch02.html">Chapter 2</a><ul class="sub-toc"><li class="level-3"><a href="#§2.0-Measuring-Devices,-Area,-Volume,-and-Length">§2.0 Measuring Devices, Area, Volume, and Length</a></li><li class="level-3"><a href="#§2.1-The-Limits-of-Elementary-School-Area">§2.1 The Limits of Elementary-School Area</a></li><li class="level-3"><a href="#§2.2-The-Three-Rules-an-Area-Measuring-Device-Must-Satisfy">§2.2 The Three Rules an Area-Measuring Device Must Satisfy</a></li><li class="level-3"><a href="#§2.3-An-Area-Measuring-Device-Is-an-"Antisymmetric-Matrix"">§2.3 An Area-Measuring Device Is an "Antisymmetric Matrix"</a></li><li class="level-3"><a href="#§2.4-Internal-Structure-of-the-Area-Measuring-Device">§2.4 Internal Structure of the Area-Measuring Device</a></li><li class="level-3"><a href="#§2.5-Volume-Measuring-Devices-and-Determinants">§2.5 Volume-Measuring Devices and Determinants</a></li><li class="level-3"><a href="#§2.6-Summary-of-This-Chapter-and-Outlook-Toward-Chapter-3">§2.6 Summary of This Chapter and Outlook Toward Chapter 3</a></li><li class="level-2"><a href="#Appendix-A:-Tensor-Product-Representation-of-the-Volume-Measuring-Device-—-Full-Component-Calculation">Appendix A: Tensor-Product Representation of the Volume-Measuring Device — Full Component Calculation</a></li></ul></li>
 <li class="level-1"><a href="ch03.html" id="link-ch03.html">Chapter 3</a></li>
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
@@ -131,6 +131,36 @@
 <h3 id="§2.0-Measuring-Devices,-Area,-Volume,-and-Length">§2.0 Measuring Devices, Area, Volume, and Length</h3>
 <p>In Chapter 1, we defined $dx$, $dy$, and $dz$ as row vectors ($1$-forms) that eat one vector and return a scalar, and we reread $\int f\,dx$ as the limit of matrix actions. In this chapter we extend that framework and <strong>discover area-measuring devices</strong> ($2$-forms), which eat two vectors, and <strong>volume-measuring devices</strong> ($3$-forms), which eat three. Both are built from the same parts: $dx$, $dy$, and $dz$.
 </p>
+<hr />
+<h3 id="§2.1-The-Limits-of-Elementary-School-Area">§2.1 The Limits of Elementary-School Area</h3>
+<p>Many readers know that “integration is, roughly speaking, a calculation for finding area.”
+ But what is area, exactly? If we think about it again, we may realize that we have not really formalized the idea since elementary school.
+</p>
+<p>So what was that elementary-school formalization? It was based on a very simple intuition: <strong>“how many $1\times 1$ squares (tiles) can be packed into the figure.”</strong>
+</p>
+<p>For a figure drawn on two-dimensional paper (the $xy$ plane), this “tiling with squares” works well. For example, the area $S$ of the parallelogram spanned by two two-dimensional vectors $\mathbf{v}_1=(x_1,y_1)$ and $\mathbf{v}_2=(x_2,y_2)$ can be written as
+</p>
+$$S=\sqrt{(x_1 y_2-x_2 y_1)^2}.$$
+<p>However, we live in three-dimensional space. When we try to compute the area of a “tilted plane” in three-dimensional space, things get a bit painful.
+</p>
+<p>Many readers were asked in high-school mathematics to find the area of the parallelogram spanned by three-dimensional vectors $\mathbf{v}_1=(x_1,y_1,z_1)$ and $\mathbf{v}_2=(x_2,y_2,z_2)$. Using high-school notation, we can write
+</p>
+$$
+S=\sqrt{|\mathbf{v}_1|^2|\mathbf{v}_2|^2-(\mathbf{v}_1\cdot\mathbf{v}_2)^2}.
+$$
+<p>If we expand in components, we fight through a calculation that fills a notebook page before we finally reach
+</p>
+$$S=\sqrt{(y_1 z_2-z_1 y_2)^2+(z_1 x_2-x_1 z_2)^2+(x_1 y_2-x_2 y_1)^2}.$$
+<p>The process is long enough that one would rather not do it more than a few times in life.
+ Why does it become so painful? Because <strong>we originally defined area inside the two-dimensional world</strong>. <strong>In three-dimensional space</strong>, the tilt of the plane and the relation between the two vectors lying on it get entangled, and the formula becomes bulky once <strong>angles</strong> have to be handled too.
+</p>
+<blockquote>
+<p><strong>Note</strong> (terms defined later)</p>
+<p>We use “angle” and “inner product” here, but at this stage the intuitive meanings from elementary school are enough. A formal definition of the inner product is given in Chapter 6, but it is not needed to follow the discussion here.</p>
+</blockquote>
+<p>Here we change viewpoint completely. <strong>We set aside the elementary-school definition of area for now</strong> and <strong>redesign from scratch an algebraic measuring device that outputs area.</strong>
+</p>
+<hr />
 <h3 id="§2.2-The-Three-Rules-an-Area-Measuring-Device-Must-Satisfy">§2.2 The Three Rules an Area-Measuring Device Must Satisfy</h3>
 <p>As a first step in the design, we do not rely only on “$1\times 1$ squares.” We take as our base the <strong>parallelogram spanned by two vectors</strong>.
 </p>
@@ -328,8 +358,8 @@ $$
 </p>
 $$
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-= \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-- \begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+= \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} -
+\begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 $$
 <p>The first term on the right-hand side is "the matrix whose only nonzero entry is row 1, column 2," and it represents the operation of extracting the $x$ component from $\mathbf{v}_1$ and the $y$ component from $\mathbf{v}_2$ and multiplying them ($x_1 y_2$).
 </p>
@@ -360,7 +390,7 @@ $$
 <p>Splendid — from combinations of the measuring devices ($1$-forms) of Chapter 1, we have constructed an area-measuring device ($2$-form) systematically.
  Because it is built from the subtraction of tensor products, please also notice that <strong>swapping the arguments flips the sign (alternating property)</strong>—Rule 2 from §2.2 is automatically "built in."
 </p>
-<h4 id="2.4.6-The-Three-Basis-__MATH_BLOCK_203__-Forms">2.4.6 The Three Basis $2$-Forms</h4>
+<h4 id="2.4.6-The-Three-Basis-__MATH_BLOCK_213__-Forms">2.4.6 The Three Basis $2$-Forms</h4>
 <p>By the same method, we can also construct the remaining two "biased pairs of glasses."
 </p>
 <p><strong>Glasses that look at the $yz$ plane:</strong> $dy \wedge dz$
@@ -562,7 +592,7 @@ $$\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \end{pma
 <blockquote>
 <p><strong>Note</strong> (the order of the six terms of the determinant) Some textbooks simply declare upfront that “the definition of the determinant is these six terms.” In the flow of this book, the order is <strong>rules of the measuring device → six terms</strong>.</p>
 </blockquote>
-<h4 id="2.5.3-Reinterpreting-the-__MATH_BLOCK_308__-form-as-a-Determinant">2.5.3 Reinterpreting the $2$-form as a Determinant</h4>
+<h4 id="2.5.3-Reinterpreting-the-__MATH_BLOCK_318__-form-as-a-Determinant">2.5.3 Reinterpreting the $2$-form as a Determinant</h4>
 <p>In fact, a determinant was hiding in the wedge product of the $2$-form defined in §2.4 as well. Let us recall the definition:
 </p>
 $$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2) - dy(\mathbf{v}_1)\,dx(\mathbf{v}_2)$$
@@ -571,7 +601,7 @@ $$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = dx(\mathbf{v}_1)\,dy(\mathbf{v}_2
 $$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
 <p>In other words, the value of the wedge product is the determinant of the matrix with “which measuring device” across the rows and “which vector” down the columns.
 </p>
-<h4 id="2.5.4-Definition-of-__MATH_BLOCK_311__-—-Completing-the-Determinant-Pattern">2.5.4 Definition of $dx \wedge dy \wedge dz$ — Completing the Determinant Pattern</h4>
+<h4 id="2.5.4-Definition-of-__MATH_BLOCK_321__-—-Completing-the-Determinant-Pattern">2.5.4 Definition of $dx \wedge dy \wedge dz$ — Completing the Determinant Pattern</h4>
 <p>Extending this “determinant pattern” straightforwardly to $3 \times 3$ gives us the volume-measuring device.
 </p>
 <p><strong>Definition:</strong> For three vectors $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$,
@@ -589,7 +619,7 @@ $$= \det\begin{pmatrix} x_1 & x_2 & x_3 \\ y_1 & y_2 & y_3 \\ z_1 & z_2 & z_3 \e
 <li><strong>Alternativity</strong>: swapping two columns of the determinant flips the sign.</li>
 <li><strong>Normalization</strong>: inserting $\hat{e}_x, \hat{e}_y, \hat{e}_z$ gives the identity matrix, and $\det(I) = 1$.</li>
 </ul>
-<h4 id="2.5.5-Tensor-Product-Representation-of-the-Volume-Measuring-Device-—-An-Array-of-Three-__MATH_BLOCK_325__-Blocks-Side-by-Side">2.5.5 Tensor-Product Representation of the Volume-Measuring Device — An Array of Three $3 \times 3$ Blocks Side by Side</h4>
+<h4 id="2.5.5-Tensor-Product-Representation-of-the-Volume-Measuring-Device-—-An-Array-of-Three-__MATH_BLOCK_335__-Blocks-Side-by-Side">2.5.5 Tensor-Product Representation of the Volume-Measuring Device — An Array of Three $3 \times 3$ Blocks Side by Side</h4>
 <p>In §2.4.4–2.4.5 we saw that the area-measuring device $dx \wedge dy$ can be built as the difference of tensor products $dx \otimes dy - dy \otimes dx$, and that the result is a $3 \times 3$ antisymmetric matrix. Can the same trick be applied to the volume-measuring device $dx \wedge dy \wedge dz$?
 </p>
 <p>Why bring out a tensor array here at all? Because we want to show that <strong>the operation of eating three vectors and returning a determinant can be written with exactly the same idea of “contraction” as for the area-measuring device</strong>. As defined in §2.4.2, contraction is the operation of summing over a shared index and eliminating that index. $1$-forms, $2$-forms, and $3$-forms all run on this single principle.
@@ -691,7 +721,7 @@ $$\mathbf{v}_1 \cdot (\mathbf{v}_2 \times \mathbf{v}_3) = \det\begin{pmatrix}x_1
 </p>
 <p>If we want the positive elementary-school volume—the scalar volume “how many unit cubes fit inside?”—we take the magnitude of the signed output. Since a $3$-form in three-dimensional space has only one independent component, this is simply $|V|=\sqrt{V^2}$. As with area, this nonlinear operation requires a metric; we will treat it again in Chapter 6.
 </p>
-<h4 id="2.5.9-The-“Size”-of-a-__MATH_BLOCK_387__-form-—-Why-Is-There-Only-One-Independent-Component?">2.5.9 The “Size” of a $3$-form — Why Is There Only One Independent Component?</h4>
+<h4 id="2.5.9-The-“Size”-of-a-__MATH_BLOCK_397__-form-—-Why-Is-There-Only-One-Independent-Component?">2.5.9 The “Size” of a $3$-form — Why Is There Only One Independent Component?</h4>
 <p>An area-measuring device ($2$-form) could be represented by a $3 \times 3$ antisymmetric matrix, with 3 independent components (the coefficients of $dy \wedge dz$, $dz \wedge dx$, $dx \wedge dy$).
 </p>
 <p>How many independent components does a volume-measuring device ($3$-form) have? Consider the candidates we can build as basis $3$-forms. The number of ways to choose three measuring devices $dx, dy, dz$ <strong>without repetition</strong> is … only one. Just $dx \wedge dy \wedge dz$ (changing the order only changes the sign; it does not produce a new basis).

--- a/docs/en/ch03.html
+++ b/docs/en/ch03.html
@@ -109,7 +109,7 @@
 <li class="level-1"><a href="portal.html" id="link-portal.html">Portal Site and a Small Experiment</a></li>
 <li class="level-1"><a href="ch01.html" id="link-ch01.html">Chapter 1</a></li>
 <li class="level-1"><a href="ch02.html" id="link-ch02.html">Chapter 2</a></li>
-<li class="level-1"><a href="ch03.html" class="active" id="link-ch03.html">Chapter 3</a><ul class="sub-toc"><li class="level-3"><a href="#§3.0-Measuring-Curved-Things-—-Paying-Back-a-Debt-from-Elementary-School">§3.0 Measuring Curved Things — Paying Back a Debt from Elementary School</a></li><li class="level-3"><a href="#§3.2-Surface-Area-—-The-Limit-of-Two-Dimensions,-Coefficient-1">§3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1</a></li><li class="level-3"><a href="#§3.3-Curves-—-The-Limit-of-One-Dimension,-Coefficient-1,-Revealed">§3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed</a></li><li class="level-3"><a href="#§3.4-Adding-Coefficients-—-Density-Times-Geometry">§3.4 Adding Coefficients — Density Times Geometry</a></li><li class="level-3"><a href="#§3.5-Summary-of-This-Chapter-and-Outlook-Toward-the-Next">§3.5 Summary of This Chapter and Outlook Toward the Next</a></li></ul></li>
+<li class="level-1"><a href="ch03.html" class="active" id="link-ch03.html">Chapter 3</a><ul class="sub-toc"><li class="level-3"><a href="#§3.0-Measuring-Curved-Things-—-Paying-Back-a-Debt-from-Elementary-School">§3.0 Measuring Curved Things — Paying Back a Debt from Elementary School</a></li><li class="level-3"><a href="#§3.1-Volume-—-Three-Dimensions,-Coefficient-1">§3.1 Volume — Three Dimensions, Coefficient 1</a></li><li class="level-3"><a href="#§3.2-Surface-Area-—-The-Limit-of-Two-Dimensions,-Coefficient-1">§3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1</a></li><li class="level-3"><a href="#§3.3-Curves-—-The-Limit-of-One-Dimension,-Coefficient-1,-Revealed">§3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed</a></li><li class="level-3"><a href="#§3.4-Adding-Coefficients-—-Density-Times-Geometry">§3.4 Adding Coefficients — Density Times Geometry</a></li><li class="level-3"><a href="#§3.5-Summary-of-This-Chapter-and-Outlook-Toward-the-Next">§3.5 Summary of This Chapter and Outlook Toward the Next</a></li></ul></li>
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
@@ -155,6 +155,90 @@
 <p><strong>Note</strong> (ground rules)</p>
 <p>We state this up front as a promise. Below, we treat curves and surfaces as sufficiently smooth, and cases where chopping into small pieces and adding converges in a straightforward way. Details such as orientation reversal and self-intersection are kept at the level of “they do not cause trouble in situations commonly used in physics.” A rigorous theory of integrability is outside the scope of this book.</p>
 </blockquote>
+<hr />
+<h3 id="§3.1-Volume-—-Three-Dimensions,-Coefficient-1">§3.1 Volume — Three Dimensions, Coefficient 1</h3>
+<h4 id="3.1.1-From-Rectangular-Boxes-to-Curved-Regions-—-Defining-by-Riemann-Sums">3.1.1 From Rectangular Boxes to Curved Regions — Defining by Riemann Sums</h4>
+<p>In Chapter 2 §2.5, we assembled the volume-measuring device $dx \wedge dy \wedge dz$. If we feed it three vectors $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$, we get the signed volume of the parallelepiped they span.
+</p>
+<p>Now we want to measure the volume of a region $V$ in space. However curved $V$ may be, if we chop finely enough each small piece can be treated as almost a rectangular box. So we slice $V$ in the $x$, $y$, and $z$ directions, label the small boxes inside $V$ by an index $i$, and take the three edge vectors of the $i$th box to be
+</p>
+$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z.$$
+<p>Feed these three vectors to the volume-measuring device $dx \wedge dy \wedge dz$:
+</p>
+$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i.$$
+<blockquote>
+<p><strong>Note</strong> (contraction of measuring device and figure)</p>
+<p>What happens here is exactly the pattern from Chapter 2 §2.5.10. A <strong>$3$-form (volume-measuring device)</strong> eats the <strong>volume element (figure)</strong> spanned by three displacement vectors and spits out a scalar. This contraction is performed on each small box. We call the oriented small box — the tiny volume figure — spanned by these three displacement vectors a <strong>volume element</strong>.</p>
+</blockquote>
+<p>Add the scalar $\Delta x_i\,\Delta y_i\,\Delta z_i$ from each small box over all boxes inside $V$:
+</p>
+$$\sum_{\text{small box }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i.$$
+<p>Then take the limit as the mesh becomes infinitely fine. We <strong>write</strong> this limit as
+</p>
+$$\iiint_V dx \wedge dy \wedge dz.$$
+<p>This is the definition of integration of a $3$-form — a volume integral.
+</p>
+<blockquote>
+<p><strong>Note</strong> (the symbol $\iiint$)</p>
+<p>In this book we <strong>define $\iiint_V$ here for the first time</strong> as the symbol for “integration of a $3$-form over a three-dimensional region $V$.” It is not a symbol assumed from high-school volume integrals; it is the name we give to the Riemann-sum limit above.</p>
+</blockquote>
+<p>We have defined it. But how do we actually compute this sum? When $V$ is a curved region such as $x^2+y^2+z^2 \le R^2$, it is tedious to decide which small boxes lie inside $V$ while adding. If we organize the sum cleverly, however, the picture improves. In the next subsection we try it in practice.
+</p>
+<h4 id="3.1.2-Volume-of-a-Sphere-—-Adding-Messily-and-Straightforwardly">3.1.2 Volume of a Sphere — Adding Messily and Straightforwardly</h4>
+<p>Let us compute the volume of a sphere $x^2 + y^2 + z^2 \le R^2$ of radius $R$ in a truly messy, straightforward way. We want to show only one thing: without fleeing to a special coordinate system, we can reach the familiar $\frac{4}{3}\pi R^3$ simply by organizing the Riemann sum honestly in $x,y,z$. We use no special coordinates. In $x,y,z$ we simply stack small boxes $\Delta x\,\Delta y\,\Delta z$.
+</p>
+<p>View the sphere as the region determined by the value of
+</p>
+$$F(x,y,z)=x^2+y^2+z^2.$$
+<p>The interior is all points with $F\le R^2$; the boundary sphere is $F=R^2$.
+</p>
+<p>To read orientation on the boundary or displacement along the sphere, the total differential $dF$ from Chapter 1 is useful. At the stage of counting volume, however, we do not use $dF$ yet. Here we first unpack the condition $F\le R^2$ and count small boxes. The main actor for measuring volume remains $dx\wedge dy\wedge dz$.
+</p>
+<p>How can we organize the Riemann sum from §3.1.1 so that it can be computed? Fix $z$ at some value. Then $F\le R^2$ becomes
+</p>
+$$x^2+y^2\le R^2-z^2.$$
+<p>So at that height, the allowed $(x,y)$ form a disk of radius $\sqrt{R^2-z^2}$. Fixing $y$ as well gives
+</p>
+$$x^2\le R^2-z^2-y^2,$$
+<p>so $x$ runs from $-\sqrt{R^2 - z^2 - y^2}$ to $+\sqrt{R^2 - z^2 - y^2}$. Similarly, $y$ runs from $-\sqrt{R^2 - z^2}$ to $+\sqrt{R^2 - z^2}$, and $z$ from $-R$ to $+R$.
+</p>
+<p>This is simply unpacking the test $F\le R^2$ in the order $z$, $y$, $x$. If we add in this order — think of stacking the one-dimensional Riemann sums from Chapter 1 §1.1 three times — then in the limit:
+</p>
+$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz.$$
+<p>The $dx, dy, dz$ on the right appear as the result of organizing the sum on the left in order; we are not omitting $\wedge$. From inside the parentheses outward: sum over $x$ ($\int dx$), then over $y$ ($\int dy$), then over $z$ ($\int dz$).
+</p>
+<p>The innermost sum over $x$ (the $x$ integral in the limit) is immediate:
+</p>
+$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}.$$
+<p>Next the $y$ integral. Set $a = \sqrt{R^2 - z^2}$:
+</p>
+$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy.$$
+<p>Use substitution from high-school calculus. With $y = a\sin t$, we have $dy = a\cos t\,dt$. As $y$ goes from $-a$ to $a$, $t$ goes from $-\pi/2$ to $\pi/2$. Also $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$ (for $t \in [-\pi/2,\pi/2]$ we have $\cos t \ge 0$, so the absolute value drops). Therefore:
+</p>
+$$\begin{aligned}
+\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy
+&= \int_{-\pi/2}^{\pi/2} 2\cdot a\cos t \cdot a\cos t\,dt \\
+&= 2a^2\!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
+\end{aligned}$$
+<p>Since $\cos^2 t = (1 + \cos 2t)/2$:
+</p>
+$$\begin{aligned}
+2a^2\!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
+&= a^2\int_{-\pi/2}^{\pi/2} (1 + \cos 2t)\,dt \\[4pt]
+&= a^2\Bigl[t + \frac{\sin 2t}{2}\Bigr]_{-\pi/2}^{\pi/2} \\[4pt]
+&= a^2\Bigl[\Bigl(\frac{\pi}{2} + 0\Bigr) - \Bigl(-\frac{\pi}{2} + 0\Bigr)\Bigr] \\[4pt]
+&= \pi a^2 = \pi(R^2 - z^2)
+\end{aligned}$$
+<p>Finally the $z$ integral:
+</p>
+$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3.$$
+<blockquote>
+<p><strong>Note</strong> (what this calculation means)</p>
+<p>What we did here is only the organization of the Riemann sum from §3.1.1. Instead of deciding which small boxes lie inside the sphere one by one, we organized the actual summation from the inside out in the order $x \to y \to z$. Each stage is a one-variable Riemann sum from Chapter 1; in the limit it becomes a familiar one-variable integral. That is all. If we aggregate the contraction of measuring device and figure honestly, we reach $\frac{4}{3}\pi R^3$.</p>
+</blockquote>
+<p>Thus we have confirmed that the integral of the single measuring device $dx \wedge dy \wedge dz$ gives the correct volume $\frac{4}{3}\pi R^3$ of a curved region. In three dimensions, a volume-measuring device with coefficient $1$ measures volume directly.
+</p>
+<hr />
 <blockquote>
 <p><strong>Checkpoint so far</strong></p>
 <p>- The integral of $dx \wedge dy \wedge dz$ is the limit of a Riemann sum that chops a region into small boxes and adds the values obtained by feeding each volume element to the volume-measuring device. $\iiint_V$ is the symbol this book gives to that limit.</p>
@@ -192,7 +276,7 @@ $$(dx \wedge dy)(\Delta\mathbf{a},\Delta\mathbf{b})
 $$\iint_S dx \wedge dy.$$
 <p>This is the definition of integration of a $2$-form — a surface integral. The structure is the same type as the volume integral in §3.1; only the number of vectors fed in has dropped from three to two.
 </p>
-<h4 id="3.2.2-What-__MATH_BLOCK_95__-Measures-—-A-Test-on-the-Sphere">3.2.2 What $dx \wedge dy$ Measures — A Test on the Sphere</h4>
+<h4 id="3.2.2-What-__MATH_BLOCK_191__-Measures-—-A-Test-on-the-Sphere">3.2.2 What $dx \wedge dy$ Measures — A Test on the Sphere</h4>
 <p>Let us actually compute on a sphere. Consider the upper half of a sphere of radius $R$ ($z \ge 0$). A point $(x,y,z)$ on the sphere satisfies
 </p>
 $$x^2+y^2+z^2=R^2,\qquad z=\sqrt{R^2-x^2-y^2}.$$
@@ -436,7 +520,7 @@ $$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}
 </blockquote>
 <p>This $ds$ is a convenient notation for measuring arc length, but it is not itself a $1$-form in the sense of this book. A $1$-form is a measuring device that acts linearly on a displacement $\mathbf{v}$, whereas $ds(\mathbf{v})$ contains a square root of a sum of squares, so in general $ds(\mathbf{v}+\mathbf{w}) = ds(\mathbf{v})+ds(\mathbf{w})$ does not hold. Therefore $ds$ cannot be written as a linear combination of $dx, dy, dz$ — in the form $P\,dx+Q\,dy+R\,dz$.
 </p>
-<h4 id="3.3.3-What-Can-a-__MATH_BLOCK_242__-Form-Measure?">3.3.3 What Can a $1$-Form Measure?</h4>
+<h4 id="3.3.3-What-Can-a-__MATH_BLOCK_338__-Form-Measure?">3.3.3 What Can a $1$-Form Measure?</h4>
 <p>Arc length could be measured by integrating the line element $ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}$. However, this $ds$ cannot be written as a linear combination of $dx, dy, dz$; it requires a square root of a sum of squares. Here we first ask: what does a $1$-form that does not use such a square root of a sum of squares — that is, a $1$-form that can be written as a linear combination of $dx, dy, dz$ — actually measure?
 </p>
 <p>Suppose a force field $\mathbf{F}(x,y,z) = (F_x, F_y, F_z)$ acts at each point in space. When we move a particle along a curve, the infinitesimal work done by the force on each subinterval is the product of the component of the force in the direction of displacement and the magnitude of the displacement — namely, $F_x\,\Delta x + F_y\,\Delta y + F_z\,\Delta z$. Summing this over the whole interval gives the work $W = \int_\gamma \mathbf{F}\cdot d\mathbf{r}$.
@@ -465,7 +549,7 @@ $$ds(\mathbf{v}) = \sqrt{dx(\mathbf{v})^2 + dy(\mathbf{v})^2 + dz(\mathbf{v})^2}
 </p>
 <p>Below, we define the integrals of forms with coefficients, in order from one to two to three dimensions.
 </p>
-<h4 id="3.4.1-Line-Integral-of-a-General-__MATH_BLOCK_273__-Form-(Work)">3.4.1 Line Integral of a General $1$-Form (Work)</h4>
+<h4 id="3.4.1-Line-Integral-of-a-General-__MATH_BLOCK_369__-Form-(Work)">3.4.1 Line Integral of a General $1$-Form (Work)</h4>
 <p>In real space, take three scalar fields $P, Q, R$ that depend on the point $(x,y,z)$, and call
 </p>
 $$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
@@ -511,7 +595,7 @@ $$\omega(\gamma'(t)) = (\sin t)(-\sin t) + (\cos t)(\cos t) = -\sin^2\!t + \cos^
 $$\int_\gamma \omega = \int_0^{2\pi} \cos 2t\,dt = \Bigl[\frac{1}{2}\sin 2t\Bigr]_0^{2\pi} = 0$$
 <p>The work is zero. This force field does no net work along the unit circle.
 </p>
-<h4 id="3.4.2-Surface-Integral-of-a-General-__MATH_BLOCK_311__-Form-(Flux)">3.4.2 Surface Integral of a General $2$-Form (Flux)</h4>
+<h4 id="3.4.2-Surface-Integral-of-a-General-__MATH_BLOCK_407__-Form-(Flux)">3.4.2 Surface Integral of a General $2$-Form (Flux)</h4>
 <p>Similarly, with three scalar fields $P,Q,R$ as coefficients,
 </p>
 $$
@@ -536,7 +620,7 @@ $$\iint_S \eta$$
 <p><strong>Note</strong> (correspondence with vector analysis is only a guidepost here)</p>
 <p>The connection with flux is nothing more than a bridge for readers who already know vector analysis. The main line of this book remains the operation of "feeding a $2$-form and aggregating." Lack of vector-analysis background will not hinder the discussion from here on.</p>
 </blockquote>
-<h4 id="3.4.3-Volume-Integral-of-a-General-__MATH_BLOCK_323__-Form-(Total-Mass)">3.4.3 Volume Integral of a General $3$-Form (Total Mass)</h4>
+<h4 id="3.4.3-Volume-Integral-of-a-General-__MATH_BLOCK_419__-Form-(Total-Mass)">3.4.3 Volume Integral of a General $3$-Form (Total Mass)</h4>
 <p>The general form of a $3$-form, with scalar field $\rho(x,y,z)$ as coefficient, is
 </p>
 $$\Omega = \rho(x,y,z)\,dx \wedge dy \wedge dz$$

--- a/docs/en/ch04.html
+++ b/docs/en/ch04.html
@@ -110,7 +110,7 @@
 <li class="level-1"><a href="ch01.html" id="link-ch01.html">Chapter 1</a></li>
 <li class="level-1"><a href="ch02.html" id="link-ch02.html">Chapter 2</a></li>
 <li class="level-1"><a href="ch03.html" id="link-ch03.html">Chapter 3</a></li>
-<li class="level-1"><a href="ch04.html" class="active" id="link-ch04.html">Chapter 4</a><ul class="sub-toc"><li class="level-3"><a href="#§4.0-Physics-Curves;-Computation-Uses-Boxes">§4.0 Physics Curves; Computation Uses Boxes</a></li><li class="level-3"><a href="#§4.1-Pullback-of-a-1-Form-—-Work-and-the-Work-Energy-Theorem">§4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem</a></li><li class="level-3"><a href="#§4.3-Pullback-of-a-3-Form-—-Conservation-of-Mass-and-Volume-Integrals">§4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals</a></li><li class="level-3"><a href="#§4.4-Properties-of-the-Pullback-—-What-We-Have-Established-So-Far">§4.4 Properties of the Pullback — What We Have Established So Far</a></li><li class="level-3"><a href="#§4.5-Summary-of-This-Chapter-and-Outlook-Toward-Chapter-5,-the-Exterior-Derivative">§4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative</a></li></ul></li>
+<li class="level-1"><a href="ch04.html" class="active" id="link-ch04.html">Chapter 4</a><ul class="sub-toc"><li class="level-3"><a href="#§4.0-Physics-Curves;-Computation-Uses-Boxes">§4.0 Physics Curves; Computation Uses Boxes</a></li><li class="level-3"><a href="#§4.1-Pullback-of-a-1-Form-—-Work-and-the-Work-Energy-Theorem">§4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem</a></li><li class="level-3"><a href="#§4.2-Pullback-of-a-2-Form-—-Conservation-of-Angular-Momentum-and-Areal-Velocity">§4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity</a></li><li class="level-3"><a href="#§4.3-Pullback-of-a-3-Form-—-Conservation-of-Mass-and-Volume-Integrals">§4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals</a></li><li class="level-3"><a href="#§4.4-Properties-of-the-Pullback-—-What-We-Have-Established-So-Far">§4.4 Properties of the Pullback — What We Have Established So Far</a></li><li class="level-3"><a href="#§4.5-Summary-of-This-Chapter-and-Outlook-Toward-Chapter-5,-the-Exterior-Derivative">§4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative</a></li></ul></li>
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
@@ -127,7 +127,7 @@
   </nav>
   <main class="main-content">
     <article class="markdown-body">
-<h1 id="Chapter-4:-What-Is-a-Change-of-Variables?-—-The-Pullback-__MATH_BLOCK_41__:-Making-Measuring-Devices-Consistent">Chapter 4: What Is a Change of Variables? — The Pullback $\Phi^*$: Making Measuring Devices Consistent</h1>
+<h1 id="Chapter-4:-What-Is-a-Change-of-Variables?-—-The-Pullback-__MATH_BLOCK_64__:-Making-Measuring-Devices-Consistent">Chapter 4: What Is a Change of Variables? — The Pullback $\Phi^*$: Making Measuring Devices Consistent</h1>
 <h3 id="§4.0-Physics-Curves;-Computation-Uses-Boxes">§4.0 Physics Curves; Computation Uses Boxes</h3>
 <p>The quantities we truly want to measure in physics do not depend on the names of coordinates.
 </p>
@@ -277,6 +277,217 @@ $$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int
 <blockquote>
 <p><strong>Note</strong> ($dx$ is a row vector, $dt$ is too) In the calculations of §4.1, $dx$, $dt$, and $dv$ all keep the same type: "eat displacement and return a scalar." The principle "row vector × column vector → scalar" from Chapter 1 §1.1.3 does not break even in the middle of a pullback. The result $\gamma^*(F\,dx)$ is again a $1$-form (row vector) on the time axis; feeding it the time-side displacement $\Delta t$ yields a scalar (a piece of work)—this consistency is what supports understanding of the pullback.</p>
 </blockquote>
+<hr />
+<h3 id="§4.2-Pullback-of-a-2-Form-—-Conservation-of-Angular-Momentum-and-Areal-Velocity">§4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity</h3>
+<p><strong>① Start from a physical quantity.</strong> In §4.1 we mapped a one-dimensional finite interval and measured its image. This time we apply the same idea to a two-dimensional finite grid.
+</p>
+<blockquote>
+<p><strong>Note</strong> (for readers without a physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.</p>
+</blockquote>
+<p>Consider a particle moving in a central force field. When the force always points toward the origin, the angular momentum
+</p>
+$$
+L
+=
+m\left(x(t)y'(t)-y(t)x'(t)\right)
+$$
+<p>is constant in time (the law of conservation of angular momentum). This conservation law has a beautiful geometric meaning—the rate at which the position vector of the particle sweeps out area (<strong>areal velocity</strong>) is constant (Kepler’s second law).
+</p>
+<p>We may assume the motion takes place in the plane $z=0$. The area of the sector $D$ swept out by the position vector from time $t_0$ to $t_1$ is
+</p>
+$$A = \iint_D dx \wedge dy$$
+<p>Here $dx \wedge dy$ is the area-measuring device ($2$-form) on the $xy$ plane.
+</p>
+<blockquote>
+<p><strong>Note</strong> (For physicists who work in two dimensions) Let us confirm this point. This book consistently assumes the reality of three-dimensional space. Setting $z=0$ in the angular-momentum discussion below is a temporary simplification to make the calculation easier to read; we are still looking at one plane inside three-dimensional space.</p>
+</blockquote>
+<p><strong>② Naive substitution—it does not match as written.</strong> The sector on the right-hand side is awkward to write in $(x,y)$. So we want to write it in $(r,\theta)$. But what happens if we replace $dx \wedge dy$ directly by $dr \wedge d\theta$? Let us compute the area of a full circle of radius $C$. The correct value is $\pi C^2$. Yet with naive substitution:
+</p>
+$$
+A_{\text{naive}}
+=
+\iint dr \wedge d\theta
+=
+\int_0^{2\pi}
+\biggl(
+  \int_0^C dr
+\biggr)
+d\theta
+=
+2\pi C
+$$
+<p>This is completely different from $\pi C^2$. With $dr \wedge d\theta$ alone, the correct area does not come out.
+</p>
+<p><strong>③ See the cause on a finite grid.</strong> This time, let us ask what measuring device should eat a finite cell on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
+</p>
+<p>Cut a grid of finite size $\Delta r \times \Delta\theta$ in $(r,\theta)$ space. Find the two displacement vectors that one cell at coordinates $(r, \theta)$ produces in $(x,y)$ space.
+</p>
+<p>Edge in the $\Delta r$ direction: only $r$ changes while $\theta$ is fixed, so the difference is exact:
+</p>
+$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$
+<p>Edge in the $\Delta\theta$ direction: use the difference formulas for trigonometric functions:
+</p>
+$$\begin{aligned}
+\Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
+= -2r\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr) \\[4pt]
+\Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
+= 2r\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr)
+\end{aligned}$$
+<p>Find the area of the parallelogram spanned by the two edges $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ and $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ by a determinant:
+</p>
+$$\begin{aligned}
+\det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
+&= 2r\Delta r\,\sin\biggl(\frac{\Delta\theta}{2}\biggr)\biggl[ \cos\theta\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr) + \sin\theta\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr) \biggr] \\
+&= r\Delta r\,\sin\Delta\theta
+\end{aligned}$$
+<p>The result is
+</p>
+$$\det = r\Delta r\,\sin\Delta\theta$$
+<p>Divide this measured value by the cell width $\Delta r_i\,\Delta\theta_j$ on the $(r,\theta)$ side, and we obtain the coefficient of the provisional measuring device used on a finite cell. That is,
+</p>
+$$
+\Phi_h^\square(dx\wedge dy)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+$$
+<p>Feed this measuring device to a finite cell, and
+</p>
+$$
+\begin{aligned}
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+&=
+\left(
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+\right)(\Delta r_i,\Delta\theta_j) \\
+&=
+r_i\,\Delta r_i\,\sin\Delta\theta_j
+\end{aligned}
+$$
+<p>The right-hand side is the signed area of the parallelogram spanned by the two finite-difference vectors.
+</p>
+<p>Let $A_h^\square$ denote the total area sum in the finite-cell version. Therefore
+</p>
+$$
+A_h^\square
+:=
+\sum_i\sum_j
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+=
+\sum_i\sum_j r_i\,\Delta r_i\,\sin\Delta\theta_j
+$$
+<p>$\sin\Delta\theta_j$ is an exact value for finite $\Delta\theta_j$. What we measure here is not the curved sector area of the polar-coordinate finite grid itself, but the signed area of the parallelogram spanned by two finite-difference vectors. Write the sector swept out by the position vector in physical space as $D$. On the other hand, write the $(r,\theta)$ range corresponding to that region in polar coordinates as $D'$.
+</p>
+<p>In the final stage of taking the limit of the sum,
+</p>
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+<p>Therefore the true area $A$ is obtained as
+</p>
+$$
+A
+=
+\lim_{h\to0} A_h^\square
+=
+\iint_{D'} r\,dr\wedge d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+<p>The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit, we obtain
+</p>
+$$
+\Phi_h^\square(dx\wedge dy)
+\xrightarrow{h\to0}
+\Phi^*(dx\wedge dy)
+=
+r\,dr\wedge d\theta
+$$
+<blockquote>
+<p><strong>Note</strong> ($\Delta r,\Delta\theta$ need not be infinitesimal) In the computation of the difference vectors so far, we have used no assumption that $\Delta r$ or $\Delta\theta$ is “sufficiently small.” The $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ found above are formulas that hold exactly no matter how large $\Delta r,\Delta\theta$ may be. By “exact” here we mean that we measure the parallelogram spanned by finite-difference vectors. The passage to infinitesimals is made only in the final stage—the limit of the sum—when we move to $\Phi^*$ and integration.</p>
+</blockquote>
+<p><strong>④ Write the standard form obtained in the limit.</strong> For the transformation to polar coordinates $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$:
+</p>
+$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
+<p>This is the $2$-form rebuilt in the limit from the finite-cell version $\Phi_h^\square$. We denote that limiting rebuild by $\Phi^*$. This $r$ plays the same role for $2$-forms that the velocity $\gamma'(t)$ played for $1$-forms in §4.1.
+</p>
+<p><strong>⑤ Pullback of a coefficient-carrying $2$-form.</strong> For a $2$-form $G(x,y)\,dx \wedge dy$ with an arbitrary coefficient $G(x,y)$, the same structure holds:
+</p>
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$
+<p>The coefficient $G$ is merely rebuilt in polar coordinates (pullback of a $0$-form), while only the $dx \wedge dy$ part changes to $r\,dr \wedge d\theta$. The pullback $\Phi^*$ naturally splits into “rebuilding the coefficient” and “rebuilding the measuring device.”
+</p>
+<p><strong>⑥ Carry the same discovery to a general transformation.</strong> Nothing here is special to polar coordinates. Consider a transformation between planes $\Phi(u,v)=(x(u,v),y(u,v))$, and map a finite rectangle on the $(u,v)$ side. Measure the two difference vectors in the $u$ and $v$ directions with $dx\wedge dy$, and we get an area value for each finite rectangle.
+</p>
+<p>Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios converge to partial derivatives, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
+</p>
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\;
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+\,du \wedge dv$$
+<p>That is,
+</p>
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr)
+=G(\Phi(u,v))\left(
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+\right)\,du\wedge dv$$
+<p>The $2\times2$ determinant that appears here is the consistency factor for rebuilding the physical-space area-measuring device $dx\wedge dy$ into a measuring device $du\wedge dv$ usable on the $(u,v)$ side.
+</p>
+<p>What we saw on the finite grid,
+</p>
+$$\Delta x_u\,\Delta y_v-\Delta x_v\,\Delta y_u$$
+<p>is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors. In the limiting rebuild written as $\Phi^*$, these finite ratios are replaced by partial-derivative coefficients. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
+</p>
+<p><strong>⑦ Return to the physical quantity.</strong> Integrate the area of the sector $D$ over the corresponding polar-coordinate region $D'$ using the pulled-back measuring device:
+</p>
+$$
+A
+=
+\iint_D dx\wedge dy
+=
+\iint_{D'} \Phi^*(dx\wedge dy)
+=
+\iint_{D'} r\,dr\wedge d\theta
+$$
+$$
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+<p>Integrating in $r$, $\frac{1}{2}r^2$ appears, and the area is reduced to a line integral of a $1$-form along the $\theta$ axis. Pull back further to the time parameter $t$. If the particle’s orbit is $r = R(t),\, \theta = \Theta(t)$, then
+</p>
+$$
+\frac{dA}{dt}
+=
+\frac{1}{2}r(t)^2\,\theta'(t)
+$$
+<p>From the definition of angular momentum
+</p>
+$$
+L
+=
+m r(t)^2\theta'(t)
+$$
+<p>the areal velocity is
+</p>
+$$\frac{dA}{dt} = \frac{L}{2m}$$
+<p>In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. This is exactly the same structure as in §4.1: there, the consistency factor $\gamma'(t)$ for a $1$-form described energy conservation; here, the consistency factor $r$ for a $2$-form describes conservation of angular momentum.
+</p>
+<hr />
 <h3 id="§4.3-Pullback-of-a-3-Form-—-Conservation-of-Mass-and-Volume-Integrals">§4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals</h3>
 <p><strong>① Start from a physical quantity.</strong> The end point is a volume integral. This time we map a three-dimensional finite box and measure it.
 </p>

--- a/docs/en/ch05.html
+++ b/docs/en/ch05.html
@@ -111,7 +111,7 @@
 <li class="level-1"><a href="ch02.html" id="link-ch02.html">Chapter 2</a></li>
 <li class="level-1"><a href="ch03.html" id="link-ch03.html">Chapter 3</a></li>
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
-<li class="level-1"><a href="ch05.html" class="active" id="link-ch05.html">Chapter 5</a><ul class="sub-toc"><li class="level-3"><a href="#§5.0-The-Bridge-to-Differentiation-—-Observation-Is-Integral,-Law-Is-Differential">§5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential</a></li><li class="level-3"><a href="#§5.2-The-"Mismatch"-Revealed-by-a-Closed-Loop">§5.2 The "Mismatch" Revealed by a Closed Loop</a></li><li class="level-3"><a href="#§5.3-Dismantling-an-Infinitesimal-Loop-—-The-Mismatch-Is-Proportional-to-Area">§5.3 Dismantling an Infinitesimal Loop — The Mismatch Is Proportional to Area</a></li><li class="level-3"><a href="#§5.4-The-Birth-of-$d$-—-A-New-Measuring-Device-for-Mismatch-per-Unit-Area">§5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area</a></li><li class="level-3"><a href="#§5.5-The-Exterior-Derivative-of-a-General-$1$-Form-—-Extension-to-Three-Dimensions">§5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions</a></li><li class="level-3"><a href="#§5.6-Accumulate-It,-and-Only-the-Boundary-Remains-—-Stokes'-Theorem">§5.6 Accumulate It, and Only the Boundary Remains — Stokes' Theorem</a></li><li class="level-3"><a href="#§5.7-The-Same-Thing-One-Degree-Higher-—-Exterior-Derivative-of-a-$2$-Form-and-Divergence">§5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence</a></li><li class="level-3"><a href="#§5.8-$d^2-=-0$-—-The-Mismatch-of-a-Mismatch-Leaves-Nothing-Behind">§5.8 $d^2 = 0$ — The Mismatch of a Mismatch Leaves Nothing Behind</a></li><li class="level-3"><a href="#§5.9-Unifying-the-Exterior-Derivative-—-One-Formula,-One-Rule">§5.9 Unifying the Exterior Derivative — One Formula, One Rule</a></li><li class="level-3"><a href="#§5.10-From-Integrals-to-Differential-Equations-—-Localizing-Physical-Laws">§5.10 From Integrals to Differential Equations — Localizing Physical Laws</a></li><li class="level-3"><a href="#§5.11-Outlook-Toward-Part-II-—-Foreshadowing-the-Hodge-Star">§5.11 Outlook Toward Part II — Foreshadowing the Hodge Star</a></li><li class="level-2"><a href="#Appendix-B:-Matrix-Representation-of-the-Exterior-Derivative">Appendix B: Matrix Representation of the Exterior Derivative</a></li><li class="level-3"><a href="#B.1-$0$-form:-the-$1-\times-3$-row-vector-of-$df$">B.1 $0$-form: the $1 \times 3$ row vector of $df$</a></li><li class="level-3"><a href="#B.2-$1$-form:-the-Jacobian-matrix-$\mathbf{J}$-of-the-coefficients">B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients</a></li><li class="level-3"><a href="#B.3-$d\omega-=-\mathbf{J}^T---\mathbf{J}$">B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</a></li><li class="level-3"><a href="#B.4-$2$-form:-$d\eta$-and-the-trace-of-the-Jacobian-matrix">B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix</a></li><li class="level-3"><a href="#B.5-$d^2-f-=-0$-and-the-Hessian">B.5 $d^2 f = 0$ and the Hessian</a></li><li class="level-2"><a href="#Appendix-C:-Integral-Forms-of-Electromagnetism-and-Differential-Forms">Appendix C: Integral Forms of Electromagnetism and Differential Forms</a></li><li class="level-3"><a href="#C.1-Degrees-of-physical-quantities">C.1 Degrees of physical quantities</a></li><li class="level-3"><a href="#C.2-Gauss's-law-for-charge">C.2 Gauss's law for charge</a></li><li class="level-3"><a href="#C.3-The-law-of-magnetic-flux">C.3 The law of magnetic flux</a></li><li class="level-3"><a href="#C.4-Faraday's-law">C.4 Faraday's law</a></li><li class="level-3"><a href="#C.5-Ampère–Maxwell's-law">C.5 Ampère–Maxwell's law</a></li><li class="level-3"><a href="#C.6-Where-a-metric-is-needed">C.6 Where a metric is needed</a></li></ul></li>
+<li class="level-1"><a href="ch05.html" class="active" id="link-ch05.html">Chapter 5</a><ul class="sub-toc"><li class="level-3"><a href="#§5.0-The-Bridge-to-Differentiation-—-Observation-Is-Integral,-Law-Is-Differential">§5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential</a></li><li class="level-3"><a href="#§5.1-Revisiting-$df$-—-Are-Differentiation-and-Integration-Inverse-Operations?">§5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?</a></li><li class="level-3"><a href="#§5.2-The-"Mismatch"-Revealed-by-a-Closed-Loop">§5.2 The "Mismatch" Revealed by a Closed Loop</a></li><li class="level-3"><a href="#§5.3-Dismantling-an-Infinitesimal-Loop-—-The-Mismatch-Is-Proportional-to-Area">§5.3 Dismantling an Infinitesimal Loop — The Mismatch Is Proportional to Area</a></li><li class="level-3"><a href="#§5.4-The-Birth-of-$d$-—-A-New-Measuring-Device-for-Mismatch-per-Unit-Area">§5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area</a></li><li class="level-3"><a href="#§5.5-The-Exterior-Derivative-of-a-General-$1$-Form-—-Extension-to-Three-Dimensions">§5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions</a></li><li class="level-3"><a href="#§5.6-Accumulate-It,-and-Only-the-Boundary-Remains-—-Stokes'-Theorem">§5.6 Accumulate It, and Only the Boundary Remains — Stokes' Theorem</a></li><li class="level-3"><a href="#§5.7-The-Same-Thing-One-Degree-Higher-—-Exterior-Derivative-of-a-$2$-Form-and-Divergence">§5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence</a></li><li class="level-3"><a href="#§5.8-$d^2-=-0$-—-The-Mismatch-of-a-Mismatch-Leaves-Nothing-Behind">§5.8 $d^2 = 0$ — The Mismatch of a Mismatch Leaves Nothing Behind</a></li><li class="level-3"><a href="#§5.9-Unifying-the-Exterior-Derivative-—-One-Formula,-One-Rule">§5.9 Unifying the Exterior Derivative — One Formula, One Rule</a></li><li class="level-3"><a href="#§5.10-From-Integrals-to-Differential-Equations-—-Localizing-Physical-Laws">§5.10 From Integrals to Differential Equations — Localizing Physical Laws</a></li><li class="level-3"><a href="#§5.11-Outlook-Toward-Part-II-—-Foreshadowing-the-Hodge-Star">§5.11 Outlook Toward Part II — Foreshadowing the Hodge Star</a></li><li class="level-2"><a href="#Appendix-B:-Matrix-Representation-of-the-Exterior-Derivative">Appendix B: Matrix Representation of the Exterior Derivative</a></li><li class="level-3"><a href="#B.1-$0$-form:-the-$1-\times-3$-row-vector-of-$df$">B.1 $0$-form: the $1 \times 3$ row vector of $df$</a></li><li class="level-3"><a href="#B.2-$1$-form:-the-Jacobian-matrix-$\mathbf{J}$-of-the-coefficients">B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients</a></li><li class="level-3"><a href="#B.3-$d\omega-=-\mathbf{J}^T---\mathbf{J}$">B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</a></li><li class="level-3"><a href="#B.4-$2$-form:-$d\eta$-and-the-trace-of-the-Jacobian-matrix">B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix</a></li><li class="level-3"><a href="#B.5-$d^2-f-=-0$-and-the-Hessian">B.5 $d^2 f = 0$ and the Hessian</a></li><li class="level-2"><a href="#Appendix-C:-Integral-Forms-of-Electromagnetism-and-Differential-Forms">Appendix C: Integral Forms of Electromagnetism and Differential Forms</a></li><li class="level-3"><a href="#C.1-Degrees-of-physical-quantities">C.1 Degrees of physical quantities</a></li><li class="level-3"><a href="#C.2-Gauss's-law-for-charge">C.2 Gauss's law for charge</a></li><li class="level-3"><a href="#C.3-The-law-of-magnetic-flux">C.3 The law of magnetic flux</a></li><li class="level-3"><a href="#C.4-Faraday's-law">C.4 Faraday's law</a></li><li class="level-3"><a href="#C.5-Ampère–Maxwell's-law">C.5 Ampère–Maxwell's law</a></li><li class="level-3"><a href="#C.6-Where-a-metric-is-needed">C.6 Where a metric is needed</a></li></ul></li>
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
@@ -127,7 +127,7 @@
   </nav>
   <main class="main-content">
     <article class="markdown-body">
-<h1 id="Chapter-5:-What-Does-It-Mean-to-Differentiate?-—-The-Exterior-Derivative-__MATH_BLOCK_98__:-Integral-Quantities-and-Local-Laws">Chapter 5: What Does It Mean to Differentiate? — The Exterior Derivative $d$: Integral Quantities and Local Laws</h1>
+<h1 id="Chapter-5:-What-Does-It-Mean-to-Differentiate?-—-The-Exterior-Derivative-__MATH_BLOCK_105__:-Integral-Quantities-and-Local-Laws">Chapter 5: What Does It Mean to Differentiate? — The Exterior Derivative $d$: Integral Quantities and Local Laws</h1>
 <h3 id="§5.0-The-Bridge-to-Differentiation-—-Observation-Is-Integral,-Law-Is-Differential">§5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential</h3>
 <p>In Chapter 3 we defined integration over curves, surfaces, and regions in the language of $k$-forms. Work along a curve $\gamma$ is $\int_\gamma \omega$, flux through a surface $S$ is $\iint_S \eta$, and the total mass of a region $V$ is $\iiint_V \Omega$. Each followed the same principle: feed $k$ displacement vectors to a $k$-form (measuring device), obtain a scalar, and aggregate over the entire region.
 </p>
@@ -149,8 +149,58 @@
 </p>
 <p>The structure of this chapter is as follows. First we recall the $df$ introduced in Chapter 1 and build $d\omega$ from the mismatch that remains when a general $1$-form is measured on a closed loop. Next we extend the same idea to $2$-forms and unify Stokes' theorem and Gauss' theorem into a single form. Finally we look at the structure $d^2=0$ and at how the exterior derivative localizes physical laws, connecting to the Hodge star in the next chapter.
 </p>
+<hr />
+<h3 id="§5.1-Revisiting-__MATH_BLOCK_126__-—-Are-Differentiation-and-Integration-Inverse-Operations?">§5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?</h3>
+<h4 id="5.1.1-__MATH_BLOCK_127__-Is-"Raising-the-Degree"">5.1.1 $df$ Is "Raising the Degree"</h4>
+<p>In Chapter 1 §1.2 we defined the total differential of a function $f(x,y,z)$ as a row vector:
+</p>
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+<p>This is an operation that takes a <strong>$0$-form (the scalar field $f$) as input and outputs a $1$-form (the row vector $df$)</strong>. The degree rises from 0 to 1.
+</p>
+<p>Recall here that $df(\mathbf{v})$ returns the first-order change in $f$ for a displacement $\mathbf{v}$. When $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ is sufficiently small:
+</p>
+$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
+<p>$df$ by itself is not "the change itself"—as agreed in Chapter 1 §1.1.6, $df$ is an operator; a numerical value is obtained only when it acts on a displacement vector.
+</p>
+<h4 id="5.1.2-A-Line-Integral-Leaves-Only-the-Difference-of-Endpoints">5.1.2 A Line Integral Leaves Only the Difference of Endpoints</h4>
+<p>Integrate this $df$ along a curve $\gamma$. As in Chapter 3 §3.3.1, partition the curve into small intervals, feed $df$ each step's displacement $\Delta\mathbf{r}_i$, and add up the results.
+</p>
+<p>To first order on each interval, $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
+</p>
+$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
+<p>Expanding this sum:
+</p>
+$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
+<p>Adjacent terms $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ cancel in plus and minus—a <strong>telescoping sum</strong>. Only the first and last survive. In the limit of infinitely fine partition:
+</p>
+$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
+<p>where $A$ is the starting point of the curve and $B$ is the endpoint.
+</p>
+<blockquote>
+<p><strong>Checkpoint so far</strong></p>
+<p>- $\int_\gamma df = f(B) - f(A)$. The result of the integral depends entirely on the endpoint values, not at all on the shape of the path.</p>
+<p>- This holds precisely because $df$ is a special $1$-form. In mechanics, it is the mathematical reason why "the work of a conservative force does not depend on the path."</p>
+</blockquote>
+<h4 id="5.1.3-Checking-with-a-Chapter-3-Example">5.1.3 Checking with a Chapter 3 Example</h4>
+<p>In Chapter 3 §3.4.1 we integrated $\omega = y\,dx + x\,dy$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ and found the result to be $0$. At the time we integrated straightforwardly along the coefficients, but viewed in today's language the story is much simpler.
+</p>
+<p>In fact $y\,dx + x\,dy$ is nothing other than $d(xy)$. For:
+</p>
+$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
+<p>Therefore $\omega = df$ (with $f = xy$), and the telescoping-sum argument of §5.1.2 applies as-is. The unit circle is a closed curve, so $B = A$, and hence:
+</p>
+$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy(\gamma(2\pi))-xy(\gamma(0))=0$$
+<p>The calculation $\int_0^{2\pi} \cos 2t\,dt = 0$ from back then mechanically gave zero precisely because $\omega$ was an <strong>exact form</strong>, namely $d(xy)$.
+</p>
+<blockquote>
+<p><strong>Note</strong> (exact forms) A $1$-form that can be written as $\omega = df$ is called an <strong>exact form</strong>. Integrating an exact form along a closed curve always gives zero, as long as $f$ is a single-valued function. On the other hand, beware: "the integral along some closed curve was zero" does not necessarily mean the form is exact (whether the integral is zero on all closed curves also depends on the topology of the region). We examine this point in detail in §5.2.</p>
+</blockquote>
+<blockquote>
+<p><strong>Note</strong> (the relation between $d$ and $\int$—a boundary formula, not an inverse map) $\int_\gamma df = f(B)-f(A)$ does not mean that integration is a global inverse of the exterior derivative $d$. Integration is a functional that depends on the choice of curve $\gamma$; it is not an operation that reconstructs the entire original function $f$ from $df$. This formula is the fundamental theorem of calculus: "integrating an exact form along a curve leaves only the boundary, namely the endpoints." It is safest to think of it as the $0$-form version of the Stokes-type formulas we will see later.</p>
+</blockquote>
+<hr />
 <h3 id="§5.2-The-"Mismatch"-Revealed-by-a-Closed-Loop">§5.2 The "Mismatch" Revealed by a Closed Loop</h3>
-<h4 id="5.2.1-What-About-a-General-__MATH_BLOCK_119__-Form?">5.2.1 What About a General $1$-Form?</h4>
+<h4 id="5.2.1-What-About-a-General-__MATH_BLOCK_172__-Form?">5.2.1 What About a General $1$-Form?</h4>
 <p>What about a general $1$-form
 </p>
 $$\omega = P(x,y,z)\,dx + Q(x,y,z)\,dy + R(x,y,z)\,dz$$
@@ -185,7 +235,7 @@ $$\oint_\gamma \omega \neq 0$$
 </p>
 <hr />
 <h3 id="§5.3-Dismantling-an-Infinitesimal-Loop-—-The-Mismatch-Is-Proportional-to-Area">§5.3 Dismantling an Infinitesimal Loop — The Mismatch Is Proportional to Area</h3>
-<h4 id="5.3.1-A-Tiny-Rectangle-in-the-__MATH_BLOCK_144__-Plane">5.3.1 A Tiny Rectangle in the $xy$ Plane</h4>
+<h4 id="5.3.1-A-Tiny-Rectangle-in-the-__MATH_BLOCK_197__-Plane">5.3.1 A Tiny Rectangle in the $xy$ Plane</h4>
 <p>Consider a tiny rectangle parallel to the $xy$ plane, with the point $(x, y, z)$ as its lower-left vertex. Let the width in the $x$ direction be $\Delta x$ and the width in the $y$ direction be $\Delta y$. Traverse the four edges of this rectangle once in the <strong>counterclockwise (right-handed) direction</strong>, and integrate $\omega = P\,dx + Q\,dy + R\,dz$.
 </p>
 <p>Let us evaluate the integral on each edge using a first-order Taylor approximation (with $\Delta x, \Delta y$ sufficiently small).
@@ -237,14 +287,14 @@ $$\lim_{\Delta x,\Delta y\to 0}\frac{1}{\Delta x\,\Delta y}\oint_{\partial R_{\D
 <p><strong>Note</strong> (why only $\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$ survives) $\frac{\partial P}{\partial x}$ and $\frac{\partial Q}{\partial y}$ do not appear. The change of $P$ in the $x$ direction ($\frac{\partial P}{\partial x}$) acts in the same direction on the bottom and top edges and cancels; the change of $Q$ in the $y$ direction ($\frac{\partial Q}{\partial y}$) likewise cancels on the right and left edges. What survives is only "the change of $P$ in the $y$ direction" and "the change of $Q$ in the $x$ direction"—the difference of <strong>partial derivatives in mutually orthogonal directions</strong>. This crosswise structure is the key to everything from the next section onward.</p>
 </blockquote>
 <hr />
-<h3 id="§5.4-The-Birth-of-__MATH_BLOCK_212__-—-A-New-Measuring-Device-for-Mismatch-per-Unit-Area">§5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area</h3>
+<h3 id="§5.4-The-Birth-of-__MATH_BLOCK_265__-—-A-New-Measuring-Device-for-Mismatch-per-Unit-Area">§5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area</h3>
 <h4 id="5.4.1-Revisiting-the-Wedge-Product">5.4.1 Revisiting the Wedge Product</h4>
 <p>Let us restate the $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$ obtained in §5.3 in the language of Chapter 2. In Chapter 2 §2.4.4 we defined the area-measuring device $dx \wedge dy$. This was a device that, when fed two vectors $\mathbf{v}_1, \mathbf{v}_2$, returns the signed area of the shadow they cast onto the $xy$ plane:
 </p>
 $$(dx \wedge dy)(\mathbf{v}_1, \mathbf{v}_2) = \det\begin{pmatrix} dx(\mathbf{v}_1) & dx(\mathbf{v}_2) \\ dy(\mathbf{v}_1) & dy(\mathbf{v}_2) \end{pmatrix}$$
 <p>In particular, if we feed the displacement $\Delta x\,\hat{e}_x$ in the $x$ direction and the displacement $\Delta y\,\hat{e}_y$ in the $y$ direction, we get $(dx \wedge dy)(\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y) = \Delta x\,\Delta y$.
 </p>
-<h4 id="5.4.2-Definition-of-__MATH_BLOCK_222__">5.4.2 Definition of $d\omega$</h4>
+<h4 id="5.4.2-Definition-of-__MATH_BLOCK_275__">5.4.2 Definition of $d\omega$</h4>
 <p>Written in this language, the result of §5.3 says that for the two edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y$ of an infinitesimal rectangle, some <strong>new $2$-form</strong> returned the leading term $(\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,\Delta x\,\Delta y$. We call this $2$-form the <strong>exterior derivative</strong> of $\omega$, and write it $d\omega$:
 </p>
 $$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
@@ -267,8 +317,8 @@ $$d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx
 <p>- We define the $2$-form that measures this proportionality coefficient as $d\omega := (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$. $d$ is the operator that raises the degree.</p>
 </blockquote>
 <hr />
-<h3 id="§5.5-The-Exterior-Derivative-of-a-General-__MATH_BLOCK_258__-Form-—-Extension-to-Three-Dimensions">§5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions</h3>
-<h4 id="5.5.1-The-__MATH_BLOCK_259__-Plane-and-the-__MATH_BLOCK_260__-Plane">5.5.1 The $yz$ Plane and the $zx$ Plane</h4>
+<h3 id="§5.5-The-Exterior-Derivative-of-a-General-__MATH_BLOCK_311__-Form-—-Extension-to-Three-Dimensions">§5.5 The Exterior Derivative of a General $1$-Form — Extension to Three Dimensions</h3>
+<h4 id="5.5.1-The-__MATH_BLOCK_312__-Plane-and-the-__MATH_BLOCK_313__-Plane">5.5.1 The $yz$ Plane and the $zx$ Plane</h4>
 <p>In §5.3–§5.4 we considered loops only in the $xy$ plane. But in three-dimensional space there are three orientations of surface. On an infinitesimal rectangle in the $yz$ plane, a similar calculation gives $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,\Delta y\,\Delta z$; on the $zx$ plane we get $(\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,\Delta z\,\Delta x$. These correspond to $dy \wedge dz$ and $dz \wedge dx$, respectively.
 </p>
 <p>The complete formula that follows from this intuition is:
@@ -277,7 +327,7 @@ $$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy 
 <blockquote>
 <p><strong>Note</strong> ($2$-forms measure tilted parallelograms) This $d\omega$ is a $2$-form—a <strong>measuring device that eats two vectors</strong>. The two vectors fed to it need not be parallel to the $xy$ plane. If we feed the two edges $\mathbf{v}_1, \mathbf{v}_2$ of an infinitesimal parallelogram floating obliquely in three-dimensional space, it returns the mismatch per unit area of a closed loop over that surface. It is exactly the same thing we did in §5.3—the only difference is that the surface being measured need not be parallel to a coordinate plane. The mechanism for extracting the area (and orientation) of a parallelogram from two vectors was already verified in Chapter 2 §2.4, when we constructed $dy \wedge dz$ and the like as antisymmetric matrices.</p>
 </blockquote>
-<h4 id="5.5.2-Algebraic-Derivation-—-Leibniz-Rule-and-__MATH_BLOCK_274__">5.5.2 Algebraic Derivation — Leibniz Rule and $d(dx)=0$</h4>
+<h4 id="5.5.2-Algebraic-Derivation-—-Leibniz-Rule-and-__MATH_BLOCK_327__">5.5.2 Algebraic Derivation — Leibniz Rule and $d(dx)=0$</h4>
 <p>The formula above can of course be derived by doing separate loop calculations on each plane. But drawing a loop and adding four edges every time is tedious. What we do here is recast the exterior derivative introduced geometrically in §5.3 as computational algebraic rules, and confirm that these rules do indeed reproduce the exterior derivative. In other words, using the intuition from the $xy$-plane example, we move to a form that can be computed mechanically.
 </p>
 <blockquote>
@@ -391,8 +441,8 @@ $$\oint_{\partial S} \bigl(P\,dx + Q\,dy + R\,dz\bigr) = \iint_S \Bigl( (\frac{\
 <p>- As with surface integrals in Chapter 3, we divide the surface into small patches, act with the measuring device on each patch, and aggregate.</p>
 </blockquote>
 <hr />
-<h3 id="§5.7-The-Same-Thing-One-Degree-Higher-—-Exterior-Derivative-of-a-__MATH_BLOCK_374__-Form-and-Divergence">§5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence</h3>
-<h4 id="5.7.1-A-__MATH_BLOCK_375__-Form-Is-a-Measuring-Device-for-Surfaces">5.7.1 A $2$-Form Is a Measuring Device for Surfaces</h4>
+<h3 id="§5.7-The-Same-Thing-One-Degree-Higher-—-Exterior-Derivative-of-a-__MATH_BLOCK_427__-Form-and-Divergence">§5.7 The Same Thing One Degree Higher — Exterior Derivative of a $2$-Form and Divergence</h3>
+<h4 id="5.7.1-A-__MATH_BLOCK_428__-Form-Is-a-Measuring-Device-for-Surfaces">5.7.1 A $2$-Form Is a Measuring Device for Surfaces</h4>
 <p>In Chapter 3 §3.4.2 we wrote a general $2$-form in the form
 </p>
 $$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
@@ -414,7 +464,7 @@ $$\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$$
 $$\iint_{\partial (\text{box})} \eta \approx (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,\Delta x\,\Delta y\,\Delta z$$
 <p>Here too the structure is the same—<strong>the leading term of the mismatch measured on the surface is proportional to the enclosed volume</strong>. The proportionality constant $\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}$ represents the "outflow per unit volume."
 </p>
-<h4 id="5.7.3-Definition-of-__MATH_BLOCK_403__-and-Algebraic-Derivation">5.7.3 Definition of $d\eta$ and Algebraic Derivation</h4>
+<h4 id="5.7.3-Definition-of-__MATH_BLOCK_456__-and-Algebraic-Derivation">5.7.3 Definition of $d\eta$ and Algebraic Derivation</h4>
 <p>As a $3$-form that eats the three edges $\Delta x\,\hat{e}_x,\; \Delta y\,\hat{e}_y,\; \Delta z\,\hat{e}_z$ of the box:
 </p>
 $$d\eta := (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$$
@@ -457,10 +507,10 @@ $$\iint_{\partial V} \bigl(A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy\b
 <p>- $\iint_{\partial V} \eta = \iiint_V d\eta$. Stokes ($1$-form $\to$ surface) and Gauss ($2$-form $\to$ solid) differ only in degree; the structure is the same.</p>
 </blockquote>
 <hr />
-<h3 id="§5.8-__MATH_BLOCK_456__-—-The-Mismatch-of-a-Mismatch-Leaves-Nothing-Behind">§5.8 $d^2 = 0$ — The Mismatch of a Mismatch Leaves Nothing Behind</h3>
+<h3 id="§5.8-__MATH_BLOCK_509__-—-The-Mismatch-of-a-Mismatch-Leaves-Nothing-Behind">§5.8 $d^2 = 0$ — The Mismatch of a Mismatch Leaves Nothing Behind</h3>
 <p>Before unifying Stokes' theorem and Gauss' theorem in the next section, let us confirm one more basic structure of the exterior derivative. $d$ raises the degree by one, but applying it twice in succession leaves no new mismatch. This fact is also connected to the geometric structure we will see later: "the boundary of a boundary cancels as an oriented sum."
 </p>
-<h4 id="5.8.1-__MATH_BLOCK_458__">5.8.1 $d(df) = 0$</h4>
+<h4 id="5.8.1-__MATH_BLOCK_511__">5.8.1 $d(df) = 0$</h4>
 <p>In §5.1 we defined $df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$. Let us apply the exterior derivative once more. Using the formula from §5.5 with $P = \frac{\partial f}{\partial x},\; Q = \frac{\partial f}{\partial y},\; R = \frac{\partial f}{\partial z}$:
 </p>
 $$d(df) = \left(\frac{\partial^2 f}{\partial y \partial z} - \frac{\partial^2 f}{\partial z \partial y}\right) dy \wedge dz + \left(\frac{\partial^2 f}{\partial z \partial x} - \frac{\partial^2 f}{\partial x \partial z}\right) dz \wedge dx + \left(\frac{\partial^2 f}{\partial x \partial y} - \frac{\partial^2 f}{\partial y \partial x}\right) dx \wedge dy$$
@@ -470,7 +520,7 @@ $$d(df) = 0$$
 <blockquote>
 <p><strong>Note</strong> ($d^2=0$ in the axiomatic viewpoint and the $C^2$ condition) When we compute concretely in coordinates, we see that $d^2=0$ is inevitable from symmetry of mixed partial derivatives and antisymmetry of the wedge product. From the axiomatic standpoint of differential forms, one may instead read things the other way around: requiring $d^2=0$ (as part of the definition) means we are implicitly working with a class of functions for which symmetry of mixed partial derivatives holds ($C^2$ functions). In this book we first understand it through concrete calculation, as the mechanism that prevents contradictions in the hierarchy of physical laws.</p>
 </blockquote>
-<h4 id="5.8.2-__MATH_BLOCK_469__">5.8.2 $d(d\omega) = 0$</h4>
+<h4 id="5.8.2-__MATH_BLOCK_522__">5.8.2 $d(d\omega) = 0$</h4>
 <p>Apply the formula of §5.7 to the $d\omega$ of §5.5. With $A = \frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z},\; B = \frac{\partial P}{\partial z} - \frac{\partial R}{\partial x},\; C = \frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y}$:
 </p>
 $$d(d\omega) = \left(\frac{\partial^2 R}{\partial x \partial y} - \frac{\partial^2 Q}{\partial x \partial z} + \frac{\partial^2 P}{\partial y \partial z} - \frac{\partial^2 R}{\partial y \partial x} + \frac{\partial^2 Q}{\partial z \partial x} - \frac{\partial^2 P}{\partial z \partial y}\right) dx \wedge dy \wedge dz$$
@@ -503,7 +553,7 @@ $$\int_{\partial(\partial M)} \omega = \int_{\partial M} d\omega = \int_M d(d\om
 <blockquote>
 <p><strong>Note</strong> (three dimensions suffice) Because the stage of this book is three-dimensional space, the dimension of $M$ is 1, 2, or 3, and $\omega$ is a $0$-form, $1$-form, or $2$-form. We do not enter $k=3$ ($M$ four-dimensional). Still, it does no harm to keep in the back of your mind that this formula holds regardless of $k$.</p>
 </blockquote>
-<h4 id="5.9.2-Exterior-Derivative-of-a-General-__MATH_BLOCK_511__-Form">5.9.2 Exterior Derivative of a General $k$-Form</h4>
+<h4 id="5.9.2-Exterior-Derivative-of-a-General-__MATH_BLOCK_564__-Form">5.9.2 Exterior Derivative of a General $k$-Form</h4>
 <p>Likewise, the action of $d$ collapses into one pattern regardless of degree. When an arbitrary $k$-form $\omega$ is written as a sum of coefficients $a_{i_1\cdots i_k}$ and basis elements $dx_{i_1}\wedge\cdots\wedge dx_{i_k}$:
 </p>
 $$d\omega = \sum \Bigl( \sum_j \frac{\partial a_{i_1\cdots i_k}}{\partial x_j}\,dx_j \Bigr) \wedge dx_{i_1}\wedge\cdots\wedge dx_{i_k}$$
@@ -714,14 +764,14 @@ $$
 <h2 id="Appendix-B:-Matrix-Representation-of-the-Exterior-Derivative">Appendix B: Matrix Representation of the Exterior Derivative</h2>
 <p>The main text of this chapter proceeded with the basis $dx, dy, dz$ and the algebra of the wedge product. Here we rewrite the exterior derivative in the language of matrix representations, following the book's convention since Chapter 2 — <strong>arranging every component without exception into matrices</strong>.
 </p>
-<h3 id="B.1-__MATH_BLOCK_634__-form:-the-__MATH_BLOCK_635__-row-vector-of-__MATH_BLOCK_636__">B.1 $0$-form: the $1 \times 3$ row vector of $df$</h3>
+<h3 id="B.1-__MATH_BLOCK_687__-form:-the-__MATH_BLOCK_688__-row-vector-of-__MATH_BLOCK_689__">B.1 $0$-form: the $1 \times 3$ row vector of $df$</h3>
 <p>For $f = f(x,y,z)$, as defined in Chapter 1 §1.2:
 </p>
 $$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz$$
 <p>As a row vector ($1 \times 3$ matrix):
 </p>
 $$df = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
-<h3 id="B.2-__MATH_BLOCK_639__-form:-the-Jacobian-matrix-__MATH_BLOCK_640__-of-the-coefficients">B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients</h3>
+<h3 id="B.2-__MATH_BLOCK_692__-form:-the-Jacobian-matrix-__MATH_BLOCK_693__-of-the-coefficients">B.2 $1$-form: the Jacobian matrix $\mathbf{J}$ of the coefficients</h3>
 <p>For $\omega = P\,dx + Q\,dy + R\,dz$, the $3 \times 3$ matrix that arranges <strong>all</strong> partial derivatives of the coefficients $(P,Q,R)$ is:
 </p>
 $$\mathbf{J} := \begin{pmatrix}
@@ -731,7 +781,7 @@ $$\mathbf{J} := \begin{pmatrix}
 \end{pmatrix}$$
 <p>This is the Jacobian matrix of the vector field obtained by stacking $(P,Q,R)$ as a column. The reason §5.1 said that "a mere matrix of partial derivatives is not enough" is precisely that this $\mathbf{J}$ is not antisymmetric.
 </p>
-<h3 id="B.3-__MATH_BLOCK_646__">B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</h3>
+<h3 id="B.3-__MATH_BLOCK_699__">B.3 $d\omega = \mathbf{J}^T - \mathbf{J}$</h3>
 <p>The result of §5.5 is:
 </p>
 $$d\omega = (\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\,dy \wedge dz + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\,dz \wedge dx + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\,dx \wedge dy$$
@@ -749,7 +799,7 @@ $$\mathbf{J}^T - \mathbf{J} = \begin{pmatrix}
 $$d\omega = \mathbf{J}^T - \mathbf{J}$$
 <p>Thus, <strong>the matrix representation of the exterior derivative $d\omega$ is the antisymmetric matrix obtained by subtracting the Jacobian matrix of the coefficients from its transpose.</strong>
 </p>
-<h3 id="B.4-__MATH_BLOCK_653__-form:-__MATH_BLOCK_654__-and-the-trace-of-the-Jacobian-matrix">B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix</h3>
+<h3 id="B.4-__MATH_BLOCK_706__-form:-__MATH_BLOCK_707__-and-the-trace-of-the-Jacobian-matrix">B.4 $2$-form: $d\eta$ and the trace of the Jacobian matrix</h3>
 <p>For $\eta = A\,dy \wedge dz + B\,dz \wedge dx + C\,dx \wedge dy$, let the Jacobian matrix of the coefficients $(A,B,C)$ be:
 </p>
 $$\mathbf{J}_\eta := \begin{pmatrix}
@@ -760,7 +810,7 @@ $$\mathbf{J}_\eta := \begin{pmatrix}
 <p>Then the coefficient in the result of §5.7, $d\eta = (\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z})\,dx \wedge dy \wedge dz$, agrees with the <strong>trace</strong> (sum of diagonal entries) of $\mathbf{J}_\eta$:
 </p>
 $$\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z} = \operatorname{tr}(\mathbf{J}_\eta)$$
-<h4 id="B.4.1-The-27-components-of-__MATH_BLOCK_659__-—-expanded-into-three-matrices">B.4.1 The 27 components of $d\eta$ — expanded into three matrices</h4>
+<h4 id="B.4.1-The-27-components-of-__MATH_BLOCK_712__-—-expanded-into-three-matrices">B.4.1 The 27 components of $d\eta$ — expanded into three matrices</h4>
 <p>The antisymmetric components of $\eta$ are $\eta_{yz}=A,\; \eta_{zx}=B,\; \eta_{xy}=C$ (the others are sign reversals or $0$). To see where all entries go, first arrange the raw derivative components $\partial_a\eta_{bc}$, where $\partial_x=\frac{\partial}{\partial x}$, $\partial_y=\frac{\partial}{\partial y}$, $\partial_z=\frac{\partial}{\partial z}$, and $a,b,c\in\{x,y,z\}$, so there are $3^3=27$ entries before antisymmetrization. Arranging them into three $3 \times 3$ matrices with $a$ fixed gives:
 </p>
 $$
@@ -792,7 +842,7 @@ $$d\eta = \left( \frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} +
 </p>
 <p>A $3$-form has only the single basis element $dx \wedge dy \wedge dz$, so in this representation it reduces to a scalar coefficient.
 </p>
-<h3 id="B.5-__MATH_BLOCK_686__-and-the-Hessian">B.5 $d^2 f = 0$ and the Hessian</h3>
+<h3 id="B.5-__MATH_BLOCK_739__-and-the-Hessian">B.5 $d^2 f = 0$ and the Hessian</h3>
 <p>The Hessian of a $0$-form $f$:
 </p>
 $$\mathbf{H}_f := \begin{pmatrix}

--- a/docs/en/ch06.html
+++ b/docs/en/ch06.html
@@ -112,7 +112,7 @@
 <li class="level-1"><a href="ch03.html" id="link-ch03.html">Chapter 3</a></li>
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
-<li class="level-1"><a href="ch06.html" class="active" id="link-ch06.html">Chapter 6</a><ul class="sub-toc"><li class="level-3"><a href="#§6.0-The-End-of-Excuses-—-Releasing-the-Inner-Product">§6.0 The End of Excuses — Releasing the Inner Product</a></li><li class="level-3"><a href="#§6.2-Converting-Between-Column-Vectors-and-Row-Vectors-Using-$g$">§6.2 Converting Between Column Vectors and Row Vectors Using $g$</a></li><li class="level-3"><a href="#§6.3-The-Hodge-Star-$\ast$-—-The-Correspondence-Connecting-Two-Routes">§6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes</a></li><li class="level-3"><a href="#§6.4-Examples-of-the-Correspondence-—-Differential-Forms-and-Vector-Analysis">§6.4 Examples of the Correspondence — Differential Forms and Vector Analysis</a></li><li class="level-3"><a href="#§6.5-The-Types-of-the-Three-Operations-—-grad,-curl,-div">§6.5 The Types of the Three Operations — grad, curl, div</a></li><li class="level-3"><a href="#§6.6-Toward-Vector-Analysis">§6.6 Toward Vector Analysis</a></li><li class="level-2"><a href="#Appendix-D:-Array-Representation-of-the-Hodge-Star">Appendix D: Array Representation of the Hodge Star</a></li><li class="level-3"><a href="#D.1-$\ast_{1\to2}$-—-placing-three-coefficients-into-an-antisymmetric-matrix">D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix</a></li><li class="level-3"><a href="#D.2-$\ast_{2\to1}$-—-extracting-coefficients-by-the-Frobenius-product">D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product</a></li><li class="level-3"><a href="#D.3-$\ast\ast=\mathrm{id}$-in-the-$1$-form-and-$2$-form-case">D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case</a></li><li class="level-3"><a href="#D.4-Array-representation-of-$\ast_{0\to3}$-and-$\ast_{3\to0}$">D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$</a></li><li class="level-3"><a href="#D.5-Summary">D.5 Summary</a></li></ul></li>
+<li class="level-1"><a href="ch06.html" class="active" id="link-ch06.html">Chapter 6</a><ul class="sub-toc"><li class="level-3"><a href="#§6.0-The-End-of-Excuses-—-Releasing-the-Inner-Product">§6.0 The End of Excuses — Releasing the Inner Product</a></li><li class="level-3"><a href="#§6.1-The-Inner-Product-on-Parameter-Space-—-The-True-Nature-of-the-Metric-$g$">§6.1 The Inner Product on Parameter Space — The True Nature of the Metric $g$</a></li><li class="level-3"><a href="#§6.2-Converting-Between-Column-Vectors-and-Row-Vectors-Using-$g$">§6.2 Converting Between Column Vectors and Row Vectors Using $g$</a></li><li class="level-3"><a href="#§6.3-The-Hodge-Star-$\ast$-—-The-Correspondence-Connecting-Two-Routes">§6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes</a></li><li class="level-3"><a href="#§6.4-Examples-of-the-Correspondence-—-Differential-Forms-and-Vector-Analysis">§6.4 Examples of the Correspondence — Differential Forms and Vector Analysis</a></li><li class="level-3"><a href="#§6.5-The-Types-of-the-Three-Operations-—-grad,-curl,-div">§6.5 The Types of the Three Operations — grad, curl, div</a></li><li class="level-3"><a href="#§6.6-Toward-Vector-Analysis">§6.6 Toward Vector Analysis</a></li><li class="level-2"><a href="#Appendix-D:-Array-Representation-of-the-Hodge-Star">Appendix D: Array Representation of the Hodge Star</a></li><li class="level-3"><a href="#D.1-$\ast_{1\to2}$-—-placing-three-coefficients-into-an-antisymmetric-matrix">D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix</a></li><li class="level-3"><a href="#D.2-$\ast_{2\to1}$-—-extracting-coefficients-by-the-Frobenius-product">D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product</a></li><li class="level-3"><a href="#D.3-$\ast\ast=\mathrm{id}$-in-the-$1$-form-and-$2$-form-case">D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case</a></li><li class="level-3"><a href="#D.4-Array-representation-of-$\ast_{0\to3}$-and-$\ast_{3\to0}$">D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$</a></li><li class="level-3"><a href="#D.5-Summary">D.5 Summary</a></li></ul></li>
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
@@ -127,7 +127,7 @@
   </nav>
   <main class="main-content">
     <article class="markdown-body">
-<h1 id="Chapter-6:-The-Metric-__MATH_BLOCK_85__-and-the-Hodge-Star-__MATH_BLOCK_86__-—-Summoning-the-Inner-Product-and-Reversing-Degree">Chapter 6: The Metric $g$ and the Hodge Star $\ast$ — Summoning the Inner Product and Reversing Degree</h1>
+<h1 id="Chapter-6:-The-Metric-__MATH_BLOCK_102__-and-the-Hodge-Star-__MATH_BLOCK_103__-—-Summoning-the-Inner-Product-and-Reversing-Degree">Chapter 6: The Metric $g$ and the Hodge Star $\ast$ — Summoning the Inner Product and Reversing Degree</h1>
 <h3 id="§6.0-The-End-of-Excuses-—-Releasing-the-Inner-Product">§6.0 The End of Excuses — Releasing the Inner Product</h3>
 <p>When, in Chapter 2, we restored the scalar area of a parallelogram as the square root of the sum of squares of three projected areas, and when, in Chapter 3, we measured the surface area $4\pi R^2$ of a sphere and the arc length $2\pi R$ of a circle by the same idea—here we have repeatedly hedged, each time we computed a length or an area, with “we have not yet formally introduced the metric (inner product).”
 </p>
@@ -154,8 +154,132 @@
 </p>
 <p>Yes—the matter is deeper than the reader may have thought. On the special stage of real space, these two often happen to return the same number, which has encouraged their confusion—and on top of that confusion a vast edifice called vector analysis has been built. The goal of this chapter is to make this distinction clear, then introduce the metric $g$ as the natural generalization of the inner product, and from there expose what the Hodge star $\ast$ really is.
 </p>
-<h3 id="§6.2-Converting-Between-Column-Vectors-and-Row-Vectors-Using-__MATH_BLOCK_96__">§6.2 Converting Between Column Vectors and Row Vectors Using $g$</h3>
-<h4 id="6.2.1-__MATH_BLOCK_97__-Is-a-Row-Vector">6.2.1 $\mathbf{v}^T \mathbf{g}$ Is a Row Vector</h4>
+<hr />
+<h3 id="§6.1-The-Inner-Product-on-Parameter-Space-—-The-True-Nature-of-the-Metric-__MATH_BLOCK_113__">§6.1 The Inner Product on Parameter Space — The True Nature of the Metric $g$</h3>
+<h4 id="6.1.1-Inner-Product-in-Real-Space">6.1.1 Inner Product in Real Space</h4>
+<p>Write two column vectors in real space $(x,y,z)$ in components:
+</p>
+$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
+<p>In this book, the <strong>inner product</strong> (dot product), denoted by $\cdot$, is the operation of multiplying components with the same index and adding the results.
+</p>
+$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
+<p>In $xyz$ coordinates, the inner product is computed simply by multiplying corresponding components and adding.
+</p>
+<h4 id="6.1.2-Rereading-the-Inner-Product-as-a-Measuring-Device">6.1.2 Rereading the Inner Product as a Measuring Device</h4>
+<p>Here let us reread the same calculation in the language of “measuring devices.” At first glance the inner product looks like an operation of a different lineage from the measuring devices we have handled until now. In fact, however, the inner product can also be read as an operation that “turns something into a measuring device, acts on something else, and yields a scalar.”
+</p>
+<p>The entry point is the transpose. Transposing $\mathbf{v}_1$ turns a column vector into a row vector:
+</p>
+$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$
+<p>This is a measuring device that eats the paired column vector $\mathbf{v}_2$ and measures “how large is the inner product with $\mathbf{v}_1$?”
+</p>
+$$\mathbf{v}_1^T\mathbf{v}_2
+= \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
+= x_1x_2 + y_1y_2 + z_1z_2$$
+<p>That is, in orthogonal Cartesian coordinates on real space, transposing a column vector $\mathbf{v}_1$ alone yields the row vector—a measuring device—for taking the inner product with that vector.
+</p>
+<blockquote>
+<p><strong>Note</strong> (What raising and lowering indices really are) In tensor analysis there is a convention of distinguishing vector components from measuring-device components by upper and lower indices. One is then told that the metric $g$ is used to raise and lower indices. In the language of this book, the true nature of that is the operation “convert a column vector into a row vector that measures the inner product.” In orthogonal Cartesian coordinates $g=I$, so transpose alone suffices; but in parameter space, as we shall see next, we must insert $\mathbf{g}=J^T J$ along the way.</p>
+</blockquote>
+<h4 id="6.1.3-Taking-the-Inner-Product-in-Parameter-Space">6.1.3 Taking the Inner Product in Parameter Space</h4>
+<p>What happens if we carry out the same rereading in parameter space $(r,\theta,z)$?
+</p>
+<p>In orthogonal Cartesian coordinates on real space, $\mathbf{v}_1^T$ was directly the “measuring device for the inner product with $\mathbf{v}_1$.” So in parameter space too we are tempted to use $\mathbf{v}_1^T$ as the measuring device as-is. But that only computes $\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$, which is not the correct inner product in real space. The correspondence between increments in parameter space and displacements in real space varies from place to place.
+</p>
+<p>What, then, must we insert to turn a column vector in parameter space into a row vector that correctly measures the inner product in real space?
+</p>
+<p>In Chapter 4 we saw how the Jacobian matrix of a coordinate change transforms components. Here we use that same matrix $J$ to read a displacement in parameter space as a displacement in real space.
+</p>
+$$J = \begin{pmatrix}
+\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
+\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
+\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
+\end{pmatrix}$$
+<p>From the cylindrical-coordinate formulas $x = r\cos\theta,\; y = r\sin\theta,\; z = z$, computing partial derivatives gives:
+</p>
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+<p>Write the vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space in components:
+</p>
+$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+<p>Read in real space, these become $J\mathbf{v}_1$ and $J\mathbf{v}_2$ respectively. By the reading of the previous subsection, the measuring device for “the inner product with $J\mathbf{v}_1$” in real space is $(J\mathbf{v}_1)^T$. Therefore the inner product we want can be written as
+</p>
+$$\text{inner product} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$
+<p>Using the rule for transposes, $(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$, so
+</p>
+$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
+<p>Let us actually compute $J^T J$. $J^T$ is $J$ with rows and columns swapped:
+</p>
+$$J^T = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+<p>Therefore,
+</p>
+$$J^T J = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+<p>The algebraic identity $\cos^2\theta + \sin^2\theta = 1$ does all the geometry’s work, leaving $1, r^2, 1$ on the diagonal. We never once thought about arc length in the $\theta$ direction—it is a purely algebraic manipulation using only matrix product and transpose properties.
+</p>
+<p><strong>Thus a new measuring device appears.</strong> To build from a column vector $\mathbf{v}_1$ in parameter space a row vector that correctly measures the inner product in real space, we must multiply on the right by $J^T J$, not merely transpose:
+</p>
+$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$
+<p>Acting this measuring device on $\mathbf{v}_2$ yields the same value as the inner product in real space.
+</p>
+<p>We call this $J^T J$ the <strong>metric matrix $\mathbf{g}$</strong>:
+</p>
+$$\mathbf{g} = J^T J$$
+<p>In $xyz$ coordinates we computed the inner product from the sum of products of components alone, never going through pullback. In parameter space we first read displacements in real space via $J$, then take the sum of products of components. Folding these two stages into matrix form puts $\mathbf{g}=J^T J$ in the middle—and its contents are found mechanically from partial derivatives and matrix products alone, as long as we know the Jacobian matrix $J$. No room remains anywhere for new axioms of geometry.
+</p>
+<p>For safety, let us check with concrete numbers. Consider the point $r=2,\; \theta=\pi/3$. Then $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$, so
+</p>
+$$J = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+<p>In parameter space consider the unit displacement $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ in the $\theta$ direction. We have $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, and since $r=2$ now, $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$. Computing the inner product (square of length) in parameter space:
+</p>
+$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
+<p>On the other hand, reading the same $\mathbf{v}$ as a displacement in real space:
+</p>
+$$J\mathbf{v} = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
+<p>The inner product (square of length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed agree. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (unit displacement in the $r$ direction) likewise, $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ agree. In this way $\mathbf{g} = J^T J$ ties the inner products in parameter space and real space without contradiction.
+</p>
+<p>We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$, with $\theta$ taken as the polar angle:
+</p>
+$$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
+<p>The factors $r^2$ and $r^2\sin^2\theta$ on the diagonal are likewise conversion factors derived mechanically from $J$, which lines up the linear coefficients of the coordinate change.
+</p>
+<p>With $g$ as mediator, we can compute inner products (lengths and angles) consistently in any coordinate system. Moreover, the action of the Hodge star $\ast$, treated later, can be read naturally from these rules of inner product.
+</p>
+<hr />
+<h3 id="§6.2-Converting-Between-Column-Vectors-and-Row-Vectors-Using-__MATH_BLOCK_176__">§6.2 Converting Between Column Vectors and Row Vectors Using $g$</h3>
+<h4 id="6.2.1-__MATH_BLOCK_177__-Is-a-Row-Vector">6.2.1 $\mathbf{v}^T \mathbf{g}$ Is a Row Vector</h4>
 <p>Look once more at the inner-product formula from §6.1, $\mathbf{v}_1^T \mathbf{g} \,\mathbf{v}_2$. Matrix products can be executed from the left in order, so this expression can be read as “first compute $\mathbf{v}_1^T \mathbf{g}$, then multiply the result by $\mathbf{v}_2$.”
 </p>
 <p>$\mathbf{v}_1$ is a column vector, but transposed $\mathbf{v}_1^T$ is a row vector. Multiplying a row vector by a square matrix again yields a row vector. So if we extract only the part $\mathbf{v}_1^T \mathbf{g}$,
@@ -206,7 +330,7 @@ $$
 </p>
 <p>Without $g$, we cannot convert between “the figure being measured” and “the measuring device” without strain. $g$ is the standard go-between that ties the two together.
 </p>
-<h4 id="6.2.2-What-the-Metric-Gives-—-Geometric-Size-of-Parallel-__MATH_BLOCK_138__-Parallelepipeds">6.2.2 What the Metric Gives — Geometric Size of Parallel $k$-Parallelepipeds</h4>
+<h4 id="6.2.2-What-the-Metric-Gives-—-Geometric-Size-of-Parallel-__MATH_BLOCK_218__-Parallelepipeds">6.2.2 What the Metric Gives — Geometric Size of Parallel $k$-Parallelepipeds</h4>
 <p>The most basic role of the metric $g$ is to define the <strong>actual geometric size</strong> (length, area, volume) of the <strong>parallel $k$-parallelepiped</strong> spanned by $k$ vectors.
 </p>
 <p>In the chapters until now we performed “oriented counting” by feeding $k$ vectors to a $k$-form. $dx(\mathbf{v})$ is the number of the $x$ component of $\mathbf{v}$; $dx \wedge dy(\mathbf{v}_1, \mathbf{v}_2)$ is the oriented area of the parallelogram spanned by $\mathbf{v}_1, \mathbf{v}_2$. But these are measurements of shadows after all; how many meters of segment the vectors span, how many square meters of parallelogram they span under that metric, is determined only once the metric $g$ is given.
@@ -257,7 +381,7 @@ $$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
 <p>- From the properties of the inner product (symmetry, linearity, positive definiteness) the symmetry of $g$ follows. This pairs with the antisymmetry of the area-measuring device $\wedge$.</p>
 </blockquote>
 <hr />
-<h3 id="§6.3-The-Hodge-Star-__MATH_BLOCK_214__-—-The-Correspondence-Connecting-Two-Routes">§6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes</h3>
+<h3 id="§6.3-The-Hodge-Star-__MATH_BLOCK_294__-—-The-Correspondence-Connecting-Two-Routes">§6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes</h3>
 <h4 id="6.3.1-Two-Ways-to-Obtain-a-Scalar">6.3.1 Two Ways to Obtain a Scalar</h4>
 <p>By now the true nature of $g = J^T J$ has been revealed, and we can compute inner products in any coordinate system. Let us step back and look at the larger picture.
 </p>
@@ -289,7 +413,7 @@ $$|\mathbf{v}|^2 = \mathbf{v}^T \mathbf{g} \,\mathbf{v}$$
 <blockquote>
 <p><strong>Note</strong> (For readers who know vector calculus) Many operations that in ordinary vector calculus are treated as face orientations or cross products can be read anew as the correspondence given by this $\ast$. In this chapter, however, we do not use those as known formulas; we rebuild them from $g$ and the basis $2$-forms of Chapter 2.</p>
 </blockquote>
-<h4 id="6.3.2-The-__MATH_BLOCK_251__-Dictionary-in-Physical-Space—Choosing-the-Partner-That-Makes-a-Volume">6.3.2 The $\ast$ Dictionary in Physical Space—Choosing the Partner That Makes a Volume</h4>
+<h4 id="6.3.2-The-__MATH_BLOCK_331__-Dictionary-in-Physical-Space—Choosing-the-Partner-That-Makes-a-Volume">6.3.2 The $\ast$ Dictionary in Physical Space—Choosing the Partner That Makes a Volume</h4>
 <p>So how is $\ast$ determined?
 </p>
 <p>Here we first consider orthogonal Cartesian coordinates in physical space $(x,y,z)$. In this space, $dx, dy, dz$ are mutually orthogonal reference measuring devices of length $1$. We also fix the orientation of space so that
@@ -348,7 +472,7 @@ $$\begin{aligned}
 <blockquote>
 <p><strong>Note</strong> (Why this dictionary is the right one) That $\ast dx = dy \wedge dz$ holds is because $dx, dy, dz$ form an orthonormal basis (mutually orthogonal, length $1$) and because we have taken the orientation of space so that $dx \wedge dy \wedge dz$ is positive in a right-handed system. Under these conditions, the dictionary above is determined uniquely. Once parameter space is taken into account, the $\ast$ dictionary depends on the metric $g$ and on how orientation is chosen—in other words, if $g$ is not $I$, the coefficients in the dictionary become more complicated.</p>
 </blockquote>
-<h4 id="6.3.3-__MATH_BLOCK_286__">6.3.3 $\ast\ast = \mathrm{id}$</h4>
+<h4 id="6.3.3-__MATH_BLOCK_366__">6.3.3 $\ast\ast = \mathrm{id}$</h4>
 <p>As the dictionary above shows immediately, applying $\ast$ twice returns the original:
 </p>
 $$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx.$$
@@ -362,7 +486,7 @@ $$\ast(\ast(dx)) = \ast(dy \wedge dz) = dx.$$
 <p>- This dictionary is not a mere memorization table; once a basis is chosen, it can be written as an array representation of a linear transformation. Details of the array representation are confirmed in Appendix D.</p>
 <p>- $\ast\ast = \mathrm{id}$ follows immediately from this dictionary.</p>
 </blockquote>
-<h4 id="6.3.4-Properties-of-__MATH_BLOCK_298__">6.3.4 Properties of $\ast$</h4>
+<h4 id="6.3.4-Properties-of-__MATH_BLOCK_378__">6.3.4 Properties of $\ast$</h4>
 <p>Following the pattern of §6.2.3, where we summarized the properties of the inner product, and of Chapter 5, where we summarized the properties of the exterior derivative $d$, let us organize the properties of $\ast$ that emerge from the construction so far.
 </p>
 <ol>
@@ -394,7 +518,7 @@ $$
 </p>
 <hr />
 <h3 id="§6.4-Examples-of-the-Correspondence-—-Differential-Forms-and-Vector-Analysis">§6.4 Examples of the Correspondence — Differential Forms and Vector Analysis</h3>
-<h4 id="6.4.1-Joule-Heating-__MATH_BLOCK_330__-—-Two-Routes">6.4.1 Joule Heating $P=VI$ — Two Routes</h4>
+<h4 id="6.4.1-Joule-Heating-__MATH_BLOCK_410__-—-Two-Routes">6.4.1 Joule Heating $P=VI$ — Two Routes</h4>
 <p>Let us verify in actual computation how $\ast$ concretely links differential forms with dot-product representations of like-kind vectors. The purpose of this section is not to learn formulas from electromagnetism or vector analysis. It is to survey, in two examples, how quantities that arise naturally in the language of differential forms can be read in the notation of scalar products and vector analysis.
 </p>
 <blockquote>
@@ -424,7 +548,7 @@ $$\ast(E \wedge J)$$
 </p>
 <p><strong>In short, $\ast$ links the $3$-form of Route ① and the scalar display of Route ② without contradiction.</strong> Because $\ast\ast = \mathrm{id}$, either route leads to the same result.
 </p>
-<h4 id="6.4.2-Helicity-__MATH_BLOCK_383__-—-The-Round-Trip-of-__MATH_BLOCK_384__">6.4.2 Helicity $A \cdot (\nabla \times A)$ — The Round Trip of $\ast$</h4>
+<h4 id="6.4.2-Helicity-__MATH_BLOCK_463__-—-The-Round-Trip-of-__MATH_BLOCK_464__">6.4.2 Helicity $A \cdot (\nabla \times A)$ — The Round Trip of $\ast$</h4>
 <p>In one more example, let us see further how $\ast$ works. Consider the following $3$-form built from a $1$-form $\alpha$ and its exterior derivative $d\alpha$:
 </p>
 $$\alpha \wedge d\alpha$$
@@ -490,7 +614,7 @@ $$
 $$
 <p>Readers who know vector analysis may read this as the field with components $(P,Q,R)$. A full systematic treatment of this correspondence is deferred to later chapters.
 </p>
-<h4 id="6.5.1-Gradient-__MATH_BLOCK_454__">6.5.1 Gradient $\mathrm{grad}\,f = df$</h4>
+<h4 id="6.5.1-Gradient-__MATH_BLOCK_534__">6.5.1 Gradient $\mathrm{grad}\,f = df$</h4>
 <p>The exterior derivative $df$ of a $0$-form (scalar field) $f$ is a $1$-form:
 </p>
 $$
@@ -505,7 +629,7 @@ $$
 $$
 <p>The operator $d$ raises the degree from $0 \to 1$. That is the form of the gradient needed in this chapter. The relation to the column-vector display $\nabla f$ of usual vector analysis is organized again in later chapters.
 </p>
-<h4 id="6.5.2-Curl-__MATH_BLOCK_463__">6.5.2 Curl $\mathrm{curl}\,\omega = \ast\,d\,\omega$</h4>
+<h4 id="6.5.2-Curl-__MATH_BLOCK_543__">6.5.2 Curl $\mathrm{curl}\,\omega = \ast\,d\,\omega$</h4>
 <p>For the $1$-form
 </p>
 $$
@@ -527,7 +651,7 @@ $$
 $$
 <p>This structure of "rising once to a surface form, then returning to a line form" corresponds to the curl. The relation to what is written $\nabla\times\mathbf F$ in usual vector analysis is treated again in later chapters.
 </p>
-<h4 id="6.5.3-Divergence-__MATH_BLOCK_475__">6.5.3 Divergence $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$</h4>
+<h4 id="6.5.3-Divergence-__MATH_BLOCK_555__">6.5.3 Divergence $\mathrm{div}\,\omega = \ast\,d\,\ast\,\omega$</h4>
 <p>Apply $\ast$ first to the $1$-form $\omega$ to obtain a $2$-form. Apply $d$ to obtain a $3$-form. Apply $\ast$ once more to return to a $0$-form, namely a scalar field:
 </p>
 $$
@@ -546,7 +670,7 @@ $$
 $$
 <p>The relation to what is written $\nabla\cdot\mathbf F$ in usual vector analysis is treated again in later chapters.
 </p>
-<h4 id="6.5.4-The-Shadow-of-__MATH_BLOCK_487__">6.5.4 The Shadow of $d^2 = 0$</h4>
+<h4 id="6.5.4-The-Shadow-of-__MATH_BLOCK_567__">6.5.4 The Shadow of $d^2 = 0$</h4>
 <p>Recall $d^2 = 0$ from Chapter 5. From this single fact, relations arise among the three operations.
 </p>
 <p>First,
@@ -636,7 +760,7 @@ $$
 <h2 id="Appendix-D:-Array-Representation-of-the-Hodge-Star">Appendix D: Array Representation of the Hodge Star</h2>
 <p>§6.3.2 gave the dictionary for $\ast$ in real space. This appendix checks how that dictionary looks as array operations. The Hodge star is not an abstract symbol; once a basis is chosen, it is a linear transformation that can be displayed as a concrete array. We first view the $1$-form $\leftrightarrow$ $2$-form correspondence through antisymmetric matrices, and finally view the $0$-form $\leftrightarrow$ $3$-form correspondence through a third-order array.
 </p>
-<h3 id="D.1-__MATH_BLOCK_537__-—-placing-three-coefficients-into-an-antisymmetric-matrix">D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix</h3>
+<h3 id="D.1-__MATH_BLOCK_617__-—-placing-three-coefficients-into-an-antisymmetric-matrix">D.1 $\ast_{1\to2}$ — placing three coefficients into an antisymmetric matrix</h3>
 <p>For the $1$-form
 </p>
 $$
@@ -734,7 +858,7 @@ $$
 <blockquote>
 <p><strong>Note</strong> (relation to $\widehat{\epsilon}$ in Chapter 2) These $E_1,E_2,E_3$ are the same matrices written in Appendix A as $\varepsilon_{1,\cdot,\cdot},\varepsilon_{2,\cdot,\cdot},\varepsilon_{3,\cdot,\cdot}$. The essence of $\ast_{1\to2}$ is to place the first index of Einstein's epsilon $\varepsilon_{ijk}$ in the direction of the components of the $1$-form, and the remaining two indices in the directions of the $3\times3$ matrix. The same triple introduced in Chapter 2 as the volume-measuring device $\widehat{\epsilon}$ reappears here as the Hodge star.</p>
 </blockquote>
-<h3 id="D.2-__MATH_BLOCK_556__-—-extracting-coefficients-by-the-Frobenius-product">D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product</h3>
+<h3 id="D.2-__MATH_BLOCK_636__-—-extracting-coefficients-by-the-Frobenius-product">D.2 $\ast_{2\to1}$ — extracting coefficients by the Frobenius product</h3>
 <p>The reverse map $\ast_{2\to1}$ is the operation that extracts three independent components from an antisymmetric matrix. Looking at matrix entries alone, it suffices to read $A=M_{23}$, $B=M_{31}$, $C=M_{12}$. That is, to return from the antisymmetric matrix
 </p>
 $$
@@ -826,7 +950,7 @@ $$
 $$
 <p>In $\ast_{1\to2}$ we multiply by coefficients and add; in $\ast_{2\to1}$ we extract coefficients by inner product. Vertical and horizontal, weighted sum and inner-product extraction, correspond to each other.
 </p>
-<h3 id="D.3-__MATH_BLOCK_607__-in-the-__MATH_BLOCK_608__-form-and-__MATH_BLOCK_609__-form-case">D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case</h3>
+<h3 id="D.3-__MATH_BLOCK_687__-in-the-__MATH_BLOCK_688__-form-and-__MATH_BLOCK_689__-form-case">D.3 $\ast\ast=\mathrm{id}$ in the $1$-form and $2$-form case</h3>
 <p>Combining D.1 and D.2, $\ast\ast=\mathrm{id}$ for $1$-forms and $2$-forms appears as orthonormality of arrays.
 </p>
 <p>For
@@ -896,7 +1020,7 @@ $$
 $$
 <p>hold. $\ast_{1\to2}$ places three coefficients into $E_1,E_2,E_3$; $\ast_{2\to1}$ extracts coefficients by inner product with $E_1,E_2,E_3$. Using the normalized Frobenius product, the transpose relation between the two appears as this correspondence between placement and coefficient extraction.
 </p>
-<h3 id="D.4-Array-representation-of-__MATH_BLOCK_626__-and-__MATH_BLOCK_627__">D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$</h3>
+<h3 id="D.4-Array-representation-of-__MATH_BLOCK_706__-and-__MATH_BLOCK_707__">D.4 Array representation of $\ast_{0\to3}$ and $\ast_{3\to0}$</h3>
 <p>So far we have displayed $\ast_{1\to2}$ and $\ast_{2\to1}$ as transformations that move coefficient arrays. What remains is $\ast_{0\to3}$ and $\ast_{3\to0}$.
 </p>
 <p>A $0$-form has a single coefficient. A $3$-form, viewed purely as an array, is a completely antisymmetric third-order array with three indices. Therefore, $\ast_{0\to3}$ is the transformation that spreads one component into $3\times3\times3$ components, and $\ast_{3\to0}$ is the transformation that extracts one component from $3\times3\times3$ components.

--- a/docs/en/ch07.html
+++ b/docs/en/ch07.html
@@ -113,7 +113,7 @@
 <li class="level-1"><a href="ch04.html" id="link-ch04.html">Chapter 4</a></li>
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
-<li class="level-1"><a href="ch07.html" class="active" id="link-ch07.html">Chapter 7</a><ul class="sub-toc"><li class="level-3"><a href="#§7.0-Enter-Nabla">§7.0 Enter Nabla</a></li><li class="level-3"><a href="#§7.2-$\nabla$-and-the-Gradient">§7.2 $\nabla$ and the Gradient</a></li><li class="level-3"><a href="#§7.3-Divergence">§7.3 Divergence</a></li><li class="level-3"><a href="#§7.4-Curl">§7.4 Curl</a></li><li class="level-3"><a href="#§7.5-The-Laplacian">§7.5 The Laplacian</a></li><li class="level-3"><a href="#§7.6-Identities">§7.6 Identities</a></li><li class="level-3"><a href="#§7.7-A-Formula-Collection-for-Nabla">§7.7 A Formula Collection for Nabla</a></li><li class="level-3"><a href="#§7.8-Integral-Theorems-—-Stokes,-Gauss,-and-Green">§7.8 Integral Theorems — Stokes, Gauss, and Green</a></li><li class="level-3"><a href="#§7.9-Toward-Chapter-8-—-Do-Not-Look-at-the-Arrows;-Look-at-the-Measuring-Devices">§7.9 Toward Chapter 8 — Do Not Look at the Arrows; Look at the Measuring Devices</a></li></ul></li>
+<li class="level-1"><a href="ch07.html" class="active" id="link-ch07.html">Chapter 7</a><ul class="sub-toc"><li class="level-3"><a href="#§7.0-Enter-Nabla">§7.0 Enter Nabla</a></li><li class="level-3"><a href="#§7.1-Dot-Products-and-Cross-Products">§7.1 Dot Products and Cross Products</a></li><li class="level-3"><a href="#§7.2-$\nabla$-and-the-Gradient">§7.2 $\nabla$ and the Gradient</a></li><li class="level-3"><a href="#§7.3-Divergence">§7.3 Divergence</a></li><li class="level-3"><a href="#§7.4-Curl">§7.4 Curl</a></li><li class="level-3"><a href="#§7.5-The-Laplacian">§7.5 The Laplacian</a></li><li class="level-3"><a href="#§7.6-Identities">§7.6 Identities</a></li><li class="level-3"><a href="#§7.7-A-Formula-Collection-for-Nabla">§7.7 A Formula Collection for Nabla</a></li><li class="level-3"><a href="#§7.8-Integral-Theorems-—-Stokes,-Gauss,-and-Green">§7.8 Integral Theorems — Stokes, Gauss, and Green</a></li><li class="level-3"><a href="#§7.9-Toward-Chapter-8-—-Do-Not-Look-at-the-Arrows;-Look-at-the-Measuring-Devices">§7.9 Toward Chapter 8 — Do Not Look at the Arrows; Look at the Measuring Devices</a></li></ul></li>
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
 <li class="level-1"><a href="ch10.html" id="link-ch10.html">Chapter 10</a></li>
@@ -142,8 +142,81 @@
 </blockquote>
 <p>The tools used in this chapter are only those we have already assembled—column vectors, row vectors, matrices, inner products, the Jacobian matrix, and partial derivatives.
 </p>
-<h3 id="§7.2-__MATH_BLOCK_49__-and-the-Gradient">§7.2 $\nabla$ and the Gradient</h3>
-<h4 id="7.2.1-Definition-of-__MATH_BLOCK_50__">7.2.1 Definition of $\nabla$</h4>
+<hr />
+<h3 id="§7.1-Dot-Products-and-Cross-Products">§7.1 Dot Products and Cross Products</h3>
+<h4 id="7.1.1-Dot-Product">7.1.1 Dot Product</h4>
+<p>For two column vectors
+</p>
+$$
+\mathbf{a}
+=
+\begin{pmatrix}
+a_x\\
+a_y\\
+a_z
+\end{pmatrix},
+\qquad
+\mathbf{b}
+=
+\begin{pmatrix}
+b_x\\
+b_y\\
+b_z
+\end{pmatrix}
+$$
+<p>we define the <strong>dot product</strong> (inner product) by
+</p>
+$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
+<p>As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. In Cartesian coordinates the same numerical computation can be written as the row-column product $\mathbf a^T\mathbf b$; conceptually, however, it is the inner product introduced in Chapter 6.
+</p>
+<h4 id="7.1.2-Cross-Product">7.1.2 Cross Product</h4>
+<p>For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> by
+</p>
+$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+<p>The result is again a column vector. The arrangement of cross-product components follows a regular pattern, and it can be written compactly using the following antisymmetric matrix:
+</p>
+$$\mathbf{a} \times = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}$$
+<p>Multiplying this $3\times 3$ matrix on the left by the vector $\mathbf{b}$ gives
+</p>
+$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}\begin{pmatrix}
+b_x \\ b_y \\ b_z
+\end{pmatrix} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+<p>We call this $(\mathbf{a} \times)$ the <strong>cross-product matrix</strong> of $\mathbf{a}$. It appeared in Chapter 2 as the matrix representation of a $2$-form, and in Appendix D of Chapter 6 it reappeared as the array form of the Hodge star—exactly the same shape. In this chapter we use it purely as the operation “multiply a vector by a vector and obtain a vector.”
+</p>
+<p>The cross product has the following basic properties:
+</p>
+<ol>
+<li><strong>Anticommutativity</strong>: $\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$</li>
+<li><strong>Cross product with itself is zero</strong>: $\mathbf{a} \times \mathbf{a} = \mathbf{0}$</li>
+<li><strong>Orthogonality</strong>: $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$, $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$</li>
+</ol>
+<p>Property 3 means that the cross product produces a vector orthogonal to both $\mathbf{a}$ and $\mathbf{b}$. That is the real content of the so-called “right-hand rule.”
+</p>
+<blockquote>
+<p><strong>Checkpoint — §7.1</strong></p>
+<p>- Dot product: $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$. In real space, transposing the column vector $\mathbf{a}$ gives $\mathbf{a}^T \mathbf{b}$.</p>
+<p>- Cross product: $\mathbf{a}\times\mathbf{b}$ can be written as $(\mathbf{a}\times)\,\mathbf{b}$ using the cross-product matrix $(\mathbf{a}\times)$.</p>
+<p>- The cross product is anticommutative, vanishes with itself, and its result is orthogonal to both input vectors.</p>
+</blockquote>
+<hr />
+<h3 id="§7.2-__MATH_BLOCK_75__-and-the-Gradient">§7.2 $\nabla$ and the Gradient</h3>
+<h4 id="7.2.1-Definition-of-__MATH_BLOCK_76__">7.2.1 Definition of $\nabla$</h4>
 <p>English textbooks usually call the symbol $\nabla$ <strong>del</strong>; it is also called <strong>nabla</strong>, the name common in Japanese texts. This book is about what div, grad, and curl do—not primarily about what to call the symbol. We define nabla $\nabla$ as a formal column vector whose components are partial-derivative operators:
 </p>
 $$\nabla = \begin{pmatrix}
@@ -325,7 +398,7 @@ $$\nabla^2 \mathbf{F} = \begin{pmatrix} \nabla^2 F_x \\ \nabla^2 F_y \\ \nabla^2
 <h3 id="§7.6-Identities">§7.6 Identities</h3>
 <p>Among the three operations defined so far, two important identities hold. Both take the form "applying twice gives zero."
 </p>
-<h4 id="7.6.1-__MATH_BLOCK_99__">7.6.1 $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$</h4>
+<h4 id="7.6.1-__MATH_BLOCK_125__">7.6.1 $\mathrm{curl}(\mathrm{grad}\,f) = \mathbf{0}$</h4>
 <p>If we take a vector field from a gradient and then take its curl, we always get the zero vector.
 </p>
 $$\nabla \times (\nabla f) = \begin{pmatrix}
@@ -337,7 +410,7 @@ $$\nabla \times (\nabla f) = \begin{pmatrix}
 </p>
 <p>Physical meaning: "A gradient field has no vortex." Conservative gravitational and electrostatic fields fall into this category.
 </p>
-<h4 id="7.6.2-__MATH_BLOCK_102__">7.6.2 $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$</h4>
+<h4 id="7.6.2-__MATH_BLOCK_128__">7.6.2 $\mathrm{div}(\mathrm{curl}\,\mathbf{F}) = 0$</h4>
 <p>If we take a vector field from a curl and then take its divergence, we always get zero.
 </p>
 $$\nabla \cdot (\nabla \times \mathbf{F}) = \frac{\partial}{\partial x}\!\left(\frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z}\right) + \frac{\partial}{\partial y}\!\left(\frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x}\right) + \frac{\partial}{\partial z}\!\left(\frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y}\right)$$

--- a/docs/en/ch08.html
+++ b/docs/en/ch08.html
@@ -114,7 +114,7 @@
 <li class="level-1"><a href="ch05.html" id="link-ch05.html">Chapter 5</a></li>
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
-<li class="level-1"><a href="ch08.html" class="active" id="link-ch08.html">Chapter 8</a><ul class="sub-toc"><li class="level-3"><a href="#§8.0-The-Highlight-of-This-Book">§8.0 The Highlight of This Book</a></li><li class="level-3"><a href="#§8.2-Completing-the-Translation-Dictionary">§8.2 Completing the Translation Dictionary</a></li><li class="level-3"><a href="#§8.3-Translating-Stokes'-Theorem">§8.3 Translating Stokes' Theorem</a></li><li class="level-3"><a href="#§8.4-Translating-Gauss'-Theorem">§8.4 Translating Gauss' Theorem</a></li><li class="level-3"><a href="#§8.5-Why-the-Two-Languages-Agree">§8.5 Why the Two Languages Agree</a></li><li class="level-3"><a href="#§8.6-Curvilinear-Coordinates-and-the-Two-Routes">§8.6 Curvilinear Coordinates and the Two Routes</a></li></ul></li>
+<li class="level-1"><a href="ch08.html" class="active" id="link-ch08.html">Chapter 8</a><ul class="sub-toc"><li class="level-3"><a href="#§8.0-The-Highlight-of-This-Book">§8.0 The Highlight of This Book</a></li><li class="level-3"><a href="#§8.1-Two-Differentials,-Two-Worlds">§8.1 Two Differentials, Two Worlds</a></li><li class="level-3"><a href="#§8.2-Completing-the-Translation-Dictionary">§8.2 Completing the Translation Dictionary</a></li><li class="level-3"><a href="#§8.3-Translating-Stokes'-Theorem">§8.3 Translating Stokes' Theorem</a></li><li class="level-3"><a href="#§8.4-Translating-Gauss'-Theorem">§8.4 Translating Gauss' Theorem</a></li><li class="level-3"><a href="#§8.5-Why-the-Two-Languages-Agree">§8.5 Why the Two Languages Agree</a></li><li class="level-3"><a href="#§8.6-Curvilinear-Coordinates-and-the-Two-Routes">§8.6 Curvilinear Coordinates and the Two Routes</a></li></ul></li>
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
 <li class="level-1"><a href="ch10.html" id="link-ch10.html">Chapter 10</a></li>
 <li class="level-1"><a href="ch11.html" id="link-ch11.html">Chapter 11</a></li>
@@ -135,6 +135,61 @@
 </p>
 <p>This chapter is the <strong>highlight</strong> of the book. The central translation itself is surprisingly short. At the end, however, to move on to the practical chapter that follows, we will take a single look at how this dictionary behaves in curvilinear coordinates. The painstaking preparation from Chapters 1 through 7—matrices, wedge products, the exterior derivative, the metric, the Hodge star, and vector analysis—was all for that purpose. Because all these tools are now assembled, in this chapter we need only “translate,” and two worlds fit into one picture. We have acquired two languages—the differential of measuring devices ($d$) and the differential of fields ($\nabla$). These two do fundamentally different things. Yet when they are linked through integration, they give exactly the same results. We will now dig thoroughly into how that works.
 </p>
+<hr />
+<h3 id="§8.1-Two-Differentials,-Two-Worlds">§8.1 Two Differentials, Two Worlds</h3>
+<h4 id="8.1.1-Differentiating-measuring-devices—the-standpoint-of-__MATH_BLOCK_39__">8.1.1 Differentiating measuring devices—the standpoint of $d$</h4>
+<p>Since Chapter 1 we have treated $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ as row-vector measuring devices. When you feed them a column vector (a displacement), they return the displacement in that direction as a scalar.
+</p>
+<p>The exterior derivative $d$ is the operation that differentiates the coefficients and produces the next measuring device.
+</p>
+<p>When $f(x,y,z)$ is a scalar field, $df$ is a new measuring device that measures changes in $f$. It becomes a row vector whose components are the partial derivatives.
+</p>
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+<p>When $\omega = P\,dx + Q\,dy + R\,dz$ is a $1$-form, $d\omega$ is a $2$-form (antisymmetric matrix) that measures the local mismatch of $\omega$.
+</p>
+$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$
+<p>When $\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ is a $2$-form, $d\eta$ is a $3$-form (third-order antisymmetric tensor).
+</p>
+$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
+<p>In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>$d$ does not produce a new arrow field in the sense of vector analysis; it differentiates the coefficients and changes the measuring-device side</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
+</p>
+<h4 id="8.1.2-The-formal-differential-operator-stays-the-same;-new-fields-are-what-we-consider—the-standpoint-of-__MATH_BLOCK_67__">8.1.2 The formal differential operator stays the same; new fields are what we consider—the standpoint of $\nabla$</h4>
+<p>Meanwhile, in the world of
+</p>
+$$
+\nabla
+=
+\begin{pmatrix}
+\frac{\partial}{\partial x}\\[0.3em]
+\frac{\partial}{\partial y}\\[0.3em]
+\frac{\partial}{\partial z}
+\end{pmatrix}
+$$
+<p>introduced in Chapter 7, <strong>the formal differential operator stays the same; depending on what it acts on, new fields are born</strong>. $\nabla$ is always the same operator, but acting on a scalar field $f$ yields a vector field $\nabla f$; acting on a vector field $\mathbf{F}$ yields a scalar field $\nabla\cdot\mathbf{F}$ or a vector field $\nabla\times\mathbf{F}$.
+</p>
+<p>Applying $\nabla$ to a scalar field $f(x,y,z)$ gives a column-vector field whose components are the rates of change in each direction.
+</p>
+$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$
+<p>This is an arrow standing at each point in space; it is no longer a measuring device. It represents the direction of steepest increase of $f$ and the strength of that increase.
+</p>
+<p>Applying $\nabla\cdot$ to a vector field $\mathbf{F}$ with components $F_x,F_y,F_z$ gives a scalar field.
+</p>
+$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+<p>It returns the sum of the rates of change in each direction—the strength of outflow.
+</p>
+<p>Applying $\nabla\times$ to the same $\mathbf{F}$ gives a column-vector field again.
+</p>
+$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$
+<p>It represents the axis and strength of the local rotation.
+</p>
+<p>In the world of $\nabla$, the result is always returned as an arrow or a scalar in real space. Both $\nabla f$ and $\nabla\times\mathbf{F}$ look like the same kind of “arrow” on the page; there is no distinction by type.
+</p>
+<blockquote>
+<p><strong>Checkpoint so far — §8.1</strong></p>
+<p>- Standpoint of $d$: $d$ does not produce a new arrow field; the measuring-device side changes. New measuring devices are born.</p>
+<p>- Standpoint of $\nabla$: the formal differential operator stays the same; new fields are born.</p>
+</blockquote>
+<hr />
 <h3 id="§8.2-Completing-the-Translation-Dictionary">§8.2 Completing the Translation Dictionary</h3>
 <p>In Chapter 6 §6.5 we introduced the correspondences $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$. Here we align this dictionary with the language of $\nabla$ and organize it in complete form. What we complete here is the translation dictionary used within three-dimensional Euclidean space and the matrix representation of this book.
 </p>
@@ -234,7 +289,7 @@ $$
 <h3 id="§8.3-Translating-Stokes'-Theorem">§8.3 Translating Stokes' Theorem</h3>
 <p>In Chapter 5 §5.6 we already derived Stokes' theorem in the form $\int_{\partial S}\omega = \int_S d\omega$. In Chapter 7 §7.8.1 we wrote the same theorem in the language of $\nabla$ as $\oint_C \mathbf{F}\cdot d\mathbf{r} = \iint_S (\nabla\times\mathbf{F})\cdot\mathbf{n}\,dS$. We now confirm that these two are the same thing, using the dictionary of §8.2.
 </p>
-<h4 id="8.3.1-From-__MATH_BLOCK_95__-to-__MATH_BLOCK_96__">8.3.1 From $\nabla$ to $d$</h4>
+<h4 id="8.3.1-From-__MATH_BLOCK_151__-to-__MATH_BLOCK_152__">8.3.1 From $\nabla$ to $d$</h4>
 <p>Start with Stokes' theorem in $\nabla$ notation.
 </p>
 $$\oint_C \mathbf{F} \cdot d\mathbf{r} = \iint_S (\nabla \times \mathbf{F}) \cdot \mathbf{n}\,dS$$

--- a/docs/en/ch09.html
+++ b/docs/en/ch09.html
@@ -115,7 +115,7 @@
 <li class="level-1"><a href="ch06.html" id="link-ch06.html">Chapter 6</a></li>
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
-<li class="level-1"><a href="ch09.html" class="active" id="link-ch09.html">Chapter 9</a><ul class="sub-toc"><li class="level-3"><a href="#§9.0-The-Central-Tools-of-This-Book-Are-Now-in-Place">§9.0 The Central Tools of This Book Are Now in Place</a></li><li class="level-3"><a href="#§9.2-Cylindrical-Coordinates-$(r,\theta,z)$">§9.2 Cylindrical Coordinates $(r,\theta,z)$</a></li><li class="level-3"><a href="#§9.3-Spherical-Coordinates-$(\rho,\theta,\phi)$">§9.3 Spherical Coordinates $(\rho,\theta,\phi)$</a></li><li class="level-3"><a href="#§9.4-A-Hard-Problem-in-Calculus-—-The-Vector-Laplacian-in-Spherical-Coordinates">§9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates</a></li><li class="level-3"><a href="#§9.5-A-Hard-Problem-in-Electromagnetism-—-Divergence-of-the-Point-Charge-Electric-Field">§9.5 A Hard Problem in Electromagnetism — Divergence of the Point-Charge Electric Field</a></li><li class="level-3"><a href="#§9.6-The-Dictionary-Ends;-the-Journey-Continues">§9.6 The Dictionary Ends; the Journey Continues</a></li></ul></li>
+<li class="level-1"><a href="ch09.html" class="active" id="link-ch09.html">Chapter 9</a><ul class="sub-toc"><li class="level-3"><a href="#§9.0-The-Central-Tools-of-This-Book-Are-Now-in-Place">§9.0 The Central Tools of This Book Are Now in Place</a></li><li class="level-3"><a href="#§9.1-Building-the-Dictionary-on-the-Spot-—-A-Mechanical-Procedure">§9.1 Building the Dictionary on the Spot — A Mechanical Procedure</a></li><li class="level-3"><a href="#§9.2-Cylindrical-Coordinates-$(r,\theta,z)$">§9.2 Cylindrical Coordinates $(r,\theta,z)$</a></li><li class="level-3"><a href="#§9.3-Spherical-Coordinates-$(\rho,\theta,\phi)$">§9.3 Spherical Coordinates $(\rho,\theta,\phi)$</a></li><li class="level-3"><a href="#§9.4-A-Hard-Problem-in-Calculus-—-The-Vector-Laplacian-in-Spherical-Coordinates">§9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates</a></li><li class="level-3"><a href="#§9.5-A-Hard-Problem-in-Electromagnetism-—-Divergence-of-the-Point-Charge-Electric-Field">§9.5 A Hard Problem in Electromagnetism — Divergence of the Point-Charge Electric Field</a></li><li class="level-3"><a href="#§9.6-The-Dictionary-Ends;-the-Journey-Continues">§9.6 The Dictionary Ends; the Journey Continues</a></li></ul></li>
 <li class="level-1"><a href="ch10.html" id="link-ch10.html">Chapter 10</a></li>
 <li class="level-1"><a href="ch11.html" id="link-ch11.html">Chapter 11</a></li>
 <li class="level-1"><a href="ch12.html" id="link-ch12.html">Chapter 12</a></li>
@@ -138,7 +138,31 @@
 <blockquote>
 <p><strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $d$, $\ast d$, or $\ast d\ast$ as appropriate, and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while manually attaching factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ to the $\nabla$ formulas. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.</p>
 </blockquote>
-<h3 id="§9.2-Cylindrical-Coordinates-__MATH_BLOCK_38__">§9.2 Cylindrical Coordinates $(r,\theta,z)$</h3>
+<hr />
+<h3 id="§9.1-Building-the-Dictionary-on-the-Spot-—-A-Mechanical-Procedure">§9.1 Building the Dictionary on the Spot — A Mechanical Procedure</h3>
+<p>The procedure for deriving the formulas for $\mathrm{grad}$, $\mathrm{div}$, and $\mathrm{curl}$ in orthogonal curvilinear coordinates boils down to the following three steps.
+</p>
+<ol>
+<li><strong>Write the Jacobian matrix $J$</strong>. From the coordinate transformation $x = x(q_1,q_2,q_3)$, $y = y(q_1,q_2,q_3)$, $z = z(q_1,q_2,q_3)$, arrange the partial derivatives. Each column of $J$ represents how a single step along one axis in parameter space moves in physical space.</li>
+</ol>
+<ol>
+<li><strong>Compute the metric $\mathbf{g} = J^T J$</strong>. This is the procedure we have followed since Chapter 6 §6.1.3. The diagonal entries of $\mathbf{g}$ are the squares of the scales along each axis; the off-diagonal entries represent how orthogonal the axes are to one another.</li>
+</ol>
+<ol>
+<li><strong>From $\mathbf{g}$, derive the dictionary for the Hodge star $\ast$, and combine it with $d$</strong>. Substitute the dictionary for $\ast$ in that coordinate system into each formula $\mathrm{grad} = d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$, and the desired formulas are obtained mechanically.</li>
+</ol>
+<p>However, the usual $\mathrm{grad}$ and $\mathrm{curl}$ of vector analysis return vector fields as arrows. By contrast, this book's $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$ are read first as formulas on the measuring-device side. To read a $1$-form obtained on the differential-forms side as a column vector, first use the metric $\mathbf{g}$ to convert it back to the form $\mathbf{g}^{-1}(\cdot)^T$. These are the column components corresponding to the coordinates. To read them as orthonormal vector components as used in vector analysis, you must also account for the scale factor in each direction.
+</p>
+<p>Also, in curvilinear coordinates, the orthonormal vector components used in vector analysis generally do not agree with the coefficients relative to the coordinate-associated $1$-forms. Because the calculation is carried out on the $1$-form side, first convert the vector field to the corresponding $1$-form. Then the coefficients of $d\theta$ and $d\phi$ pick up scale factors.
+</p>
+<blockquote>
+<p><strong>Note</strong> (vector components and $1$-form coefficients)</p>
+<p>In curvilinear coordinates you must distinguish the coordinate-associated $1$-forms from the $1$-forms that measure actual length in units of 1. For example, in polar coordinates, the angular scale $d\theta$ itself differs from the unit-length scale $r\,d\theta$. The dictionary of the Hodge star absorbs all of this scale-factor information. That is what lets us carry out "straight computation" on a "distorted coordinate system."</p>
+</blockquote>
+<p>Below, we demonstrate this procedure in cylindrical and spherical coordinates. Keep in mind the flow: compute first as $1$-forms and $2$-forms, then convert back to orthonormal vector components at the end.
+</p>
+<hr />
+<h3 id="§9.2-Cylindrical-Coordinates-__MATH_BLOCK_75__">§9.2 Cylindrical Coordinates $(r,\theta,z)$</h3>
 <h4 id="9.2.1-Deriving-the-Dictionary">9.2.1 Deriving the Dictionary</h4>
 <p>The coordinate transformation to cylindrical coordinates is $x = r\cos\theta$, $y = r\sin\theta$, $z = z$.
 </p>
@@ -231,7 +255,7 @@ $$\nabla \times \mathbf{F} = \begin{pmatrix}
 <p>The structure in which $r$ appears both inside and outside $\frac{\partial}{\partial r}$ has exactly the same origin as the $\frac{1}{r}$ that appeared when we counted the area element of a sector in the previous chapter.
 </p>
 <hr />
-<h3 id="§9.3-Spherical-Coordinates-__MATH_BLOCK_104__">§9.3 Spherical Coordinates $(\rho,\theta,\phi)$</h3>
+<h3 id="§9.3-Spherical-Coordinates-__MATH_BLOCK_141__">§9.3 Spherical Coordinates $(\rho,\theta,\phi)$</h3>
 <h4 id="9.3.1-Deriving-the-Dictionary">9.3.1 Deriving the Dictionary</h4>
 <p>The conversion to spherical coordinates is $x = \rho\sin\theta\cos\phi$, $y = \rho\sin\theta\sin\phi$, $z = \rho\cos\theta$ ($\theta$ is the angle from the $z$-axis, $\phi$ is the azimuthal angle in the $xy$ plane).
 </p>

--- a/docs/en/ch10.html
+++ b/docs/en/ch10.html
@@ -116,7 +116,7 @@
 <li class="level-1"><a href="ch07.html" id="link-ch07.html">Chapter 7</a></li>
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
-<li class="level-1"><a href="ch10.html" class="active" id="link-ch10.html">Chapter 10</a><ul class="sub-toc"><li class="level-3"><a href="#§10.0-The-Usual-Caveat">§10.0 The Usual Caveat</a></li><li class="level-3"><a href="#§10.2-The-Electromagnetic-Field-$F$-and-Fixing-Sign-Conventions">§10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions</a></li><li class="level-3"><a href="#§10.3-The-Minkowski-Metric-—-From-$\mathbb{R}^3$-to-Four-Dimensions">§10.3 The Minkowski Metric — From $\mathbb{R}^3$ to Four Dimensions</a></li><li class="level-3"><a href="#§10.4-Writing-Out-$dF=0$-in-Full">§10.4 Writing Out $dF=0$ in Full</a></li><li class="level-3"><a href="#§10.5-$\ast-F$-and-the-Remaining-Two-Equations">§10.5 $\ast F$ and the Remaining Two Equations</a></li><li class="level-3"><a href="#§10.6-Constructing-the-Potential-—-Starting-from-$F=-d\mathcal{A}$">§10.6 Constructing the Potential — Starting from $F=-d\mathcal{A}$</a></li><li class="level-2"><a href="#Appendix-E:-Slice-Matrix-Representation-of-$d_4F$-and-$d_4(\ast_4F)$-—-Seeing-Maxwell's-Equations-as-$4\times4\times4$-Arrays">Appendix E: Slice-Matrix Representation of $d_4F$ and $d_4(\ast_4F)$ — Seeing Maxwell's Equations as $4\times4\times4$ Arrays</a></li><li class="level-3"><a href="#E.1-Basis-$3$-forms-and-their-slice-matrices-—-all-16">E.1 Basis $3$-forms and their slice matrices — all 16</a></li><li class="level-3"><a href="#E.2-Writing-$dF$-with-slice-matrices">E.2 Writing $dF$ with slice matrices</a></li><li class="level-3"><a href="#E.3-Extracting-coefficients-by-the-Frobenius-product">E.3 Extracting coefficients by the Frobenius product</a></li><li class="level-3"><a href="#E.4-Reading-$dF=0$-through-the-slices">E.4 Reading $dF=0$ through the slices</a></li><li class="level-3"><a href="#E.5-Slice-representation-of-$d_4(\ast_4F)-=-\mu_0(\ast_4\mathcal{J})$">E.5 Slice representation of $d_4(\ast_4F) = \mu_0(\ast_4\mathcal{J})$</a></li><li class="level-2"><a href="#Appendix-F:-The-Four-Equations-of-Chapter-5-and-the-Two-Equations-of-Chapter-10">Appendix F: The Four Equations of Chapter 5 and the Two Equations of Chapter 10</a></li><li class="level-3"><a href="#F.1-$(E,B,J,\rho_{\mathrm-e})$-on-space">F.1 $(E,B,J,\rho_{\mathrm e})$ on space</a></li><li class="level-3"><a href="#F.2-The-four-equations-on-space">F.2 The four equations on space</a></li><li class="level-3"><a href="#F.3-Two-equations-emerge-from-$d_4F=0$">F.3 Two equations emerge from $d_4F=0$</a></li><li class="level-3"><a href="#F.4-The-remaining-two-emerge-from-$d_4(\ast_4F)=\mu_0(\ast_4\mathcal-J)$">F.4 The remaining two emerge from $d_4(\ast_4F)=\mu_0(\ast_4\mathcal J)$</a></li><li class="level-3"><a href="#F.5-Summary">F.5 Summary</a></li></ul></li>
+<li class="level-1"><a href="ch10.html" class="active" id="link-ch10.html">Chapter 10</a><ul class="sub-toc"><li class="level-3"><a href="#§10.0-The-Usual-Caveat">§10.0 The Usual Caveat</a></li><li class="level-3"><a href="#§10.1-Maxwell's-Equations-—-Two-Equations">§10.1 Maxwell's Equations — Two Equations</a></li><li class="level-3"><a href="#§10.2-The-Electromagnetic-Field-$F$-and-Fixing-Sign-Conventions">§10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions</a></li><li class="level-3"><a href="#§10.3-The-Minkowski-Metric-—-From-$\mathbb{R}^3$-to-Four-Dimensions">§10.3 The Minkowski Metric — From $\mathbb{R}^3$ to Four Dimensions</a></li><li class="level-3"><a href="#§10.4-Writing-Out-$dF=0$-in-Full">§10.4 Writing Out $dF=0$ in Full</a></li><li class="level-3"><a href="#§10.5-$\ast-F$-and-the-Remaining-Two-Equations">§10.5 $\ast F$ and the Remaining Two Equations</a></li><li class="level-3"><a href="#§10.6-Constructing-the-Potential-—-Starting-from-$F=-d\mathcal{A}$">§10.6 Constructing the Potential — Starting from $F=-d\mathcal{A}$</a></li><li class="level-2"><a href="#Appendix-E:-Slice-Matrix-Representation-of-$d_4F$-and-$d_4(\ast_4F)$-—-Seeing-Maxwell's-Equations-as-$4\times4\times4$-Arrays">Appendix E: Slice-Matrix Representation of $d_4F$ and $d_4(\ast_4F)$ — Seeing Maxwell's Equations as $4\times4\times4$ Arrays</a></li><li class="level-3"><a href="#E.1-Basis-$3$-forms-and-their-slice-matrices-—-all-16">E.1 Basis $3$-forms and their slice matrices — all 16</a></li><li class="level-3"><a href="#E.2-Writing-$dF$-with-slice-matrices">E.2 Writing $dF$ with slice matrices</a></li><li class="level-3"><a href="#E.3-Extracting-coefficients-by-the-Frobenius-product">E.3 Extracting coefficients by the Frobenius product</a></li><li class="level-3"><a href="#E.4-Reading-$dF=0$-through-the-slices">E.4 Reading $dF=0$ through the slices</a></li><li class="level-3"><a href="#E.5-Slice-representation-of-$d_4(\ast_4F)-=-\mu_0(\ast_4\mathcal{J})$">E.5 Slice representation of $d_4(\ast_4F) = \mu_0(\ast_4\mathcal{J})$</a></li><li class="level-2"><a href="#Appendix-F:-The-Four-Equations-of-Chapter-5-and-the-Two-Equations-of-Chapter-10">Appendix F: The Four Equations of Chapter 5 and the Two Equations of Chapter 10</a></li><li class="level-3"><a href="#F.1-$(E,B,J,\rho_{\mathrm-e})$-on-space">F.1 $(E,B,J,\rho_{\mathrm e})$ on space</a></li><li class="level-3"><a href="#F.2-The-four-equations-on-space">F.2 The four equations on space</a></li><li class="level-3"><a href="#F.3-Two-equations-emerge-from-$d_4F=0$">F.3 Two equations emerge from $d_4F=0$</a></li><li class="level-3"><a href="#F.4-The-remaining-two-emerge-from-$d_4(\ast_4F)=\mu_0(\ast_4\mathcal-J)$">F.4 The remaining two emerge from $d_4(\ast_4F)=\mu_0(\ast_4\mathcal J)$</a></li><li class="level-3"><a href="#F.5-Summary">F.5 Summary</a></li></ul></li>
 <li class="level-1"><a href="ch11.html" id="link-ch11.html">Chapter 11</a></li>
 <li class="level-1"><a href="ch12.html" id="link-ch12.html">Chapter 12</a></li>
 <li class="level-1"><a href="postscript.html" id="link-postscript.html">Afterword</a></li>
@@ -139,7 +139,52 @@
 <blockquote>
 <p><strong>Note</strong> (the role of this chapter) The core of this book is complete by Chapter 9. This chapter is, so to speak, a bonus, or nearly a digression. Do not take it too seriously; read it at your leisure.</p>
 </blockquote>
-<h3 id="§10.2-The-Electromagnetic-Field-__MATH_BLOCK_127__-and-Fixing-Sign-Conventions">§10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions</h3>
+<hr />
+<h3 id="§10.1-Maxwell's-Equations-—-Two-Equations">§10.1 Maxwell's Equations — Two Equations</h3>
+<p>The fundamental laws of electromagnetism are summarized in vector-analysis notation as the following four equations. We adopt SI units.
+</p>
+$$\begin{aligned}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho_{\mathrm e}}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B} &= 0 \\[0.5em]
+\mathrm{curl}\,\mathbf{B} &= \mu_0\mathbf{J} + \frac{1}{c^2}\frac{\partial \mathbf{E}}{\partial t} &
+\mathrm{curl}\,\mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t}
+\end{aligned}$$
+<p>As they stand, the "types" are not aligned for packing into a $4\times4$ matrix. The electric field $\mathbf{E}$ (dimension $\mathrm{V/m}$) and magnetic flux density $\mathbf{B}$ (dimension $\mathrm{T}$) have different units, and spatial derivatives ($\mathrm{curl}$ and $\mathrm{div}$) and the time derivative with respect to $t$ also have different dimensions.
+</p>
+<p>So we introduce a length-dimension time coordinate and rescale the magnetic field to match the electric field.
+</p>
+<ol>
+<li><strong>Time conversion</strong>: Multiply time $t$ by the speed of light $c$ to introduce the coordinate $w = ct$ with dimension of length. The time derivative becomes $\frac{\partial}{\partial t} = c\frac{\partial}{\partial w}$.</li>
+</ol>
+<ol>
+<li><strong>Magnetic field conversion</strong>: Multiply magnetic flux density $\mathbf{B}$ by $c$ to define $\mathbf{B}' = c\mathbf{B}$, which has the same $\mathrm{V/m}$ dimension as the electric field.</li>
+</ol>
+<p>Substitute these into the four equations above. Faraday's law becomes
+</p>
+$$\mathrm{curl}\,\mathbf{E} = -\frac{\partial}{\partial t}\!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}\!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$
+<p>and Ampère's law is similarly rearranged to give
+</p>
+$$\begin{aligned}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho_{\mathrm e}}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B}' &= 0 \\[0.5em]
+\mathrm{curl}\,\mathbf{B}' &= c\mu_0\mathbf{J} + \frac{\partial \mathbf{E}}{\partial w} &
+\mathrm{curl}\,\mathbf{E} &= -\frac{\partial \mathbf{B}'}{\partial w}
+\end{aligned}$$
+<p>Time derivatives are now written with respect to the length-dimension coordinate $w$, so the denominators in time and space derivatives are aligned.
+</p>
+<p>Henceforth we rename $\mathbf{B}'$ back to $\mathbf{B}$ and write $w$ as $t$. That is, from here on $\mathbf{B}$ is not the original magnetic flux density but the dimension-aligned field scaled by $c$, and $t$ is not the original time but the length-dimension time coordinate scaled by $c$.
+</p>
+<p>Now we are ready. $\mathbf{E}$ and $\mathbf{B}$ have the same dimension and can be arranged in the same matrix. With the $2$-form $F$ combining the electromagnetic field and the $1$-form $\mathcal{J}$ combining current and charge (strictly, the four-current lowered by the metric), the four equations consolidate into <strong>two</strong> under this book's normalization and sign conventions.
+</p>
+$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
+<p>Here, to show the form as physical laws, we write the Hodge star without subscript as $\ast$. When entering component calculations, we write the exterior derivative and Hodge star on four-dimensional spacetime as $d_4,\ast_4$, and those on spatial three dimensions at each instant as $d_3,\ast_3$. In this chapter's convention, we will define $\mu_0\ast\mathcal{J}$ directly in components.
+</p>
+<p>That is all. Four equations become two—this conciseness symbolizes the expressive power of differential forms.
+</p>
+<p>However, this book does not end here. What is inside $F$? When we expand $dF=0$ in components, do we really get $\mathrm{curl}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ and $\mathrm{div}\,\mathbf{B} = 0$? We will write all of that out in this chapter.
+</p>
+<hr />
+<h3 id="§10.2-The-Electromagnetic-Field-__MATH_BLOCK_170__-and-Fixing-Sign-Conventions">§10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions</h3>
 <p>Before writing the electromagnetic field $F$ in explicit components, let us rigorously fix the sign conventions for spacetime used in this chapter. There are several traditions for sign choices, but this book adopts the following set.
 </p>
 <ul>
@@ -170,7 +215,7 @@ E_z & B_y & -B_x & 0
 <p>In this book's matrix convention, the coefficient $-E_x$ of $dt \wedge dx$ is placed in the matrix component $(t,x)$. Therefore $F_{tx}=-E_x,\;F_{xt}=E_x$. Many textbooks define $F_{t x}$ as positive $E_x$, but then one must either use $F = E_x dx \wedge dt + \dots$ (reversed order) or adjust the sign in the potential definition $F=d\mathcal{A}$. This book prioritizes $F=-d\mathcal{A}$ and the order $dt \wedge dx$, and adopts this sign.</p>
 </blockquote>
 <hr />
-<h3 id="§10.3-The-Minkowski-Metric-—-From-__MATH_BLOCK_154__-to-Four-Dimensions">§10.3 The Minkowski Metric — From $\mathbb{R}^3$ to Four Dimensions</h3>
+<h3 id="§10.3-The-Minkowski-Metric-—-From-__MATH_BLOCK_197__-to-Four-Dimensions">§10.3 The Minkowski Metric — From $\mathbb{R}^3$ to Four Dimensions</h3>
 <p>Throughout this book we have consistently worked on $\mathbb{R}^3$ with Cartesian coordinates $(x,y,z)$. However, to treat $F$ we need four-dimensional spacetime $(t,x,y,z)$ with time $t$ adjoined.
 </p>
 <p>Fortunately, with the knowledge accumulated so far, the extension is easy. In Chapter 6 we derived $\mathbf{g} = J^T J$, and in Chapter 9 we practiced the procedure of building the $\ast$ dictionary from $\mathbf{g}$. We need only do the same in spacetime. The metric is as follows (the only new element is that the sign of the time component differs from that of the spatial components):
@@ -189,7 +234,7 @@ $$\mathbf{g} = \begin{pmatrix}
 <p>In this chapter we take the orientation (order of basis elements) to be $dt\wedge dx\wedge dy\wedge dz$ and the spacetime metric signature to be $(-,+,+,+)$. Under this convention we use the following $\ast F$ and $\ast\mathcal{J}$. When writing Maxwell's equations symbolically we still write $\ast$ as usual, but in component calculations we distinguish the Hodge star on four-dimensional spacetime as $\ast_4$ and the Hodge star on three-dimensional space as $\ast_3$. With different signatures or orientation conventions, note that several signs will flip.</p>
 </blockquote>
 <hr />
-<h3 id="§10.4-Writing-Out-__MATH_BLOCK_175__-in-Full">§10.4 Writing Out $dF=0$ in Full</h3>
+<h3 id="§10.4-Writing-Out-__MATH_BLOCK_218__-in-Full">§10.4 Writing Out $dF=0$ in Full</h3>
 <p>Since $F$ is a $2$-form, $dF$ is a $3$-form. In the component calculations from here on, we write $d_4F$ to make explicit that the exterior derivative is on four-dimensional spacetime. A $3$-form in four dimensions has four independent components. Apply $d_4$ to the $F$ redefined in §10.2 (with the minus sign on the electric-field terms) and collect the coefficients on the same basis $3$-forms.
 </p>
 $$F = -E_x\,dt\wedge dx - E_y\,dt\wedge dy - E_z\,dt\wedge dz + B_x\,dy\wedge dz + B_y\,dz\wedge dx + B_z\,dx\wedge dy$$
@@ -224,7 +269,7 @@ $$d_4F = 0 \Longleftrightarrow \begin{cases}
 <p>The first line is Gauss's law for magnetism; the second through fourth lines are Faraday's law of electromagnetic induction. By placing minus signs on the electric-field terms, the familiar vector-analysis formulas with the correct signs are derived from the single differential-form equation $dF=0$ (computationally $d_4F=0$).
 </p>
 <hr />
-<h3 id="§10.5-__MATH_BLOCK_192__-and-the-Remaining-Two-Equations">§10.5 $\ast F$ and the Remaining Two Equations</h3>
+<h3 id="§10.5-__MATH_BLOCK_235__-and-the-Remaining-Two-Equations">§10.5 $\ast F$ and the Remaining Two Equations</h3>
 <p>Let us also write out in full the other equation $d(\ast F) = \mu_0(\ast\mathcal{J})$ by the same procedure as §10.4. Symbolically we write $\ast$, but in the component calculations from here on we make explicit the Hodge star on four-dimensional spacetime and write $d_4(\ast_4F)=\mu_0(\ast_4\mathcal{J})$.
 </p>
 <p>First, compute $\ast_4F$ from the $F$ redefined in §10.2. Applying the four-dimensional Hodge star under the Minkowski metric signature $(-,+,+,+)$ and orientation $dt\wedge dx\wedge dy\wedge dz$ of §10.3, $\ast_4F$ becomes:
@@ -339,7 +384,7 @@ $$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
 <p><strong>Note</strong> (Why stop here?) Many textbooks close at the point where $dF=0$ has been shown, with "and thus Maxwell's equations are geometric." But this book's approach is different. Writing out every matrix component in full, using $d_4$ and $\ast_4$ in the calculations, and returning to $d_3$ and $\ast_3$ in the spatial dictionary to reproduce the vector-analysis formulas—the ability to make that round trip is precisely the destination of the "measuring device" framework built up from Chapter 1.</p>
 </blockquote>
 <hr />
-<h3 id="§10.6-Constructing-the-Potential-—-Starting-from-__MATH_BLOCK_243__">§10.6 Constructing the Potential — Starting from $F=-d\mathcal{A}$</h3>
+<h3 id="§10.6-Constructing-the-Potential-—-Starting-from-__MATH_BLOCK_286__">§10.6 Constructing the Potential — Starting from $F=-d\mathcal{A}$</h3>
 <p>In §10.2, we defined the electromagnetic field $F$ as an assembly of $\mathbf{E}$ and $\mathbf{B}$.
 </p>
 <p>But there is a deeper way to look at it.
@@ -423,7 +468,7 @@ $$
 </p>
 <p>The point of this calculation is to confirm that the components of $F$ defined in §10.2 agree at the same time with the usual potential formulas.
 </p>
-<h4 id="Computing-__MATH_BLOCK_274__-component-by-component">Computing $d\mathcal{A}$ component by component</h4>
+<h4 id="Computing-__MATH_BLOCK_317__-component-by-component">Computing $d\mathcal{A}$ component by component</h4>
 <p>The computation of $d\mathcal{A}$ is exactly the procedure we have followed since Chapter 5. Apply $d$ to each of the four terms of $\mathcal{A}$.
 </p>
 $$
@@ -681,7 +726,7 @@ $$
 <p><strong>Note</strong> ($F$ and sign conventions for potentials)</p>
 <p>The definition $F=-d\mathcal{A}$ is adopted so that simultaneously: the $dt\wedge dx$ coefficient of $F$ in §10.2 is $-E_x$; and $\mathbf{E}=-\nabla\phi-\partial\mathbf{A}/\partial t$, $\mathbf{B}=\nabla\times\mathbf{A}$ hold. Other sign conventions exist, such as $F=+d\mathcal{A}$, $\mathcal{A}=-\phi\,dt+\cdots$, and so on.</p>
 </blockquote>
-<h4 id="__MATH_BLOCK_317__-Proves-__MATH_BLOCK_318__">$dd=0$ Proves $dF=0$</h4>
+<h4 id="__MATH_BLOCK_360__-Proves-__MATH_BLOCK_361__">$dd=0$ Proves $dF=0$</h4>
 <p>Now let us return to the opening discussion.
 </p>
 <p>Since $F=-d\mathcal{A}$,
@@ -760,10 +805,10 @@ $$
 <p>- The other equation $d(\ast F)=\mu_0(\ast\mathcal{J})$ becomes, upon substituting $F=-d\mathcal{A}$, an equation satisfied by the potential $\mathcal{A}$. In component calculations, read this as $d_4(\ast_4F)=\mu_0(\ast_4\mathcal{J})$.</p>
 </blockquote>
 <hr />
-<h2 id="Appendix-E:-Slice-Matrix-Representation-of-__MATH_BLOCK_372__-and-__MATH_BLOCK_373__-—-Seeing-Maxwell's-Equations-as-__MATH_BLOCK_374__-Arrays">Appendix E: Slice-Matrix Representation of $d_4F$ and $d_4(\ast_4F)$ — Seeing Maxwell's Equations as $4\times4\times4$ Arrays</h2>
+<h2 id="Appendix-E:-Slice-Matrix-Representation-of-__MATH_BLOCK_415__-and-__MATH_BLOCK_416__-—-Seeing-Maxwell's-Equations-as-__MATH_BLOCK_417__-Arrays">Appendix E: Slice-Matrix Representation of $d_4F$ and $d_4(\ast_4F)$ — Seeing Maxwell's Equations as $4\times4\times4$ Arrays</h2>
 <p>In §10.4 and §10.5 we rewrote the symbolic equations $dF=0,\;d(\ast F)=\mu_0(\ast\mathcal J)$ into the computational notation $d_4F,\;d_4(\ast_4F)$ and expanded them as coefficients of basis $3$-forms. In this appendix we visualize the same calculation as a <strong>bundle of $4\times4$ slice matrices</strong>—essentially a third-order $4\times4\times4$ tensor. It extends Appendix A and is the culmination of this book's practice of "putting everything into matrices."
 </p>
-<h3 id="E.1-Basis-__MATH_BLOCK_380__-forms-and-their-slice-matrices-—-all-16">E.1 Basis $3$-forms and their slice matrices — all 16</h3>
+<h3 id="E.1-Basis-__MATH_BLOCK_423__-forms-and-their-slice-matrices-—-all-16">E.1 Basis $3$-forms and their slice matrices — all 16</h3>
 <p>The four basis $3$-forms in four dimensions are (compared with the ordering in §10.4, the signs and order of $\omega_2$ and $\omega_3$ differ, but the four forms themselves are the same):
 </p>
 $$
@@ -816,7 +861,7 @@ $$
 $$
 <p>Of the 16 matrices, $\mathbf{S}_{z}^{(\omega_1)}, \mathbf{S}_{y}^{(\omega_2)}, \mathbf{S}_{x}^{(\omega_3)}, \mathbf{S}_{t}^{(\omega_4)}$ are zero matrices. The remaining 12 each contain one $\pm1$ (and one antisymmetric partner). This is the substance of the $4\times4\times4$ tensor.
 </p>
-<h3 id="E.2-Writing-__MATH_BLOCK_401__-with-slice-matrices">E.2 Writing $dF$ with slice matrices</h3>
+<h3 id="E.2-Writing-__MATH_BLOCK_444__-with-slice-matrices">E.2 Writing $dF$ with slice matrices</h3>
 <p>From the expansion in §10.4, the basis coefficients of $dF$ are given by
 </p>
 $$
@@ -872,7 +917,7 @@ $$
 </p>
 <p>Similarly, <strong>every coefficient is obtained by the Frobenius product with the corresponding basis slice</strong>. This structure is completely analogous to Appendix D, where $\ast_{2\to1}(\mathbf{M}) = (E_1\!\cdot\!\mathbf{M},\;E_2\!\cdot\!\mathbf{M},\;E_3\!\cdot\!\mathbf{M})$ extracted the components of a $2$-form $\mathbf{M}$. Only the degree has risen from $1\to2$ to $2\to3$, and the inner-product partner has changed from a column vector to a bundle of $4\times4$ matrices.
 </p>
-<h3 id="E.4-Reading-__MATH_BLOCK_425__-through-the-slices">E.4 Reading $dF=0$ through the slices</h3>
+<h3 id="E.4-Reading-__MATH_BLOCK_468__-through-the-slices">E.4 Reading $dF=0$ through the slices</h3>
 <p>$dF=0$ means that all four slice matrices are zero matrices:
 </p>
 $$
@@ -890,7 +935,7 @@ $$
 </ul>
 <p>These three are nothing but $\mathrm{curl}\,\mathbf{E} = -\partial\mathbf{B}/\partial t$. From the nonzero entries of the $z$-slice (arising from $\mathbf{S}_{z}^{(\omega_4)}$) we obtain $\mathrm{div}\,\mathbf{B} = 0$. The appearance is huge, but the content is merely the repetition of the four coefficient comparisons from §10.4.
 </p>
-<h3 id="E.5-Slice-representation-of-__MATH_BLOCK_441__">E.5 Slice representation of $d_4(\ast_4F) = \mu_0(\ast_4\mathcal{J})$</h3>
+<h3 id="E.5-Slice-representation-of-__MATH_BLOCK_484__">E.5 Slice representation of $d_4(\ast_4F) = \mu_0(\ast_4\mathcal{J})$</h3>
 <p>The source side has the same structure. $\ast_4F$ and $\ast_4\mathcal{J}$ were expanded in §10.5, and $d_4(\ast_4F)$ becomes slice matrices of the same type as $d_4F$—only the positions of the $\mathbf{E}$ and $\mathbf{B}$ coefficients are swapped.
 </p>
 <p>Write the $\omega_1\sim\omega_4$ coefficients of $d_4(\ast_4F)$ as $B_{txy}, B_{txz}, B_{tyz}, B_{xyz}$.
@@ -969,7 +1014,7 @@ $$
 </p>
 <p>This appendix confirms that the "four equations on space" from Chapter 5 and the "two equations on spacetime" from the main text of Chapter 10 are simply the same Maxwell equations written in different splittings.
 </p>
-<h3 id="F.1-__MATH_BLOCK_474__-on-space">F.1 $(E,B,J,\rho_{\mathrm e})$ on space</h3>
+<h3 id="F.1-__MATH_BLOCK_517__-on-space">F.1 $(E,B,J,\rho_{\mathrm e})$ on space</h3>
 <p>Consider space $(x,y,z)$ at each instant $t$.
 </p>
 <p>Place the electric field as a $1$-form on space:
@@ -1055,7 +1100,7 @@ $$
 <blockquote>
 <p><strong>Note</strong> (There is also a way to write without the metric) In this book we do not take the vector-analytic $\mathrm{div}$ as our starting basic operation, but read $\mathrm{div}=\ast d\ast$ to match the dictionary built up so far. Gauss's law is also written as $d_3(\ast_3E) = \ast_3\left(\frac{\rho_{\mathrm e}}{\varepsilon_0}\right)$ and then, when needed, read as $\mathrm{div}\,\mathbf E=\rho_{\mathrm e}/\varepsilon_0$. That is, we move back and forth among scalar fields, vector fields, and forms using the $\ast$ built from the metric. Maxwell's equations, however, also admit a standpoint that does not use the metric. In the view emphasized in Hehl–Obukhov's <em>Foundations of Classical Electrodynamics: Charge, Flux, and Metric</em>, one first separates two forms $F$ and $H$ and writes $dF=0, dH=J$. Here the Hodge star does not enter the equations themselves. The metric and properties of the medium enter later as a relation linking $H$ and $F$. This book does not go deep in that direction. The purpose is strictly to use the dictionary of $d$ and $\ast$ built up so far and see how the usual vector-analytic equations appear as components.</p>
 </blockquote>
-<h3 id="F.3-Two-equations-emerge-from-__MATH_BLOCK_511__">F.3 Two equations emerge from $d_4F=0$</h3>
+<h3 id="F.3-Two-equations-emerge-from-__MATH_BLOCK_554__">F.3 Two equations emerge from $d_4F=0$</h3>
 <p>In the main text of Chapter 10, the electromagnetic field $F$ was defined by
 </p>
 $$
@@ -1115,7 +1160,7 @@ d_3B=0,
 \qquad
 d_3E+\frac{\partial B}{\partial t}=0
 $$
-<h3 id="F.4-The-remaining-two-emerge-from-__MATH_BLOCK_517__">F.4 The remaining two emerge from $d_4(\ast_4F)=\mu_0(\ast_4\mathcal J)$</h3>
+<h3 id="F.4-The-remaining-two-emerge-from-__MATH_BLOCK_560__">F.4 The remaining two emerge from $d_4(\ast_4F)=\mu_0(\ast_4\mathcal J)$</h3>
 <p>Next we look at the source side.
 </p>
 <p>Under the conventions of the main text of Chapter 10,

--- a/docs/en/ch11.html
+++ b/docs/en/ch11.html
@@ -117,7 +117,7 @@
 <li class="level-1"><a href="ch08.html" id="link-ch08.html">Chapter 8</a></li>
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
 <li class="level-1"><a href="ch10.html" id="link-ch10.html">Chapter 10</a></li>
-<li class="level-1"><a href="ch11.html" class="active" id="link-ch11.html">Chapter 11</a><ul class="sub-toc"><li class="level-3"><a href="#§11.0-The-Position-of-This-Chapter-—-A-Guidepost-for-Readers-Who-Want-to-Look-Further-Ahead">§11.0 The Position of This Chapter — A Guidepost for Readers Who Want to Look Further Ahead</a></li><li class="level-3"><a href="#§11.1-Manifolds-—-Starting-from-$\mathbf{g}(x)$">§11.1 Manifolds — Starting from $\mathbf{g}(x)$</a></li></ul></li>
+<li class="level-1"><a href="ch11.html" class="active" id="link-ch11.html">Chapter 11</a><ul class="sub-toc"><li class="level-3"><a href="#§11.0-The-Position-of-This-Chapter-—-A-Guidepost-for-Readers-Who-Want-to-Look-Further-Ahead">§11.0 The Position of This Chapter — A Guidepost for Readers Who Want to Look Further Ahead</a></li><li class="level-3"><a href="#§11.1-Manifolds-—-Starting-from-$\mathbf{g}(x)$">§11.1 Manifolds — Starting from $\mathbf{g}(x)$</a></li><li class="level-3"><a href="#§11.2-Riemannian-Geometry-—-The-Tensor-Analysis-Style">§11.2 Riemannian Geometry — The Tensor-Analysis Style</a></li><li class="level-3"><a href="#§11.3-Beyond-That">§11.3 Beyond That</a></li></ul></li>
 <li class="level-1"><a href="ch12.html" id="link-ch12.html">Chapter 12</a></li>
 <li class="level-1"><a href="postscript.html" id="link-postscript.html">Afterword</a></li>
 <li class="level-1"><a href="refs.html" id="link-refs.html">References (with Comments from the Author)</a></li>
@@ -156,7 +156,7 @@
 <p>In other words, this book may be called an intermediate approach for gaining both "the geometric intuition of differential forms" and "the computational power of tensor analysis."</p>
 <p>—though I must admit that, seen from either tradition, it has unavoidably halfway aspects.</p>
 </blockquote>
-<h3 id="§11.1-Manifolds-—-Starting-from-__MATH_BLOCK_16__">§11.1 Manifolds — Starting from $\mathbf{g}(x)$</h3>
+<h3 id="§11.1-Manifolds-—-Starting-from-__MATH_BLOCK_23__">§11.1 Manifolds — Starting from $\mathbf{g}(x)$</h3>
 <p>In this book we introduced the metric $\mathbf{g}$ in Chapter 6, and in Chapter 9 we practiced building the dictionary for $\ast$ from $\mathbf{g}$. In Cartesian coordinates in Chapter 6, $\mathbf{g} = I$ was a constant matrix, but in cylindrical and spherical coordinates in Chapter 9, the components of $\mathbf{g}$ already depended on $r, \rho, \theta$. What happens, then, if we view this not as a matter of coordinate representation but as a metric $\mathbf{g}(p)$ assigned to each point of space itself?
 </p>
 <p>The dictionary for $\ast$ is built from $\mathbf{g}$. If $\mathbf{g}$ changes from place to place, the dictionary for $\ast$ changes from place to place as well. The correspondence table $dx \mapsto \ast(dx) = \cdots\, dy \wedge dz$ comes to have different coefficients at each point in space.
@@ -226,7 +226,7 @@ $$(f^*\omega)_p(v_1, \dots, v_k) = \omega_{f(p)}(df_p(v_1), \dots, df_p(v_k))$$
 </p>
 <p>This duality extends to higher-degree forms. Representing $k$-forms by matrices in Chapter 2 ($k=1$ as row vectors, $k=2$ as antisymmetric matrices, $k=3$ as antisymmetric third-order tensors) is nothing but the component representation of $k$-forms as alternating multilinear maps. When we handled $4\times4\times4$ slice matrices in Appendix E, we were already practicing component calculation for 3-forms on a manifold.
 </p>
-<h4 id="11.1.4-Exterior-Derivative-__MATH_BLOCK_145__-—-What-Does-Not-Change-on-a-Manifold">11.1.4 Exterior Derivative $d$ — What Does Not Change on a Manifold</h4>
+<h4 id="11.1.4-Exterior-Derivative-__MATH_BLOCK_152__-—-What-Does-Not-Change-on-a-Manifold">11.1.4 Exterior Derivative $d$ — What Does Not Change on a Manifold</h4>
 <p>The exterior derivative $d$ is one of the few differential operators that can be defined on a manifold <strong>without using the metric at all</strong>. For a $k$-form $\omega$, $d\omega$ is a $(k+1)$-form, and its definition agrees completely with what we learned in Chapter 5 as a combination of partial derivatives and the wedge product.
 </p>
 <p>The exterior derivative $d$ is a linear operator from $\Omega^k(M)$ to $\Omega^{k+1}(M)$; on functions it gives the ordinary total differential, it satisfies the graded Leibniz rule, and in local coordinates it is given by partial derivatives and the wedge product. For this operator, $d^2 = 0$ holds. The metric appears nowhere. Curved or flat, we can use the same computational rules for $d$ that we grew familiar with in this book.
@@ -312,6 +312,80 @@ $$\ast: \Omega^k(M) \to \Omega^{n-k}(M)$$
 </tr>
 </tbody>
 </table></div>
+<hr />
+<h3 id="§11.2-Riemannian-Geometry-—-The-Tensor-Analysis-Style">§11.2 Riemannian Geometry — The Tensor-Analysis Style</h3>
+<p>Whereas manifold theory aims to define geometric objects without dependence on coordinates, classical Riemannian geometry—the tensor analysis used in Einstein's general relativity—adopts the style of "choosing coordinates and confronting component transformation laws head-on." This is closer to the approach of this book, which has made matrix components explicit throughout.
+</p>
+<h4 id="11.2.1-Tensors-—-Definition-by-Transformation-Laws">11.2.1 Tensors — Definition by Transformation Laws</h4>
+<p>In classical tensor analysis, tensors are defined by their "transformation rules under coordinate changes." Under a change from coordinates $x^i$ to $\bar{x}^i$,
+</p>
+<p><strong>contravariant vectors</strong> $V^i$ transform as $\bar{V}^i = \sum_j \frac{\partial \bar{x}^i}{\partial x^j} V^j$, and
+ <strong>covariant vectors</strong> $\omega_i$ transform as $\bar{\omega}_i = \sum_j \frac{\partial x^j}{\partial \bar{x}^i} \omega_j$.
+</p>
+<p>This distinction already appeared in Chapter 4 of this book. The components $v^i$ of a displacement vector $\mathbf{v}$ are contravariant (transform by the inverse Jacobian), whereas the coefficients $\omega_i$ of a $1$-form $\omega$ are covariant (transform by the Jacobian). A general $(r,s)$-tensor $T^{i_1\cdots i_r}_{j_1\cdots j_s}$ has $r$ contravariant indices and $s$ covariant indices, and each index follows the transformation law above.
+</p>
+<p>The components $g_{ij}$ of the matrix $\mathbf{g}$ representing the metric in this book are a $(0,2)$-tensor (a second-order covariant tensor). Under coordinate transformation, $g_{ij}$ transforms as
+</p>
+$$\bar{g}_{ij} = \sum_{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$
+<p>The relation $\mathbf{g} = J^T J$ derived in Chapter 6 of this book is none other than the formula for computing $\bar{g}_{ij}$ in curvilinear coordinates when $g_{ij} = \delta_{ij}$ in Cartesian coordinates. A general Riemannian metric is not necessarily obtained as $J^T J$ from the Jacobian $J$ of a single coordinate transformation. The $J^T J$ of Chapter 6 is simply the most concrete example of computing an induced metric within Euclidean space.
+</p>
+<h4 id="11.2.2-Christoffel-Symbols-—-When-Differentiation-Fails-to-Be-Tensorial">11.2.2 Christoffel Symbols — When Differentiation Fails to Be Tensorial</h4>
+<p>The partial derivatives $\partial_j V^i$ of a vector field $V^i$ do not, as they stand, behave as a tensor—under coordinate transformation extra terms appear. Choosing the Levi-Civita connection compatible with the metric $g$, its connection coefficients, namely the <strong>Christoffel symbols</strong>, are given by
+</p>
+$$\Gamma^i_{jk} = \frac{1}{2}\sum_m g^{im}(\partial_j g_{km} + \partial_k g_{jm} - \partial_m g_{jk})$$
+<p>Here $g^{im}$ are the components of the inverse matrix of $g_{ij}$. In the terminology of this book, $\Gamma^i_{jk}$ are "coefficients that compensate for changes in the basis and the metric in that coordinate representation," and in general they involve first derivatives of $g_{ij}$.
+</p>
+<p>Defining the <strong>covariant derivative</strong>
+</p>
+$$\nabla_j V^i = \partial_j V^i + \sum_k \Gamma^i_{jk} V^k$$
+<p>using the Christoffel symbols, $\nabla_j V^i$ transforms correctly as a $(1,1)$-tensor. The covariant derivative is precisely the tool that defines "straightness" in curved space. The component representation of the connection concept (§11.1.7) is none other than $\Gamma^i_{jk}$.
+</p>
+<p>Let us rephrase this in terms of the book's experience. In Chapter 9 we derived formulas for $\mathrm{div}$ and $\mathrm{curl}$ from $\mathbf{g}$ in cylindrical and spherical coordinates. The derivation via the $\ast$ dictionary in Chapter 9 differs from the method of explicitly computing Christoffel symbols. Rather, we should say that by using $d$ and $\ast$, we reached the same coordinate formulas without putting $\Gamma^i_{jk}$ in a table. If one derives the same formulas in tensor analysis, covariant derivatives and Christoffel symbols appear there. Learning Riemannian geometry is revisiting the same coordinate formulas from the side of the connection coefficients $\Gamma^i_{jk}$ and the curvature tensor $R^i_{\,mjk}$.
+</p>
+<h4 id="11.2.3-The-Riemann-Curvature-Tensor">11.2.3 The Riemann Curvature Tensor</h4>
+<p>The non-commutativity of covariant derivatives quantifies how curved space is. For a vector field $V^i$,
+</p>
+$$(\nabla_j \nabla_k - \nabla_k \nabla_j) V^i = \sum_m R^i_{\,mjk} V^m$$
+<p>This defines the curvature. Written out in Christoffel symbols, $R^i_{\,mjk}$ is expressed as a combination of first derivatives of $\Gamma$ and products $\Gamma\Gamma$. The precise index order and sign depend on conventions in the literature, but for example, in coordinates where $\mathbf g$ is constant, the Christoffel symbols vanish and $R^i{}_{mjk}=0$; this is the flat case.
+</p>
+<blockquote>
+<p><strong>Note</strong> (Coordinate-dependent metric and curvature) That $\mathbf{g}(x)$ depends on location does not by itself mean curvature is nonzero. Writing Euclidean space in curvilinear coordinates (polar, spherical, etc.), $g_{ij}(x)$ may depend on location yet curvature is zero. Curvature becomes nonzero when $R^i_{\,mjk}$, built from $\Gamma$ and its derivatives, does not vanish.</p>
+</blockquote>
+<p>The curvature tensor has $n^4$ components, but many symmetries make the number of independent components far smaller. Writing the fully covariant curvature tensor as $R_{abcd}$, a representative convention gives
+</p>
+$$R_{abcd}=-R_{bacd},\qquad R_{abcd}=-R_{abdc},\qquad R_{abcd}=R_{cdab}$$
+<p>and the first Bianchi identity also holds. This leaves 20 independent components in four dimensions.
+</p>
+<blockquote>
+<p><strong>Note</strong> (Sign and index conventions for the curvature tensor)</p>
+<p>There are several conventions for the sign and index order of the curvature tensor. This section showed one representative convention, but other texts may use different index orders or signs.</p>
+$$
+\nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
+$$
+<p>This identity suggests the same "double boundary yields zero" structure as $d^2=0$ for the exterior derivative, but strictly it is an identity for the exterior covariant derivative $D$ involving the connection, not simply $d^2=0$.</p>
+</blockquote>
+<p>The Ricci tensor is obtained by contracting one pair of indices of the curvature tensor. The precise position and sign of the contraction depend on the curvature tensor convention. Here we do not fix the convention in detail. Together with the <strong>scalar curvature</strong> $R = \sum_i\sum_j g^{ij} \mathrm{Ric}_{ij}$, these constitute the left-hand side of the Einstein equations:
+</p>
+$$R_{ij} - \frac{1}{2}R\,g_{ij} = \frac{8\pi G}{c^4}\,T_{ij}$$
+<p>The left-hand side represents the geometry of spacetime (curvature); the right-hand side represents the matter energy-momentum tensor $T_{ij}$.
+</p>
+<blockquote>
+<p><strong>Note</strong> (Sign convention and cosmological constant in the Einstein equations) This equation adopts one sign convention and sets the cosmological constant $\Lambda = 0$. Depending on sign conventions (metric signature, coordinate system, definition of the curvature tensor), the form of the equation changes, and extensions including a cosmological term also exist. This book neither derives nor proves it, but we record it as a warning for readers consulting other literature.</p>
+</blockquote>
+<p>This book does not derive this equation, nor does it ask the reader to understand it. Nevertheless, the foundation behind it—manifold, metric, covariant derivative, curvature—cannot be exhausted by the $d$ and $\ast$ treated in this book alone. Rather, the connection $\nabla$—in the sense of a covariant derivative, introduced here in Chapter 11—is indispensable. Even so, the differential-forms viewpoint is a powerful entry point for advancing into these structures.
+</p>
+<h4 id="11.2.4-Two-Styles-—-Relation-to-This-Book">11.2.4 Two Styles — Relation to This Book</h4>
+<p>Descriptions via differential forms and via index-based tensor analysis are both languages for handling tensor fields. The former foreground antisymmetric tensors and the exterior derivative; the latter foreground components and transformation laws.
+</p>
+<p>This book has consistently adopted the style of making components explicit—matrices, index-free partial derivatives, expansions of wedge products. In this sense, the natural extension of this book lies in concrete tensor-analysis calculations rather than in the abstract theory of differential forms. Already when we pulled the $\ast$ dictionary for curvilinear coordinates in Chapter 9, we reached coordinate formulas for $\mathrm{curl}$ and $\mathrm{div}$ without explicitly writing $\Gamma^i_{jk}$. If one derives the same formulas in tensor analysis, behind them appear the world of $g_{ij}$, connection coefficients $\Gamma^i_{jk}$, and covariant derivatives. Beyond that lies the full scope of Riemannian geometry.
+</p>
+<h3 id="§11.3-Beyond-That">§11.3 Beyond That</h3>
+<p>This book ends here. The framework of $d$ and $\ast$ built up from Chapter 1 has fulfilled the original goal of deconstructing vector analysis.
+</p>
+<p>But having come this far, if only as a hobby, let us peek just a little at the face of another school.
+</p>
+<p>In modern mathematical physics there is <strong>geometric algebra</strong>, a world that from the outset integrates the exterior product ($\wedge$) and inner product (metric) that we struggled to separate into a single algebra as the "geometric product." The two tools $d$ and $\ast$ are also absorbed there into more fundamental operators. Only those who have known the pain of separation can taste the power of integration—that alone we convey, and with that we close this book.
+</p>
       <div class="nav-buttons">
         <a href="ch10.html">← Chapter 10...</a>
         <a href="ch12.html">Chapter 12... →</a>

--- a/docs/en/ch12.html
+++ b/docs/en/ch12.html
@@ -118,7 +118,7 @@
 <li class="level-1"><a href="ch09.html" id="link-ch09.html">Chapter 9</a></li>
 <li class="level-1"><a href="ch10.html" id="link-ch10.html">Chapter 10</a></li>
 <li class="level-1"><a href="ch11.html" id="link-ch11.html">Chapter 11</a></li>
-<li class="level-1"><a href="ch12.html" class="active" id="link-ch12.html">Chapter 12</a><ul class="sub-toc"><li class="level-3"><a href="#§12.0-Combining-Two-Equations-into-One">§12.0 Combining Two Equations into One</a></li><li class="level-3"><a href="#§12.2-Pauli-Matrices-—-The-Magic-of-Adding-Different-Degrees">§12.2 Pauli Matrices — The Magic of Adding Different Degrees</a></li><li class="level-3"><a href="#§12.3-The-Dirac-Operator-and-the-"True-Nabla"">§12.3 The Dirac Operator and the "True Nabla"</a></li><li class="level-3"><a href="#§12.4-The-Operator-$\nabla$">§12.4 The Operator $\nabla$</a></li></ul></li>
+<li class="level-1"><a href="ch12.html" class="active" id="link-ch12.html">Chapter 12</a><ul class="sub-toc"><li class="level-3"><a href="#§12.0-Combining-Two-Equations-into-One">§12.0 Combining Two Equations into One</a></li><li class="level-3"><a href="#§12.1-Combining-Them-with-the-Imaginary-Unit-—-Unifying-Maxwell's-Equations">§12.1 Combining Them with the Imaginary Unit — Unifying Maxwell's Equations</a></li><li class="level-3"><a href="#§12.2-Pauli-Matrices-—-The-Magic-of-Adding-Different-Degrees">§12.2 Pauli Matrices — The Magic of Adding Different Degrees</a></li><li class="level-3"><a href="#§12.3-The-Dirac-Operator-and-the-"True-Nabla"">§12.3 The Dirac Operator and the "True Nabla"</a></li><li class="level-3"><a href="#§12.4-The-Operator-$\nabla$">§12.4 The Operator $\nabla$</a></li></ul></li>
 <li class="level-1"><a href="postscript.html" id="link-postscript.html">Afterword</a></li>
 <li class="level-1"><a href="refs.html" id="link-refs.html">References (with Comments from the Author)</a></li>
 <li class="level-1"><a href="appendix.html" id="link-appendix.html">Appendix</a></li>
@@ -136,6 +136,31 @@
 <blockquote>
 <p><strong>Note</strong> (the position of this chapter) This chapter is an advanced supplement and lies off the main line of the book. Chapter 9 completed the rewrite of vector analysis, and Chapter 10 finished the matrix expansion of Maxwell's equations. Here we do not intend to write a textbook of rigorous geometric algebra (Clifford algebra). The purpose is to see, as an entry point to calculation, how grad, curl, and div—which this book has dismantled—are integrated again into a single operator inside Pauli matrices and the Dirac operator.</p>
 </blockquote>
+<hr />
+<h3 id="§12.1-Combining-Them-with-the-Imaginary-Unit-—-Unifying-Maxwell's-Equations">§12.1 Combining Them with the Imaginary Unit — Unifying Maxwell's Equations</h3>
+<p>In Chapter 10 we consolidated Maxwell's equations into the two equations
+</p>
+$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
+<p>Notice here that both $F$ and $\ast F$ are $2$-forms. In four-dimensional spacetime, the Hodge star $\ast$ maps $2$-forms to $2$-forms. So $F$ and $\ast F$ are forms of the same degree.
+</p>
+<p>When the degrees match, there is no obstacle to addition. Using the imaginary unit $i$, we build a single complex $2$-form (in this chapter we follow the sign conventions of Chapter 10; on a Lorentzian metric the sign of $\ast^2$ depends on dimension and signature conventions, so here we prioritize consistency with the component expansion).
+</p>
+$$G = F + i\ast F$$
+<p>Apply the exterior derivative $d$ to $G$. Since $d$ is a real differential operator, $d(i\ast F) = i\,d(\ast F)$.
+</p>
+$$dG = dF + i\,d(\ast F) = 0 + i\mu_0(\ast\mathcal{J})$$
+<p>That is,
+</p>
+$$d(F + i\ast F) = i\mu_0(\ast\mathcal{J})$$
+<p>That is all. The two equations $dF=0$ and $d(\ast F)=\mu_0(\ast\mathcal{J})$ have been unified into a single complex equation. The real part $F$ and the imaginary part $\ast F$ share the source-free and source Maxwell equations between them.
+</p>
+<p>But pause here and think. This trick works only because, <strong>by accident</strong>, in four dimensions $\ast$ maps $2$-forms to $2$-forms. In general $n$ dimensions, $\ast$ maps $k$-forms to $(n-k)$-forms. Being able to add $2$-form to $2$-form is a privilege of $n=4$; adding $1$-form to $2$-form directly is not allowed in the usual framework of differential forms.
+</p>
+<p>When $d$ and $\ast$ are combined, conversions between different degrees appear—grad ($0\to1$), curl ($1\to1$), div ($1\to0$), and so on. If we could treat the origins of these in a single algebra, we should be able not to dismantle $\nabla$ but to <strong>unify</strong> it.
+</p>
+<p>Adding forms of different degrees—is there no such "magic box"?
+</p>
+<hr />
 <h3 id="§12.2-Pauli-Matrices-—-The-Magic-of-Adding-Different-Degrees">§12.2 Pauli Matrices — The Magic of Adding Different Degrees</h3>
 <p>There is, in fact, a "magic box." Tools that physicists discovered for quantum mechanics can be used directly as that box. The Pauli matrices. More precisely, what we look at here is the Clifford algebra of three-dimensional Euclidean space, represented by Pauli matrices. Not differential forms themselves, but each degree ($0$ through $3$) is matched (under this chapter's convention) to basis elements inside this algebra.
 </p>
@@ -233,7 +258,7 @@ $$\psi = \varphi\,I + A_1\sigma_1 + A_2\sigma_2 + A_3\sigma_3$$
 </blockquote>
 <hr />
 <h3 id="§12.3-The-Dirac-Operator-and-the-"True-Nabla"">§12.3 The Dirac Operator and the "True Nabla"</h3>
-<h4 id="12.3.1-__MATH_BLOCK_100__-—-A-Unified-Differential-Operator">12.3.1 $\bm{\sigma}\!\cdot\!\nabla$ — A Unified Differential Operator</h4>
+<h4 id="12.3.1-__MATH_BLOCK_141__-—-A-Unified-Differential-Operator">12.3.1 $\bm{\sigma}\!\cdot\!\nabla$ — A Unified Differential Operator</h4>
 <p>Combine Pauli matrices with nabla $\nabla = (\frac{\partial}{\partial x}, \frac{\partial}{\partial y}, \frac{\partial}{\partial z})$ and define the operator
 </p>
 $$D = \sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z} = \bm{\sigma}\!\cdot\!\nabla$$
@@ -270,7 +295,7 @@ $$D(\mathbf{A}\!\cdot\!\bm{\sigma}) = (\mathrm{div}\,\mathbf{A})\,I \;+\; i\,(\m
 <blockquote>
 <p><strong>Note</strong> (in the language of $d$ and $\ast$) $D$ can also be expressed in this book's language. Up to sign conventions, $D$ can be understood as an operator combining $d$ (raising degree) and $\ast d\ast$ (lowering degree). The latter is called the <strong>codifferential</strong> $\delta$, defined by $\delta = \pm\ast d\ast$ (the sign depends on dimension and degree). Here we do not enter the exact signs; it is enough to keep in mind the structure $D \sim d + \delta$. $d$ raises degree and $\delta$ lowers it—the sum $D$ of these two binds grad, curl, and div into one operator.</p>
 </blockquote>
-<h4 id="12.3.2-__MATH_BLOCK_139__-—-The-Laplacian">12.3.2 $D^2$ — The Laplacian</h4>
+<h4 id="12.3.2-__MATH_BLOCK_180__-—-The-Laplacian">12.3.2 $D^2$ — The Laplacian</h4>
 <p>What happens if we apply $D$ twice?
 </p>
 $$D^2 = (\bm{\sigma}\!\cdot\!\nabla)(\bm{\sigma}\!\cdot\!\nabla) = (\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})(\sigma_1\frac{\partial}{\partial x} + \sigma_2\frac{\partial}{\partial y} + \sigma_3\frac{\partial}{\partial z})$$
@@ -324,7 +349,7 @@ $$(D + \frac{\partial}{\partial t})F = \frac{\rho_{\mathrm e}}{\varepsilon_0} - 
 </blockquote>
 <p>The two equations $dF=0$ and $d(\ast F)=\mu_0(\ast\mathcal{J})$ have been unified into a single complex equation in front of $D$. Whereas the four-dimensional trick of §12.1 depended on a special dimension, here the unified operator $D$ itself achieves the unification.
 </p>
-<h4 id="12.3.4-__MATH_BLOCK_173__-—-The-Dirac-Operator-in-Four-Dimensional-Spacetime">12.3.4 $\cancel{\partial} F = J$ — The Dirac Operator in Four-Dimensional Spacetime</h4>
+<h4 id="12.3.4-__MATH_BLOCK_214__-—-The-Dirac-Operator-in-Four-Dimensional-Spacetime">12.3.4 $\cancel{\partial} F = J$ — The Dirac Operator in Four-Dimensional Spacetime</h4>
 <p>In §12.3.3, $(D + \frac{\partial}{\partial t})F = \rho_{\mathrm e} + \mathbf{J}\!\cdot\!\bm{\sigma}$ still separates time and space. That is because it was built on the three-dimensional Pauli matrices $\sigma_1,\sigma_2,\sigma_3$. If we treat four-dimensional spacetime from the start, even this separation disappears.
 </p>
 <p>Extending Pauli matrices to $4\times4$ gives the <strong>gamma matrices</strong> $\gamma^0,\gamma^1,\gamma^2,\gamma^3$. They satisfy anticommutativity $\gamma^\mu\gamma^\nu + \gamma^\nu\gamma^\mu = 2g^{\mu\nu}I$ ($g^{\mu\nu}$ is the Minkowski metric). The signs of the real coefficients in this equation depend on the chosen metric signature and index conventions. As in Chapter 10, this chapter adopts the convention with spacetime metric signature $(-,+,+,+)$. Using these gamma matrices, define the four-dimensional Dirac operator by
@@ -340,7 +365,7 @@ $$\cancel{\partial} F = J$$
 </blockquote>
 <p>Both §12.1's $F + i\ast F$ and §12.3.3's $(D + \frac{\partial}{\partial t})F$ are absorbed into this single line. That is the farthest landscape on the journey that began with dismantling $\nabla$. The operator Dirac discovered in 1928 to derive the equation for the electron is the core of <strong>geometric algebra</strong>, which describes the geometry of spacetime and physical laws in one algebra; see Doran & Lasenby's <em>Geometric Algebra for Physicists</em> for details.
 </p>
-<h3 id="§12.4-The-Operator-__MATH_BLOCK_196__">§12.4 The Operator $\nabla$</h3>
+<h3 id="§12.4-The-Operator-__MATH_BLOCK_237__">§12.4 The Operator $\nabla$</h3>
 <p>Now let us return to the first question. What was $\nabla$?
 </p>
 <p>In vector analysis, $\nabla$ was introduced as a formal vector of partial derivatives and was a mysterious symbol with three faces: grad, curl, and div. This book <strong>dismantled</strong> it into $d$ and $\ast$, thereby revealing what each operator truly is.

--- a/docs/en/intro.html
+++ b/docs/en/intro.html
@@ -105,7 +105,7 @@
       <ul>
 <li class="level-1"><a href="toc.html" id="link-toc.html">Contents</a></li>
 <li class="level-1"><a href="index.html" id="link-index.html">Preface</a></li>
-<li class="level-1"><a href="intro.html" class="active" id="link-intro.html">Introduction</a><ul class="sub-toc"><li class="level-2"><a href="#Prerequisites">Prerequisites</a></li><li class="level-2"><a href="#What-Is-$dx$?">What Is $dx$?</a></li><li class="level-2"><a href="#What-Is-Nabla?">What Is Nabla?</a></li></ul></li>
+<li class="level-1"><a href="intro.html" class="active" id="link-intro.html">Introduction</a><ul class="sub-toc"><li class="level-2"><a href="#Prerequisites">Prerequisites</a></li><li class="level-2"><a href="#What-Is-$dx$?">What Is $dx$?</a></li><li class="level-2"><a href="#What-Is-Nabla?">What Is Nabla?</a></li><li class="level-2"><a href="#Roadmap-of-This-Book">Roadmap of This Book</a></li></ul></li>
 <li class="level-1"><a href="portal.html" id="link-portal.html">Portal Site and a Small Experiment</a></li>
 <li class="level-1"><a href="ch01.html" id="link-ch01.html">Chapter 1</a></li>
 <li class="level-1"><a href="ch02.html" id="link-ch02.html">Chapter 2</a></li>
@@ -189,6 +189,19 @@ $$
 </p>
 <p>It will not help you in time for tomorrow’s midterm. But perhaps it will make it in time for the final.
 </p>
+<hr />
+<h2 id="Roadmap-of-This-Book">Roadmap of This Book</h2>
+<p>This book has twelve chapters, divided into three large parts.
+</p>
+<ol>
+<li><strong>Part I: Differential Forms on $\mathbb{R}^3$ (Chapters 1–4)</strong></li>
+<p>   We redefine $dx$ as a “matrix” and algebraically build the mechanism that measures area and volume, then reach integration and the pullback.
+<li><strong>Part II: Vector Analysis (Chapters 5–9)</strong></li>
+<p>   This is the core of the book. We treat the exterior derivative $d$, the metric and Hodge star $\ast$, vector analysis via nabla, translation between the two languages, and curvilinear coordinates in practice.
+<li><strong>Part III: Development and Integration (Chapters 10–12)</strong></li>
+<p>   We look at applications to electromagnetism, namely Maxwell’s equations, and then glance toward the worlds of manifolds and Geometric Algebra.
+</p>
+</ol>
       <div class="nav-buttons">
         <a href="index.html">← Preface...</a>
         <a href="portal.html">Portal Site and... →</a>

--- a/docs/en/refs.html
+++ b/docs/en/refs.html
@@ -130,6 +130,12 @@
 <h1 id="References-(with-Comments-from-the-Author)">References (with Comments from the Author)</h1>
 <p>This book's peculiar algebraic approach was built by combining the insights of the following pioneers.
 </p>
+<hr />
+<p><strong>1. Daniel Fleisch, <em>A Student's Guide to Vectors and Tensors</em>, Cambridge University Press (2011)</strong>
+</p>
+<p>Comment: A careful guide to the traditional approach. A well-regarded introduction that treats traditional vector analysis and tensor analysis component calculation with extreme care. The best book for acquiring the power to break through head-on the jungle of Christoffel symbols and index manipulation—the route this book tries to bypass via differential forms.
+</p>
+<hr />
 <p><strong>2. David Bachman, <em>A Geometric Approach to Differential Forms</em>, Birkhäuser (2nd ed. 2011)</strong>
 </p>
 <p>Comment: A geometric introduction to differential forms. A good book that explains differential forms not from axioms but from geometric intuition such as "measuring shadows." Much of this book's intuition that "$dx$ is a measuring device" comes from Bachman, but here computational closure is prioritized and that intuition is adopted by dropping it into matrix algebra.

--- a/docs/en/toc.html
+++ b/docs/en/toc.html
@@ -134,6 +134,7 @@
 <h3><a href="ch01.html">Chapter 1: What Is $dx$? — A Measuring Device That Eats Vectors, or a Row Vector</a></h3>
 <ul>
 <li class="level-3"><a href="ch01.html#§1.0-The-Mathematician’s-One-Dimension,-the-Physicist’s-One-Dimension">§1.0 The Mathematician’s One Dimension, the Physicist’s One Dimension</a></li>
+<li class="level-3"><a href="ch01.html#§1.1-Riemann-Sums-and-Matrix-Products">§1.1 Riemann Sums and Matrix Products</a></li>
 <li class="level-3"><a href="ch01.html#§1.2-The-Total-Differential-$df$-—-An-Operator-That-Packs-Rates-of-Change-into-a-Matrix">§1.2 The Total Differential $df$ — An Operator That Packs Rates of Change into a Matrix</a></li>
 <li class="level-3"><a href="ch01.html#§1.3-Leibniz-Notation-and-Algebraic-Intuition">§1.3 Leibniz Notation and Algebraic Intuition</a></li>
 <li class="level-3"><a href="ch01.html#§1.4-Coordinate-Transformations-—-Rebuilding-Measuring-Devices-in-New-Coordinates">§1.4 Coordinate Transformations — Rebuilding Measuring Devices in New Coordinates</a></li>
@@ -143,6 +144,7 @@
 <h3><a href="ch02.html">Chapter 2: What Is Area? — The Sign Rule Hidden in Parallelepipeds</a></h3>
 <ul>
 <li class="level-3"><a href="ch02.html#§2.0-Measuring-Devices,-Area,-Volume,-and-Length">§2.0 Measuring Devices, Area, Volume, and Length</a></li>
+<li class="level-3"><a href="ch02.html#§2.1-The-Limits-of-Elementary-School-Area">§2.1 The Limits of Elementary-School Area</a></li>
 <li class="level-3"><a href="ch02.html#§2.2-The-Three-Rules-an-Area-Measuring-Device-Must-Satisfy">§2.2 The Three Rules an Area-Measuring Device Must Satisfy</a></li>
 <li class="level-3"><a href="ch02.html#§2.3-An-Area-Measuring-Device-Is-an-"Antisymmetric-Matrix"">§2.3 An Area-Measuring Device Is an "Antisymmetric Matrix"</a></li>
 <li class="level-3"><a href="ch02.html#§2.4-Internal-Structure-of-the-Area-Measuring-Device">§2.4 Internal Structure of the Area-Measuring Device</a></li>
@@ -153,6 +155,7 @@
 <h3><a href="ch03.html">Chapter 3: What Does It Mean to Integrate? — Count Finite Masses, Then Take the Limit</a></h3>
 <ul>
 <li class="level-3"><a href="ch03.html#§3.0-Measuring-Curved-Things-—-Paying-Back-a-Debt-from-Elementary-School">§3.0 Measuring Curved Things — Paying Back a Debt from Elementary School</a></li>
+<li class="level-3"><a href="ch03.html#§3.1-Volume-—-Three-Dimensions,-Coefficient-1">§3.1 Volume — Three Dimensions, Coefficient 1</a></li>
 <li class="level-3"><a href="ch03.html#§3.2-Surface-Area-—-The-Limit-of-Two-Dimensions,-Coefficient-1">§3.2 Surface Area — The Limit of Two Dimensions, Coefficient 1</a></li>
 <li class="level-3"><a href="ch03.html#§3.3-Curves-—-The-Limit-of-One-Dimension,-Coefficient-1,-Revealed">§3.3 Curves — The Limit of One Dimension, Coefficient 1, Revealed</a></li>
 <li class="level-3"><a href="ch03.html#§3.4-Adding-Coefficients-—-Density-Times-Geometry">§3.4 Adding Coefficients — Density Times Geometry</a></li>
@@ -162,6 +165,7 @@
 <ul>
 <li class="level-3"><a href="ch04.html#§4.0-Physics-Curves;-Computation-Uses-Boxes">§4.0 Physics Curves; Computation Uses Boxes</a></li>
 <li class="level-3"><a href="ch04.html#§4.1-Pullback-of-a-1-Form-—-Work-and-the-Work-Energy-Theorem">§4.1 Pullback of a 1-Form — Work and the Work-Energy Theorem</a></li>
+<li class="level-3"><a href="ch04.html#§4.2-Pullback-of-a-2-Form-—-Conservation-of-Angular-Momentum-and-Areal-Velocity">§4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity</a></li>
 <li class="level-3"><a href="ch04.html#§4.3-Pullback-of-a-3-Form-—-Conservation-of-Mass-and-Volume-Integrals">§4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals</a></li>
 <li class="level-3"><a href="ch04.html#§4.4-Properties-of-the-Pullback-—-What-We-Have-Established-So-Far">§4.4 Properties of the Pullback — What We Have Established So Far</a></li>
 <li class="level-3"><a href="ch04.html#§4.5-Summary-of-This-Chapter-and-Outlook-Toward-Chapter-5,-the-Exterior-Derivative">§4.5 Summary of This Chapter and Outlook Toward Chapter 5, the Exterior Derivative</a></li>
@@ -169,6 +173,7 @@
 <h3><a href="ch05.html">Chapter 5: What Does It Mean to Differentiate? — The Exterior Derivative $d$: Integral Quantities and Local Laws</a></h3>
 <ul>
 <li class="level-3"><a href="ch05.html#§5.0-The-Bridge-to-Differentiation-—-Observation-Is-Integral,-Law-Is-Differential">§5.0 The Bridge to Differentiation — Observation Is Integral, Law Is Differential</a></li>
+<li class="level-3"><a href="ch05.html#§5.1-Revisiting-$df$-—-Are-Differentiation-and-Integration-Inverse-Operations?">§5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?</a></li>
 <li class="level-3"><a href="ch05.html#§5.2-The-"Mismatch"-Revealed-by-a-Closed-Loop">§5.2 The "Mismatch" Revealed by a Closed Loop</a></li>
 <li class="level-3"><a href="ch05.html#§5.3-Dismantling-an-Infinitesimal-Loop-—-The-Mismatch-Is-Proportional-to-Area">§5.3 Dismantling an Infinitesimal Loop — The Mismatch Is Proportional to Area</a></li>
 <li class="level-3"><a href="ch05.html#§5.4-The-Birth-of-$d$-—-A-New-Measuring-Device-for-Mismatch-per-Unit-Area">§5.4 The Birth of $d$ — A New Measuring Device for Mismatch per Unit Area</a></li>
@@ -198,6 +203,7 @@
 <h3><a href="ch06.html">Chapter 6: The Metric $g$ and the Hodge Star $\ast$ — Summoning the Inner Product and Reversing Degree</a></h3>
 <ul>
 <li class="level-3"><a href="ch06.html#§6.0-The-End-of-Excuses-—-Releasing-the-Inner-Product">§6.0 The End of Excuses — Releasing the Inner Product</a></li>
+<li class="level-3"><a href="ch06.html#§6.1-The-Inner-Product-on-Parameter-Space-—-The-True-Nature-of-the-Metric-$g$">§6.1 The Inner Product on Parameter Space — The True Nature of the Metric $g$</a></li>
 <li class="level-3"><a href="ch06.html#§6.2-Converting-Between-Column-Vectors-and-Row-Vectors-Using-$g$">§6.2 Converting Between Column Vectors and Row Vectors Using $g$</a></li>
 <li class="level-3"><a href="ch06.html#§6.3-The-Hodge-Star-$\ast$-—-The-Correspondence-Connecting-Two-Routes">§6.3 The Hodge Star $\ast$ — The Correspondence Connecting Two Routes</a></li>
 <li class="level-3"><a href="ch06.html#§6.4-Examples-of-the-Correspondence-—-Differential-Forms-and-Vector-Analysis">§6.4 Examples of the Correspondence — Differential Forms and Vector Analysis</a></li>
@@ -213,6 +219,7 @@
 <h3><a href="ch07.html">Chapter 7: Vector Analysis — Enter Nabla</a></h3>
 <ul>
 <li class="level-3"><a href="ch07.html#§7.0-Enter-Nabla">§7.0 Enter Nabla</a></li>
+<li class="level-3"><a href="ch07.html#§7.1-Dot-Products-and-Cross-Products">§7.1 Dot Products and Cross Products</a></li>
 <li class="level-3"><a href="ch07.html#§7.2-$\nabla$-and-the-Gradient">§7.2 $\nabla$ and the Gradient</a></li>
 <li class="level-3"><a href="ch07.html#§7.3-Divergence">§7.3 Divergence</a></li>
 <li class="level-3"><a href="ch07.html#§7.4-Curl">§7.4 Curl</a></li>
@@ -225,6 +232,7 @@
 <h3><a href="ch08.html">Chapter 8: Two Languages — Differentiating Measuring Devices and Differentiating Fields</a></h3>
 <ul>
 <li class="level-3"><a href="ch08.html#§8.0-The-Highlight-of-This-Book">§8.0 The Highlight of This Book</a></li>
+<li class="level-3"><a href="ch08.html#§8.1-Two-Differentials,-Two-Worlds">§8.1 Two Differentials, Two Worlds</a></li>
 <li class="level-3"><a href="ch08.html#§8.2-Completing-the-Translation-Dictionary">§8.2 Completing the Translation Dictionary</a></li>
 <li class="level-3"><a href="ch08.html#§8.3-Translating-Stokes'-Theorem">§8.3 Translating Stokes' Theorem</a></li>
 <li class="level-3"><a href="ch08.html#§8.4-Translating-Gauss'-Theorem">§8.4 Translating Gauss' Theorem</a></li>
@@ -234,6 +242,7 @@
 <h3><a href="ch09.html">Chapter 9: In Practice — Build the Dictionary and Solve Hard Problems</a></h3>
 <ul>
 <li class="level-3"><a href="ch09.html#§9.0-The-Central-Tools-of-This-Book-Are-Now-in-Place">§9.0 The Central Tools of This Book Are Now in Place</a></li>
+<li class="level-3"><a href="ch09.html#§9.1-Building-the-Dictionary-on-the-Spot-—-A-Mechanical-Procedure">§9.1 Building the Dictionary on the Spot — A Mechanical Procedure</a></li>
 <li class="level-3"><a href="ch09.html#§9.2-Cylindrical-Coordinates-$(r,\theta,z)$">§9.2 Cylindrical Coordinates $(r,\theta,z)$</a></li>
 <li class="level-3"><a href="ch09.html#§9.3-Spherical-Coordinates-$(\rho,\theta,\phi)$">§9.3 Spherical Coordinates $(\rho,\theta,\phi)$</a></li>
 <li class="level-3"><a href="ch09.html#§9.4-A-Hard-Problem-in-Calculus-—-The-Vector-Laplacian-in-Spherical-Coordinates">§9.4 A Hard Problem in Calculus — The Vector Laplacian in Spherical Coordinates</a></li>
@@ -245,6 +254,7 @@
 <h3><a href="ch10.html">Chapter 10: Maxwell's Equations — Beyond Beauty</a></h3>
 <ul>
 <li class="level-3"><a href="ch10.html#§10.0-The-Usual-Caveat">§10.0 The Usual Caveat</a></li>
+<li class="level-3"><a href="ch10.html#§10.1-Maxwell's-Equations-—-Two-Equations">§10.1 Maxwell's Equations — Two Equations</a></li>
 <li class="level-3"><a href="ch10.html#§10.2-The-Electromagnetic-Field-$F$-and-Fixing-Sign-Conventions">§10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions</a></li>
 <li class="level-3"><a href="ch10.html#§10.3-The-Minkowski-Metric-—-From-$\mathbb{R}^3$-to-Four-Dimensions">§10.3 The Minkowski Metric — From $\mathbb{R}^3$ to Four Dimensions</a></li>
 <li class="level-3"><a href="ch10.html#§10.4-Writing-Out-$dF=0$-in-Full">§10.4 Writing Out $dF=0$ in Full</a></li>
@@ -267,10 +277,13 @@
 <ul>
 <li class="level-3"><a href="ch11.html#§11.0-The-Position-of-This-Chapter-—-A-Guidepost-for-Readers-Who-Want-to-Look-Further-Ahead">§11.0 The Position of This Chapter — A Guidepost for Readers Who Want to Look Further Ahead</a></li>
 <li class="level-3"><a href="ch11.html#§11.1-Manifolds-—-Starting-from-$\mathbf{g}(x)$">§11.1 Manifolds — Starting from $\mathbf{g}(x)$</a></li>
+<li class="level-3"><a href="ch11.html#§11.2-Riemannian-Geometry-—-The-Tensor-Analysis-Style">§11.2 Riemannian Geometry — The Tensor-Analysis Style</a></li>
+<li class="level-3"><a href="ch11.html#§11.3-Beyond-That">§11.3 Beyond That</a></li>
 </ul>
 <h3><a href="ch12.html">Chapter 12: The True Nabla — Clifford, Pauli, Dirac, and Hamilton</a></h3>
 <ul>
 <li class="level-3"><a href="ch12.html#§12.0-Combining-Two-Equations-into-One">§12.0 Combining Two Equations into One</a></li>
+<li class="level-3"><a href="ch12.html#§12.1-Combining-Them-with-the-Imaginary-Unit-—-Unifying-Maxwell's-Equations">§12.1 Combining Them with the Imaginary Unit — Unifying Maxwell's Equations</a></li>
 <li class="level-3"><a href="ch12.html#§12.2-Pauli-Matrices-—-The-Magic-of-Adding-Different-Degrees">§12.2 Pauli Matrices — The Magic of Adding Different Degrees</a></li>
 <li class="level-3"><a href="ch12.html#§12.3-The-Dirac-Operator-and-the-"True-Nabla"">§12.3 The Dirac Operator and the "True Nabla"</a></li>
 <li class="level-3"><a href="ch12.html#§12.4-The-Operator-$\nabla$">§12.4 The Operator $\nabla$</a></li>
@@ -280,6 +293,7 @@
 <h2><a href="refs.html">References (with Comments from the Author)</a></h2>
 <h2><a href="appendix.html">Appendix: What This Book Did Not Discuss</a></h2>
 <ul>
+<li class="level-2"><a href="appendix.html#I.-On-the-Theoretical-Framework-and-Rigor">I. On the Theoretical Framework and Rigor</a></li>
 <li class="level-2"><a href="appendix.html#II.-On-Methodological-Choices-and-Limits-of-Application">II. On Methodological Choices and Limits of Application</a></li>
 <li class="level-2"><a href="appendix.html#III.-On-Physical-Definitions-and-Pedagogical-Choices">III. On Physical Definitions and Pedagogical Choices</a></li>
 </ul>

--- a/exports/manuscript-en_combined.md
+++ b/exports/manuscript-en_combined.md
@@ -98,6 +98,18 @@ From $dx$, we rethink what area is and what volume is. Then we move on to integr
 
 It will not help you in time for tomorrow’s midterm. But perhaps it will make it in time for the final.
 
+---
+
+## Roadmap of This Book
+
+This book has twelve chapters, divided into three large parts.
+
+1. <strong>Part I: Differential Forms on $\mathbb{R}^3$ (Chapters 1–4)</strong>  
+   We redefine $dx$ as a “matrix” and algebraically build the mechanism that measures area and volume, then reach integration and the pullback.
+2. <strong>Part II: Vector Analysis (Chapters 5–9)</strong>  
+   This is the core of the book. We treat the exterior derivative $d$, the metric and Hodge star $\ast$, vector analysis via nabla, translation between the two languages, and curvilinear coordinates in practice.
+3. <strong>Part III: Development and Integration (Chapters 10–12)</strong>  
+   We look at applications to electromagnetism, namely Maxwell’s equations, and then glance toward the worlds of manifolds and Geometric Algebra.
 
 # Portal Site and a Small Experiment
 
@@ -191,6 +203,268 @@ This physicist’s three-dimensional point of view lets us see that $dx$ is not 
 > <strong>Note</strong> (extensions in Part III)  
 > In Part III, however, we will touch on curvilinear coordinates and extensions to higher dimensions as needed.
 
+---
+
+### §1.1 Riemann Sums and Matrix Products
+
+In the previous section, we reinterpreted a physical infinitesimal displacement as the column vector $\mathbf{v}$. As in §1.0,
+
+$$
+\mathbf{v} = \begin{pmatrix} \Delta x \\ 0 \\ 0 \end{pmatrix}.
+$$
+
+With that picture in place, let us rewrite the familiar Riemann integral and see what perspective “$dx$ as a matrix” gives us.
+
+> <strong>Note</strong> (on transpose notation)  
+> In mathematics and in other books, a column vector is sometimes laid sideways on the page and marked with a superscript ${}^T$, as in $(\Delta x,\Delta y,\Delta z)^T$. In this book, I avoid this kind of space-saving transpose notation as much as possible. Column vectors are written as columns, and row vectors as rows. If ${}^T$ appears exceptionally, read it as an intentional transpose operation.
+
+#### 1.1.1 The Standard Construction of a Riemann Sum (Review)
+
+The definite integral of a function $f(x)$ over the interval $[a,b]$ is defined as follows. In high-school language, this is the method of exhaustion by subdivision.
+
+> <strong>Note</strong> (closed intervals)  
+> The notation $[a,b]$ denotes the <strong>closed interval</strong> containing both endpoints $a$ and $b$: the set of real numbers $x$ such that $a \le x \le b$.
+
+1. Divide the interval into $n$ subintervals: $a=x_0<x_1<\cdots<x_n=b$.
+2. Let the width of the small interval be $\Delta x_i=x_i-x_{i-1}$.
+3. Choose one representative point $\xi_i$ <strong>inside</strong> each subinterval $[x_{i-1},x_i]$.
+4. Form the Riemann sum $R_n:=\sum_{i=1}^n f(\xi_i)\Delta x_i$. We write the sum for this particular $n$-fold partition as $R_n$.
+5. Take the limit as the partition becomes finer. Strictly speaking, the <strong>maximum</strong> width of the subintervals approaches $0$. Merely increasing the number of pieces $n$ can still leave a large interval somewhere, so more advanced mathematics emphasizes this condition. In what follows, $\lim_{n\to\infty}R_n$ assumes partitions satisfying this condition:
+
+$$
+\int_a^b f(x)\,dx = \lim_{n\to\infty} R_n.
+$$
+
+In the usual textbook explanation, you read $dx$ as what the “tiny width $\Delta x_i$” becomes in the limit. Here we go one step deeper.
+
+#### 1.1.2 Displacement on Each Subinterval
+
+For the $i$-th subinterval $[x_{i-1},x_i]$, we write the displacement vector from §1.0, adjusted to the width of that interval, as
+
+$$
+\mathbf{v}_i = \begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}.
+$$
+
+The subscript $i$ only means “for the $i$-th subinterval.” The object $\mathbf{v}_i$ is still a displacement vector. Since we are currently considering straight-line motion, the $y$ and $z$ components are zero. But that is not a condition imposed in advance; rather, in this particular situation, those components simply come out to be zero.
+
+<!-- pagebreak -->
+
+#### 1.1.3 The Appearance of $dx$ — The Defining Assertion of This Book
+
+Now we give the symbol $dx$ the following meaning. <strong>This may look bold, even strange, but it is also the defining feature of this book</strong>: here, we <strong>declare</strong> that $dx$ is the following $1\times3$ matrix.
+
+That is, we <strong>define</strong> $dx$ as the following <strong>row vector</strong>, with its components written horizontally as a $1\times3$ matrix:
+
+$$
+dx := \begin{pmatrix} 1 & 0 & 0 \end{pmatrix}.
+$$
+
+This is not, in fact, a private notation detached from the standard point of view. The same object already appears in standard linear algebra, tensor analysis, and manifold theory. What I am doing here is fixing standard coordinates on $\mathbb{R}^3$ and writing it out as a matrix from the beginning. I spell this out in the note below.
+
+For readers familiar with more advanced mathematics: this is the matrix representation of the linear operator that takes an input column vector and returns only its $x$-component. It is the representation of $dx$ in the standard coordinates of $\mathbb{R}^3$.
+
+> <strong>Note</strong> ($dx=(1\ 0\ 0)$ and its relation to textbooks)  
+> This notation is not often brought to the foreground in ordinary textbooks, but it is already there implicitly.
+>
+> <strong>For readers who have studied vector analysis</strong>  
+> For a scalar-valued function $f:\mathbb{R}^3\to\mathbb{R}$, the gradient is
+> $$
+> \nabla f = \begin{pmatrix}
+> \frac{\partial f}{\partial x} \\
+> \frac{\partial f}{\partial y} \\
+> \frac{\partial f}{\partial z}
+> \end{pmatrix}.
+> $$
+> Its transpose
+> $$
+> (\nabla f)^T=
+> \begin{pmatrix}
+> \frac{\partial f}{\partial x} &
+> \frac{\partial f}{\partial y} &
+> \frac{\partial f}{\partial z}
+> \end{pmatrix}
+> $$
+> is a $1\times3$ row vector. If we set $f=x$, then $(\nabla x)^T=(1\ 0\ 0)$. In the Cartesian coordinates and matrix convention used in this book, this transpose of the gradient is precisely the row-vector representation of $dx$.
+>
+> <strong>For readers who have studied tensor analysis</strong>  
+> The symbols $dx^i$ are the dual basis to the coordinate basis $\frac{\partial}{\partial x^j}$, so
+> $$
+> dx^i\!\left(\frac{\partial}{\partial x^j}\right)=\delta^i_j.
+> $$
+> Therefore, in Cartesian coordinates, their row-vector representations are
+> $$
+> dx^1=(1\ 0\ 0),\qquad dx^2=(0\ 1\ 0),\qquad dx^3=(0\ 0\ 1).
+> $$
+>
+> <strong>For readers familiar with manifold theory</strong>  
+> We have $df_p:T_p\mathbb{R}^3\to\mathbb{R}$, $df_p(v)=v(f)$, and $dx^i_p(v)=v(x^i)$. In standard coordinates, if
+> $$
+> v=v^i\frac{\partial}{\partial x^i}
+> \longmapsto
+> \begin{pmatrix}v^1\\v^2\\v^3\end{pmatrix},
+> $$
+> then $dx^1_p(v)=v^1$, $dx^2_p(v)=v^2$, and $dx^3_p(v)=v^3$. Thus, in standard coordinate representation,
+> $$
+> dx^1_p\longmapsto(1\ 0\ 0),\qquad
+> dx^2_p\longmapsto(0\ 1\ 0),\qquad
+> dx^3_p\longmapsto(0\ 0\ 1).
+> $$
+
+Now multiply the displacement vector $\mathbf{v}_i$ on the left by the row vector $dx$:
+
+$$
+dx\,\mathbf{v}_i
+=
+\begin{pmatrix} 1 & 0 & 0 \end{pmatrix}
+\begin{pmatrix} \Delta x_i \\ 0 \\ 0 \end{pmatrix}
+=
+\Delta x_i.
+$$
+
+Here we write the image that “$dx$ eats the displacement vector $\mathbf{v}_i$ and spits out the scalar $\Delta x_i$” <strong>as if it were a function value</strong>:
+
+$$
+dx(\mathbf{v}_i)
+:=
+dx\,\mathbf{v}_i
+=
+\Delta x_i.
+$$
+
+In this book, I will often emphasize this form $dx(\mathbf{v})$: the row vector $dx$ acts on the column vector $\mathbf{v}$. This point cannot be emphasized too often.
+
+> <strong>Note</strong> (operator, functional, function, or map?)  
+> Different books use different words for this $dx(\mathbf{v})$: <strong>operator</strong>, <strong>functional</strong>, <strong>function</strong>, or <strong>map</strong>. I prefer to call it an <strong>operator</strong>, so that is the word I will often use from here on.
+
+The $\Delta x_i$ that appears in the Riemann sum is not a “mysterious one-dimensional infinitesimal quantity.” It is <strong>the result of applying the matrix $dx$ above to the displacement vector $\mathbf{v}_i$ in three-dimensional space and extracting only its $x$-component</strong>.
+
+In other words,
+
+$$
+\Delta x_i = dx(\mathbf{v}_i).
+$$
+
+<strong>This is the decisive moment</strong>:
+
+* Left-hand side: $dx(\mathbf{v}_i)$ is the algebraic operation in which the matrix $dx$ acts on the <strong>displacement vector</strong> $\mathbf{v}_i$.
+* Right-hand side: the “small interval width $\Delta x_i$” that appears in the conventional Riemann sum.
+
+Thus $\Delta x_i$ is <strong>not a mysterious one-dimensional infinitesimal displacement, but $dx(\mathbf{v}_i)$, obtained by extracting only the $x$-direction component from the three-dimensional infinitesimal displacement $\mathbf{v}_i$</strong>.
+
+> <strong>Note</strong> (component-order convention)  
+> For row vectors and abbreviated row components, I write $(1\ 0\ 0)$, with <strong>no commas</strong>, separating components only by spaces. I use notation with <strong>commas followed by spaces</strong>, such as $(1, 0, 0)$, when emphasizing <strong>coordinates</strong>, such as the position of a point. I do <strong>not</strong> use that notation for abbreviated matrices or row vectors.
+
+Once this one line lands, the $dx$ at the end of the integral sign starts to look different. Next, let us rewrite the ordinary Riemann sum in this notation.
+
+#### 1.1.4 Vector Reinterpretation of the Riemann Sum and the Integral Sign
+
+From this point of view, the Riemann sum becomes
+
+$$
+R_n
+=
+\sum_{i=1}^n f(\xi_i)\,dx(\mathbf{v}_i).
+$$
+
+Since
+
+$$
+dx(\mathbf{v}_i)=\Delta x_i,
+$$
+
+this is the same as the ordinary Riemann sum
+
+$$
+R_n
+=
+\sum_{i=1}^n f(\xi_i)\,\Delta x_i.
+$$
+
+But the same notation admits a second reading. On each subinterval, consider the row vector obtained by multiplying the measuring device $dx$ by the function value $f(\xi_i)$:
+
+$$
+\bigl(f(\xi_i)\,dx\bigr)
+:=
+f(\xi_i)\,dx
+=
+\begin{pmatrix}
+f(\xi_i) & 0 & 0
+\end{pmatrix}.
+$$
+
+If this row vector acts on the displacement vector $\mathbf{v}_i$, then
+
+$$
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i)
+=
+f(\xi_i)\,dx(\mathbf{v}_i)
+=
+f(\xi_i)\,\Delta x_i.
+$$
+
+In other words, we obtain the individual terms of the Riemann sum themselves.
+
+Therefore, the Riemann sum can also be read as
+
+$$
+R_n
+=
+\sum_{i=1}^n
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i).
+$$
+
+In the limit where the partition becomes infinitely fine, that is, in the limit where the maximum width tends to $0$, the definition of the Riemann integral gives
+
+$$
+\int_a^b f(x)\,dx
+=
+\lim_{n\to\infty} R_n
+=
+\lim_{n\to\infty}
+\sum_{i=1}^n
+\bigl(f(\xi_i)\,dx\bigr)(\mathbf{v}_i).
+$$
+
+The left-hand side, $\int_a^b f(x)\,dx$, is the familiar integral notation we have known since high school. It is the same quantity as $\lim_{n\to\infty}R_n$ in the construction above.
+
+The right-hand side is another face of the same integral: <strong>the limit of the sum, over subintervals, of the values obtained when the measuring device $f(\xi_i)\,dx$ acts on the displacement vector $\mathbf{v}_i$</strong>.
+
+Thus the $dx$ at the end of the integral sign is not a mere decoration. At least in this reading, it works as a measuring device that extracts the $x$-direction width from the displacement vector on each subinterval. And $f(x)\,dx$ can be read as a new row vector obtained by multiplying that measuring device by the value of the function.
+
+> <strong>Note</strong> (work integrals)  
+> The work integral $W=\int F(x)\,dx$ from mechanics can be read in the same way. On each subinterval, the row vector $F(\xi_i)\,dx$ eats the displacement vector $\mathbf{v}_i$ and returns $F(\xi_i)\Delta x_i$. The limit of the sum is the work.
+
+#### 1.1.5 Linear Forms ($1$-Forms)
+
+So far, we have defined $dx$ as a row vector that acts on a displacement vector, extracts a specified component, and returns a scalar, that is, a real number. A <strong>linear</strong> measuring device of this kind, one that eats a vector and spits out a scalar, is technically called a <strong>linear form</strong>, or a <strong>$1$-form</strong>. What we have been calling “$dx$ as a matrix” is precisely this $1$-form.
+
+> <strong>Note</strong> (the term “covector”)  
+> Mathematicians also often use the term <strong>covector</strong> as another name for a <strong>linear form</strong>, or <strong>$1$-form</strong>. Keep it in the corner of your mind as a dictionary entry for reading other books.
+
+The origin of the name is simple:
+
+* <strong>“linear”</strong>: because it processes the displacement vector <strong>linearly</strong>;
+* <strong>“form”</strong>: for now, think of it as a fixed pattern of measurement or action.
+
+From here on, I will call this measuring device a “matrix,” a “linear form ($1$-form),” or an operator. These all refer to the same object.
+
+> <strong>Note</strong> (matrix, linear form, measuring device)  
+> To repeat: from the standpoint of this book, these are represented by the same array. Throughout the book, I will call the same object a “matrix,” a “linear form,” or a “measuring device,” depending on what needs to be emphasized.
+
+#### 1.1.6 The Notational Contract of This Book
+
+In this book, <strong>we do not use a standalone $dx$ to mean an “infinitesimal displacement” or an “infinitesimal change.”</strong> To avoid confusing the width of a displacement with the measuring device, the row vector, we make the following agreement. For the magnitude of an infinitesimal displacement in the $x$ direction, we use $\Delta x$, or we explicitly write the displacement vector $\mathbf{v}$ and write $dx(\mathbf{v})$.
+
+On the other hand, a <strong>standalone $dx$</strong> means the operator, the row vector or $1$-form, that <strong>extracts the $x$-component</strong>. A $dx$ appearing in an expression such as $df=f'(x)\,dx$ is also <strong>always read as an operator</strong>. <strong>Keep this distinction clear. Everything that follows depends on it.</strong>
+
+From here on, the $dx$ at the end of the integral sign $\int_a^b f(x)\,dx$ will remain as <strong>conventional notation</strong> inherited from high school. But outside the integral sign, we will always write it in the form $dx(\mathbf{v})$ when the action is being shown explicitly. In the main text, when speaking about displacements and infinitesimal widths, we will use $\Delta x$ or $dx(\mathbf{v})$, and we will not attach the image of width or amount of change to a bare $dx$.
+
+> <strong>Note</strong> (usage of $dx$ in the literature)  
+> Physicists often use the convention of writing the displacement component itself as $dx$. But once you get used to the notation of this book, it becomes easier to read by separating <strong>$dx$ as a measuring device</strong> from the scalar of displacement. In more advanced books, that distinction will matter directly.
+
+In the next section, we extend this point of view to the differential of a function and define the total differential $df$ as a matrix.
+
+---
 
 > <strong>Checkpoint so far</strong>
 > - An infinitesimal displacement is a column vector $\mathbf{v}$. The symbol $\Delta x$ is a scalar width, while a standalone $dx$ is an operator, a row vector or $1$-form.
@@ -1076,6 +1350,40 @@ Let us gradually unravel how three-dimensional Euclidean space looks.
 
 In Chapter 1, we defined $dx$, $dy$, and $dz$ as row vectors ($1$-forms) that eat one vector and return a scalar, and we reread $\int f\,dx$ as the limit of matrix actions. In this chapter we extend that framework and <strong>discover area-measuring devices</strong> ($2$-forms), which eat two vectors, and <strong>volume-measuring devices</strong> ($3$-forms), which eat three. Both are built from the same parts: $dx$, $dy$, and $dz$.
 
+---
+
+### §2.1 The Limits of Elementary-School Area
+
+Many readers know that “integration is, roughly speaking, a calculation for finding area.”
+But what is area, exactly? If we think about it again, we may realize that we have not really formalized the idea since elementary school.
+
+So what was that elementary-school formalization? It was based on a very simple intuition: **“how many $1\times 1$ squares (tiles) can be packed into the figure.”**
+
+For a figure drawn on two-dimensional paper (the $xy$ plane), this “tiling with squares” works well. For example, the area $S$ of the parallelogram spanned by two two-dimensional vectors $\mathbf{v}_1=(x_1,y_1)$ and $\mathbf{v}_2=(x_2,y_2)$ can be written as
+
+$$S=\sqrt{(x_1 y_2-x_2 y_1)^2}.$$
+
+However, we live in three-dimensional space. When we try to compute the area of a “tilted plane” in three-dimensional space, things get a bit painful.
+
+Many readers were asked in high-school mathematics to find the area of the parallelogram spanned by three-dimensional vectors $\mathbf{v}_1=(x_1,y_1,z_1)$ and $\mathbf{v}_2=(x_2,y_2,z_2)$. Using high-school notation, we can write
+
+$$
+S=\sqrt{|\mathbf{v}_1|^2|\mathbf{v}_2|^2-(\mathbf{v}_1\cdot\mathbf{v}_2)^2}.
+$$
+
+If we expand in components, we fight through a calculation that fills a notebook page before we finally reach
+
+$$S=\sqrt{(y_1 z_2-z_1 y_2)^2+(z_1 x_2-x_1 z_2)^2+(x_1 y_2-x_2 y_1)^2}.$$
+
+The process is long enough that one would rather not do it more than a few times in life.
+Why does it become so painful? Because <strong>we originally defined area inside the two-dimensional world</strong>. <strong>In three-dimensional space</strong>, the tilt of the plane and the relation between the two vectors lying on it get entangled, and the formula becomes bulky once <strong>angles</strong> have to be handled too.
+
+> <strong>Note</strong> (terms defined later)  
+> We use “angle” and “inner product” here, but at this stage the intuitive meanings from elementary school are enough. A formal definition of the inner product is given in Chapter 6, but it is not needed to follow the discussion here.
+
+Here we change viewpoint completely. <strong>We set aside the elementary-school definition of area for now</strong> and <strong>redesign from scratch an algebraic measuring device that outputs area.</strong>
+
+---
 
 ### §2.2 The Three Rules an Area-Measuring Device Must Satisfy
 
@@ -1295,8 +1603,8 @@ Now, if we look closely at the matrix $M$ of this area-measuring device, we see 
 
 $$
 \begin{pmatrix} 0 & 1 & 0 \\ -1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-= \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
-- \begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
+= \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix} -
+\begin{pmatrix} 0 & 0 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}
 $$
 
 The first term on the right-hand side is "the matrix whose only nonzero entry is row 1, column 2," and it represents the operation of extracting the $x$ component from $\mathbf{v}_1$ and the $y$ component from $\mathbf{v}_2$ and multiplying them ($x_1 y_2$).
@@ -1778,6 +2086,104 @@ The principle is the same at every degree. We begin with the case where a volume
 > <strong>Note</strong> (ground rules)  
 > We state this up front as a promise. Below, we treat curves and surfaces as sufficiently smooth, and cases where chopping into small pieces and adding converges in a straightforward way. Details such as orientation reversal and self-intersection are kept at the level of “they do not cause trouble in situations commonly used in physics.” A rigorous theory of integrability is outside the scope of this book.
 
+---
+
+### §3.1 Volume — Three Dimensions, Coefficient 1
+
+#### 3.1.1 From Rectangular Boxes to Curved Regions — Defining by Riemann Sums
+
+In Chapter 2 §2.5, we assembled the volume-measuring device $dx \wedge dy \wedge dz$. If we feed it three vectors $\mathbf{v}_1, \mathbf{v}_2, \mathbf{v}_3$, we get the signed volume of the parallelepiped they span.
+
+Now we want to measure the volume of a region $V$ in space. However curved $V$ may be, if we chop finely enough each small piece can be treated as almost a rectangular box. So we slice $V$ in the $x$, $y$, and $z$ directions, label the small boxes inside $V$ by an index $i$, and take the three edge vectors of the $i$th box to be
+
+$$\Delta x_i\,\hat{e}_x,\quad \Delta y_i\,\hat{e}_y,\quad \Delta z_i\,\hat{e}_z.$$
+
+Feed these three vectors to the volume-measuring device $dx \wedge dy \wedge dz$:
+
+$$(dx \wedge dy \wedge dz)(\Delta x_i\,\hat{e}_x,\; \Delta y_i\,\hat{e}_y,\; \Delta z_i\,\hat{e}_z) = \det\begin{pmatrix}\Delta x_i & 0 & 0 \\ 0 & \Delta y_i & 0 \\ 0 & 0 & \Delta z_i\end{pmatrix} = \Delta x_i\,\Delta y_i\,\Delta z_i.$$
+
+> <strong>Note</strong> (contraction of measuring device and figure)  
+> What happens here is exactly the pattern from Chapter 2 §2.5.10. A <strong>$3$-form (volume-measuring device)</strong> eats the <strong>volume element (figure)</strong> spanned by three displacement vectors and spits out a scalar. This contraction is performed on each small box. We call the oriented small box — the tiny volume figure — spanned by these three displacement vectors a <strong>volume element</strong>.
+
+Add the scalar $\Delta x_i\,\Delta y_i\,\Delta z_i$ from each small box over all boxes inside $V$:
+
+$$\sum_{\text{small box }i \subset V} \Delta x_i\,\Delta y_i\,\Delta z_i.$$
+
+Then take the limit as the mesh becomes infinitely fine. We <strong>write</strong> this limit as
+
+$$\iiint_V dx \wedge dy \wedge dz.$$
+
+This is the definition of integration of a $3$-form — a volume integral.
+
+> <strong>Note</strong> (the symbol $\iiint$)  
+> In this book we <strong>define $\iiint_V$ here for the first time</strong> as the symbol for “integration of a $3$-form over a three-dimensional region $V$.” It is not a symbol assumed from high-school volume integrals; it is the name we give to the Riemann-sum limit above.
+
+We have defined it. But how do we actually compute this sum? When $V$ is a curved region such as $x^2+y^2+z^2 \le R^2$, it is tedious to decide which small boxes lie inside $V$ while adding. If we organize the sum cleverly, however, the picture improves. In the next subsection we try it in practice.
+
+#### 3.1.2 Volume of a Sphere — Adding Messily and Straightforwardly
+
+Let us compute the volume of a sphere $x^2 + y^2 + z^2 \le R^2$ of radius $R$ in a truly messy, straightforward way. We want to show only one thing: without fleeing to a special coordinate system, we can reach the familiar $\frac{4}{3}\pi R^3$ simply by organizing the Riemann sum honestly in $x,y,z$. We use no special coordinates. In $x,y,z$ we simply stack small boxes $\Delta x\,\Delta y\,\Delta z$.
+
+View the sphere as the region determined by the value of
+
+$$F(x,y,z)=x^2+y^2+z^2.$$
+
+The interior is all points with $F\le R^2$; the boundary sphere is $F=R^2$.
+
+To read orientation on the boundary or displacement along the sphere, the total differential $dF$ from Chapter 1 is useful. At the stage of counting volume, however, we do not use $dF$ yet. Here we first unpack the condition $F\le R^2$ and count small boxes. The main actor for measuring volume remains $dx\wedge dy\wedge dz$.
+
+How can we organize the Riemann sum from §3.1.1 so that it can be computed? Fix $z$ at some value. Then $F\le R^2$ becomes
+
+$$x^2+y^2\le R^2-z^2.$$
+
+So at that height, the allowed $(x,y)$ form a disk of radius $\sqrt{R^2-z^2}$. Fixing $y$ as well gives
+
+$$x^2\le R^2-z^2-y^2,$$
+
+so $x$ runs from $-\sqrt{R^2 - z^2 - y^2}$ to $+\sqrt{R^2 - z^2 - y^2}$. Similarly, $y$ runs from $-\sqrt{R^2 - z^2}$ to $+\sqrt{R^2 - z^2}$, and $z$ from $-R$ to $+R$.
+
+This is simply unpacking the test $F\le R^2$ in the order $z$, $y$, $x$. If we add in this order — think of stacking the one-dimensional Riemann sums from Chapter 1 §1.1 three times — then in the limit:
+
+$$\iiint_V dx \wedge dy \wedge dz = \int_{-R}^{R} \Biggl( \int_{-\sqrt{R^2 - z^2}}^{\sqrt{R^2 - z^2}} \Biggl( \int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx \Biggr) dy \Biggr) dz.$$
+
+The $dx, dy, dz$ on the right appear as the result of organizing the sum on the left in order; we are not omitting $\wedge$. From inside the parentheses outward: sum over $x$ ($\int dx$), then over $y$ ($\int dy$), then over $z$ ($\int dz$).
+
+The innermost sum over $x$ (the $x$ integral in the limit) is immediate:
+
+$$\int_{-\sqrt{R^2 - z^2 - y^2}}^{\sqrt{R^2 - z^2 - y^2}} dx = 2\sqrt{R^2 - z^2 - y^2}.$$
+
+Next the $y$ integral. Set $a = \sqrt{R^2 - z^2}$:
+
+$$\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy.$$
+
+Use substitution from high-school calculus. With $y = a\sin t$, we have $dy = a\cos t\,dt$. As $y$ goes from $-a$ to $a$, $t$ goes from $-\pi/2$ to $\pi/2$. Also $\sqrt{a^2 - y^2} = \sqrt{a^2 - a^2\sin^2 t} = a\cos t$ (for $t \in [-\pi/2,\pi/2]$ we have $\cos t \ge 0$, so the absolute value drops). Therefore:
+
+$$\begin{aligned}
+\int_{-a}^{a} 2\sqrt{a^2 - y^2}\,dy
+&= \int_{-\pi/2}^{\pi/2} 2\cdot a\cos t \cdot a\cos t\,dt \\
+&= 2a^2\!\int_{-\pi/2}^{\pi/2} \cos^2 t\,dt
+\end{aligned}$$
+
+Since $\cos^2 t = (1 + \cos 2t)/2$:
+
+$$\begin{aligned}
+2a^2\!\int_{-\pi/2}^{\pi/2} \frac{1 + \cos 2t}{2}\,dt
+&= a^2\int_{-\pi/2}^{\pi/2} (1 + \cos 2t)\,dt \\[4pt]
+&= a^2\Bigl[t + \frac{\sin 2t}{2}\Bigr]_{-\pi/2}^{\pi/2} \\[4pt]
+&= a^2\Bigl[\Bigl(\frac{\pi}{2} + 0\Bigr) - \Bigl(-\frac{\pi}{2} + 0\Bigr)\Bigr] \\[4pt]
+&= \pi a^2 = \pi(R^2 - z^2)
+\end{aligned}$$
+
+Finally the $z$ integral:
+
+$$\int_{-R}^{R} \pi(R^2 - z^2)\,dz = 2\pi\Bigl[R^2 z - \frac{z^3}{3}\Bigr]_{0}^{R} = 2\pi\cdot\frac{2R^3}{3} = \frac{4}{3}\pi R^3.$$
+
+> <strong>Note</strong> (what this calculation means)  
+> What we did here is only the organization of the Riemann sum from §3.1.1. Instead of deciding which small boxes lie inside the sphere one by one, we organized the actual summation from the inside out in the order $x \to y \to z$. Each stage is a one-variable Riemann sum from Chapter 1; in the limit it becomes a familiar one-variable integral. That is all. If we aggregate the contraction of measuring device and figure honestly, we reach $\frac{4}{3}\pi R^3$.
+
+Thus we have confirmed that the integral of the single measuring device $dx \wedge dy \wedge dz$ gives the correct volume $\frac{4}{3}\pi R^3$ of a curved region. In three dimensions, a volume-measuring device with coefficient $1$ measures volume directly.
+
+---
 
 > <strong>Checkpoint so far</strong>
 > - The integral of $dx \wedge dy \wedge dz$ is the limit of a Riemann sum that chops a region into small boxes and adds the values obtained by feeding each volume element to the volume-measuring device. $\iiint_V$ is the symbol this book gives to that limit.
@@ -2489,6 +2895,240 @@ $$W = \int F\,dx = \int_{\gamma} F\,dx = \int_{t_0}^{t_1} \gamma^*(F\,dx) = \int
 
 > <strong>Note</strong> ($dx$ is a row vector, $dt$ is too) In the calculations of §4.1, $dx$, $dt$, and $dv$ all keep the same type: "eat displacement and return a scalar." The principle "row vector × column vector → scalar" from Chapter 1 §1.1.3 does not break even in the middle of a pullback. The result $\gamma^*(F\,dx)$ is again a $1$-form (row vector) on the time axis; feeding it the time-side displacement $\Delta t$ yields a scalar (a piece of work)—this consistency is what supports understanding of the pullback.
 
+---
+
+### §4.2 Pullback of a 2-Form — Conservation of Angular Momentum and Areal Velocity
+
+<strong>① Start from a physical quantity.</strong> In §4.1 we mapped a one-dimensional finite interval and measured its image. This time we apply the same idea to a two-dimensional finite grid.
+
+> <strong>Note</strong> (for readers without a physics background) The words “conservation of angular momentum” and “Kepler’s second law” appear below, but what this section really uses is the fact that “area on a plane can be remeasured in different variables.” The physical meaning can be read afterward.
+
+Consider a particle moving in a central force field. When the force always points toward the origin, the angular momentum
+
+$$
+L
+=
+m\left(x(t)y'(t)-y(t)x'(t)\right)
+$$
+
+is constant in time (the law of conservation of angular momentum). This conservation law has a beautiful geometric meaning—the rate at which the position vector of the particle sweeps out area (<strong>areal velocity</strong>) is constant (Kepler’s second law).
+
+We may assume the motion takes place in the plane $z=0$. The area of the sector $D$ swept out by the position vector from time $t_0$ to $t_1$ is
+
+$$A = \iint_D dx \wedge dy$$
+
+Here $dx \wedge dy$ is the area-measuring device ($2$-form) on the $xy$ plane.
+
+> <strong>Note</strong> (For physicists who work in two dimensions) Let us confirm this point. This book consistently assumes the reality of three-dimensional space. Setting $z=0$ in the angular-momentum discussion below is a temporary simplification to make the calculation easier to read; we are still looking at one plane inside three-dimensional space.
+
+<strong>② Naive substitution—it does not match as written.</strong> The sector on the right-hand side is awkward to write in $(x,y)$. So we want to write it in $(r,\theta)$. But what happens if we replace $dx \wedge dy$ directly by $dr \wedge d\theta$? Let us compute the area of a full circle of radius $C$. The correct value is $\pi C^2$. Yet with naive substitution:
+
+$$
+A_{\text{naive}}
+=
+\iint dr \wedge d\theta
+=
+\int_0^{2\pi}
+\biggl(
+  \int_0^C dr
+\biggr)
+d\theta
+=
+2\pi C
+$$
+
+This is completely different from $\pi C^2$. With $dr \wedge d\theta$ alone, the correct area does not come out.
+
+<strong>③ See the cause on a finite grid.</strong> This time, let us ask what measuring device should eat a finite cell on the $(r,\theta)$ side so that we get the same area value as on the $xy$ side.
+
+Cut a grid of finite size $\Delta r \times \Delta\theta$ in $(r,\theta)$ space. Find the two displacement vectors that one cell at coordinates $(r, \theta)$ produces in $(x,y)$ space.
+
+Edge in the $\Delta r$ direction: only $r$ changes while $\theta$ is fixed, so the difference is exact:
+
+$$\Delta x_r = \Delta r \cos\theta,\qquad \Delta y_r = \Delta r \sin\theta$$
+
+Edge in the $\Delta\theta$ direction: use the difference formulas for trigonometric functions:
+
+$$\begin{aligned}
+\Delta x_\theta &= r\bigl(\cos(\theta+\Delta\theta) - \cos\theta\bigr)
+= -2r\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr) \\[4pt]
+\Delta y_\theta &= r\bigl(\sin(\theta+\Delta\theta) - \sin\theta\bigr)
+= 2r\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr)\sin\biggl(\frac{\Delta\theta}{2}\biggr)
+\end{aligned}$$
+
+Find the area of the parallelogram spanned by the two edges $\mathbf{v}_r = (\Delta x_r, \Delta y_r)$ and $\mathbf{v}_\theta = (\Delta x_\theta, \Delta y_\theta)$ by a determinant:
+
+$$\begin{aligned}
+\det(\mathbf{v}_r,\mathbf{v}_\theta) &= \Delta x_r\,\Delta y_\theta - \Delta x_\theta\,\Delta y_r \\
+&= 2r\Delta r\,\sin\biggl(\frac{\Delta\theta}{2}\biggr)\biggl[ \cos\theta\cos\biggl(\theta+\frac{\Delta\theta}{2}\biggr) + \sin\theta\sin\biggl(\theta+\frac{\Delta\theta}{2}\biggr) \biggr] \\
+&= r\Delta r\,\sin\Delta\theta
+\end{aligned}$$
+
+The result is
+
+$$\det = r\Delta r\,\sin\Delta\theta$$
+
+Divide this measured value by the cell width $\Delta r_i\,\Delta\theta_j$ on the $(r,\theta)$ side, and we obtain the coefficient of the provisional measuring device used on a finite cell. That is,
+
+$$
+\Phi_h^\square(dx\wedge dy)
+:=
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+$$
+
+Feed this measuring device to a finite cell, and
+
+$$
+\begin{aligned}
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+&=
+\left(
+r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}\,dr\wedge d\theta
+\right)(\Delta r_i,\Delta\theta_j) \\
+&=
+r_i\,\Delta r_i\,\sin\Delta\theta_j
+\end{aligned}
+$$
+
+The right-hand side is the signed area of the parallelogram spanned by the two finite-difference vectors.
+
+Let $A_h^\square$ denote the total area sum in the finite-cell version. Therefore
+
+$$
+A_h^\square
+:=
+\sum_i\sum_j
+\Phi_h^\square(dx\wedge dy)(\Delta r_i,\Delta\theta_j)
+=
+\sum_i\sum_j r_i\,\Delta r_i\,\sin\Delta\theta_j
+$$
+
+$\sin\Delta\theta_j$ is an exact value for finite $\Delta\theta_j$. What we measure here is not the curved sector area of the polar-coordinate finite grid itself, but the signed area of the parallelogram spanned by two finite-difference vectors. Write the sector swept out by the position vector in physical space as $D$. On the other hand, write the $(r,\theta)$ range corresponding to that region in polar coordinates as $D'$.
+
+In the final stage of taking the limit of the sum,
+
+$$
+\frac{\sin\Delta\theta_j}{\Delta\theta_j}\to 1
+$$
+
+Therefore the true area $A$ is obtained as
+
+$$
+A
+=
+\lim_{h\to0} A_h^\square
+=
+\iint_{D'} r\,dr\wedge d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+The coefficient of the measuring device on a finite cell is $r_i\frac{\sin\Delta\theta_j}{\Delta\theta_j}$. As the partition is refined, this coefficient approaches $r$. Thus, in the limit, we obtain
+
+$$
+\Phi_h^\square(dx\wedge dy)
+\xrightarrow{h\to0}
+\Phi^*(dx\wedge dy)
+=
+r\,dr\wedge d\theta
+$$
+
+> <strong>Note</strong> ($\Delta r,\Delta\theta$ need not be infinitesimal) In the computation of the difference vectors so far, we have used no assumption that $\Delta r$ or $\Delta\theta$ is “sufficiently small.” The $\Delta x_r, \Delta y_r, \Delta x_\theta, \Delta y_\theta$ found above are formulas that hold exactly no matter how large $\Delta r,\Delta\theta$ may be. By “exact” here we mean that we measure the parallelogram spanned by finite-difference vectors. The passage to infinitesimals is made only in the final stage—the limit of the sum—when we move to $\Phi^*$ and integration.
+
+<strong>④ Write the standard form obtained in the limit.</strong> For the transformation to polar coordinates $\Phi(r,\theta) = (r\cos\theta,\; r\sin\theta)$:
+
+$$\Phi^*(dx \wedge dy) = r\,dr \wedge d\theta$$
+
+This is the $2$-form rebuilt in the limit from the finite-cell version $\Phi_h^\square$. We denote that limiting rebuild by $\Phi^*$. This $r$ plays the same role for $2$-forms that the velocity $\gamma'(t)$ played for $1$-forms in §4.1.
+
+<strong>⑤ Pullback of a coefficient-carrying $2$-form.</strong> For a $2$-form $G(x,y)\,dx \wedge dy$ with an arbitrary coefficient $G(x,y)$, the same structure holds:
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(r\cos\theta,\, r\sin\theta)\; r\,dr \wedge d\theta$$
+
+The coefficient $G$ is merely rebuilt in polar coordinates (pullback of a $0$-form), while only the $dx \wedge dy$ part changes to $r\,dr \wedge d\theta$. The pullback $\Phi^*$ naturally splits into “rebuilding the coefficient” and “rebuilding the measuring device.”
+
+<strong>⑥ Carry the same discovery to a general transformation.</strong> Nothing here is special to polar coordinates. Consider a transformation between planes $\Phi(u,v)=(x(u,v),y(u,v))$, and map a finite rectangle on the $(u,v)$ side. Measure the two difference vectors in the $u$ and $v$ directions with $dx\wedge dy$, and we get an area value for each finite rectangle.
+
+Divide that area value by $\Delta u\,\Delta v$, and refine the partition. Then the difference ratios converge to partial derivatives, and a $2\times2$ determinant appears. Therefore, after $h\to0$, the rebuilding is
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr) = G(x(u,v), y(u,v))\;
+\det\!\begin{pmatrix}
+\frac{\partial x}{\partial u} & \frac{\partial x}{\partial v} \\[6pt]
+\frac{\partial y}{\partial u} & \frac{\partial y}{\partial v}
+\end{pmatrix}
+\,du \wedge dv$$
+
+That is,
+
+$$\Phi^*\bigl(G(x,y)\,dx \wedge dy\bigr)
+=G(\Phi(u,v))\left(
+\frac{\partial x}{\partial u}\frac{\partial y}{\partial v}
+-\frac{\partial x}{\partial v}\frac{\partial y}{\partial u}
+\right)\,du\wedge dv$$
+
+The $2\times2$ determinant that appears here is the consistency factor for rebuilding the physical-space area-measuring device $dx\wedge dy$ into a measuring device $du\wedge dv$ usable on the $(u,v)$ side.
+
+What we saw on the finite grid,
+
+$$\Delta x_u\,\Delta y_v-\Delta x_v\,\Delta y_u$$
+
+is the finite-cell version for discovering this partial-derivative determinant. It is an equality for the parallelogram spanned by finite-difference vectors. In the limiting rebuild written as $\Phi^*$, these finite ratios are replaced by partial-derivative coefficients. The coefficient obtained by dividing the measured value on a finite cell by $\Delta u\,\Delta v$ converges to the $2\times2$ determinant above as the partition width $h$ is taken toward $0$.
+
+<strong>⑦ Return to the physical quantity.</strong> Integrate the area of the sector $D$ over the corresponding polar-coordinate region $D'$ using the pulled-back measuring device:
+
+$$
+A
+=
+\iint_D dx\wedge dy
+=
+\iint_{D'} \Phi^*(dx\wedge dy)
+=
+\iint_{D'} r\,dr\wedge d\theta
+$$
+
+$$
+=
+\int_{\theta_0}^{\theta_1}
+\biggl(
+  \int_0^{R(\theta)} r\,dr
+\biggr)
+d\theta
+=
+\int_{\theta_0}^{\theta_1}
+\frac{1}{2}R(\theta)^2\,d\theta
+$$
+
+Integrating in $r$, $\frac{1}{2}r^2$ appears, and the area is reduced to a line integral of a $1$-form along the $\theta$ axis. Pull back further to the time parameter $t$. If the particle’s orbit is $r = R(t),\, \theta = \Theta(t)$, then
+
+$$
+\frac{dA}{dt}
+=
+\frac{1}{2}r(t)^2\,\theta'(t)
+$$
+
+From the definition of angular momentum
+
+$$
+L
+=
+m r(t)^2\theta'(t)
+$$
+
+the areal velocity is
+
+$$\frac{dA}{dt} = \frac{L}{2m}$$
+
+In a central force field, $L$ is conserved, so the areal velocity is also constant—this is Kepler’s second law, the geometric expression of the law of conservation of angular momentum. This is exactly the same structure as in §4.1: there, the consistency factor $\gamma'(t)$ for a $1$-form described energy conservation; here, the consistency factor $r$ for a $2$-form describes conservation of angular momentum.
+
+
+---
 
 ### §4.3 Pullback of a 3-Form — Conservation of Mass and Volume Integrals
 
@@ -2834,6 +3474,65 @@ The subject of this chapter—the <strong>exterior derivative $d$</strong>—ans
 
 The structure of this chapter is as follows. First we recall the $df$ introduced in Chapter 1 and build $d\omega$ from the mismatch that remains when a general $1$-form is measured on a closed loop. Next we extend the same idea to $2$-forms and unify Stokes' theorem and Gauss' theorem into a single form. Finally we look at the structure $d^2=0$ and at how the exterior derivative localizes physical laws, connecting to the Hodge star in the next chapter.
 
+---
+
+### §5.1 Revisiting $df$ — Are Differentiation and Integration Inverse Operations?
+
+#### 5.1.1 $df$ Is "Raising the Degree"
+
+In Chapter 1 §1.2 we defined the total differential of a function $f(x,y,z)$ as a row vector:
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+This is an operation that takes a <strong>$0$-form (the scalar field $f$) as input and outputs a $1$-form (the row vector $df$)</strong>. The degree rises from 0 to 1.
+
+Recall here that $df(\mathbf{v})$ returns the first-order change in $f$ for a displacement $\mathbf{v}$. When $\mathbf{v} = \begin{pmatrix}\Delta x\\\Delta y\\\Delta z\end{pmatrix}$ is sufficiently small:
+
+$$df(\mathbf{v}) = \frac{\partial f}{\partial x}\,\Delta x + \frac{\partial f}{\partial y}\,\Delta y + \frac{\partial f}{\partial z}\,\Delta z \approx f(\mathbf{r}+\mathbf{v}) - f(\mathbf{r})$$
+
+$df$ by itself is not "the change itself"—as agreed in Chapter 1 §1.1.6, $df$ is an operator; a numerical value is obtained only when it acts on a displacement vector.
+
+#### 5.1.2 A Line Integral Leaves Only the Difference of Endpoints
+
+Integrate this $df$ along a curve $\gamma$. As in Chapter 3 §3.3.1, partition the curve into small intervals, feed $df$ each step's displacement $\Delta\mathbf{r}_i$, and add up the results.
+
+To first order on each interval, $df(\Delta\mathbf{r}_i) \approx f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})$, so the sum over all intervals is:
+
+$$\sum_{i=1}^n df(\Delta\mathbf{r}_i) \approx \sum_{i=1}^n \bigl(f(\mathbf{r}_i) - f(\mathbf{r}_{i-1})\bigr)$$
+
+Expanding this sum:
+
+$$\bigl(f(\mathbf{r}_1)-f(\mathbf{r}_0)\bigr) + \bigl(f(\mathbf{r}_2)-f(\mathbf{r}_1)\bigr) + \cdots + \bigl(f(\mathbf{r}_n)-f(\mathbf{r}_{n-1})\bigr)$$
+
+Adjacent terms $f(\mathbf{r}_1), f(\mathbf{r}_2), \dots, f(\mathbf{r}_{n-1})$ cancel in plus and minus—a <strong>telescoping sum</strong>. Only the first and last survive. In the limit of infinitely fine partition:
+
+$$\int_\gamma df = f(\mathbf{r}_n) - f(\mathbf{r}_0) = f(B) - f(A)$$
+
+where $A$ is the starting point of the curve and $B$ is the endpoint.
+
+> <strong>Checkpoint so far</strong>
+> - $\int_\gamma df = f(B) - f(A)$. The result of the integral depends entirely on the endpoint values, not at all on the shape of the path.
+> - This holds precisely because $df$ is a special $1$-form. In mechanics, it is the mathematical reason why "the work of a conservative force does not depend on the path."
+
+#### 5.1.3 Checking with a Chapter 3 Example
+
+In Chapter 3 §3.4.1 we integrated $\omega = y\,dx + x\,dy$ along the unit circle $\gamma(t) = (\cos t,\; \sin t,\; 0),\; t \in [0,2\pi]$ and found the result to be $0$. At the time we integrated straightforwardly along the coefficients, but viewed in today's language the story is much simpler.
+
+In fact $y\,dx + x\,dy$ is nothing other than $d(xy)$. For:
+
+$$d(xy) = \frac{\partial (xy)}{\partial x}\,dx + \frac{\partial (xy)}{\partial y}\,dy + \frac{\partial (xy)}{\partial z}\,dz = y\,dx + x\,dy$$
+
+Therefore $\omega = df$ (with $f = xy$), and the telescoping-sum argument of §5.1.2 applies as-is. The unit circle is a closed curve, so $B = A$, and hence:
+
+$$\oint_\gamma \omega = \oint_\gamma d(xy) = xy(\gamma(2\pi))-xy(\gamma(0))=0$$
+
+The calculation $\int_0^{2\pi} \cos 2t\,dt = 0$ from back then mechanically gave zero precisely because $\omega$ was an <strong>exact form</strong>, namely $d(xy)$.
+
+> <strong>Note</strong> (exact forms) A $1$-form that can be written as $\omega = df$ is called an <strong>exact form</strong>. Integrating an exact form along a closed curve always gives zero, as long as $f$ is a single-valued function. On the other hand, beware: "the integral along some closed curve was zero" does not necessarily mean the form is exact (whether the integral is zero on all closed curves also depends on the topology of the region). We examine this point in detail in §5.2.
+
+> <strong>Note</strong> (the relation between $d$ and $\int$—a boundary formula, not an inverse map) $\int_\gamma df = f(B)-f(A)$ does not mean that integration is a global inverse of the exterior derivative $d$. Integration is a functional that depends on the choice of curve $\gamma$; it is not an operation that reconstructs the entire original function $f$ from $df$. This formula is the fundamental theorem of calculus: "integrating an exact form along a curve leaves only the boundary, namely the endpoints." It is safest to think of it as the $0$-form version of the Stokes-type formulas we will see later.
+
+---
 
 ### §5.2 The "Mismatch" Revealed by a Closed Loop
 
@@ -3828,6 +4527,151 @@ The conclusion: <strong>they are completely different things</strong>. Row vecto
 
 Yes—the matter is deeper than the reader may have thought. On the special stage of real space, these two often happen to return the same number, which has encouraged their confusion—and on top of that confusion a vast edifice called vector analysis has been built. The goal of this chapter is to make this distinction clear, then introduce the metric $g$ as the natural generalization of the inner product, and from there expose what the Hodge star $\ast$ really is.
 
+---
+
+### §6.1 The Inner Product on Parameter Space — The True Nature of the Metric $g$
+
+#### 6.1.1 Inner Product in Real Space
+
+Write two column vectors in real space $(x,y,z)$ in components:
+
+$$\mathbf{v}_1 = \begin{pmatrix} x_1 \\ y_1 \\ z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}$$
+
+In this book, the <strong>inner product</strong> (dot product), denoted by $\cdot$, is the operation of multiplying components with the same index and adding the results.
+
+$$\mathbf{v}_1 \cdot \mathbf{v}_2 = x_1 x_2 + y_1 y_2 + z_1 z_2$$
+
+In $xyz$ coordinates, the inner product is computed simply by multiplying corresponding components and adding.
+
+#### 6.1.2 Rereading the Inner Product as a Measuring Device
+
+Here let us reread the same calculation in the language of “measuring devices.” At first glance the inner product looks like an operation of a different lineage from the measuring devices we have handled until now. In fact, however, the inner product can also be read as an operation that “turns something into a measuring device, acts on something else, and yields a scalar.”
+
+The entry point is the transpose. Transposing $\mathbf{v}_1$ turns a column vector into a row vector:
+
+$$\mathbf{v}_1^T = \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}$$
+
+This is a measuring device that eats the paired column vector $\mathbf{v}_2$ and measures “how large is the inner product with $\mathbf{v}_1$?”
+
+$$\mathbf{v}_1^T\mathbf{v}_2
+= \begin{pmatrix} x_1 & y_1 & z_1 \end{pmatrix}
+\begin{pmatrix} x_2 \\ y_2 \\ z_2 \end{pmatrix}
+= x_1x_2 + y_1y_2 + z_1z_2$$
+
+That is, in orthogonal Cartesian coordinates on real space, transposing a column vector $\mathbf{v}_1$ alone yields the row vector—a measuring device—for taking the inner product with that vector.
+
+> <strong>Note</strong> (What raising and lowering indices really are) In tensor analysis there is a convention of distinguishing vector components from measuring-device components by upper and lower indices. One is then told that the metric $g$ is used to raise and lower indices. In the language of this book, the true nature of that is the operation “convert a column vector into a row vector that measures the inner product.” In orthogonal Cartesian coordinates $g=I$, so transpose alone suffices; but in parameter space, as we shall see next, we must insert $\mathbf{g}=J^T J$ along the way.
+
+#### 6.1.3 Taking the Inner Product in Parameter Space
+
+What happens if we carry out the same rereading in parameter space $(r,\theta,z)$?
+
+In orthogonal Cartesian coordinates on real space, $\mathbf{v}_1^T$ was directly the “measuring device for the inner product with $\mathbf{v}_1$.” So in parameter space too we are tempted to use $\mathbf{v}_1^T$ as the measuring device as-is. But that only computes $\Delta r_1 \Delta r_2 + \Delta\theta_1 \Delta\theta_2 + \Delta z_1 \Delta z_2$, which is not the correct inner product in real space. The correspondence between increments in parameter space and displacements in real space varies from place to place.
+
+What, then, must we insert to turn a column vector in parameter space into a row vector that correctly measures the inner product in real space?
+
+In Chapter 4 we saw how the Jacobian matrix of a coordinate change transforms components. Here we use that same matrix $J$ to read a displacement in parameter space as a displacement in real space.
+
+$$J = \begin{pmatrix}
+\frac{\partial x}{\partial r} & \frac{\partial x}{\partial \theta} & \frac{\partial x}{\partial z} \\
+\frac{\partial y}{\partial r} & \frac{\partial y}{\partial \theta} & \frac{\partial y}{\partial z} \\
+\frac{\partial z}{\partial r} & \frac{\partial z}{\partial \theta} & \frac{\partial z}{\partial z}
+\end{pmatrix}$$
+
+From the cylindrical-coordinate formulas $x = r\cos\theta,\; y = r\sin\theta,\; z = z$, computing partial derivatives gives:
+
+$$J = \begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+Write the vectors $\mathbf{v}_1, \mathbf{v}_2$ in parameter space in components:
+
+$$\mathbf{v}_1 = \begin{pmatrix} \Delta r_1 \\ \Delta\theta_1 \\ \Delta z_1 \end{pmatrix},\qquad \mathbf{v}_2 = \begin{pmatrix} \Delta r_2 \\ \Delta\theta_2 \\ \Delta z_2 \end{pmatrix}$$
+
+Read in real space, these become $J\mathbf{v}_1$ and $J\mathbf{v}_2$ respectively. By the reading of the previous subsection, the measuring device for “the inner product with $J\mathbf{v}_1$” in real space is $(J\mathbf{v}_1)^T$. Therefore the inner product we want can be written as
+
+$$\text{inner product} = (J\mathbf{v}_1)^T (J\mathbf{v}_2)$$
+
+Using the rule for transposes, $(J\mathbf{v}_1)^T = \mathbf{v}_1^T J^T$, so
+
+$$= \mathbf{v}_1^T (J^T J) \mathbf{v}_2$$
+
+Let us actually compute $J^T J$. $J^T$ is $J$ with rows and columns swapped:
+
+$$J^T = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+Therefore,
+
+$$J^T J = \begin{pmatrix}
+\cos\theta & \sin\theta & 0 \\
+-r\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix}
+\cos\theta & -r\sin\theta & 0 \\
+\sin\theta & r\cos\theta & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+1 & 0 & 0 \\
+0 & r^2 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+The algebraic identity $\cos^2\theta + \sin^2\theta = 1$ does all the geometry’s work, leaving $1, r^2, 1$ on the diagonal. We never once thought about arc length in the $\theta$ direction—it is a purely algebraic manipulation using only matrix product and transpose properties.
+
+<strong>Thus a new measuring device appears.</strong> To build from a column vector $\mathbf{v}_1$ in parameter space a row vector that correctly measures the inner product in real space, we must multiply on the right by $J^T J$, not merely transpose:
+
+$$\omega_{\mathbf{v}_1} = \mathbf{v}_1^T (J^T J)$$
+
+Acting this measuring device on $\mathbf{v}_2$ yields the same value as the inner product in real space.
+
+We call this $J^T J$ the <strong>metric matrix $\mathbf{g}$</strong>:
+
+$$\mathbf{g} = J^T J$$
+
+In $xyz$ coordinates we computed the inner product from the sum of products of components alone, never going through pullback. In parameter space we first read displacements in real space via $J$, then take the sum of products of components. Folding these two stages into matrix form puts $\mathbf{g}=J^T J$ in the middle—and its contents are found mechanically from partial derivatives and matrix products alone, as long as we know the Jacobian matrix $J$. No room remains anywhere for new axioms of geometry.
+
+For safety, let us check with concrete numbers. Consider the point $r=2,\; \theta=\pi/3$. Then $\cos\theta = 1/2,\; \sin\theta = \sqrt{3}/2$, so
+
+$$J = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}$$
+
+In parameter space consider the unit displacement $\mathbf{v} = \begin{pmatrix}0 \\ 1 \\ 0\end{pmatrix}$ in the $\theta$ direction. We have $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & 1 \end{pmatrix}$, and since $r=2$ now, $\mathbf{g} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}$. Computing the inner product (square of length) in parameter space:
+
+$$\mathbf{v}^T \mathbf{g} \,\mathbf{v} = \begin{pmatrix} 0 & 1 & 0 \end{pmatrix}
+\begin{pmatrix} 1 & 0 & 0 \\ 0 & 4 & 0 \\ 0 & 0 & 1 \end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = 4$$
+
+On the other hand, reading the same $\mathbf{v}$ as a displacement in real space:
+
+$$J\mathbf{v} = \begin{pmatrix}
+1/2 & -\sqrt{3} & 0 \\
+\sqrt{3}/2 & 1 & 0 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix} 0 \\ 1 \\ 0 \end{pmatrix} = \begin{pmatrix} -\sqrt{3} \\ 1 \\ 0 \end{pmatrix}$$
+
+The inner product (square of length) in real space is $(-\sqrt{3})^2 + 1^2 + 0^2 = 4$. They indeed agree. For $\mathbf{v} = \begin{pmatrix}1 \\ 0 \\ 0\end{pmatrix}$ (unit displacement in the $r$ direction) likewise, $\mathbf{v}^T \mathbf{g} \,\mathbf{v} = 1$ and $(J\mathbf{v})^T (J\mathbf{v}) = \cos^2\theta + \sin^2\theta = 1$ agree. In this way $\mathbf{g} = J^T J$ ties the inner products in parameter space and real space without contradiction.
+
+We computed here in cylindrical coordinates $(r,\theta,z)$, but for spherical coordinates $(r,\theta,\phi)$ likewise $\mathbf{g}$ is obtained from $J$, with $\theta$ taken as the polar angle:
+
+$$\mathbf{g}_{\text{spherical}} = \begin{pmatrix} 1 & 0 & 0 \\ 0 & r^2 & 0 \\ 0 & 0 & r^2\sin^2\theta \end{pmatrix}$$
+
+The factors $r^2$ and $r^2\sin^2\theta$ on the diagonal are likewise conversion factors derived mechanically from $J$, which lines up the linear coefficients of the coordinate change.
+
+With $g$ as mediator, we can compute inner products (lengths and angles) consistently in any coordinate system. Moreover, the action of the Hodge star $\ast$, treated later, can be read naturally from these rules of inner product.
+
+---
 
 ### §6.2 Converting Between Column Vectors and Row Vectors Using $g$
 
@@ -4849,7 +5693,7 @@ In the end, what we saw here is the same as in D.1–D.3. In $\ast_{1\to2}$ we d
 
 ### §7.0 Enter Nabla
 
-The title of this book is *Unmasking Nabla*—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
+The title of this book is *Unmasking Div, Grad, and Curl* (or *Unmasking Nabla*, as the Japanese title suggests)—yet up to this point we have never once defined nabla $\nabla$ head-on, at least officially. In Chapter 6 we got a preview of the shapes of grad, curl, and div by combining $d$ and $\ast$. In this chapter we rewrite the same objects in the standard notation of vector analysis.
 
 What have we been doing instead? We have piled up the backstage tools: $dx$ as a row vector, $2$-forms as antisymmetric matrices, $d$ as the operation that raises degree—and so on. Some readers have surely been wondering, “When is $\nabla$ finally going to show up?”
 
@@ -4861,6 +5705,86 @@ In this chapter we finally define $\nabla$. Then we unfold standard vector analy
 
 The tools used in this chapter are only those we have already assembled—column vectors, row vectors, matrices, inner products, the Jacobian matrix, and partial derivatives.
 
+---
+
+### §7.1 Dot Products and Cross Products
+
+#### 7.1.1 Dot Product
+
+For two column vectors
+
+$$
+\mathbf{a}
+=
+\begin{pmatrix}
+a_x\\
+a_y\\
+a_z
+\end{pmatrix},
+\qquad
+\mathbf{b}
+=
+\begin{pmatrix}
+b_x\\
+b_y\\
+b_z
+\end{pmatrix}
+$$
+
+we define the <strong>dot product</strong> (inner product) by
+
+$$\mathbf{a} \cdot \mathbf{b} = a_x b_x + a_y b_y + a_z b_z$$
+
+As we saw in §6.1, in real space $(x,y,z)$ this can be written as $\mathbf{a}^T \mathbf{b}$. In Cartesian coordinates the same numerical computation can be written as the row-column product $\mathbf a^T\mathbf b$; conceptually, however, it is the inner product introduced in Chapter 6.
+
+#### 7.1.2 Cross Product
+
+For two column vectors $\mathbf{a}, \mathbf{b}$, we define the <strong>cross product</strong> by
+
+$$\mathbf{a} \times \mathbf{b} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+The result is again a column vector. The arrangement of cross-product components follows a regular pattern, and it can be written compactly using the following antisymmetric matrix:
+
+$$\mathbf{a} \times = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}$$
+
+Multiplying this $3\times 3$ matrix on the left by the vector $\mathbf{b}$ gives
+
+$$\mathbf{a} \times \mathbf{b} = (\mathbf{a} \times)\,\mathbf{b} = \begin{pmatrix}
+0 & -a_z & a_y \\
+a_z & 0 & -a_x \\
+-a_y & a_x & 0
+\end{pmatrix}\begin{pmatrix}
+b_x \\ b_y \\ b_z
+\end{pmatrix} = \begin{pmatrix}
+a_y b_z - a_z b_y \\
+a_z b_x - a_x b_z \\
+a_x b_y - a_y b_x
+\end{pmatrix}$$
+
+We call this $(\mathbf{a} \times)$ the <strong>cross-product matrix</strong> of $\mathbf{a}$. It appeared in Chapter 2 as the matrix representation of a $2$-form, and in Appendix D of Chapter 6 it reappeared as the array form of the Hodge star—exactly the same shape. In this chapter we use it purely as the operation “multiply a vector by a vector and obtain a vector.”
+
+The cross product has the following basic properties:
+
+1. <strong>Anticommutativity</strong>: $\mathbf{a} \times \mathbf{b} = -\,\mathbf{b} \times \mathbf{a}$
+2. <strong>Cross product with itself is zero</strong>: $\mathbf{a} \times \mathbf{a} = \mathbf{0}$
+3. <strong>Orthogonality</strong>: $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{a} = 0$, $(\mathbf{a} \times \mathbf{b}) \cdot \mathbf{b} = 0$
+
+Property 3 means that the cross product produces a vector orthogonal to both $\mathbf{a}$ and $\mathbf{b}$. That is the real content of the so-called “right-hand rule.”
+
+> <strong>Checkpoint — §7.1</strong>
+> - Dot product: $\mathbf{a}\cdot\mathbf{b} = a_x b_x + a_y b_y + a_z b_z$. In real space, transposing the column vector $\mathbf{a}$ gives $\mathbf{a}^T \mathbf{b}$.
+> - Cross product: $\mathbf{a}\times\mathbf{b}$ can be written as $(\mathbf{a}\times)\,\mathbf{b}$ using the cross-product matrix $(\mathbf{a}\times)$.
+> - The cross product is anticommutative, vanishes with itself, and its result is orthogonal to both input vectors.
+
+---
 
 ### §7.2 $\nabla$ and the Gradient
 
@@ -5257,6 +6181,71 @@ From here on, there is no holding back. $d$, $\ast$, and $\nabla$—all the tool
 
 This chapter is the <strong>highlight</strong> of the book. The central translation itself is surprisingly short. At the end, however, to move on to the practical chapter that follows, we will take a single look at how this dictionary behaves in curvilinear coordinates. The painstaking preparation from Chapters 1 through 7—matrices, wedge products, the exterior derivative, the metric, the Hodge star, and vector analysis—was all for that purpose. Because all these tools are now assembled, in this chapter we need only “translate,” and two worlds fit into one picture. We have acquired two languages—the differential of measuring devices ($d$) and the differential of fields ($\nabla$). These two do fundamentally different things. Yet when they are linked through integration, they give exactly the same results. We will now dig thoroughly into how that works.
 
+---
+
+### §8.1 Two Differentials, Two Worlds
+
+#### 8.1.1 Differentiating measuring devices—the standpoint of $d$
+
+Since Chapter 1 we have treated $dx = \begin{pmatrix}1&0&0\end{pmatrix}$, $dy = \begin{pmatrix}0&1&0\end{pmatrix}$, $dz = \begin{pmatrix}0&0&1\end{pmatrix}$ as row-vector measuring devices. When you feed them a column vector (a displacement), they return the displacement in that direction as a scalar.
+
+The exterior derivative $d$ is the operation that differentiates the coefficients and produces the next measuring device.
+
+When $f(x,y,z)$ is a scalar field, $df$ is a new measuring device that measures changes in $f$. It becomes a row vector whose components are the partial derivatives.
+
+$$df = \frac{\partial f}{\partial x}\,dx + \frac{\partial f}{\partial y}\,dy + \frac{\partial f}{\partial z}\,dz = \begin{pmatrix} \frac{\partial f}{\partial x} & \frac{\partial f}{\partial y} & \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+When $\omega = P\,dx + Q\,dy + R\,dz$ is a $1$-form, $d\omega$ is a $2$-form (antisymmetric matrix) that measures the local mismatch of $\omega$.
+
+$$d\omega = \left(\frac{\partial R}{\partial y}-\frac{\partial Q}{\partial z}\right)dy\wedge dz + \left(\frac{\partial P}{\partial z}-\frac{\partial R}{\partial x}\right)dz\wedge dx + \left(\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}\right)dx\wedge dy$$
+
+When $\eta = A\,dy\wedge dz + B\,dz\wedge dx + C\,dx\wedge dy$ is a $2$-form, $d\eta$ is a $3$-form (third-order antisymmetric tensor).
+
+$$d\eta = \left(\frac{\partial A}{\partial x} + \frac{\partial B}{\partial y} + \frac{\partial C}{\partial z}\right) dx\wedge dy\wedge dz$$
+
+In this way, each time $d$ acts, the degree of the measuring device rises one step: $0\to1\to2\to3$. The core point is that <strong>$d$ does not produce a new arrow field in the sense of vector analysis; it differentiates the coefficients and changes the measuring-device side</strong>. $f$ remains a scalar field, but each time $d$ acts it generates a new measuring device—$df$ ($1$-form), $d\omega$ ($2$-form), $d\eta$ ($3$-form).
+
+#### 8.1.2 The formal differential operator stays the same; new fields are what we consider—the standpoint of $\nabla$
+
+Meanwhile, in the world of
+
+$$
+\nabla
+=
+\begin{pmatrix}
+\frac{\partial}{\partial x}\\[0.3em]
+\frac{\partial}{\partial y}\\[0.3em]
+\frac{\partial}{\partial z}
+\end{pmatrix}
+$$
+
+introduced in Chapter 7, <strong>the formal differential operator stays the same; depending on what it acts on, new fields are born</strong>. $\nabla$ is always the same operator, but acting on a scalar field $f$ yields a vector field $\nabla f$; acting on a vector field $\mathbf{F}$ yields a scalar field $\nabla\cdot\mathbf{F}$ or a vector field $\nabla\times\mathbf{F}$.
+
+Applying $\nabla$ to a scalar field $f(x,y,z)$ gives a column-vector field whose components are the rates of change in each direction.
+
+$$\nabla f = \begin{pmatrix} \frac{\partial f}{\partial x} \\[0.3em] \frac{\partial f}{\partial y} \\[0.3em] \frac{\partial f}{\partial z} \end{pmatrix}$$
+
+This is an arrow standing at each point in space; it is no longer a measuring device. It represents the direction of steepest increase of $f$ and the strength of that increase.
+
+Applying $\nabla\cdot$ to a vector field $\mathbf{F}$ with components $F_x,F_y,F_z$ gives a scalar field.
+
+$$\nabla \cdot \mathbf{F} = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}$$
+
+It returns the sum of the rates of change in each direction—the strength of outflow.
+
+Applying $\nabla\times$ to the same $\mathbf{F}$ gives a column-vector field again.
+
+$$\nabla \times \mathbf{F} = \begin{pmatrix} \frac{\partial F_z}{\partial y} - \frac{\partial F_y}{\partial z} \\[0.3em] \frac{\partial F_x}{\partial z} - \frac{\partial F_z}{\partial x} \\[0.3em] \frac{\partial F_y}{\partial x} - \frac{\partial F_x}{\partial y} \end{pmatrix}$$
+
+It represents the axis and strength of the local rotation.
+
+In the world of $\nabla$, the result is always returned as an arrow or a scalar in real space. Both $\nabla f$ and $\nabla\times\mathbf{F}$ look like the same kind of “arrow” on the page; there is no distinction by type.
+
+> <strong>Checkpoint so far — §8.1</strong>
+> - Standpoint of $d$: $d$ does not produce a new arrow field; the measuring-device side changes. New measuring devices are born.
+> - Standpoint of $\nabla$: the formal differential operator stays the same; new fields are born.
+
+---
 
 ### §8.2 Completing the Translation Dictionary
 
@@ -5561,6 +6550,28 @@ The reader may simply watch the calculations below—or follow along by hand. Ei
 
 > <strong>Note</strong> (for readers who have not studied vector analysis) Among the calculations below, every derivation of grad, div, and curl takes only a few lines. Substitute the dictionary into $d$, $\ast d$, or $\ast d\ast$ as appropriate, and expand the partial derivatives—that is all. That is why it looks easy. But if you try to derive the same results in the style of vector analysis, you are forced through pages of manipulation while manually attaching factors such as $\frac{1}{r}\frac{\partial}{\partial r}(r\,\cdot\,)$ and $\frac{1}{\rho^2\sin\theta}$ to the $\nabla$ formulas. It looks easy because $\ast$ automatically organizes measuring devices of different degrees. The Laplacian in §9.4 is admittedly tough, but even there all you do is consult the dictionary and expand partial derivatives—the method does not change. This difference is exactly the value of the "measuring device" framework that this book has built up from Chapter 1.
 
+---
+
+### §9.1 Building the Dictionary on the Spot — A Mechanical Procedure
+
+The procedure for deriving the formulas for $\mathrm{grad}$, $\mathrm{div}$, and $\mathrm{curl}$ in orthogonal curvilinear coordinates boils down to the following three steps.
+
+1. <strong>Write the Jacobian matrix $J$</strong>. From the coordinate transformation $x = x(q_1,q_2,q_3)$, $y = y(q_1,q_2,q_3)$, $z = z(q_1,q_2,q_3)$, arrange the partial derivatives. Each column of $J$ represents how a single step along one axis in parameter space moves in physical space.
+
+2. <strong>Compute the metric $\mathbf{g} = J^T J$</strong>. This is the procedure we have followed since Chapter 6 §6.1.3. The diagonal entries of $\mathbf{g}$ are the squares of the scales along each axis; the off-diagonal entries represent how orthogonal the axes are to one another.
+
+3. <strong>From $\mathbf{g}$, derive the dictionary for the Hodge star $\ast$, and combine it with $d$</strong>. Substitute the dictionary for $\ast$ in that coordinate system into each formula $\mathrm{grad} = d$, $\mathrm{curl}=\ast d$, $\mathrm{div}=\ast d\ast$, and the desired formulas are obtained mechanically.
+
+However, the usual $\mathrm{grad}$ and $\mathrm{curl}$ of vector analysis return vector fields as arrows. By contrast, this book's $\mathrm{grad}=d$, $\mathrm{curl}=\ast d$, and $\mathrm{div}=\ast d\ast$ are read first as formulas on the measuring-device side. To read a $1$-form obtained on the differential-forms side as a column vector, first use the metric $\mathbf{g}$ to convert it back to the form $\mathbf{g}^{-1}(\cdot)^T$. These are the column components corresponding to the coordinates. To read them as orthonormal vector components as used in vector analysis, you must also account for the scale factor in each direction.
+
+Also, in curvilinear coordinates, the orthonormal vector components used in vector analysis generally do not agree with the coefficients relative to the coordinate-associated $1$-forms. Because the calculation is carried out on the $1$-form side, first convert the vector field to the corresponding $1$-form. Then the coefficients of $d\theta$ and $d\phi$ pick up scale factors.
+
+> <strong>Note</strong> (vector components and $1$-form coefficients)
+> In curvilinear coordinates you must distinguish the coordinate-associated $1$-forms from the $1$-forms that measure actual length in units of 1. For example, in polar coordinates, the angular scale $d\theta$ itself differs from the unit-length scale $r\,d\theta$. The dictionary of the Hodge star absorbs all of this scale-factor information. That is what lets us carry out "straight computation" on a "distorted coordinate system."
+
+Below, we demonstrate this procedure in cylindrical and spherical coordinates. Keep in mind the flow: compute first as $1$-forms and $2$-forms, then convert back to orthonormal vector components at the end.
+
+---
 
 ### §9.2 Cylindrical Coordinates $(r,\theta,z)$
 
@@ -5862,6 +6873,55 @@ However, one caveat. This book is not an electromagnetism textbook. If you know 
 
 > <strong>Note</strong> (the role of this chapter) The core of this book is complete by Chapter 9. This chapter is, so to speak, a bonus, or nearly a digression. Do not take it too seriously; read it at your leisure.
 
+---
+
+### §10.1 Maxwell's Equations — Two Equations
+
+The fundamental laws of electromagnetism are summarized in vector-analysis notation as the following four equations. We adopt SI units.
+
+$$\begin{aligned}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho_{\mathrm e}}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B} &= 0 \\[0.5em]
+\mathrm{curl}\,\mathbf{B} &= \mu_0\mathbf{J} + \frac{1}{c^2}\frac{\partial \mathbf{E}}{\partial t} &
+\mathrm{curl}\,\mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t}
+\end{aligned}$$
+
+As they stand, the "types" are not aligned for packing into a $4\times4$ matrix. The electric field $\mathbf{E}$ (dimension $\mathrm{V/m}$) and magnetic flux density $\mathbf{B}$ (dimension $\mathrm{T}$) have different units, and spatial derivatives ($\mathrm{curl}$ and $\mathrm{div}$) and the time derivative with respect to $t$ also have different dimensions.
+
+So we introduce a length-dimension time coordinate and rescale the magnetic field to match the electric field.
+
+1. <strong>Time conversion</strong>: Multiply time $t$ by the speed of light $c$ to introduce the coordinate $w = ct$ with dimension of length. The time derivative becomes $\frac{\partial}{\partial t} = c\frac{\partial}{\partial w}$.
+
+2. <strong>Magnetic field conversion</strong>: Multiply magnetic flux density $\mathbf{B}$ by $c$ to define $\mathbf{B}' = c\mathbf{B}$, which has the same $\mathrm{V/m}$ dimension as the electric field.
+
+Substitute these into the four equations above. Faraday's law becomes
+
+$$\mathrm{curl}\,\mathbf{E} = -\frac{\partial}{\partial t}\!\left(\frac{1}{c}\mathbf{B}'\right) = -c\frac{\partial}{\partial w}\!\left(\frac{1}{c}\mathbf{B}'\right) = -\frac{\partial \mathbf{B}'}{\partial w}$$
+
+and Ampère's law is similarly rearranged to give
+
+$$\begin{aligned}
+\mathrm{div}\,\mathbf{E} &= \frac{\rho_{\mathrm e}}{\varepsilon_0} &
+\mathrm{div}\,\mathbf{B}' &= 0 \\[0.5em]
+\mathrm{curl}\,\mathbf{B}' &= c\mu_0\mathbf{J} + \frac{\partial \mathbf{E}}{\partial w} &
+\mathrm{curl}\,\mathbf{E} &= -\frac{\partial \mathbf{B}'}{\partial w}
+\end{aligned}$$
+
+Time derivatives are now written with respect to the length-dimension coordinate $w$, so the denominators in time and space derivatives are aligned.
+
+Henceforth we rename $\mathbf{B}'$ back to $\mathbf{B}$ and write $w$ as $t$. That is, from here on $\mathbf{B}$ is not the original magnetic flux density but the dimension-aligned field scaled by $c$, and $t$ is not the original time but the length-dimension time coordinate scaled by $c$.
+
+Now we are ready. $\mathbf{E}$ and $\mathbf{B}$ have the same dimension and can be arranged in the same matrix. With the $2$-form $F$ combining the electromagnetic field and the $1$-form $\mathcal{J}$ combining current and charge (strictly, the four-current lowered by the metric), the four equations consolidate into <strong>two</strong> under this book's normalization and sign conventions.
+
+$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
+
+Here, to show the form as physical laws, we write the Hodge star without subscript as $\ast$. When entering component calculations, we write the exterior derivative and Hodge star on four-dimensional spacetime as $d_4,\ast_4$, and those on spatial three dimensions at each instant as $d_3,\ast_3$. In this chapter's convention, we will define $\mu_0\ast\mathcal{J}$ directly in components.
+
+That is all. Four equations become two—this conciseness symbolizes the expressive power of differential forms.
+
+However, this book does not end here. What is inside $F$? When we expand $dF=0$ in components, do we really get $\mathrm{curl}\,\mathbf{E} = -\frac{\partial\mathbf{B}}{\partial t}$ and $\mathrm{div}\,\mathbf{B} = 0$? We will write all of that out in this chapter.
+
+---
 
 ### §10.2 The Electromagnetic Field $F$ and Fixing Sign Conventions
 
@@ -7263,6 +8323,85 @@ Let us collect in one table where the concepts of this book sit in manifold theo
 | $dF=0$, $d(\ast F)=\mu_0(\ast\mathcal{J})$ (Chapter 10) | On curved spacetime as well, the same form if we use the Hodge star from the spacetime metric and an appropriate current form |
 | $4\times4\times4$ slices in Appendix E (Chapter 10) | Component calculation for a 3-form on a 4-dimensional manifold |
 
+---
+
+### §11.2 Riemannian Geometry — The Tensor-Analysis Style
+
+Whereas manifold theory aims to define geometric objects without dependence on coordinates, classical Riemannian geometry—the tensor analysis used in Einstein's general relativity—adopts the style of "choosing coordinates and confronting component transformation laws head-on." This is closer to the approach of this book, which has made matrix components explicit throughout.
+
+#### 11.2.1 Tensors — Definition by Transformation Laws
+
+In classical tensor analysis, tensors are defined by their "transformation rules under coordinate changes." Under a change from coordinates $x^i$ to $\bar{x}^i$,
+
+<strong>contravariant vectors</strong> $V^i$ transform as $\bar{V}^i = \sum_j \frac{\partial \bar{x}^i}{\partial x^j} V^j$, and
+<strong>covariant vectors</strong> $\omega_i$ transform as $\bar{\omega}_i = \sum_j \frac{\partial x^j}{\partial \bar{x}^i} \omega_j$.
+
+This distinction already appeared in Chapter 4 of this book. The components $v^i$ of a displacement vector $\mathbf{v}$ are contravariant (transform by the inverse Jacobian), whereas the coefficients $\omega_i$ of a $1$-form $\omega$ are covariant (transform by the Jacobian). A general $(r,s)$-tensor $T^{i_1\cdots i_r}_{j_1\cdots j_s}$ has $r$ contravariant indices and $s$ covariant indices, and each index follows the transformation law above.
+
+The components $g_{ij}$ of the matrix $\mathbf{g}$ representing the metric in this book are a $(0,2)$-tensor (a second-order covariant tensor). Under coordinate transformation, $g_{ij}$ transforms as
+
+$$\bar{g}_{ij} = \sum_{p,q} \frac{\partial x^p}{\partial \bar{x}^i} \frac{\partial x^q}{\partial \bar{x}^j}\,g_{pq}$$
+
+The relation $\mathbf{g} = J^T J$ derived in Chapter 6 of this book is none other than the formula for computing $\bar{g}_{ij}$ in curvilinear coordinates when $g_{ij} = \delta_{ij}$ in Cartesian coordinates. A general Riemannian metric is not necessarily obtained as $J^T J$ from the Jacobian $J$ of a single coordinate transformation. The $J^T J$ of Chapter 6 is simply the most concrete example of computing an induced metric within Euclidean space.
+
+#### 11.2.2 Christoffel Symbols — When Differentiation Fails to Be Tensorial
+
+The partial derivatives $\partial_j V^i$ of a vector field $V^i$ do not, as they stand, behave as a tensor—under coordinate transformation extra terms appear. Choosing the Levi-Civita connection compatible with the metric $g$, its connection coefficients, namely the <strong>Christoffel symbols</strong>, are given by
+
+$$\Gamma^i_{jk} = \frac{1}{2}\sum_m g^{im}(\partial_j g_{km} + \partial_k g_{jm} - \partial_m g_{jk})$$
+
+Here $g^{im}$ are the components of the inverse matrix of $g_{ij}$. In the terminology of this book, $\Gamma^i_{jk}$ are "coefficients that compensate for changes in the basis and the metric in that coordinate representation," and in general they involve first derivatives of $g_{ij}$.
+
+Defining the <strong>covariant derivative</strong>
+
+$$\nabla_j V^i = \partial_j V^i + \sum_k \Gamma^i_{jk} V^k$$
+
+using the Christoffel symbols, $\nabla_j V^i$ transforms correctly as a $(1,1)$-tensor. The covariant derivative is precisely the tool that defines "straightness" in curved space. The component representation of the connection concept (§11.1.7) is none other than $\Gamma^i_{jk}$.
+
+Let us rephrase this in terms of the book's experience. In Chapter 9 we derived formulas for $\mathrm{div}$ and $\mathrm{curl}$ from $\mathbf{g}$ in cylindrical and spherical coordinates. The derivation via the $\ast$ dictionary in Chapter 9 differs from the method of explicitly computing Christoffel symbols. Rather, we should say that by using $d$ and $\ast$, we reached the same coordinate formulas without putting $\Gamma^i_{jk}$ in a table. If one derives the same formulas in tensor analysis, covariant derivatives and Christoffel symbols appear there. Learning Riemannian geometry is revisiting the same coordinate formulas from the side of the connection coefficients $\Gamma^i_{jk}$ and the curvature tensor $R^i_{\,mjk}$.
+
+#### 11.2.3 The Riemann Curvature Tensor
+
+The non-commutativity of covariant derivatives quantifies how curved space is. For a vector field $V^i$,
+$$(\nabla_j \nabla_k - \nabla_k \nabla_j) V^i = \sum_m R^i_{\,mjk} V^m$$
+This defines the curvature. Written out in Christoffel symbols, $R^i_{\,mjk}$ is expressed as a combination of first derivatives of $\Gamma$ and products $\Gamma\Gamma$. The precise index order and sign depend on conventions in the literature, but for example, in coordinates where $\mathbf g$ is constant, the Christoffel symbols vanish and $R^i{}_{mjk}=0$; this is the flat case.
+
+> <strong>Note</strong> (Coordinate-dependent metric and curvature) That $\mathbf{g}(x)$ depends on location does not by itself mean curvature is nonzero. Writing Euclidean space in curvilinear coordinates (polar, spherical, etc.), $g_{ij}(x)$ may depend on location yet curvature is zero. Curvature becomes nonzero when $R^i_{\,mjk}$, built from $\Gamma$ and its derivatives, does not vanish.
+
+The curvature tensor has $n^4$ components, but many symmetries make the number of independent components far smaller. Writing the fully covariant curvature tensor as $R_{abcd}$, a representative convention gives
+$$R_{abcd}=-R_{bacd},\qquad R_{abcd}=-R_{abdc},\qquad R_{abcd}=R_{cdab}$$
+and the first Bianchi identity also holds. This leaves 20 independent components in four dimensions.
+
+> <strong>Note</strong> (Sign and index conventions for the curvature tensor)
+> There are several conventions for the sign and index order of the curvature tensor. This section showed one representative convention, but other texts may use different index orders or signs.
+> $$
+> \nabla_i R_{mjkl}+\nabla_j R_{mkil}+\nabla_k R_{mijl}=0
+> $$
+> This identity suggests the same "double boundary yields zero" structure as $d^2=0$ for the exterior derivative, but strictly it is an identity for the exterior covariant derivative $D$ involving the connection, not simply $d^2=0$.
+
+The Ricci tensor is obtained by contracting one pair of indices of the curvature tensor. The precise position and sign of the contraction depend on the curvature tensor convention. Here we do not fix the convention in detail. Together with the <strong>scalar curvature</strong> $R = \sum_i\sum_j g^{ij} \mathrm{Ric}_{ij}$, these constitute the left-hand side of the Einstein equations:
+
+$$R_{ij} - \frac{1}{2}R\,g_{ij} = \frac{8\pi G}{c^4}\,T_{ij}$$
+
+The left-hand side represents the geometry of spacetime (curvature); the right-hand side represents the matter energy-momentum tensor $T_{ij}$.
+
+> <strong>Note</strong> (Sign convention and cosmological constant in the Einstein equations) This equation adopts one sign convention and sets the cosmological constant $\Lambda = 0$. Depending on sign conventions (metric signature, coordinate system, definition of the curvature tensor), the form of the equation changes, and extensions including a cosmological term also exist. This book neither derives nor proves it, but we record it as a warning for readers consulting other literature.
+
+This book does not derive this equation, nor does it ask the reader to understand it. Nevertheless, the foundation behind it—manifold, metric, covariant derivative, curvature—cannot be exhausted by the $d$ and $\ast$ treated in this book alone. Rather, the connection $\nabla$—in the sense of a covariant derivative, introduced here in Chapter 11—is indispensable. Even so, the differential-forms viewpoint is a powerful entry point for advancing into these structures.
+
+#### 11.2.4 Two Styles — Relation to This Book
+
+Descriptions via differential forms and via index-based tensor analysis are both languages for handling tensor fields. The former foreground antisymmetric tensors and the exterior derivative; the latter foreground components and transformation laws.
+
+This book has consistently adopted the style of making components explicit—matrices, index-free partial derivatives, expansions of wedge products. In this sense, the natural extension of this book lies in concrete tensor-analysis calculations rather than in the abstract theory of differential forms. Already when we pulled the $\ast$ dictionary for curvilinear coordinates in Chapter 9, we reached coordinate formulas for $\mathrm{curl}$ and $\mathrm{div}$ without explicitly writing $\Gamma^i_{jk}$. If one derives the same formulas in tensor analysis, behind them appear the world of $g_{ij}$, connection coefficients $\Gamma^i_{jk}$, and covariant derivatives. Beyond that lies the full scope of Riemannian geometry.
+
+### §11.3 Beyond That
+
+This book ends here. The framework of $d$ and $\ast$ built up from Chapter 1 has fulfilled the original goal of deconstructing vector analysis.
+
+But having come this far, if only as a hobby, let us peek just a little at the face of another school.
+
+In modern mathematical physics there is <strong>geometric algebra</strong>, a world that from the outset integrates the exterior product ($\wedge$) and inner product (metric) that we struggled to separate into a single algebra as the "geometric product." The two tools $d$ and $\ast$ are also absorbed there into more fundamental operators. Only those who have known the pain of separation can taste the power of integration—that alone we convey, and with that we close this book.
 
 # Chapter 12: The True Nabla — Clifford, Pauli, Dirac, and Hamilton
 
@@ -7276,6 +8415,37 @@ We can. And quite easily. Bring out the imaginary unit $i$, and they collapse in
 
 > <strong>Note</strong> (the position of this chapter) This chapter is an advanced supplement and lies off the main line of the book. Chapter 9 completed the rewrite of vector analysis, and Chapter 10 finished the matrix expansion of Maxwell's equations. Here we do not intend to write a textbook of rigorous geometric algebra (Clifford algebra). The purpose is to see, as an entry point to calculation, how grad, curl, and div—which this book has dismantled—are integrated again into a single operator inside Pauli matrices and the Dirac operator.
 
+---
+
+### §12.1 Combining Them with the Imaginary Unit — Unifying Maxwell's Equations
+
+In Chapter 10 we consolidated Maxwell's equations into the two equations
+
+$$dF = 0, \qquad d(\ast F) = \mu_0(\ast\mathcal{J})$$
+
+Notice here that both $F$ and $\ast F$ are $2$-forms. In four-dimensional spacetime, the Hodge star $\ast$ maps $2$-forms to $2$-forms. So $F$ and $\ast F$ are forms of the same degree.
+
+When the degrees match, there is no obstacle to addition. Using the imaginary unit $i$, we build a single complex $2$-form (in this chapter we follow the sign conventions of Chapter 10; on a Lorentzian metric the sign of $\ast^2$ depends on dimension and signature conventions, so here we prioritize consistency with the component expansion).
+
+$$G = F + i\ast F$$
+
+Apply the exterior derivative $d$ to $G$. Since $d$ is a real differential operator, $d(i\ast F) = i\,d(\ast F)$.
+
+$$dG = dF + i\,d(\ast F) = 0 + i\mu_0(\ast\mathcal{J})$$
+
+That is,
+
+$$d(F + i\ast F) = i\mu_0(\ast\mathcal{J})$$
+
+That is all. The two equations $dF=0$ and $d(\ast F)=\mu_0(\ast\mathcal{J})$ have been unified into a single complex equation. The real part $F$ and the imaginary part $\ast F$ share the source-free and source Maxwell equations between them.
+
+But pause here and think. This trick works only because, **by accident**, in four dimensions $\ast$ maps $2$-forms to $2$-forms. In general $n$ dimensions, $\ast$ maps $k$-forms to $(n-k)$-forms. Being able to add $2$-form to $2$-form is a privilege of $n=4$; adding $1$-form to $2$-form directly is not allowed in the usual framework of differential forms.
+
+When $d$ and $\ast$ are combined, conversions between different degrees appear—grad ($0\to1$), curl ($1\to1$), div ($1\to0$), and so on. If we could treat the origins of these in a single algebra, we should be able not to dismantle $\nabla$ but to **unify** it.
+
+Adding forms of different degrees—is there no such "magic box"?
+
+---
 
 ### §12.2 Pauli Matrices — The Magic of Adding Different Degrees
 
@@ -7589,6 +8759,13 @@ As the author, I sincerely hope that *Unmasking Div, Grad, and Curl* will be a s
 
 This book's peculiar algebraic approach was built by combining the insights of the following pioneers.
 
+---
+
+<strong>1. Daniel Fleisch, *A Student's Guide to Vectors and Tensors*, Cambridge University Press (2011)</strong>
+
+Comment: A careful guide to the traditional approach. A well-regarded introduction that treats traditional vector analysis and tensor analysis component calculation with extreme care. The best book for acquiring the power to break through head-on the jungle of Christoffel symbols and index manipulation—the route this book tries to bypass via differential forms.
+
+---
 
 <strong>2. David Bachman, *A Geometric Approach to Differential Forms*, Birkhäuser (2nd ed. 2011)</strong>
 
@@ -7655,6 +8832,35 @@ This book is not an axiomatic development of differential forms on general manif
 > <strong>Note</strong> (will the day come when I am not fooled?)
 > They say one stands at thirty; when I actually reached that milestone, I was still getting angry at formulas rather than standing upright. I have started making dad jokes.
 
+---
+
+## I. On the Theoretical Framework and Rigor
+
+- <strong>Introducing the exterior derivative $d$ without mathematical definitions of manifolds, atlases, tangent spaces, and so on is inaccurate</strong>
+  → This book is not a textbook of differential forms on general manifolds; it is an introductory book for reaching vector analysis on three-dimensional Euclidean space. Chapter 11 gives signposts for moving to general manifolds.
+
+- <strong>Contravariant and covariant vectors (dual spaces) should be distinguished clearly from the start</strong>
+  → Chapter 1 §1.1.6 introduces the distinction between "column vectors (displacements)" and "row vectors (measuring devices)," which is a concrete representation of the dual-space idea. A more abstract formulation of dual spaces is connected in Chapter 6 and Chapter 11.
+
+- <strong>Treating $dx$ as a row vector is not standard notation in mathematics books</strong>
+  → An intentional choice. Defined in Chapter 1 §1.1 and used consistently throughout. The aim is to translate the abstract idea "1-form = function that eats vectors" into "matrix multiplication" that the reader already knows. Correspondence with standard differential-form notation is shown in Chapter 11.
+
+- <strong>The exterior derivative $d$ should be defined generally from axioms (Leibniz rule, $d^2=0$)</strong>
+  → This book does not start from axioms; in Chapter 5 §5.3 it discovery-style derives $d$ from the physical intuition of "mismatch when traversing an infinitesimal loop." $d^2=0$ is understood in Chapter 5 §5.8 as a consequence of symmetry of mixed partial derivatives. The axiomatic definition is supplemented in Chapter 11.
+
+- <strong>A complete proof of Stokes' theorem on general $n$-dimensional manifolds is not given</strong>
+  → This book derives the concrete cases in three-dimensional Euclidean space (Gauss, Stokes, Green) directly from the definition of integration (Chapters 5 and 8). Proof of Stokes' theorem in general dimension is outside the book's scope; Chapter 11 gives signposts only.
+
+- <strong>The axiomatic approach via universal properties of exterior algebra is not used in defining the wedge product</strong>
+  → In §2.4 this book builds the wedge product as antisymmetrization of the tensor product. That is a concrete entry point toward the axiomatic approach, chosen so the reader can work by hand with matrix subtraction. The more standard abstract viewpoint is signposted in Chapter 11.
+
+- <strong>The book relies too much on component representations even though geometric objects have no absolute coordinate representation</strong>
+  → An intentional choice. The subject of this book is "how to use differential forms," not the philosophy of "differential forms as coordinate-independent geometric entities." Like standard vector-analysis textbooks, it adopts component representations as a practical computational tool. The coordinate-invariant viewpoint is connected in Chapter 11.
+
+- <strong>Avoiding standard notation makes the book look like it claims a private school</strong>
+  → The notation is chosen with top priority on "beginners can work by hand with matrix calculations." Why standard notation (index contraction, $\partial_\mu$, and so on) is deliberately avoided is explained in Chapter 11. This policy itself is widely seen in numerical computation and similar fields; the author does not especially claim anything new. There simply seemed to be no Japanese book in this style, so the author wrote one.
+
+---
 
 ## II. On Methodological Choices and Limits of Application
 

--- a/tools/core/manuscript.py
+++ b/tools/core/manuscript.py
@@ -43,33 +43,31 @@ class ManuscriptModel:
         if not os.path.exists(filepath):
             return title, lines, toc
 
-        in_yaml = False
-        yaml_done = False
         with open(filepath, 'r', encoding='utf-8') as f:
-            for line in f:
-                stripped = line.rstrip('\n')
-                if not yaml_done and stripped == '---':
-                    if not in_yaml:
-                        in_yaml = True
-                        continue
-                    else:
-                        in_yaml = False
-                        yaml_done = True
-                        continue
-                if in_yaml:
-                    continue
-                    
-                lines.append(stripped)
-                # Extract headers
-                h_match = re.match(r'^(#{1,3})\s+(.+)$', stripped)
-                if h_match:
-                    level = len(h_match.group(1))
-                    text = h_match.group(2).strip()
-                    if level == 1 and not title:
-                        title = text
-                    elif level > 1:
-                        anchor = self._slugify(text)
-                        toc.append(TocItem(level=level, title=text, anchor=anchor))
+            raw_lines = [line.rstrip('\n') for line in f]
+
+        # Strip YAML front matter only when the file begins with '---'.
+        # Otherwise horizontal rules ('---') in chapter bodies must be kept
+        # (EN chapters often omit opening YAML that JA chapters include).
+        start = 0
+        if raw_lines and raw_lines[0].strip() == '---':
+            for i in range(1, len(raw_lines)):
+                if raw_lines[i].strip() == '---':
+                    start = i + 1
+                    break
+
+        for stripped in raw_lines[start:]:
+            lines.append(stripped)
+            # Extract headers
+            h_match = re.match(r'^(#{1,3})\s+(.+)$', stripped)
+            if h_match:
+                level = len(h_match.group(1))
+                text = h_match.group(2).strip()
+                if level == 1 and not title:
+                    title = text
+                elif level > 1:
+                    anchor = self._slugify(text)
+                    toc.append(TocItem(level=level, title=text, anchor=anchor))
         return title, lines, toc
 
     def _load_chapter(self, ch_id: str, is_front: bool = False) -> Optional[Chapter]:


### PR DESCRIPTION
## Summary
- Fixes `_parse_markdown()` so YAML front matter is stripped **only when the file begins with `---`** (Pandoc-compatible).
- EN chapters without opening YAML were losing everything between the first and second `---` horizontal rules (e.g. **ch01 §1.1**, ch02 §2.1, … all 12 chapters affected).
- Regenerates `docs/en/*.html` and `exports/manuscript-en_combined.md` with restored content.

Closes #201

## Root cause
JA chapters start with `---` YAML; EN chapters start with `# Chapter N`. The old parser treated the first body `---` as YAML open and skipped until the next `---`.

## Test plan
- [x] Script: EN ch01–ch12 h3 heading counts match source; ch01 includes `### §1.1 Riemann Sums and Matrix Products`
- [x] `python3 tools/build_html.py --lang en` — ch01 sidebar TOC lists §1.1
- [ ] CI build-manuscript workflow (EN PDF rebuild on merge)
- [ ] Spot-check EN PDF ch01 §1.1 after merge

## Related
- #197 / #199 — separate Pandoc list-marker bugs inside `$$` blocks (orthogonal to this loader bug)

Made with [Cursor](https://cursor.com)