### PR TITLE
Clarify EN appendix: kihaji and “standing at thirty” wordplay

### DIFF
--- a/docs/en/appendix.html
+++ b/docs/en/appendix.html
@@ -146,15 +146,16 @@
 <p>If a definition in this book looks different from a mathematician's textbook, I want you first to read the definition inside this book. Then please distinguish whether there is a real contradiction or whether someone has simply imported notation from a different context. After that, by all means criticize me harshly again. Having read the definitions, I want you to point out my mistakes.</p>
 </blockquote>
 <blockquote>
-<p><strong>Note</strong> (as advanced "gatekeeping")</p>
-<p>As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than sophisticated gatekeeping.</p>
+<p><strong>Note</strong> (as advanced <em>kihaji</em>, or high-level rote mnemonics)</p>
+<p>Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure by a surface mnemonic, without understanding the underlying structure.</p>
+<p>As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level version of procedural mnemonic that works without grasping the underlying structure.</p>
 <p>If I put that into words it looks like an excuse; if I stay silent it will be misunderstood. Worse, I half believe such criticism myself, so I cannot speak about it well.</p>
 <p>Even so, a shortcut is not necessarily bad. A shortcut does not replace a professional system, nor is it merely subordinate to one. It can be a powerful language for treating three-dimensional physical mathematics in the tangible words of matrix representation—at least a system of operations on concrete symbols.</p>
 <p>Once again, the first purpose of this book is my own act of compensation. Even so, if a reader takes home one language they can move with their hands, that is an unexpected bonus.</p>
 </blockquote>
 <blockquote>
 <p><strong>Note</strong> (will the day come when I am not fooled?)</p>
-<p>They say one stands at thirty; when I actually reached that milestone, I was still getting angry at formulas rather than standing upright. I have started making dad jokes.</p>
+<p>They say, in an old East Asian classical phrase, that one should “stand” at thirty. In Japanese, “standing,” “setting up” an equation, and “getting angry” all echo the same verb. When I reached that age, I was still setting up formulas and getting angry at them rather than standing upright. I have started making dad jokes.</p>
 </blockquote>
 <hr />
 <h2 id="I.-On-the-Theoretical-Framework-and-Rigor">I. On the Theoretical Framework and Rigor</h2>

--- a/manuscript/en/appendix.md
+++ b/manuscript/en/appendix.md
@@ -20,8 +20,9 @@ This book is not an axiomatic development of differential forms on general manif
 >
 > If a definition in this book looks different from a mathematician's textbook, I want you first to read the definition inside this book. Then please distinguish whether there is a real contradiction or whether someone has simply imported notation from a different context. After that, by all means criticize me harshly again. Having read the definitions, I want you to point out my mistakes.
 
-> <strong>Note</strong> (as advanced "gatekeeping")
-> As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than sophisticated gatekeeping.
+> <strong>Note</strong> (as advanced <em>kihaji</em>, or high-level rote mnemonics)
+> Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure by a surface mnemonic, without understanding the underlying structure.
+> As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level version of procedural mnemonic that works without grasping the underlying structure.
 >
 > If I put that into words it looks like an excuse; if I stay silent it will be misunderstood. Worse, I half believe such criticism myself, so I cannot speak about it well.
 >
@@ -30,7 +31,7 @@ This book is not an axiomatic development of differential forms on general manif
 > Once again, the first purpose of this book is my own act of compensation. Even so, if a reader takes home one language they can move with their hands, that is an unexpected bonus.
 
 > <strong>Note</strong> (will the day come when I am not fooled?)
-> They say one stands at thirty; when I actually reached that milestone, I was still getting angry at formulas rather than standing upright. I have started making dad jokes.
+> They say, in an old East Asian classical phrase, that one should “stand” at thirty. In Japanese, “standing,” “setting up” an equation, and “getting angry” all echo the same verb. When I reached that age, I was still setting up formulas and getting angry at them rather than standing upright. I have started making dad jokes.
 
 ---
 


### PR DESCRIPTION
## Summary
- **高級なきはじ:** replace misleading `advanced "gatekeeping"` / `sophisticated gatekeeping` with *kihaji* / high-level rote mnemonics, plus a one-sentence gloss for non-Japanese readers.
- **三十にして立つ:** clarify East Asian classical reference and the Japanese verb pun (stand / set up an equation / get angry).
- Regenerate `docs/en/appendix.html`.

Closes #209

## Scope
Appendix author notes only; no broader appendix rewrite.

## Test plan
- [x] No `advanced "gatekeeping"` / `sophisticated gatekeeping` in `manuscript/en/appendix.md` or `docs/en/appendix.html`
- [x] `kihaji` and thirty-phrase explanation present in rebuilt HTML
- [ ] CI passes

Made with [Cursor](https://cursor.com)