### PR TITLE
Fix ch08 §8.6.2 notation: scalar×form, not dot product

### DIFF
--- a/docs/ch08.html
+++ b/docs/ch08.html
@@ -459,7 +459,7 @@ $$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
 <p>ここから先は $\ast d\ast$ の機械的な計算だ。極座標の計量 $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$ から $\ast$ の辞書は $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ となる（§8.6.1 の二次元版）。$d$ は偏微分の係数をそのまま拾うだけ——途中に $\frac{1}{r}$ などを挟み込む必要は一切ない。
 </p>
 $$\begin{aligned}
-\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+\ast\tilde{\omega} &= F_r(r\,d\theta) + (r F_\theta)\!\left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
 d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$

--- a/docs/en/ch08.html
+++ b/docs/en/ch08.html
@@ -461,7 +461,7 @@ $$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
 <p>From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are; the metric factors are handled by $\ast$, not inserted into $d$ by hand.
 </p>
 $$\begin{aligned}
-\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+\ast\tilde{\omega} &= F_r(r\,d\theta) + (r F_\theta)\!\left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
 d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$

--- a/manuscript/en/ch08/ch08.md
+++ b/manuscript/en/ch08/ch08.md
@@ -315,7 +315,7 @@ is obtained.
 From here on it is the mechanical computation of $\ast d\ast$. From the polar metric $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$, the $\ast$ dictionary becomes $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ (the two-dimensional version of §8.6.1). $d$ simply picks up partial-derivative coefficients as they are; the metric factors are handled by $\ast$, not inserted into $d$ by hand.
 
 $$\begin{aligned}
-\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+\ast\tilde{\omega} &= F_r(r\,d\theta) + (r F_\theta)\!\left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
 d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$

--- a/manuscript/ja/ch08/ch08.md
+++ b/manuscript/ja/ch08/ch08.md
@@ -352,7 +352,7 @@ $$\tilde{\omega} = F_r\,dr + (r F_\theta)\,d\theta$$
 ここから先は $\ast d\ast$ の機械的な計算だ。極座標の計量 $\mathbf{g} = \begin{pmatrix} 1 & 0 \\ 0 & r^2 \end{pmatrix}$ から $\ast$ の辞書は $\ast(dr) = r\,d\theta$, $\ast(d\theta) = -\frac{1}{r}\,dr$ となる（§8.6.1 の二次元版）。$d$ は偏微分の係数をそのまま拾うだけ——途中に $\frac{1}{r}$ などを挟み込む必要は一切ない。
 
 $$\begin{aligned}
-\ast\tilde{\omega} &= F_r \cdot r\,d\theta + (r F_\theta) \cdot \left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
+\ast\tilde{\omega} &= F_r(r\,d\theta) + (r F_\theta)\!\left(-\frac{1}{r}\,dr\right) = r F_r\,d\theta - F_\theta\,dr \\[0.3em]
 d\ast\tilde{\omega} &= \left(\frac{\partial}{\partial r}(r F_r) + \frac{\partial F_\theta}{\partial \theta}\right) dr \wedge d\theta \\[0.3em]
 \ast d\ast\tilde{\omega} &= \frac{1}{r}\frac{\partial}{\partial r}(r F_r) + \frac{1}{r}\frac{\partial F_\theta}{\partial \theta}
 \end{aligned}$$


### PR DESCRIPTION
## Summary
- Replaces `\cdot` in the Route ① `\ast\tilde{\omega}` expansion (ch08 §8.6.2) with parenthesized scalar×$1$-form notation, matching ch09 cylindrical `\ast\omega` style.
- EN and JA manuscripts updated; EN/JA ch08 HTML regenerated.

Closes #205

## Why
`\ast(F_r\,dr + rF_\theta\,d\theta)` is linearity of `\ast`, not an inner product. This book reserves `\cdot` for dot products (§7.1+). Route ② flux `\cdot` lines are unchanged.

## Test plan
- [x] `grep F_r(r\\,d\\theta` in `docs/en/ch08.html` and `docs/ch08.html`
- [ ] CI build-manuscript passes

Made with [Cursor](https://cursor.com)