### PR TITLE
Polish EN appendix kihaji note grammar

### DIFF
--- a/docs/en/appendix.html
+++ b/docs/en/appendix.html
@@ -147,8 +147,8 @@
 </blockquote>
 <blockquote>
 <p><strong>Note</strong> (as advanced <em>kihaji</em>, or high-level rote mnemonics)</p>
-<p>Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure by a surface mnemonic, without understanding the underlying structure.</p>
-<p>As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level version of procedural mnemonic that works without grasping the underlying structure.</p>
+<p>Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure through a surface mnemonic, without understanding the underlying structure.</p>
+<p>As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level form of rote procedural mnemonics that works without grasping the underlying structure.</p>
 <p>If I put that into words it looks like an excuse; if I stay silent it will be misunderstood. Worse, I half believe such criticism myself, so I cannot speak about it well.</p>
 <p>Even so, a shortcut is not necessarily bad. A shortcut does not replace a professional system, nor is it merely subordinate to one. It can be a powerful language for treating three-dimensional physical mathematics in the tangible words of matrix representation—at least a system of operations on concrete symbols.</p>
 <p>Once again, the first purpose of this book is my own act of compensation. Even so, if a reader takes home one language they can move with their hands, that is an unexpected bonus.</p>

--- a/manuscript/en/appendix.md
+++ b/manuscript/en/appendix.md
@@ -21,8 +21,8 @@ This book is not an axiomatic development of differential forms on general manif
 > If a definition in this book looks different from a mathematician's textbook, I want you first to read the definition inside this book. Then please distinguish whether there is a real contradiction or whether someone has simply imported notation from a different context. After that, by all means criticize me harshly again. Having read the definitions, I want you to point out my mistakes.
 
 > <strong>Note</strong> (as advanced <em>kihaji</em>, or high-level rote mnemonics)
-> Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure by a surface mnemonic, without understanding the underlying structure.
-> As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level version of procedural mnemonic that works without grasping the underlying structure.
+> Here <em>kihaji</em> refers to a Japanese elementary-school style of memorizing a procedure through a surface mnemonic, without understanding the underlying structure.
+> As I read mathematics books, I have internalized, at least somewhat, the beauty and strength of abstract orders of definition. The result is that what this book does can suddenly look like nothing more than advanced <em>kihaji</em>: a high-level form of rote procedural mnemonics that works without grasping the underlying structure.
 >
 > If I put that into words it looks like an excuse; if I stay silent it will be misunderstood. Worse, I half believe such criticism myself, so I cannot speak about it well.
 >


### PR DESCRIPTION
## Summary
- Minimal English polish in the *kihaji* appendix note (follow-up to merged #209).
- `by a surface mnemonic` → `through a surface mnemonic`
- `a high-level version of procedural mnemonic` → `a high-level form of rote procedural mnemonics`
- Regenerate `docs/en/appendix.html`

Closes #211

## Out of scope
Thirty / “standing at thirty” note unchanged (already reads well).

## Test plan
- [x] No `procedural mnemonic` (singular) or `by a surface mnemonic` in source/HTML
- [ ] CI passes

Made with [Cursor](https://cursor.com)